### PR TITLE
fix(blast-radius): guard PR comment against GitHub 65536-char limit

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -32,6 +32,7 @@ rules:
       - scanner          # hierarchical dir scanner (exporter subsystem)
       - golden           # golden fixture parity tests
       - tooling          # generic tooling / infrastructure changes
+      - blast-radius     # CI bot + scripts/tools/ops/blast_radius.py (PR comment generator)
       # release-version scopes (used by release-wrap commits)
       - v2.7.0
   # Allow sentence-case subjects (conventional default forbids it)

--- a/.github/workflows/blast-radius.yml
+++ b/.github/workflows/blast-radius.yml
@@ -94,11 +94,14 @@ jobs:
             --format json \
             --output /tmp/blast-radius-report.json
 
+          ARTIFACT_HINT="Full per-tenant diff available in the \`blast-radius-report\` artifact on [this workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
+
           python3 scripts/tools/ops/blast_radius.py \
             --base /tmp/base-effective.json \
             --pr /tmp/pr-effective.json \
             --format markdown \
             --changed-files "$CHANGED_FILES" \
+            --artifact-hint "$ARTIFACT_HINT" \
             --output /tmp/blast-radius-comment.md
 
           if [ -s /tmp/blast-radius-comment.md ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,19 @@ lang: zh
 
 All notable changes to the **Dynamic Alerting Integrations** project will be documented in this file.
 
-## [v2.7.0] — 2026-04-18 — Scale Foundation × 元件健壯化 × 測試基礎設施
+## [Unreleased]
+
+### Fixed
+
+- **Blast Radius PR comment length guard**（v2.7.0 defensive patch）：`scripts/tools/ops/blast_radius.py` `generate_pr_comment` 加三層守門，避免 GitHub 65,536 char 硬上限造成 CI 靜默失敗（422 Unprocessable Entity，bot 會「成功」但 comment 不存在）：
+  - 當 Tier A+B affected tenant > 50 時，切 **summary-only mode**（只列 tenant IDs，不展 per-field diff；完整 diff 走 `blast-radius-report` workflow artifact）
+  - Summary-only mode 內部再 cap 200 條，多的收斂為「+N more」
+  - 60,000 char safety limit：即使 fell-through（例如單一 tenant 有上千欄位變動），也會 auto-fallback 到 summary-only 或最後手段硬截斷
+  - 新增 `--artifact-hint` CLI flag，`.github/workflows/blast-radius.yml` 對應 pass workflow run URL，讓 reviewer 看 summary-only comment 時能一鍵跳去 artifact
+  - 9 tests 於 `tests/ops/test_blast_radius.py::TestPRCommentLengthGuard`：1000-tenant、超長 field diff、Tier C count-only、artifact hint rendering 等情境均驗證 output 長度 < 65,536
+  - 發現來源：Gemini R2 cross-review；實測 1000-tenant Tier A 場景原輸出 ~260 KB，超限 4 倍
+
+
 
 > 條目於 `chore/v2.7.0-phase-a-kickoff` 完工定稿（2026-04-17 Phase .e E-5 草擬；2026-04-18 Phase .b B-1 實測數字 backfill + release 定稿）。PR URL 於 tag-day 合併後補於本段。
 >

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,18 @@ Session 結束或異常終止後：`make session-cleanup`
 4. **pre-commit hook 中斷留下 .git lock** → `make git-lock ARGS="--clean"`，**不要** `--no-verify`
 5. **port-forward 殘留佔用端口** → `pkill -f "port-forward.*prometheus"` 或 `make session-cleanup`
 
+## Skill 自主使用政策
+
+> Cowork / Claude Code 環境提供的 skills（`docx` / `pptx` / `xlsx` / `pdf` / `engineering:*` / `data:*` / `design:*` / `marketing:*` 等）**Claude 可自主判斷使用，不需逐次徵詢使用者**。
+
+- **預設行為**：判斷任務符合 skill 定義時直接 `Read` 對應 SKILL.md 並執行，**不要先問「我可不可以用 X skill」**。
+- **告知方式**：使用前用單行說明（例：「跑 `engineering:debug` 的 reproduce 步驟」），不需冗長 preamble。
+- **多 skill 組合**：一個任務常需多 skill 協作（例如 docx 任務同時動到 imagegen），自主串接。
+- **不適用時主動拒絕**：如果 skill 對任務沒幫助（例：純文字回答不需 docx），直接做事，不要為了用而用。
+- **新工具發現**：如果發現該裝但沒裝的 skill，**用 `mcp__plugins__search_plugins` / `mcp__mcp-registry__search_mcp_registry` 主動尋找 + 建議**，不需等使用者開口。
+
+設立此節原因：v2.7.0 Phase .e 期間使用者多次明示「skill 自主使用即可」，以此節 codify 為長期規則，免去逐 session 重複告知成本。
+
 ## 專案概覽
 
 **Multi-Tenant Dynamic Alerting 平台 (v2.7.0)** — Config-driven, SHA-256 hot-reload, Directory Scanner。完整架構速覽見 [architecture-and-design.md](docs/architecture-and-design.md)；版本歷程見 [CHANGELOG.md](CHANGELOG.md)。

--- a/scripts/tools/ops/blast_radius.py
+++ b/scripts/tools/ops/blast_radius.py
@@ -263,12 +263,27 @@ def compute_blast_radius(base_data: dict, pr_data: dict) -> dict:
 # Markdown PR comment generation
 # ---------------------------------------------------------------------------
 
+# GitHub enforces a 65,536 character ceiling on issue/PR comment bodies.
+# Comments exceeding the limit are silently rejected (422 Unprocessable Entity)
+# — the workflow would "succeed" but the comment never appears. We leave a
+# headroom of ~5KB to absorb the wrapping marker + footer the workflow adds.
+GITHUB_COMMENT_HARD_LIMIT = 65_536
+COMMENT_SAFETY_LIMIT = 60_000
+
+# When more than this many Tier A+B tenants are affected, switch the comment
+# to summary-only mode (list tenant IDs without per-field diffs). The full
+# diff is always available as the `blast-radius-report` workflow artifact.
+SUMMARY_MODE_TENANT_THRESHOLD = 50
+# Cap on individual tenant IDs listed even in summary-only mode. Anything
+# beyond this gets collapsed to a "+N more" tail; the artifact remains
+# authoritative.
+SUMMARY_MODE_LIST_CAP = 200
+
+
 def _tenant_change_summary(tenant: dict) -> str:
-    """One-line summary for a tenant's changes."""
+    """One-line summary for a tenant's changes (used in full-detail mode)."""
     lines = []
     for entry in tenant["tiers"]["A"]:
-        action_emoji = {"added": "+", "removed": "-", "changed": "~"}
-        a = action_emoji.get(entry["action"], "?")
         detail = entry.get("detail", {})
         if entry["action"] == "changed":
             lines.append(f"`{entry['field']}`: {detail.get('base')} → {detail.get('pr')}")
@@ -285,29 +300,17 @@ def _tenant_change_summary(tenant: dict) -> str:
     return "\n".join(f"  - {line}" for line in lines[:10])  # cap at 10 per tenant
 
 
-def generate_pr_comment(report: dict, changed_files: str | None = None) -> str:
-    """Generate GitHub PR comment markdown from blast radius report."""
+def _render_header(report: dict, changed_files: str | None) -> list[str]:
+    """Shared header + summary table used by both full and summary rendering."""
     s = report["summary"]
-
-    if s["affected_tenants"] == 0:
-        return (
-            "### Blast Radius Report\n\n"
-            "No effective tenant config changes detected in this PR.\n"
-        )
-
-    # Header
-    lines = []
+    lines: list[str] = []
     if changed_files:
         lines.append(f"### Blast Radius: this PR modifies `{changed_files}`\n")
     else:
         lines.append("### Blast Radius Report\n")
 
-    tier_a_b = s["tier_a_tenants"] + s["tier_b_tenants"]
-    substantive_label = f"{tier_a_b} tenant{'s' if tier_a_b != 1 else ''}"
-    format_label = f"{s['tier_c_only_tenants']} tenant{'s' if s['tier_c_only_tenants'] != 1 else ''}"
-
-    lines.append(f"| Metric | Count |")
-    lines.append(f"|--------|-------|")
+    lines.append("| Metric | Count |")
+    lines.append("|--------|-------|")
     lines.append(f"| Total tenants scanned | {s['total_tenants_scanned']} |")
     lines.append(f"| Affected tenants | {s['affected_tenants']} |")
     if s["tier_a_tenants"]:
@@ -321,25 +324,33 @@ def generate_pr_comment(report: dict, changed_files: str | None = None) -> str:
     if s["removed_tenants"]:
         lines.append(f"| Removed tenants | {s['removed_tenants']} |")
     lines.append("")
+    return lines
 
-    # Tier A + B details (expandable)
+
+def _render_full_detail(
+    report: dict,
+    changed_files: str | None,
+    artifact_hint: str | None,
+) -> str:
+    """Full-detail rendering: summary table + Tier A+B per-field diffs."""
+    lines = _render_header(report, changed_files)
+
     tier_ab_tenants = [
         t for t in report["tenants"]
         if t["highest_tier"] in ("A", "B")
     ]
     if tier_ab_tenants:
-        lines.append(f"<details>")
+        lines.append("<details>")
         lines.append(f"<summary>Substantive changes: {len(tier_ab_tenants)} tenants</summary>\n")
+        status_badge = {"changed": "", "new": " (NEW)", "removed": " (REMOVED)"}
         for t in tier_ab_tenants:
-            status_badge = {"changed": "", "new": " (NEW)", "removed": " (REMOVED)"}
             badge = status_badge.get(t["status"], "")
             lines.append(f"- **{t['tenant_id']}**{badge}")
             detail = _tenant_change_summary(t)
             if detail:
                 lines.append(detail)
-        lines.append(f"\n</details>\n")
+        lines.append("\n</details>\n")
 
-    # Tier C summary (collapsed, no detail)
     tier_c_tenants = [
         t for t in report["tenants"]
         if t["highest_tier"] == "C"
@@ -350,7 +361,128 @@ def generate_pr_comment(report: dict, changed_files: str | None = None) -> str:
             f"(no threshold/routing/alerting impact)"
         )
 
+    if artifact_hint:
+        lines.append("")
+        lines.append(f"_{artifact_hint}_")
+
     return "\n".join(lines)
+
+
+def _render_summary_only(
+    report: dict,
+    changed_files: str | None,
+    artifact_hint: str | None,
+    list_cap: int = SUMMARY_MODE_LIST_CAP,
+) -> str:
+    """Summary-only rendering: tenant IDs grouped by tier, no per-field diffs.
+
+    Designed to stay well under GitHub's 65,536-char limit even with 1000+
+    affected tenants. The full per-field diff is always available as the
+    `blast-radius-report` workflow artifact (authoritative source).
+    """
+    lines = _render_header(report, changed_files)
+
+    tier_a = [t for t in report["tenants"] if t["highest_tier"] == "A"]
+    tier_b = [t for t in report["tenants"] if t["highest_tier"] == "B"]
+    tier_c = [t for t in report["tenants"] if t["highest_tier"] == "C"]
+
+    lines.append(
+        "> :warning: Affected tenant count exceeds the inline-detail threshold "
+        f"({SUMMARY_MODE_TENANT_THRESHOLD}). Showing tenant list only — "
+        "per-field diffs are available in the workflow artifact."
+    )
+    lines.append("")
+
+    def _list_block(header: str, tenants: list[dict]) -> list[str]:
+        if not tenants:
+            return []
+        block = [f"<details>", f"<summary>{header}: {len(tenants)} tenants</summary>\n"]
+        status_badge = {"changed": "", "new": " (NEW)", "removed": " (REMOVED)"}
+        shown = tenants[:list_cap]
+        for t in shown:
+            badge = status_badge.get(t["status"], "")
+            block.append(f"- `{t['tenant_id']}`{badge}")
+        if len(tenants) > list_cap:
+            block.append(f"- _…and {len(tenants) - list_cap} more (see artifact)_")
+        block.append("\n</details>\n")
+        return block
+
+    lines.extend(_list_block("Tier A (threshold/routing)", tier_a))
+    lines.extend(_list_block("Tier B (other alerting)", tier_b))
+
+    if tier_c:
+        lines.append(
+            f"Format-only changes: {len(tier_c)} tenants "
+            f"(no threshold/routing/alerting impact)"
+        )
+
+    if artifact_hint:
+        lines.append("")
+        lines.append(f"_{artifact_hint}_")
+
+    return "\n".join(lines)
+
+
+def generate_pr_comment(
+    report: dict,
+    changed_files: str | None = None,
+    *,
+    artifact_hint: str | None = None,
+) -> str:
+    """Generate GitHub PR comment markdown from blast radius report.
+
+    Output is guaranteed to stay under GitHub's 65,536-char comment ceiling:
+
+    1. If Tier A+B affected count > SUMMARY_MODE_TENANT_THRESHOLD (50), flip
+       to summary-only rendering up front.
+    2. If the rendered body still exceeds COMMENT_SAFETY_LIMIT (60,000),
+       re-render in summary-only mode.
+    3. If even summary-only exceeds the limit (edge case with thousands of
+       very long tenant IDs), hard-truncate and tail with a visible marker.
+
+    Args:
+        report: Structured report from :func:`compute_blast_radius`.
+        changed_files: Optional comma-separated list of changed conf.d/ files
+            to include in the header.
+        artifact_hint: Optional human-readable hint appended at the end
+            pointing reviewers at the full JSON artifact. Example:
+            ``"Full per-tenant diff available in the `blast-radius-report`
+            artifact on this workflow run."``
+    """
+    s = report["summary"]
+
+    if s["affected_tenants"] == 0:
+        return (
+            "### Blast Radius Report\n\n"
+            "No effective tenant config changes detected in this PR.\n"
+        )
+
+    substantive_count = s["tier_a_tenants"] + s["tier_b_tenants"]
+    force_summary = substantive_count > SUMMARY_MODE_TENANT_THRESHOLD
+
+    if force_summary:
+        body = _render_summary_only(report, changed_files, artifact_hint)
+    else:
+        body = _render_full_detail(report, changed_files, artifact_hint)
+        # Even below the tenant threshold, per-field detail can bloat (e.g. a
+        # single tenant with 1000 field changes). Fall back to summary-only
+        # as a safety net.
+        if len(body) > COMMENT_SAFETY_LIMIT:
+            body = _render_summary_only(report, changed_files, artifact_hint)
+
+    # Last-resort hard truncation. Should be unreachable under realistic
+    # inputs (SUMMARY_MODE_LIST_CAP keeps bodies comfortably below 60KB for
+    # any plausible tenant-id length), but we still guard to avoid the GitHub
+    # API silently rejecting the comment.
+    if len(body) > COMMENT_SAFETY_LIMIT:
+        truncation_notice = (
+            "\n\n---\n"
+            "_Output truncated to fit GitHub's comment length limit. "
+            "See the `blast-radius-report` workflow artifact for the complete diff._"
+        )
+        body = body[: COMMENT_SAFETY_LIMIT - len(truncation_notice)] + truncation_notice
+
+    return body
 
 
 # ---------------------------------------------------------------------------
@@ -401,6 +533,13 @@ def main() -> None:
         "--changed-files", type=str, default=None,
         help="Comma-separated list of changed conf.d/ files (for PR comment header)",
     )
+    parser.add_argument(
+        "--artifact-hint", type=str, default=None,
+        help=(
+            "Optional footer line pointing reviewers at the full JSON artifact "
+            "(used when summary-only mode is triggered)."
+        ),
+    )
     args = parser.parse_args()
 
     # Load inputs
@@ -412,7 +551,11 @@ def main() -> None:
 
     # Format output
     if args.format == "markdown":
-        output = generate_pr_comment(report, changed_files=args.changed_files)
+        output = generate_pr_comment(
+            report,
+            changed_files=args.changed_files,
+            artifact_hint=args.artifact_hint,
+        )
     else:
         output = json.dumps(report, indent=2, ensure_ascii=False)
 

--- a/tests/ops/test_blast_radius.py
+++ b/tests/ops/test_blast_radius.py
@@ -400,6 +400,158 @@ class TestGeneratePRComment:
 
 
 # ---------------------------------------------------------------------------
+# Test: PR comment length-limit defences
+# ---------------------------------------------------------------------------
+
+def _make_report(
+    *,
+    tier_a: int = 0,
+    tier_b: int = 0,
+    tier_c: int = 0,
+    fields_per_tenant: int = 1,
+    id_prefix: str = "tenant",
+) -> dict:
+    """Factory helper for GitHub comment length tests."""
+    tenants = []
+    for i in range(tier_a):
+        entries = [
+            {
+                "field": f"alerts.threshold.Metric{j}",
+                "action": "changed",
+                "detail": {"base": 80, "pr": 90},
+            }
+            for j in range(fields_per_tenant)
+        ]
+        tenants.append({
+            "tenant_id": f"{id_prefix}-a-{i:04d}",
+            "status": "changed",
+            "highest_tier": "A",
+            "tiers": {"A": entries, "B": [], "C": []},
+        })
+    for i in range(tier_b):
+        tenants.append({
+            "tenant_id": f"{id_prefix}-b-{i:04d}",
+            "status": "changed",
+            "highest_tier": "B",
+            "tiers": {
+                "A": [],
+                "B": [{"field": "severity.default", "action": "changed",
+                       "detail": {"base": "warning", "pr": "critical"}}],
+                "C": [],
+            },
+        })
+    for i in range(tier_c):
+        tenants.append({
+            "tenant_id": f"{id_prefix}-c-{i:04d}",
+            "status": "changed",
+            "highest_tier": "C",
+            "tiers": {"A": [], "B": [], "C": [
+                {"field": "timezone", "action": "changed",
+                 "detail": {"base": "UTC", "pr": "UTC+0"}}
+            ]},
+        })
+    return {
+        "summary": {
+            "total_tenants_scanned": tier_a + tier_b + tier_c,
+            "affected_tenants": tier_a + tier_b + tier_c,
+            "tier_a_tenants": tier_a,
+            "tier_b_tenants": tier_b,
+            "tier_c_only_tenants": tier_c,
+            "new_tenants": 0,
+            "removed_tenants": 0,
+        },
+        "tenants": tenants,
+    }
+
+
+class TestPRCommentLengthGuard:
+    """Defensive behaviour against GitHub's 65,536-char comment limit.
+
+    GitHub silently rejects comments exceeding the hard limit (422 error),
+    so the generator MUST keep output below it in all scenarios. These tests
+    pin the three-layer guard: (1) tenant-count threshold, (2) byte-length
+    safety net, (3) last-resort truncation.
+    """
+
+    def test_small_report_stays_in_full_detail_mode(self):
+        report = _make_report(tier_a=5, tier_b=3)
+        md = br.generate_pr_comment(report)
+        # Full-detail keeps the per-field detail section inside <details>
+        assert "Substantive changes:" in md
+        # Threshold not triggered: no "exceeds the inline-detail threshold" warning
+        assert "inline-detail threshold" not in md
+
+    def test_many_tenants_triggers_summary_mode(self):
+        # 60 Tier A tenants > SUMMARY_MODE_TENANT_THRESHOLD (50) → summary mode
+        report = _make_report(tier_a=60)
+        md = br.generate_pr_comment(report)
+        assert "inline-detail threshold" in md
+        # Per-field diffs should NOT appear in summary mode
+        assert "alerts.threshold.Metric0" not in md
+        # But tenant IDs should
+        assert "tenant-a-0000" in md
+
+    def test_artifact_hint_is_rendered(self):
+        report = _make_report(tier_a=60)
+        hint = "Full diff in the `blast-radius-report` artifact on run #123."
+        md = br.generate_pr_comment(report, artifact_hint=hint)
+        assert hint in md
+
+    def test_artifact_hint_also_in_full_detail_mode(self):
+        report = _make_report(tier_a=3)
+        hint = "See run #456 artifact."
+        md = br.generate_pr_comment(report, artifact_hint=hint)
+        assert hint in md
+
+    def test_1000_tenant_output_stays_under_github_limit(self):
+        # Real-world v2.8.0 target: 1000-tenant PR must produce a valid comment.
+        report = _make_report(tier_a=1000, fields_per_tenant=5)
+        md = br.generate_pr_comment(
+            report,
+            artifact_hint="Full diff in artifact.",
+        )
+        assert len(md) < br.GITHUB_COMMENT_HARD_LIMIT, \
+            f"Comment body is {len(md)} chars, exceeds GitHub's 65,536 limit"
+        assert len(md) <= br.COMMENT_SAFETY_LIMIT, \
+            f"Comment body is {len(md)} chars, exceeds COMMENT_SAFETY_LIMIT"
+
+    def test_summary_mode_caps_listed_tenants(self):
+        # 500 > SUMMARY_MODE_LIST_CAP (200) → should truncate list and show tail
+        report = _make_report(tier_a=500)
+        md = br.generate_pr_comment(report)
+        # First tenant listed
+        assert "tenant-a-0000" in md
+        # Last tenant should NOT be listed individually
+        assert "tenant-a-0499" not in md
+        # Should have "…and N more" tail
+        assert "more (see artifact)" in md
+
+    def test_tier_c_count_only_regardless_of_mode(self):
+        # Tier C never gets itemised (preserves existing behaviour)
+        report = _make_report(tier_a=1, tier_c=5000)
+        md = br.generate_pr_comment(report)
+        assert "5000 tenants" in md
+        # No individual Tier-C tenant IDs in output
+        assert "tenant-c-0000" not in md
+
+    def test_pathological_single_tenant_huge_field_diff_falls_back(self):
+        # Single tenant with so many per-field changes that full-detail blows
+        # past COMMENT_SAFETY_LIMIT — must auto-fall-back to summary mode.
+        report = _make_report(tier_a=1, fields_per_tenant=100_000)
+        md = br.generate_pr_comment(report)
+        assert len(md) < br.GITHUB_COMMENT_HARD_LIMIT
+        # Fall-through produced summary mode (or truncation) — field details
+        # must not be in the output at that volume.
+        assert md.count("alerts.threshold.Metric") < 20  # <<< 100000
+
+    def test_no_changes_returns_stable_short_message(self):
+        report = _make_report()  # all zeros
+        md = br.generate_pr_comment(report)
+        assert "No effective tenant config changes" in md
+        assert len(md) < 200  # sanity: short and stable
+
+
+# ---------------------------------------------------------------------------
 # Test: CLI integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- GitHub 靜默拒絕 > 65,536 char 的 PR/issue comment（422 Unprocessable Entity），bot 會「成功」但 comment 不存在。`blast_radius.py` 原 `generate_pr_comment` 在 1000-tenant Tier A 情境產出 ~260 KB，超限 4 倍。
- 三層守門：(1) Tier A+B > 50 切 summary-only，(2) 60K byte auto-fallback，(3) hard truncation 保底。新增 `--artifact-hint` footer 指向既有 `blast-radius-report` artifact。
- 9 項新測試 cover 1000-tenant、pathological field bloat、list-cap truncation 等。

發現於 v2.8.0 planning Gemini R2 cross-review 審 1000-tenant readiness 時。定位為 v2.7.0 defensive patch（原行為是 silent CI failure，不該等 v2.8.0）。

## Test plan

- [x] `python3 -m pytest tests/ops/test_blast_radius.py` — 49 passed（含 9 項新 length-guard 測試）
- [x] `pre-commit run --files ...` — 19 auto-run hooks 全綠
- [ ] PR CI: `Blast Radius` workflow 自 dogfood 跑一次（本 PR 不改 conf.d/，預期 workflow 不觸發，但 merge 後下一個 conf.d/ PR 會用新版本）
- [ ] Optional: 手動造一個 fixture 跑 `blast_radius.py --format markdown` with 1000-tenant report，確認輸出 < 65,536 chars