### PR TITLE
docs: fix MkDocs link resolution (batch A)

### DIFF
--- a/docs/design/roadmap-future.en.md
+++ b/docs/design/roadmap-future.en.md
@@ -71,4 +71,4 @@ Tag push → auto-generate GitHub Release Notes (from CHANGELOG sections) → OC
 | v2.2.0 | Adoption Pipeline × CLI Extension | init, config-history, gitops-check |
 | v2.1.0 | Routing Profiles × Domain Policy | ADR-007, four-layer routing merge |
 
-Full version history: [CHANGELOG.md](../../CHANGELOG.md).
+Full version history: [CHANGELOG.md](../CHANGELOG.md).

--- a/docs/design/roadmap-future.md
+++ b/docs/design/roadmap-future.md
@@ -71,4 +71,4 @@ tag push → GitHub Release Notes 自動產生（基於 CHANGELOG section）→ 
 | v2.2.0 | Adoption Pipeline × CLI 擴展 | init、config-history、gitops-check |
 | v2.1.0 | Routing Profiles × Domain Policy | ADR-007、四層路由合併 |
 
-完整版本歷程見 [CHANGELOG.md](../../CHANGELOG.md)。
+完整版本歷程見 [CHANGELOG.md](../CHANGELOG.md)。

--- a/docs/interactive/index.html
+++ b/docs/interactive/index.html
@@ -815,27 +815,27 @@
   <div style="margin-bottom: 32px;">
     <div class="section-title" id="docs-title">Documentation</div>
     <div class="links">
-      <a class="link-item" href="../../README.md" id="link-readme">
+      <a class="link-item" href="https://github.com/vencil/Dynamic-Alerting-Integrations/blob/main/README.md" id="link-readme">
         <span class="link-icon">📖</span>
         <span id="link-readme-text">README</span>
       </a>
-      <a class="link-item" href="../../docs/architecture-and-design.md" id="link-arch">
+      <a class="link-item" href="../architecture-and-design/" id="link-arch">
         <span class="link-icon">🏗️</span>
         <span id="link-arch-text">Architecture</span>
       </a>
-      <a class="link-item" href="../../docs/getting-started/" id="link-gs">
+      <a class="link-item" href="../getting-started/" id="link-gs">
         <span class="link-icon">🚀</span>
         <span id="link-gs-text">Getting Started</span>
       </a>
-      <a class="link-item" href="../../docs/cli-reference.md" id="link-cli">
+      <a class="link-item" href="../cli-reference/" id="link-cli">
         <span class="link-icon">⚡</span>
         <span id="link-cli-text">CLI Reference</span>
       </a>
-      <a class="link-item" href="../../docs/scenarios/" id="link-scenarios">
+      <a class="link-item" href="../scenarios/" id="link-scenarios">
         <span class="link-icon">📋</span>
         <span id="link-scenarios-text">Scenarios</span>
       </a>
-      <a class="link-item" href="../../docs/adr/" id="link-adr">
+      <a class="link-item" href="../adr/" id="link-adr">
         <span class="link-icon">🎯</span>
         <span id="link-adr-text">ADRs</span>
       </a>
@@ -926,8 +926,8 @@
 
 <footer>
   <p id="footer-text">
-    Dynamic Alerting Platform — <a href="../../CHANGELOG.md">v2.5.0</a> |
-    <a href="../../docs/getting-started/for-platform-engineers.md" id="footer-link">Platform Setup</a>
+    Dynamic Alerting Platform — <a href="../CHANGELOG/">v2.5.0</a> |
+    <a href="../getting-started/for-platform-engineers/" id="footer-link">Platform Setup</a>
   </p>
 </footer>
 

--- a/docs/internal/design-system-guide.md
+++ b/docs/internal/design-system-guide.md
@@ -560,7 +560,7 @@ docs/
 - [`docs/interactive/index.html`](../interactive/index.html) — Tools Hub
 - [`docs/assets/jsx-loader.html`](../assets/jsx-loader.html) — JSX 工具載入器
 - [`docs/internal/tool-map.md`](tool-map.md) — 所有工具清單
-- [`CHANGELOG.md`](../../CHANGELOG.md) — 版本歷程
+- [`CHANGELOG.md`](../CHANGELOG.md) — 版本歷程
 
 ---
 

--- a/docs/internal/doc-template.md
+++ b/docs/internal/doc-template.md
@@ -10,7 +10,7 @@ lang: zh
 
 > **受眾**：所有貢獻者 (All Contributors)
 > **版本**：v2.3.0
-> **相關文件**：[文件導航地圖](doc-map.md) · [開發規範](../../CLAUDE.md)
+> **相關文件**：[文件導航地圖](doc-map.md) · [開發規範](https://github.com/vencil/Dynamic-Alerting-Integrations/blob/main/CLAUDE.md)
 
 本文件定義 Dynamic Alerting 平台所有 Markdown 文檔的標準結構與撰寫規範。遵循本模板能確保文件風格一致、可維護性高、易於自動化檢查。
 
@@ -370,7 +370,7 @@ lang: zh
 | 資源 | 說明 |
 |------|------|
 | [文件導航地圖](./doc-map.md) | 所有 83 個文檔的完整列表與分類 |
-| [開發規範](../../CLAUDE.md) | 平台整體開發指引與架構速查 |
+| [開發規範](https://github.com/vencil/Dynamic-Alerting-Integrations/blob/main/CLAUDE.md) | 平台整體開發指引與架構速查 |
 | [文件維護 Playbook](./testing-playbook.md#文件敘述風格) | 文件更新與版本管理的實務指南 |
 | [Lint 工具使用](../cli-reference.md) | 文件 Lint 工具詳細用法 |
 | [GitHub Release Playbook](./github-release-playbook.md) | 文件版本更新與 Release 流程 |

--- a/docs/internal/ssot-language-evaluation.md
+++ b/docs/internal/ssot-language-evaluation.md
@@ -752,9 +752,9 @@ done
 
 ## 相關文件
 
-- [`CLAUDE.md`](../../CLAUDE.md) — 開發上下文指引
+- [`CLAUDE.md`](https://github.com/vencil/Dynamic-Alerting-Integrations/blob/main/CLAUDE.md) — 開發上下文指引
 - [`docs/internal/doc-map.md`](../internal/doc-map.md) — 文檔對照表
 - [`docs/internal/tool-map.md`](../internal/tool-map.md) — 工具清單
-- [`.pre-commit-config.yaml`](../../.pre-commit-config.yaml) — Lint hook 配置
+- [`.pre-commit-config.yaml`](https://github.com/vencil/Dynamic-Alerting-Integrations/blob/main/.pre-commit-config.yaml) — Lint hook 配置
 - [`docs/assets/tool-registry.yaml`](../assets/tool-registry.yaml) — 工具 metadata
 - [`docs/assets/platform-data.json`](../assets/platform-data.json) — Rule Pack 數據

--- a/docs/vcs-integration-guide.md
+++ b/docs/vcs-integration-guide.md
@@ -7,7 +7,7 @@ lang: zh
 ---
 # VCS 整合指南 — GitHub / GitLab / 自託管實例
 
-> **v2.6.0** | 相關文件：[ADR-011 PR-based Write-back](adr/011-pr-based-write-back.md) · [tenant-api README](../components/tenant-api/README.md) · [GitOps 部署指南](gitops-deployment.md)
+> **v2.6.0** | 相關文件：[ADR-011 PR-based Write-back](adr/011-pr-based-write-back.md) · [tenant-api README](https://github.com/vencil/Dynamic-Alerting-Integrations/blob/main/components/tenant-api/README.md) · [GitOps 部署指南](gitops-deployment.md)
 
 ## 概覽
 
@@ -128,5 +128,5 @@ tenantApi:
 | 資源 | 相關性 |
 |------|--------|
 | [ADR-011 PR-based Write-back](adr/011-pr-based-write-back.md) | ⭐⭐⭐ |
-| [tenant-api README](../components/tenant-api/README.md) | ⭐⭐⭐ |
+| [tenant-api README](https://github.com/vencil/Dynamic-Alerting-Integrations/blob/main/components/tenant-api/README.md) | ⭐⭐⭐ |
 | [GitOps 部署指南](gitops-deployment.md) | ⭐⭐ |


### PR DESCRIPTION
## Summary

First stacked PR tackling ~100 MkDocs strict-mode warnings surfaced after `mkdocs build` was restabilized (Priority 2 from `_resume-2026-04-11.md`).

**Baseline (before this PR):** ~100 MkDocs warnings
**After this PR (local build):** 51 warnings

## Changes

- `docs/interactive/index.html` — 8 `../../` HTML links rewritten to MkDocs-aware published paths (`use_directory_urls`) and external GitHub URLs for repo-root files
- `docs/design/roadmap-future.md` / `.en.md` — `../../CHANGELOG.md` -> `../CHANGELOG.md`
- `docs/internal/design-system-guide.md` — same CHANGELOG fix
- `docs/internal/doc-template.md` — `../../CLAUDE.md` -> external GitHub URL (x2)
- `docs/internal/ssot-language-evaluation.md` — `CLAUDE.md` + `.pre-commit-config.yaml` -> external GitHub URLs
- `docs/vcs-integration-guide.md` — `../components/tenant-api/README.md` -> external GitHub URL (x2)

## Why external GitHub URLs?

Repo-root files (`README.md`, `CLAUDE.md`, `.pre-commit-config.yaml`, `components/*`) sit outside the MkDocs `docs_dir` so they cannot be resolved as documentation pages. External links are the correct form.

## Remaining warnings (for future stacked PRs)

| Cluster | Count | Plan |
|---------|------:|------|
| `rule-packs/README.md` / `rule-packs/ALERT-REFERENCE.md` | ~20 | Needs rule-packs symlink investigation |
| `.en.md` <-> `.md` cross-refs filtered by mkdocs_static_i18n | ~7 | Replace with language switcher pattern |
| `README.en.md` / `index.en.md` self-ref anchors | ~3 | Fix anchor targets |
| `components/backstage-plugin/README.md` | ~1 | External GitHub URL |
| i18n / README-vs-index meta warnings | ~3 | Config-level fix |

## Test plan

- [x] Local `mkdocs build` succeeds (warnings reduced 100 -> 51)
- [x] `lint_html_doc_links.py --ci` passes on `docs/interactive/index.html`
- [ ] CI `Lint` job passes on PR
- [ ] CI `docs-ci` / `mkdocs-deploy` succeeds