### PR TITLE
docs: exclude repo-root README symlinks from MkDocs (batch B)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,14 @@ edit_uri: edit/main/
 
 copyright: Copyright &copy; 2025 Vencil. Licensed under Apache 2.0.
 
+# Exclude repo-root README symlinks from the MkDocs site build.
+# docs/README-root.md and docs/README-root.en.md are symlinks to the
+# repo-root README files, intended for GitHub display only. Their
+# `docs/foo.md` style links don't resolve when built inside docs_dir.
+exclude_docs: |
+  README-root.md
+  README-root.en.md
+
 theme:
   name: material
   language: zh


### PR DESCRIPTION
## Summary

Excludes repo-root README symlinks from MkDocs build. These are git symlinks (docs/README-root.md -> ../README.md, docs/README-root.en.md -> ../README.en.md) intended for GitHub display only, producing ~60 broken docs/* link warnings on CI.

Uses MkDocs 1.6+ built-in `exclude_docs` (no plugin needed).

## Expected impact

| Metric | Before | After |
|--------|-------:|------:|
| Local mkdocs warnings | 51 | 48 |
| CI mkdocs warnings | 84 | ~24 (est.) |

Second of several stacked PRs tackling ~100 MkDocs strict-mode warnings (Priority 2 from `_resume-2026-04-11.md`). Follows #15 (batch A).

## Test plan

- [x] Local `mkdocs build` succeeds
- [ ] CI MkDocs Build Verification dramatically reduced warnings