### PR TITLE
fix(ci): add fetch-depth: 0 to Lint Documentation job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # make lint-docs runs validate_all.py --only ...,changelog,...
+          # which calls generate_changelog.py --check, which walks
+          # `<latest-tag>..HEAD` via git-describe. The default
+          # fetch-depth: 1 shallow clone has no tags, so it falls
+          # back to reading the single PR merge commit (auto-generated
+          # by GitHub, not a conventional commit) and fails. Same root
+          # cause as the Lint job fix in #9 — apply it here too.
+          fetch-depth: 0
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary

Follow-up to #9. The `Lint Documentation` job (distinct from `Lint`) runs `make lint-docs` → `validate_all.py --only ...,changelog,...` → `generate_changelog.py --check`, which walks `<latest-tag>..HEAD` via `git describe --tags --abbrev=0`. With the default `fetch-depth: 1` shallow clone, there are no tags in the clone and no history, so the script falls back to reading only the GitHub-generated PR merge commit (not a conventional commit) and always fails the changelog check.

PR #9 applied this fix to the `Lint` job but the `lint-docs` job has been silently failing on every PR since (visible in PR #10, #11 runs). Same one-line fix.

## Fix

Add `fetch-depth: 0` to `.github/workflows/ci.yml` `lint-docs` job checkout, mirroring the pattern from #9.

## Verification

- [ ] CI `Lint Documentation` turns green on this PR