### PR TITLE
fix(ci): sync tests/e2e/package-lock.json with @axe-core/playwright

### DIFF
--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,15 +1,29 @@
 {
   "name": "@vibe-k8s-lab/e2e-tests",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vibe-k8s-lab/e2e-tests",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "devDependencies": {
+        "@axe-core/playwright": "^4.8.0",
         "@playwright/test": "^1.59.1",
         "@types/node": "^20.19.39"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -32,6 +46,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
+      "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/fsevents": {


### PR DESCRIPTION
`tests/e2e/package.json` added `@axe-core/playwright` but the lockfile was never regenerated, so `npm ci` in the Smoke Tests (Chromium) workflow fails with `Missing: @axe-core/playwright from lock file`.

Regenerated `tests/e2e/package-lock.json` via `npm install --package-lock-only` which pulled in `@axe-core/playwright@4.11.1` (the current ^4.8.0 resolution).

## Test plan
- [x] `npm ci` succeeds against the new lockfile in an isolated tmp dir
- [ ] Smoke Tests (Chromium) CI job turns green