### PR TITLE
fix(a11y): resolve TECH-DEBT-007 via --da-color-tile-muted token-split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ All notable changes to the **Dynamic Alerting Integrations** project will be doc
 
 ### Fixed
 
+- **TECH-DEBT-007 resolved — `--da-color-hero-muted` contrast fail via token-split**（v2.8.0 Phase .a PR#1c）：修復 multi-tenant-comparison / dependency-graph 在 light bg 下 axe-core `color-contrast` 40-node 違規。根因並非 token 色值單純「太淺」，而是**單一 semantic token 被迫服務兩種亮度相差 > 40% 的背景**（hero dark `#0f172a` + tile light `hsl(x,60%,90%)` / SVG white）——任何單值都無法同時滿足 WCAG AA 4.5:1。
+  - `docs/assets/design-tokens.css`：保留 `--da-color-hero-muted: #94a3b8`（hero dark bg 7.2:1 AA pass）；新增 `--da-color-tile-muted: #6b7280`（white 4.83:1 AA pass），light / dark mode 皆同值（consumer 背景不翻色）
+  - `docs/interactive/tools/multi-tenant-comparison.jsx` L194 `defaultBadgeStyle`：`hero-muted` → `tile-muted`（HeatmapRow cell badge 處於 `hsl(hue,60%,90%)` 永遠亮底）
+  - `docs/interactive/tools/dependency-graph.jsx` L215：SVG `<text fill>` `hero-muted` → `tile-muted`（parent `bg-white` SVG 容器）
+  - L133 `MetricCard subStyle` **刻意排除在 PR#1c scope 外**：card bg 隨 `[data-theme="dark"]` 翻色（light `#f8fafc` ↔ dark `#334155`），需 theme-aware override 另案處理 → 登錄 TECH-DEBT-016 追蹤
+  - 新增 `dev-rules.md §S5 單一 semantic token 不可 serve 亮度相差 > 40% 的兩種背景`：固化 token-split 規則 + 命名慣例（`--da-color-<surface>-<intent>`）+ 雙主題翻色 caveat
+  - `known-regressions.md`：TECH-DEBT-007 狀態 open → **resolved**（附 fixed_in 引述本 PR）；TECH-DEBT-016 新登錄
+  - 背景分析：plan.md §12.4 Trap #10（shared-token-across-opposing-backgrounds 反模式）、§12.5 PR#1c spec
+
 - **Blast Radius PR comment length guard**（v2.7.0 defensive patch）：`scripts/tools/ops/blast_radius.py` `generate_pr_comment` 加三層守門，避免 GitHub 65,536 char 硬上限造成 CI 靜默失敗（422 Unprocessable Entity，bot 會「成功」但 comment 不存在）：
   - 當 Tier A+B affected tenant > 50 時，切 **summary-only mode**（只列 tenant IDs，不展 per-field diff；完整 diff 走 `blast-radius-report` workflow artifact）
   - Summary-only mode 內部再 cap 200 條，多的收斂為「+N more」

--- a/docs/assets/design-tokens.css
+++ b/docs/assets/design-tokens.css
@@ -388,4 +388,6 @@
   to   { opacity: 1; transform: translateY(0); }
 }
 @keyframes da-toast-out {
-  from { opacity: 1; transform
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(12px); }
+}

--- a/docs/assets/design-tokens.css
+++ b/docs/assets/design-tokens.css
@@ -36,8 +36,11 @@
   /* ── Hero (dark header area) ── */
   --da-color-hero-bg:         #0f172a;
   --da-color-hero-fg:         #e2e8f0;
-  --da-color-hero-muted:      #94a3b8; /* TECH-DEBT-007 deferred to PR#1c: hero-bg #0f172a requires >=5.0:1; #6b7280 gives 4.2:1 (FAIL). Needs token-split. See v2.8.0-planning.md section 12. */
+  --da-color-hero-muted:      #94a3b8; /* Hero dark bg (#0f172a) context ONLY: 7.2:1 on dark navy (AA pass). Do NOT use for light-bg text -- see --da-color-tile-muted below. */
   --da-color-hero-accent:     #38bdf8;
+
+  /* ── Tile / Card muted text (light-bg contexts regardless of theme) ── */
+  --da-color-tile-muted:      #6b7280; /* TECH-DEBT-007 resolution (PR#1c): for muted text on always-light backgrounds like table cells with hsl(x, 60%, 90%) or SVG on bg-white. 4.83:1 on white (AA pass). See v2.8.0-planning.md section 12.4 Trap #10 + dev-rules.md token-split clause. */
 
   /* ── Card ── */
   --da-color-card-bg:         #ffffff;
@@ -133,8 +136,11 @@
 
   --da-color-hero-bg:         #0f172a;
   --da-color-hero-fg:         #e2e8f0;
-  --da-color-hero-muted:      #94a3b8; /* TECH-DEBT-007 deferred (see light mode note). Reverting to main value. */
+  --da-color-hero-muted:      #94a3b8; /* Hero dark bg context ONLY (same as light mode; hero bg does not flip themes). See light-mode comment. */
   --da-color-hero-accent:     #38bdf8;
+
+  /* Tile / Card muted text: same value as light mode -- always-light-bg consumers */
+  --da-color-tile-muted:      #6b7280;
 
   --da-color-card-bg:         #1e293b;
   --da-color-card-border:     #334155;
@@ -382,6 +388,4 @@
   to   { opacity: 1; transform: translateY(0); }
 }
 @keyframes da-toast-out {
-  from { opacity: 1; transform: translateY(0); }
-  to   { opacity: 0; transform: translateY(12px); }
-}
+  from { opacity: 1; transform

--- a/docs/interactive/tools/dependency-graph.jsx
+++ b/docs/interactive/tools/dependency-graph.jsx
@@ -212,7 +212,7 @@ export default function DependencyGraph() {
                       fill={isSelected ? '#fff' : color.text}>
                       {pack.label}
                     </text>
-                    <text x={pos.x} y={pos.y + 42} textAnchor="middle" fontSize="9" fill="var(--da-color-hero-muted)">
+                    <text x={pos.x} y={pos.y + 42} textAnchor="middle" fontSize="9" fill="var(--da-color-tile-muted)">
                       {pack.alerts}a / {pack.metrics}m
                     </text>
                   </g>

--- a/docs/interactive/tools/multi-tenant-comparison.jsx
+++ b/docs/interactive/tools/multi-tenant-comparison.jsx
@@ -191,7 +191,7 @@ function HeatmapRow({ metric, tenants, stats }) {
           fontWeight: isDefault ? 400 : 700,
           color: isDefault ? 'var(--da-color-muted)' : '#1e293b',
         };
-        const defaultBadgeStyle = { fontSize: 10, color: 'var(--da-color-hero-muted)' };
+        const defaultBadgeStyle = { fontSize: 10, color: 'var(--da-color-tile-muted)' };
         return (
           <td key={i} style={cellStyle}>
             {val}{isDefault && <span style={defaultBadgeStyle}> (d)</span>}

--- a/docs/internal/dev-rules.md
+++ b/docs/internal/dev-rules.md
@@ -310,6 +310,53 @@ Phase .a0 token 遷移期間確立的慣例，適用所有 JSX 互動工具。
 
 **實作檢查**：互動工具 PR 送審前，手動 `grep -n '<\(input\|select\|textarea\)' <tool>.jsx` 配 `grep -n 'aria-label\|htmlFor' <tool>.jsx`，確認每個 form element 都有對應的 accessible name。
 
+### S5. 單一 semantic token 不可 serve 亮度相差 > 40% 的兩種背景（v2.8.0 Phase .a PR#1c 新增）
+
+**規則**：在 `docs/assets/design-tokens.css` 定義文字色 / foreground token 時，如果 consumer 包含**語意背景亮度差異 > 40%** 的場景（例：hero dark bg `#0f172a` vs tile 白 / 淺灰），**必須 split 為兩個 token**。**禁止**把「hero muted」與「tile muted」用同一 token 服務。
+
+**為什麼**：WCAG 2.1 AA 要求文字對背景達 4.5:1 對比。單一色值在 dark bg 上高對比（白灰系列）→ 同一色值在 light bg 上必然低對比，反之亦然。Phase .a0 PR#1 Day 5 retrospective 踩過這坑（TECH-DEBT-007：`--da-color-hero-muted` 用 `gray-400` 一口氣套在 hero dark bg + card light bg + SVG white bg 上，axe-core 在 multi-tenant-comparison 報出 40 nodes color-contrast 違規）。v2.8.0 Phase .a PR#1c 用 token-split 徹底解決——保留 `--da-color-hero-muted` 給 hero dark bg，新增 `--da-color-tile-muted` 給 tile / card / SVG 永遠亮底的 consumers。
+
+**反例**（TECH-DEBT-007 原始犯案）：
+
+```css
+/* ❌ 一個 token 服務兩種背景 */
+:root {
+  --da-color-hero-muted: #94a3b8;  /* slate-400 */
+}
+```
+
+```jsx
+// ❌ hero dark bg 用（7.2:1 pass）
+<p style={{ color: 'var(--da-color-hero-muted)', background: '#0f172a' }}>subtitle</p>
+
+// ❌ tile light bg 也用（3.12:1 fail）— 同一 token，不同語意
+<td style={{ color: 'var(--da-color-hero-muted)', background: '#fef3c7' }}>label</td>
+```
+
+**正例**（PR#1c 修後 token-split）：
+
+```css
+/* ✅ 按 bg 語意 split */
+:root {
+  --da-color-hero-muted: #94a3b8;  /* Hero dark bg ONLY: 7.2:1 on #0f172a */
+  --da-color-tile-muted: #6b7280;  /* Light bg contexts: 4.83:1 on white */
+}
+```
+
+```jsx
+// ✅ Hero dark bg
+<p style={{ color: 'var(--da-color-hero-muted)', background: '#0f172a' }}>subtitle</p>
+
+// ✅ Tile always-light bg
+<td style={{ color: 'var(--da-color-tile-muted)', background: '#fef3c7' }}>label</td>
+```
+
+**命名慣例**：`--da-color-<surface>-<intent>`，`<surface>` 明示語意背景族群（`hero` / `tile` / `card` / `chip` / `toast` 等），`<intent>` 為 foreground 角色（`muted` / `accent` / `strong` / `danger` 等）。避免 `--da-color-muted`（無 surface scope）這類涵蓋過廣的命名。
+
+**雙主題翻色 caveat**：如果 surface 本身會在 `[data-theme="dark"]` 翻色（例：MetricCard light `#f8fafc` → dark `#334155`），**token-split 仍不夠**，需再 split 為 light / dark mode 各自的值（在 `[data-theme="dark"]` 區塊 override）；或改走 theme-aware JSX conditional（useTheme hook）。此情境見 TECH-DEBT-016（PR#1c 分析衍生，L133 MetricCard subStyle 雙背景問題，另案追蹤）。
+
+**收束驗收**：(1) design-tokens.css 每個 foreground token 須有 JSDoc-style 註解標明「allowed bg contexts + contrast ratio」；(2) axe-core `color-contrast` rule 在 light + dark dual-mode 皆 0 violations；(3) design-system-guide.md §TL;DR 的「Token 速查」應列出 surface scope 分類。
+
 ## 常被違反 Top 4（CLAUDE.md 會保留這四條）
 
 根據歷史 LL 與 pre-commit 攔截記錄，以下四條最容易被違反：


### PR DESCRIPTION
## Summary

解 TECH-DEBT-007：`multi-tenant-comparison` + `dependency-graph` 在亮底場景 axe-core `color-contrast` 40-node 違規。

**根因更新（相較 PR #34 revert）**：不是 `--da-color-hero-muted` 色值太淺，而是**單一 semantic token 被迫服務亮度相差 > 40% 的兩種背景** (hero dark `#0f172a` + tile light `hsl,60%,90%` / white)；任何單值都無法同時滿足 WCAG AA 4.5:1。PR #34 嘗試改值 → hero dark 變暗導致新的對比違規 → Layer 5 revert 回 `#94a3b8`。本 PR 採用 **token-split** 徹底解決。

## Scope

| Layer | File | Change |
|---|---|---|
| 1 | `docs/assets/design-tokens.css` | 保留 `--da-color-hero-muted: #94a3b8` (hero dark bg 7.2:1) + 新增 `--da-color-tile-muted: #6b7280` (white 4.83:1)，light / dark mode 同值 |
| 2 | `docs/interactive/tools/multi-tenant-comparison.jsx` L194 | `defaultBadgeStyle` hero-muted → tile-muted (HeatmapRow cell `hsl,60%,90%`) |
| 2 | `docs/interactive/tools/dependency-graph.jsx` L215 | SVG `<text fill>` hero-muted → tile-muted (parent `bg-white`) |
| 3 | `docs/internal/dev-rules.md` | 新增 §S5「單一 semantic token 不可 serve 亮度相差 > 40% 的兩種背景」規則 |
| 3 | `CHANGELOG.md` | [Unreleased] Fixed — TECH-DEBT-007 resolved 完整紀錄 |

**排除於本 PR**：

- `multi-tenant-comparison.jsx` L133 `MetricCard.subStyle` — card bg 隨 `[data-theme="dark"]` 翻色 (light `#f8fafc` ↔ dark `#334155`)，需 theme-aware override 另案。已登錄 **TECH-DEBT-016**（PR#1c 衍生）

## Why token-split not value change

PR #34 / Session #09 已驗證：任何單一色值嘗試同時滿足 hero dark bg + light bg 必有一邊 fail：
- `#94a3b8` (slate-400)：hero 7.2:1 ✅ / white 3.12:1 ❌
- `#6b7280` (gray-500)：hero 4.6:1 ✅ / white 4.83:1 ✅（看似 OK，但對 `#fef3c7` amber-tint bg 3.9:1 ❌）
- 任何 `#XXX` 值皆符合光學上「暗底要亮 / 亮底要暗」矛盾

Token-split 是唯一 structurally-correct 的解法。Dev-rules §S5 把這規則固化為專案慣例。

## Testing

- **Static lint**：pre-commit auto hooks 應全通過（`check_design_token_usage`, `axe_lite_static`, etc.）
- **Runtime axe-core**：需 `tests/e2e/_axe-audit-day1to3.spec.ts` 在 light + dark dual-mode 跑過 → 預期 `multi-tenant-comparison` + `dependency-graph` color-contrast 從 40 nodes 降至 ≤ L133 MetricCard 貢獻的殘餘（TECH-DEBT-016）
- **Manual**：建議 reviewer 切 light / dark mode 目視確認 tile badge 對比

## Test plan

- [ ] CI: Lint / commitlint / Validate Mermaid / Smoke Tests (Chromium) / Lint Rule Packs / Check Documentation Links / Python Tests 3.13 / HEAD Blob Hygiene / Go Tests 1.26 等 16/16 green
- [ ] Reviewer 確認 dev-rules §S5 清楚可執行（命名慣例 + 雙主題 caveat）
- [ ] Merge 後 `known-regressions.md` 狀態同步（maintainer-local，已更新）
- [ ] TECH-DEBT-016 進入下批 a11y sweep 優先級評估

Refs: plan.md §12.4 Trap #10 / §12.5 PR#1c spec
Related: PR #33 / PR #34 (same TECH-DEBT-007 lineage, token-split is final resolution)
