### PR TITLE
fix(rule-packs): add required tenant label to all alert rules

### DIFF
--- a/rule-packs/rule-pack-clickhouse.yaml
+++ b/rule-packs/rule-pack-clickhouse.yaml
@@ -123,6 +123,7 @@ groups:
         for: 2m
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "ClickHouse instance is DOWN"
           summary_zh: "ClickHouse 實例已關閉"
@@ -143,6 +144,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "ClickHouse query rate exceeds threshold"
           summary_zh: "ClickHouse 查詢率超出閾值"
@@ -170,6 +172,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "ClickHouse active connections exceed threshold"
           summary_zh: "ClickHouse 活動連線超出閾值"
@@ -197,6 +200,7 @@ groups:
         for: 10m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "ClickHouse max part count per partition exceeds threshold (merge pressure)"
           summary_zh: "ClickHouse partition 最大 part 數超出閾值（merge 壓力）"
@@ -224,6 +228,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "ClickHouse replication queue size exceeds threshold"
           summary_zh: "ClickHouse 複寫隊列大小超出閾值"
@@ -251,6 +256,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "ClickHouse memory tracking exceeds threshold"
           summary_zh: "ClickHouse 記憶體追蹤超出閾值"
@@ -269,6 +275,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "ClickHouse failed query rate > 10/s"
           summary_zh: "ClickHouse 查詢失敗率 > 10/秒"

--- a/rule-packs/rule-pack-db2.yaml
+++ b/rule-packs/rule-pack-db2.yaml
@@ -93,6 +93,7 @@ groups:
         for: 15s
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "DB2 instance {{ $labels.instance }} is DOWN"
           summary_zh: "DB2 實例 {{ $labels.instance }} 已關閉"
@@ -115,6 +116,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "DB2 high active connections on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 DB2 連線數過高"
@@ -142,6 +144,7 @@ groups:
         for: 10m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "DB2 low bufferpool hit ratio on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 DB2 bufferpool 命中率偏低"
@@ -169,6 +172,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "DB2 high transaction log usage on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 DB2 交易日誌使用率過高"
@@ -196,6 +200,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "DB2 high deadlock rate on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 DB2 死鎖率過高"
@@ -223,6 +228,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "DB2 tablespace nearing capacity on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 DB2 tablespace 即將滿容"
@@ -246,6 +252,7 @@ groups:
         for: 10m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "DB2 high sort overflow ratio on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 DB2 sort overflow 比率過高"

--- a/rule-packs/rule-pack-elasticsearch.yaml
+++ b/rule-packs/rule-pack-elasticsearch.yaml
@@ -99,6 +99,7 @@ groups:
         for: 30s
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Elasticsearch cluster RED on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Elasticsearch 叢集狀態為 RED"
@@ -117,6 +118,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Elasticsearch cluster YELLOW on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Elasticsearch 叢集狀態為 YELLOW"
@@ -144,6 +146,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Elasticsearch high heap usage on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Elasticsearch JVM heap 使用率過高"
@@ -171,6 +174,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Elasticsearch high disk usage on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Elasticsearch 磁碟使用率過高"
@@ -198,6 +202,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Elasticsearch high search latency on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Elasticsearch 搜尋延遲過高"
@@ -221,6 +226,7 @@ groups:
         for: 10m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Elasticsearch has unassigned shards on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Elasticsearch 有未分配的分片"
@@ -248,6 +254,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Elasticsearch pending cluster tasks on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Elasticsearch 有待處理的叢集工作"

--- a/rule-packs/rule-pack-jvm.yaml
+++ b/rule-packs/rule-pack-jvm.yaml
@@ -94,6 +94,7 @@ groups:
         labels:
           severity: warning
           metric_group: "jvm_gc_pause"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "JVMHighGCPause on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 JVM GC pause 過高"
@@ -122,6 +123,7 @@ groups:
         labels:
           severity: critical
           metric_group: "jvm_gc_pause"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "JVMHighGCPauseCritical on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 JVM GC pause 嚴重過高"
@@ -151,6 +153,7 @@ groups:
         labels:
           severity: warning
           metric_group: "jvm_memory"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "JVMMemoryPressure on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 JVM 記憶體壓力"
@@ -179,6 +182,7 @@ groups:
         labels:
           severity: critical
           metric_group: "jvm_memory"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "JVMMemoryPressureCritical on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 JVM 記憶體壓力嚴重"
@@ -208,6 +212,7 @@ groups:
         labels:
           severity: warning
           metric_group: "jvm_threads"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "JVMThreadPoolExhaustion on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 JVM thread pool 耗盡"
@@ -236,6 +241,7 @@ groups:
         labels:
           severity: critical
           metric_group: "jvm_threads"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "JVMThreadPoolExhaustionCritical on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 JVM thread pool 嚴重耗盡"
@@ -265,6 +271,7 @@ groups:
         labels:
           severity: critical
           metric_group: "jvm_performance"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "JVMPerformanceDegraded on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 JVM 效能降級"

--- a/rule-packs/rule-pack-kafka.yaml
+++ b/rule-packs/rule-pack-kafka.yaml
@@ -88,6 +88,7 @@ groups:
         for: 30s
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Kafka exporter target missing"
           summary_zh: "Kafka exporter 目標缺失"
@@ -111,6 +112,7 @@ groups:
         labels:
           severity: warning
           metric_group: "kafka_consumer_lag"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High Kafka consumer lag on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Kafka 消費者延遲過高"
@@ -140,6 +142,7 @@ groups:
         labels:
           severity: critical
           metric_group: "kafka_consumer_lag"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Critical Kafka consumer lag on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Kafka 消費者延遲嚴重"
@@ -168,6 +171,7 @@ groups:
         labels:
           severity: warning
           metric_group: "kafka_under_replicated_partitions"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Under-replicated partitions detected on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 偵測到複製不足的分割區"
@@ -197,6 +201,7 @@ groups:
         labels:
           severity: critical
           metric_group: "kafka_under_replicated_partitions"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Critical under-replicated partitions on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的複製不足分割區情況嚴重"
@@ -225,6 +230,7 @@ groups:
         labels:
           severity: critical
           metric_group: "kafka_active_controllers"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "No active Kafka controller on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上沒有活躍的 Kafka controller"
@@ -253,6 +259,7 @@ groups:
         labels:
           severity: warning
           metric_group: "kafka_broker_count"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Low Kafka broker count on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Kafka broker 數量過少"
@@ -281,6 +288,7 @@ groups:
         labels:
           severity: warning
           metric_group: "kafka_request_rate"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High Kafka request rate on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Kafka 請求率過高"
@@ -310,6 +318,7 @@ groups:
         labels:
           severity: critical
           metric_group: "kafka_request_rate"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Critical Kafka request rate on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Kafka 請求率嚴重過高"

--- a/rule-packs/rule-pack-kubernetes.yaml
+++ b/rule-packs/rule-pack-kubernetes.yaml
@@ -110,6 +110,7 @@ groups:
         for: 60s
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High container CPU in {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的容器 CPU 使用率過高"
@@ -137,6 +138,7 @@ groups:
         for: 60s
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High container memory in {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的容器記憶體使用率過高"
@@ -171,6 +173,7 @@ groups:
         for: 30s
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Container crash loop detected in {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 偵測到容器崩潰迴圈"
@@ -200,6 +203,7 @@ groups:
         for: 30s
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Image pull failure detected in {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 偵測到映像檔案拉取失敗"

--- a/rule-packs/rule-pack-mariadb.yaml
+++ b/rule-packs/rule-pack-mariadb.yaml
@@ -79,6 +79,7 @@ groups:
         for: 15s
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "MariaDB instance {{ $labels.instance }} is DOWN"
           summary_zh: "MariaDB 實例 {{ $labels.instance }} 已關閉"
@@ -90,6 +91,7 @@ groups:
         for: 30s
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "mysqld-exporter target missing"
           summary_zh: "mysqld-exporter 目標缺失"
@@ -113,6 +115,7 @@ groups:
         labels:
           severity: warning
           metric_group: "connections"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High connections on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 連線數過高"
@@ -142,6 +145,7 @@ groups:
         labels:
           severity: critical
           metric_group: "connections"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Critical connections on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 連線數嚴重過高"
@@ -178,6 +182,7 @@ groups:
         for: 60s
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "System bottleneck on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 系統瓶頸"
@@ -194,6 +199,7 @@ groups:
         for: 0s
         labels:
           severity: info
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "{{ $labels.instance }} restarted recently"
           summary_zh: "{{ $labels.instance }} 最近已重新啟動"
@@ -213,6 +219,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High slow query rate on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 慢查詢率過高"
@@ -237,6 +244,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High aborted connections on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 中止的連線數過高"

--- a/rule-packs/rule-pack-mongodb.yaml
+++ b/rule-packs/rule-pack-mongodb.yaml
@@ -84,6 +84,7 @@ groups:
         for: 15s
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "MongoDB instance {{ $labels.instance }} is DOWN"
           summary_zh: "MongoDB 實例 {{ $labels.instance }} 已停機"
@@ -104,6 +105,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "MongoDB high connection count on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 MongoDB 連線數過高"
@@ -131,6 +133,7 @@ groups:
         for: 2m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "MongoDB replication lag on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 MongoDB 複製延遲"
@@ -158,6 +161,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "MongoDB high operation rate on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 MongoDB 作業率過高"
@@ -181,6 +185,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "MongoDB high page faults on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 MongoDB Page Fault 過多"
@@ -204,6 +209,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "MongoDB connection pool near saturation on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 MongoDB 連線池接近飽和"

--- a/rule-packs/rule-pack-nginx.yaml
+++ b/rule-packs/rule-pack-nginx.yaml
@@ -91,6 +91,7 @@ groups:
         labels:
           severity: warning
           metric_group: "nginx_connections"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "NginxHighConnections on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 Nginx 連線數過高"
@@ -119,6 +120,7 @@ groups:
         labels:
           severity: critical
           metric_group: "nginx_connections"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "NginxHighConnectionsCritical on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 Nginx 連線飽和嚴重"
@@ -148,6 +150,7 @@ groups:
         labels:
           severity: warning
           metric_group: "nginx_request_rate"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "NginxRequestRateSpike on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 Nginx request 速率尖峰"
@@ -176,6 +179,7 @@ groups:
         labels:
           severity: critical
           metric_group: "nginx_request_rate"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "NginxRequestRateSpikeCritical on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 Nginx request 速率尖峰嚴重"
@@ -205,6 +209,7 @@ groups:
         labels:
           severity: warning
           metric_group: "nginx_waiting"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "NginxConnectionBacklog on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 Nginx 連線積壓"
@@ -233,6 +238,7 @@ groups:
         labels:
           severity: critical
           metric_group: "nginx_waiting"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "NginxConnectionBacklogCritical on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 Nginx 連線積壓嚴重"

--- a/rule-packs/rule-pack-operational.yaml
+++ b/rule-packs/rule-pack-operational.yaml
@@ -46,6 +46,7 @@ groups:
         expr: user_silent_mode{target_severity="warning"} == 1
         labels:
           severity: none
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Silent mode (warning) active for {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的靜默模式（警告級別）已啟用"
@@ -58,6 +59,7 @@ groups:
         expr: user_silent_mode{target_severity="critical"} == 1
         labels:
           severity: none
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Silent mode (critical) active for {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的靜默模式（嚴重級別）已啟用"
@@ -72,6 +74,7 @@ groups:
         expr: user_severity_dedup{mode="enable"} == 1
         labels:
           severity: none
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Severity dedup enabled for {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 已啟用嚴重等級去重"
@@ -88,6 +91,7 @@ groups:
         for: 0s
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Config expired for {{ $labels.tenant }}: {{ $labels.event }}"
           summary_zh: "{{ $labels.tenant }} 的組態已過期：{{ $labels.event }}"

--- a/rule-packs/rule-pack-oracle.yaml
+++ b/rule-packs/rule-pack-oracle.yaml
@@ -89,6 +89,7 @@ groups:
         for: 15s
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Oracle instance {{ $labels.instance }} is DOWN"
           summary_zh: "Oracle 實例 {{ $labels.instance }} 已關閉"
@@ -111,6 +112,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Oracle high active sessions on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 Oracle 活動 session 數過高"
@@ -138,6 +140,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Oracle tablespace nearing capacity on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 Oracle tablespace 即將滿容"
@@ -165,6 +168,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Oracle high wait time on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 Oracle 等待時間過高"
@@ -192,6 +196,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Oracle high process count on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 Oracle process 數過高"
@@ -219,6 +224,7 @@ groups:
         for: 10m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Oracle high PGA usage on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 Oracle PGA 使用率過高"
@@ -242,6 +248,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Oracle session limit approaching on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 上 Oracle session 限制即將達到"

--- a/rule-packs/rule-pack-postgresql.yaml
+++ b/rule-packs/rule-pack-postgresql.yaml
@@ -91,6 +91,7 @@ groups:
         for: 15s
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "PostgreSQL instance {{ $labels.instance }} is DOWN"
           summary_zh: "PostgreSQL 實例 {{ $labels.instance }} 已關閉"
@@ -102,6 +103,7 @@ groups:
         for: 30s
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "postgres_exporter target missing"
           summary_zh: "postgres_exporter 目標缺失"
@@ -125,6 +127,7 @@ groups:
         labels:
           severity: warning
           metric_group: "pg_connections"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High connection usage on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 連線使用率過高"
@@ -154,6 +157,7 @@ groups:
         labels:
           severity: critical
           metric_group: "pg_connections"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Critical connection usage on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 連線使用率嚴重過高"
@@ -182,6 +186,7 @@ groups:
         labels:
           severity: warning
           metric_group: "pg_replication_lag"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High replication lag on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 複寫延遲過高"
@@ -211,6 +216,7 @@ groups:
         labels:
           severity: critical
           metric_group: "pg_replication_lag"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Critical replication lag on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 複寫延遲嚴重"
@@ -235,6 +241,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Deadlocks detected on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 偵測到死鎖"
@@ -259,6 +266,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High rollback ratio on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 回滾比率過高"
@@ -276,6 +284,7 @@ groups:
         for: 0s
         labels:
           severity: info
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "{{ $labels.instance }} restarted recently"
           summary_zh: "{{ $labels.instance }} 最近已重新啟動"

--- a/rule-packs/rule-pack-rabbitmq.yaml
+++ b/rule-packs/rule-pack-rabbitmq.yaml
@@ -87,6 +87,7 @@ groups:
         for: 30s
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "RabbitMQ exporter target missing"
           summary_zh: "RabbitMQ exporter 目標缺失"
@@ -110,6 +111,7 @@ groups:
         labels:
           severity: warning
           metric_group: "rabbitmq_queue_messages"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High RabbitMQ queue depth on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 RabbitMQ 佇列深度過高"
@@ -139,6 +141,7 @@ groups:
         labels:
           severity: critical
           metric_group: "rabbitmq_queue_messages"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Critical RabbitMQ queue depth on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 RabbitMQ 佇列深度嚴重過高"
@@ -167,6 +170,7 @@ groups:
         labels:
           severity: warning
           metric_group: "rabbitmq_node_mem_percent"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High RabbitMQ memory usage on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 RabbitMQ 記憶體使用率過高"
@@ -196,6 +200,7 @@ groups:
         labels:
           severity: critical
           metric_group: "rabbitmq_node_mem_percent"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Critical RabbitMQ memory usage on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 RabbitMQ 記憶體使用率嚴重過高"
@@ -224,6 +229,7 @@ groups:
         labels:
           severity: warning
           metric_group: "rabbitmq_connections"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High RabbitMQ connection count on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 RabbitMQ 連線數過高"
@@ -252,6 +258,7 @@ groups:
         labels:
           severity: warning
           metric_group: "rabbitmq_consumers"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Low RabbitMQ consumer count on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 RabbitMQ 消費者數量過少"
@@ -280,6 +287,7 @@ groups:
         labels:
           severity: warning
           metric_group: "rabbitmq_unacked_messages"
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "High unacknowledged messages on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 RabbitMQ 未確認訊息過多"

--- a/rule-packs/rule-pack-redis.yaml
+++ b/rule-packs/rule-pack-redis.yaml
@@ -93,6 +93,7 @@ groups:
         for: 15s
         labels:
           severity: critical
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Redis instance {{ $labels.instance }} is DOWN"
           summary_zh: "Redis 實例 {{ $labels.instance }} 已停機"
@@ -113,6 +114,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Redis high memory usage on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Redis 記憶體使用率過高"
@@ -140,6 +142,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Redis high connection count on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Redis 連線數過高"
@@ -167,6 +170,7 @@ groups:
         for: 5m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Redis high key eviction rate on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Redis Key 驅逐率過高"
@@ -194,6 +198,7 @@ groups:
         for: 2m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Redis replication lag on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Redis 複製延遲"
@@ -217,6 +222,7 @@ groups:
         for: 10m
         labels:
           severity: warning
+          tenant: "{{ $labels.tenant }}"
         annotations:
           summary: "Redis low hit ratio on {{ $labels.tenant }}"
           summary_zh: "{{ $labels.tenant }} 的 Redis 快取命中率過低"


### PR DESCRIPTION
## Summary

Fix root cause (F) from the v2.6.0 CI stabilization triage: all 14 rule-pack files had alert rules missing the required `tenant` label, violating dev-rule #2 (Tenant-Agnostic) and the Custom Rule deny-list policy.

`scripts/tools/ops/lint_custom_rules.py rule-packs/ --ci` reported **95 errors**, uniformly `missing required label 'tenant'` — split across postgresql(9), kafka(9), rabbitmq(8), mariadb(8), oracle(7), jvm(7), elasticsearch(7), db2(7), clickhouse(7), redis(6), nginx(6), mongodb(6), operational(4), kubernetes(4).

## Fix

Add `tenant: "{{ $labels.tenant }}"` to each alert rule's `labels:` block. The template resolves at firing time from the `tenant` label on the underlying PromQL vector (every alert joins `group_left` against `tenant_metadata_info`).

Scope: **95 insertions, 0 deletions**, 14 files. Only the `labels:` blocks of alert rules are touched — no changes to `expr`, `for`, `annotations`, or recording rules.

## Verification

- `python scripts/tools/ops/lint_custom_rules.py rule-packs/ --policy .github/custom-rule-policy.yaml --ci` → `Errors: 0  Warnings: 190` (expiry/owner warnings tracked separately)
- `python scripts/tools/dx/generate_rule_pack_stats.py --check` → up to date
- `python scripts/tools/dx/generate_platform_data.py --check` → up to date

## Test plan

- [ ] CI: Lint
- [ ] CI: validate (lint_custom_rules)
- [ ] CI: Python Tests
- [ ] CI: Go Tests