### PR TITLE
fix(tools): pass --no-sandbox to mmdc via puppeteer config

### DIFF
--- a/scripts/tools/lint/validate_mermaid.py
+++ b/scripts/tools/lint/validate_mermaid.py
@@ -10,6 +10,7 @@
 """
 
 import argparse
+import atexit
 import os
 import re
 import subprocess
@@ -17,6 +18,16 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import List, Tuple, Dict, Optional
+
+# Puppeteer config required for mmdc to launch headless Chrome inside
+# sandboxed CI runners (GitHub Actions, containers, WSL, etc.). Without
+# --no-sandbox, mmdc fails with "Failed to launch the browser process!"
+# whenever the runner cannot grant the default Chrome sandbox capabilities.
+# The config is materialised lazily on first render via
+# MermaidValidator._ensure_puppeteer_config and cleaned up at process exit.
+_PUPPETEER_CONFIG_JSON = (
+    '{"args": ["--no-sandbox", "--disable-setuid-sandbox"]}'
+)
 
 
 class MermaidValidator:
@@ -32,6 +43,46 @@ class MermaidValidator:
         self.errors: List[Dict] = []
         self.total_diagrams = 0
         self.valid_diagrams = 0
+        # Lazily materialised on first render call.
+        self._puppeteer_config_path: Optional[str] = None
+
+    def _ensure_puppeteer_config(self) -> str:
+        """Materialise the puppeteer config file once per instance.
+
+        Returns the path to a JSON file that tells mmdc to launch
+        headless Chrome with --no-sandbox / --disable-setuid-sandbox.
+        Required on GitHub Actions runners and most container/sandbox
+        environments where Chrome cannot grant itself a user namespace.
+
+        The temp file is registered for cleanup at interpreter exit.
+        """
+        if self._puppeteer_config_path is not None:
+            return self._puppeteer_config_path
+
+        fd, path = tempfile.mkstemp(
+            prefix='mmdc-puppeteer-', suffix='.json'
+        )
+        try:
+            with os.fdopen(fd, 'w', encoding='utf-8') as f:
+                f.write(_PUPPETEER_CONFIG_JSON)
+        except Exception:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            raise
+
+        # Best-effort cleanup at exit; ignore failures (file may be gone
+        # already if /tmp was wiped between calls).
+        def _cleanup(p: str = path) -> None:
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+        atexit.register(_cleanup)
+        self._puppeteer_config_path = path
+        return path
 
     def validate_file(self, filepath: Path) -> List[Dict]:
         """驗證單個檔案中的所有 Mermaid 區塊"""
@@ -307,10 +358,18 @@ class MermaidValidator:
                 tmp_path = tmp.name
 
             try:
-                # Run mmdc with output to temp PNG (just validation, not stored)
+                # Run mmdc with output to temp PNG (just validation, not stored).
+                # -p <puppeteer-config> is required so headless Chrome can launch
+                # in sandboxed environments (CI runners, containers, WSL).
+                puppeteer_cfg = self._ensure_puppeteer_config()
                 with tempfile.NamedTemporaryFile(suffix='.png', delete=True) as out:
                     result = subprocess.run(
-                        ['mmdc', '-i', tmp_path, '-o', out.name],
+                        [
+                            'mmdc',
+                            '-p', puppeteer_cfg,
+                            '-i', tmp_path,
+                            '-o', out.name,
+                        ],
                         capture_output=True,
                         text=True,
                         timeout=10,


### PR DESCRIPTION
## Summary

Fixes root cause (A) from the PR #2 CI triage: `Validate Mermaid Diagrams` on GitHub Actions failed on every rule-pack diagram with `Failed to launch the browser process!`.

On GitHub Actions runners (and most sandboxed containers / WSL), headless Chrome cannot grant itself a user namespace, so puppeteer must launch with `--no-sandbox --disable-setuid-sandbox`. `mmdc` exposes this via its `-p / --puppeteerConfigFile` flag.

> **Note:** This PR was originally opened as #4 stacked on top of #3. When #3 was squash-merged with `--delete-branch`, GitHub auto-closed #4 (closed state, no auto-retarget). PR #4 cannot be reopened via API after that state. This PR carries the same commit rebased cleanly onto `main` (`f11136c`).

## What changed

`scripts/tools/lint/validate_mermaid.py`:

- New module constant `_PUPPETEER_CONFIG_JSON = '{"args": ["--no-sandbox", "--disable-setuid-sandbox"]}'`
- New `MermaidValidator._ensure_puppeteer_config()` writes the JSON once per process to `tempfile.mkstemp` and registers `atexit` cleanup
- `_render_diagram` now invokes `mmdc -p <cfg> -i ... -o ...` instead of `mmdc -i ... -o ...`
- Non-`--render` code path (the default — every pre-commit invocation) pays zero cost

## Why a Python-side fix (not a workflow-side env var)

Puppeteer has several ways to inject `--no-sandbox` (`PUPPETEER_ARGS` env var, `~/.puppeteerrc.cjs`, etc.), but all of them are either undocumented, version-dependent, or global-side-effect. The `-p` flag is the only officially documented, mmdc-supported path, and it keeps the fix co-located with the tool that needs it — so local `make lint-docs --render` runs inside containers also benefit.

## Verification

- [x] 49 existing `tests/tools/lint/test_validate_mermaid.py` cases pass
- [x] `python -m py_compile scripts/tools/lint/validate_mermaid.py`
- [x] `mmdc -p` flag confirmed upstream in `@mermaid-js/mermaid-cli` source
- [x] **End-to-end verified on PR #4 (pre-rebase)**: run 24248434407 — `Validate Mermaid Diagrams` pass 2m36s, 46 rule-pack diagrams rendered successfully. Commit tree `f11136c` is byte-identical to the validated `4c8467e`; only the commit message differs (rebase dropped the already-merged PR #3 commit).

## Context

- PR #2 triage identified 7 root causes; this is root cause (A)
- PR #3 fixed root cause (C) — workflow-vs-script CLI drift — and has been merged (`20fe3a7`)
- Deferred: root causes (B), (D), (E), (F), (G) + content debt, tracked as separate follow-ups