### PR TITLE
ci(docs): align workflow with current script CLIs

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -39,15 +39,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "18"
-          cache: "npm"
+          # NOTE: cache: "npm" is intentionally omitted — this repo has no
+          # root-level package-lock.json (only docs/interactive/ has one).
+          # Enabling cache without a lockfile makes setup-node fail with
+          # "Dependencies lock file is not found".
 
-      - name: Cache npm dependencies
+      - name: Cache npm global dir (mermaid-cli, puppeteer)
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-npm-mermaid-cli
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-npm-mermaid-
 
       - name: Install mermaid-cli
         run: |
@@ -72,9 +75,11 @@ jobs:
 
       - name: Validate and render Mermaid diagrams
         run: |
-          python scripts/tools/lint/validate_mermaid.py \
-            docs/ rule-packs/ \
-            --ci --render
+          # validate_mermaid.py takes a single positional path (nargs='?').
+          # Run it twice — once for docs/, once for rule-packs/ — so both
+          # trees are covered. Both must pass.
+          python scripts/tools/lint/validate_mermaid.py docs/ --ci --render
+          python scripts/tools/lint/validate_mermaid.py rule-packs/ --ci --render
 
   check-links:
     name: Check Documentation Links
@@ -102,9 +107,11 @@ jobs:
 
       - name: Check document links and cross-references
         run: |
-          python scripts/tools/lint/check_doc_links.py \
-            docs/ rule-packs/ \
-            --ci
+          # check_doc_links.py scans the whole repo from --repo-root (default
+          # ".") and does not accept positional path arguments. Passing
+          # `docs/ rule-packs/` here used to fail with
+          # `unrecognized arguments: docs/ rule-packs/`.
+          python scripts/tools/lint/check_doc_links.py --ci
 
   check-frontmatter:
     name: Check Documentation Front Matter
@@ -132,9 +139,11 @@ jobs:
 
       - name: Validate documentation YAML front matter
         run: |
-          python scripts/tools/dx/add_frontmatter.py \
-            docs/ rule-packs/ \
-            --check
+          # add_frontmatter.py scans a single base directory via --base-dir
+          # and does not accept positional paths. Run it twice so both
+          # docs/ and rule-packs/ are covered; both must pass.
+          python scripts/tools/dx/add_frontmatter.py --check --base-dir docs/
+          python scripts/tools/dx/add_frontmatter.py --check --base-dir rule-packs/
 
   check-coverage:
     name: Check Documentation Coverage
@@ -162,16 +171,16 @@ jobs:
 
       - name: Check documentation coverage (80% minimum)
         run: |
-          python scripts/tools/dx/doc_coverage.py \
-            docs/ rule-packs/ \
-            --ci
+          # doc_coverage.py scans the whole repo from --repo-root (default
+          # ".") and does not accept positional paths. Passing
+          # `docs/ rule-packs/` here used to fail with
+          # `unrecognized arguments: docs/ rule-packs/`.
+          python scripts/tools/dx/doc_coverage.py --ci
 
       - name: Update coverage badge JSON
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          python scripts/tools/dx/doc_coverage.py \
-            docs/ rule-packs/ \
-            --badge --json > docs/assets/doc-coverage-badge.json || true
+          python scripts/tools/dx/doc_coverage.py --badge --json > docs/assets/doc-coverage-badge.json || true
 
       - name: Sync glossary abbreviations
         run: |


### PR DESCRIPTION
## Summary

Documentation CI was failing on five jobs because the workflow's invocations had drifted from the script CLIs:

| Job | Symptom | Root cause |
|---|---|---|
| `check-links` | `check_doc_links.py: error: unrecognized arguments: docs/ rule-packs/` | Script was refactored to scan from `--repo-root` (default `.`); workflow still passed positional paths |
| `check-frontmatter` | `add_frontmatter.py: error: unrecognized arguments: docs/ rule-packs/` | Script uses `--base-dir`, not positional |
| `check-coverage` | `doc_coverage.py: error: unrecognized arguments: docs/ rule-packs/` | Same as `check-links` |
| `validate-mermaid` | `Dependencies lock file is not found` | `actions/setup-node` had `cache: ""npm""` but the repo has no root-level `package-lock.json`. Even after that's fixed, the script only takes a single positional path |
| `all-checks` (aggregator) | cascading failure | Above |

## Changes (`.github/workflows/docs-ci.yaml` only)

- **validate-mermaid**: drop `cache: ""npm""`; cache `~/.npm` directly with a static key (we install `mermaid-cli`/`puppeteer` globally, not from a lockfile). Split `validate_mermaid.py` into two single-path invocations (the script takes `nargs='?'`).
- **check-links**: drop `docs/ rule-packs/` positionals — `check_doc_links.py` already scans the whole repo from `--repo-root`.
- **check-frontmatter**: split into two `add_frontmatter.py --check --base-dir <path>` invocations.
- **check-coverage**: drop positional args from both `doc_coverage.py` calls.

Net diff: 28 insertions, 19 deletions in one file. No script changes, no behavior changes other than CI now actually running.

## Out of scope (deferred to follow-ups)

These were also flagged on the harness-hardening PR but are independent root causes:

- `commitlint`: PR title needs `type:` prefix (fixable by editing the PR title)
- `Lint` (CI): `changelog-lint` hook reads only the auto-generated PR merge commit because checkout is shallow + no tag boundary
- `Python Tests (3.13)`: `test_bump_docs.py::test_reads_from_real_repo` expects a `platform` version key that `bump_docs.py` no longer emits
- `Validate Tenant Config & Routes`: `rule-pack-clickhouse/db2/elasticsearch.yaml` rules missing required `tenant` label (governance debt)
- `Smoke Tests (Chromium)`: `docs/interactive/` `package.json` and `package-lock.json` are out of sync (`@axe-core/playwright` missing from lockfile)
- `MkDocs Build`: 100 actionable warnings from broken links — needs separate triage to determine pre-existing vs. introduced

## Test plan

- [ ] `validate-mermaid` job runs (no more setup-node lockfile error) and either passes or fails on actual content (not on argv)
- [ ] `check-links` runs `check_doc_links.py --ci` without `unrecognized arguments`
- [ ] `check-frontmatter` runs `add_frontmatter.py --check --base-dir docs/` and `--base-dir rule-packs/` without arg errors
- [ ] `check-coverage` runs `doc_coverage.py --ci` without arg errors
- [ ] `all-checks` aggregator now reflects real status of the underlying jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)