### PR TITLE
feat(dx): codify Trap #12 three-layer defense

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -2,7 +2,9 @@ name: Commitlint
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # `edited` lets PR title amendments re-trigger commitlint without close/reopen.
+    # See dev-rules.md §S6 / v2.8.0-planning.md Trap #12.
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   commitlint:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -342,6 +342,17 @@ repos:
         stages: [manual]
         additional_dependencies: ['pyyaml']
 
+      - id: check-techdebt-drift
+        name: TECH-DEBT/REG registry vs git log drift
+        entry: python3 -X utf8 scripts/tools/lint/check_techdebt_drift.py --check
+        language: python
+        pass_filenames: false
+        # Registry file is maintainer-local (gitignored); script is the only
+        # tracked trigger. Manual stage — opt-in via pre-commit run --hook-stage manual.
+        # See dev-rules.md §S6 / v2.8.0-planning.md Trap #12.
+        files: ^scripts/tools/lint/check_techdebt_drift\.py$
+        stages: [manual]
+
       - id: playwright-e2e
         name: Playwright Portal E2E smoke tests
         entry: bash -c 'cd tests/e2e && npx playwright test'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -347,11 +347,13 @@ repos:
         entry: python3 -X utf8 scripts/tools/lint/check_techdebt_drift.py --check
         language: python
         pass_filenames: false
-        # Registry file is maintainer-local (gitignored); script is the only
-        # tracked trigger. Manual stage — opt-in via pre-commit run --hook-stage manual.
-        # See dev-rules.md §S6 / v2.8.0-planning.md Trap #12.
-        files: ^scripts/tools/lint/check_techdebt_drift\.py$
-        stages: [manual]
+        always_run: true
+        # Class A drift (commit trailer refers to an ID still `open` in registry)
+        # blocks the push; Class B (registry resolved but no trailer) is advisory.
+        # Runs at pre-push only — registry file is maintainer-local (gitignored),
+        # so file-change triggering doesn't work; and scanning git log at every
+        # commit is wasteful. See dev-rules.md §P1 for the rule rationale.
+        stages: [pre-push]
 
       - id: playwright-e2e
         name: Playwright Portal E2E smoke tests

--- a/components/threshold-exporter/app/watchloop_test.go
+++ b/components/threshold-exporter/app/watchloop_test.go
@@ -342,6 +342,12 @@ defaults:
 
 // ============================================================
 // WatchLoop — error in scan (dir deleted)
+//
+// TECH-DEBT-017: this test and TestWatchLoop_SingleFile_ErrorOnRead
+// below use time.Sleep as a synchronisation primitive and are
+// flake-prone under `go test -race` on Go 1.26 CI. Planned fix is
+// m.Stop()+sync.WaitGroup so the watcher goroutine is guaranteed
+// to have exited before os.Remove runs.
 // ============================================================
 
 func TestWatchLoop_Dir_ErrorOnScan(t *testing.T) {

--- a/docs/internal/dev-rules.md
+++ b/docs/internal/dev-rules.md
@@ -394,55 +394,17 @@ tools:
 - `tests/dx/test_scan_component_health.py`：12 個測試覆蓋 tier / archived / candidate 三條路徑
 - 與 Q2 policy 對齊：警告型（不 fail），可在 CI 印出 `archived_tools` + `archive_candidates` 供 PR review
 
-## §P 流程紀律（v2.8.0 Phase .a 新增）
+## §P 流程紀律
 
-§S 管程式碼風格、§T 管工具生命週期，§P 管**寫進 commit 與 planning 的人類流程紀律**——這些不會被既有 lint hook 擋下來，但會讓未來 session 找不到 ground truth 或讓文件爆炸。
+§S 管程式碼風格、§T 管工具生命週期，§P 管**寫進 commit 的人類流程紀律**。規則的「why」敘述放這裡，攔截則由 hook 做。
 
 ### P1. Commit trailer 必含 `Resolves <ID>`（追蹤項目修復時）
 
-**規則**：任何 commit 修復了已登錄的追蹤項目（`docs/internal/known-regressions.md` 的 `TECH-DEBT-XXX` / `REG-XXX`，或 `v2.8.0-planning.md` §12.4 的 `Trap #N`），commit message 必須含 trailer：
+修復已登錄的追蹤項目（`known-regressions.md` 的 `TECH-DEBT-XXX` / `REG-XXX`，或 `v2.8.0-planning.md` §12.4 的 `Trap #N`）時，commit message 必須含 trailer：`Resolves TECH-DEBT-005` / `Fixes Trap #12` / `Closes REG-003`（動詞大小寫不敏感）。
 
-```
-Resolves TECH-DEBT-005
-Resolves REG-003
-Resolves Trap #12
-```
+**原因**：沒有 trailer 時 registry 與 git log 失聯，下次 session 會把已修項目當新項目再 audit 一次。
 
-支援的動詞：`Resolves` / `Fixes` / `Closes`（大小寫不敏感）。
-
-**為什麼**：v2.8.0 Phase .a Session #16 發現 8 個 TECH-DEBT phantom（fix 已 merge 但 registry 仍 `open`），原因正是 commit 缺 trailer，registry 與 git log 失聯，下次 session 重複 audit 同一條已修項目燒掉大量 context（`v2.8.0-planning.md` §12.4 Trap #12，maintainer-local 文件）。
-
-**自動化攔截**：`scripts/tools/lint/check_techdebt_drift.py --check`（pre-commit `manual` stage hook id `check-techdebt-drift`）。Class A drift（commit 有 trailer 但 registry 仍 open）會 exit 1 阻擋 commit；Class B drift（registry resolved 但無 trailer）僅資訊性提示，不 fail。
-
-**例外**：純文件、純 refactor、跨多個追蹤項目的批次清理可不寫 trailer（這時改在 commit body 用 prose 列出受影響 IDs；drift checker 不會抓到 prose-only 提及，由 reviewer 把關）。
-
-### P2. `v2.8.0-planning.md` §12.1 Session row ≤ 5 行 / 200 字
-
-**規則**：每筆 session 寫回 `planning.md` §12.1 Session Ledger 的單列**長度上限 5 markdown 行 / 200 字**。長敘述（root cause / Lesson Learned / 詳細 reproduce）改寫進 commit message body 與相關 playbook（`testing-playbook.md` / `windows-mcp-playbook.md` / 本檔 §S/§T/§P）。
-
-**為什麼**：v2.8.0 Phase .a 累積到 Session #16 時 §12.1 單列已膨脹到 1500–4000 字（21 列共 ~50KB），佔 planning.md 總 size 22%。Claude 每個新 session 都被迫重讀，是 context compaction 的最大單一兇手。Session #17（2026-04-19）將 #01-#15 移至 `v2.8.0-planning-archive.md`（maintainer-local；.gitignore L64）並設此上限防復發。
-
-**寫回模板**：
-```
-| #N | YYYY-MM-DD | <觸發 ≤ 1 句> | <交付物列表 ≤ 2 行> | <狀態變更 ≤ 1 行> | <Next ≤ 1 行> |
-```
-
-詳細推理走 commit message；持久學習走 playbook；planning ledger 只管「誰、做了什麼、下一步」。
-
-### P3. 知識退火優先序（既有原則的明文化）
-
-當同一 trap / lesson 在跨 session 重複出現時，按以下順序選擇定型方式（**自動化 > 規範 > 紀錄**）：
-
-1. **Lint / hook 自動化**（pre-commit / CI gate）— 不可被人類繞過的最強形式
-2. **本檔 §S/§T/§P 規則** — 寫入規範，下次 PR review 時可直接引用條號
-3. **Playbook 章節** — 環境/工具陷阱的詳細 reproduce 與 fix step
-4. **planning.md §12.4 Trap 表** — 短期 working log，跨 minor 版本後須升級到上面三種其中之一（`make playbook-freshness` 會檢查 `verified-at-version`）
-
-### 相關自動化（§P）
-
-- `scripts/tools/lint/check_techdebt_drift.py`：registry vs git log 雙向 drift 檢查（P1）
-- `.pre-commit-config.yaml` hook id `check-techdebt-drift`：opt-in manual stage
-- `.github/workflows/commitlint.yaml`：PR title `edited` event 觸發補強（Trap #12 同源；防 PR title 修改後 commitlint 不重跑）
+**自動化攔截**：pre-push hook `check-techdebt-drift`（`scripts/tools/lint/check_techdebt_drift.py`）。Class A（trailer 指向仍 `open` 的 ID）exit 1 擋住 push；Class B（registry 已 resolved 但無 trailer）僅印資訊。純文件 / 純 refactor / 跨多項目的批次清理可不寫 trailer，改在 body 用 prose 列 IDs。
 
 ## 常被違反 Top 4（CLAUDE.md 會保留這四條）
 
@@ -459,4 +421,4 @@ Resolves Trap #12
 |------|------|
 | v2.6.0 | 從 `CLAUDE.md` 搬出，作為 11 條規範的 SSOT |
 | v2.8.0 | 新增 §T 工具生命週期（A-5b scan_component_health archived opt-in）|
-| v2.8.0 Phase .a | 新增 §P 流程紀律（P1 commit trailer / P2 planning row 上限 / P3 知識退火優先序）— Trap #12 三層防禦的「規範層」|
+| v2.8.0 Phase .a | 新增 §P1 Commit trailer 紀律 + pre-push hook `check-techdebt-drift`（Trap #12 三層防禦的「規範層 + 攔截層」）|

--- a/docs/internal/dev-rules.md
+++ b/docs/internal/dev-rules.md
@@ -394,6 +394,56 @@ tools:
 - `tests/dx/test_scan_component_health.py`：12 個測試覆蓋 tier / archived / candidate 三條路徑
 - 與 Q2 policy 對齊：警告型（不 fail），可在 CI 印出 `archived_tools` + `archive_candidates` 供 PR review
 
+## §P 流程紀律（v2.8.0 Phase .a 新增）
+
+§S 管程式碼風格、§T 管工具生命週期，§P 管**寫進 commit 與 planning 的人類流程紀律**——這些不會被既有 lint hook 擋下來，但會讓未來 session 找不到 ground truth 或讓文件爆炸。
+
+### P1. Commit trailer 必含 `Resolves <ID>`（追蹤項目修復時）
+
+**規則**：任何 commit 修復了已登錄的追蹤項目（`docs/internal/known-regressions.md` 的 `TECH-DEBT-XXX` / `REG-XXX`，或 `v2.8.0-planning.md` §12.4 的 `Trap #N`），commit message 必須含 trailer：
+
+```
+Resolves TECH-DEBT-005
+Resolves REG-003
+Resolves Trap #12
+```
+
+支援的動詞：`Resolves` / `Fixes` / `Closes`（大小寫不敏感）。
+
+**為什麼**：v2.8.0 Phase .a Session #16 發現 8 個 TECH-DEBT phantom（fix 已 merge 但 registry 仍 `open`），原因正是 commit 缺 trailer，registry 與 git log 失聯，下次 session 重複 audit 同一條已修項目燒掉大量 context（[v2.8.0-planning.md Trap #12](v2.8.0-planning.md)）。
+
+**自動化攔截**：`scripts/tools/lint/check_techdebt_drift.py --check`（pre-commit `manual` stage hook id `check-techdebt-drift`）。Class A drift（commit 有 trailer 但 registry 仍 open）會 exit 1 阻擋 commit；Class B drift（registry resolved 但無 trailer）僅資訊性提示，不 fail。
+
+**例外**：純文件、純 refactor、跨多個追蹤項目的批次清理可不寫 trailer（這時改在 commit body 用 prose 列出受影響 IDs；drift checker 不會抓到 prose-only 提及，由 reviewer 把關）。
+
+### P2. `v2.8.0-planning.md` §12.1 Session row ≤ 5 行 / 200 字
+
+**規則**：每筆 session 寫回 `planning.md` §12.1 Session Ledger 的單列**長度上限 5 markdown 行 / 200 字**。長敘述（root cause / Lesson Learned / 詳細 reproduce）改寫進 commit message body 與相關 playbook（`testing-playbook.md` / `windows-mcp-playbook.md` / 本檔 §S/§T/§P）。
+
+**為什麼**：v2.8.0 Phase .a 累積到 Session #16 時 §12.1 單列已膨脹到 1500–4000 字（21 列共 ~50KB），佔 planning.md 總 size 22%。Claude 每個新 session 都被迫重讀，是 context compaction 的最大單一兇手。Session #17（2026-04-19）將 #01-#15 移至 [`v2.8.0-planning-archive.md`](v2.8.0-planning-archive.md) 並設此上限防復發。
+
+**寫回模板**：
+```
+| #N | YYYY-MM-DD | <觸發 ≤ 1 句> | <交付物列表 ≤ 2 行> | <狀態變更 ≤ 1 行> | <Next ≤ 1 行> |
+```
+
+詳細推理走 commit message；持久學習走 playbook；planning ledger 只管「誰、做了什麼、下一步」。
+
+### P3. 知識退火優先序（既有原則的明文化）
+
+當同一 trap / lesson 在跨 session 重複出現時，按以下順序選擇定型方式（**自動化 > 規範 > 紀錄**）：
+
+1. **Lint / hook 自動化**（pre-commit / CI gate）— 不可被人類繞過的最強形式
+2. **本檔 §S/§T/§P 規則** — 寫入規範，下次 PR review 時可直接引用條號
+3. **Playbook 章節** — 環境/工具陷阱的詳細 reproduce 與 fix step
+4. **planning.md §12.4 Trap 表** — 短期 working log，跨 minor 版本後須升級到上面三種其中之一（`make playbook-freshness` 會檢查 `verified-at-version`）
+
+### 相關自動化（§P）
+
+- `scripts/tools/lint/check_techdebt_drift.py`：registry vs git log 雙向 drift 檢查（P1）
+- `.pre-commit-config.yaml` hook id `check-techdebt-drift`：opt-in manual stage
+- `.github/workflows/commitlint.yaml`：PR title `edited` event 觸發補強（Trap #12 同源；防 PR title 修改後 commitlint 不重跑）
+
 ## 常被違反 Top 4（CLAUDE.md 會保留這四條）
 
 根據歷史 LL 與 pre-commit 攔截記錄，以下四條最容易被違反：
@@ -409,3 +459,4 @@ tools:
 |------|------|
 | v2.6.0 | 從 `CLAUDE.md` 搬出，作為 11 條規範的 SSOT |
 | v2.8.0 | 新增 §T 工具生命週期（A-5b scan_component_health archived opt-in）|
+| v2.8.0 Phase .a | 新增 §P 流程紀律（P1 commit trailer / P2 planning row 上限 / P3 知識退火優先序）— Trap #12 三層防禦的「規範層」|

--- a/docs/internal/dev-rules.md
+++ b/docs/internal/dev-rules.md
@@ -410,7 +410,7 @@ Resolves Trap #12
 
 支援的動詞：`Resolves` / `Fixes` / `Closes`（大小寫不敏感）。
 
-**為什麼**：v2.8.0 Phase .a Session #16 發現 8 個 TECH-DEBT phantom（fix 已 merge 但 registry 仍 `open`），原因正是 commit 缺 trailer，registry 與 git log 失聯，下次 session 重複 audit 同一條已修項目燒掉大量 context（[v2.8.0-planning.md Trap #12](v2.8.0-planning.md)）。
+**為什麼**：v2.8.0 Phase .a Session #16 發現 8 個 TECH-DEBT phantom（fix 已 merge 但 registry 仍 `open`），原因正是 commit 缺 trailer，registry 與 git log 失聯，下次 session 重複 audit 同一條已修項目燒掉大量 context（`v2.8.0-planning.md` §12.4 Trap #12，maintainer-local 文件）。
 
 **自動化攔截**：`scripts/tools/lint/check_techdebt_drift.py --check`（pre-commit `manual` stage hook id `check-techdebt-drift`）。Class A drift（commit 有 trailer 但 registry 仍 open）會 exit 1 阻擋 commit；Class B drift（registry resolved 但無 trailer）僅資訊性提示，不 fail。
 
@@ -420,7 +420,7 @@ Resolves Trap #12
 
 **規則**：每筆 session 寫回 `planning.md` §12.1 Session Ledger 的單列**長度上限 5 markdown 行 / 200 字**。長敘述（root cause / Lesson Learned / 詳細 reproduce）改寫進 commit message body 與相關 playbook（`testing-playbook.md` / `windows-mcp-playbook.md` / 本檔 §S/§T/§P）。
 
-**為什麼**：v2.8.0 Phase .a 累積到 Session #16 時 §12.1 單列已膨脹到 1500–4000 字（21 列共 ~50KB），佔 planning.md 總 size 22%。Claude 每個新 session 都被迫重讀，是 context compaction 的最大單一兇手。Session #17（2026-04-19）將 #01-#15 移至 [`v2.8.0-planning-archive.md`](v2.8.0-planning-archive.md) 並設此上限防復發。
+**為什麼**：v2.8.0 Phase .a 累積到 Session #16 時 §12.1 單列已膨脹到 1500–4000 字（21 列共 ~50KB），佔 planning.md 總 size 22%。Claude 每個新 session 都被迫重讀，是 context compaction 的最大單一兇手。Session #17（2026-04-19）將 #01-#15 移至 `v2.8.0-planning-archive.md`（maintainer-local；.gitignore L64）並設此上限防復發。
 
 **寫回模板**：
 ```

--- a/docs/internal/tool-map.en.md
+++ b/docs/internal/tool-map.en.md
@@ -128,6 +128,7 @@ lang: en
 | `check_repo_name.py` | Prevent wrong repository name in source files. |
 | `check_routing_profiles.py` | Lint routing profiles and domain policies (ADR-007). |
 | `check_structure.py` | Project structure enforcement. |
+| `check_techdebt_drift.py` | TECH-DEBT / REG registry drift checker. |
 | `check_translation.py` | 自動化翻譯品質檢查 |
 | `detect_sed_damage.py` | Detect sed -i damage on staged files. |
 | `fix_doc_links.py` | Auto-fix broken MkDocs cross-reference links. |

--- a/docs/internal/tool-map.md
+++ b/docs/internal/tool-map.md
@@ -128,6 +128,7 @@ lang: zh
 | `check_repo_name.py` | Prevent wrong repository name in source files. |
 | `check_routing_profiles.py` | Lint routing profiles and domain policies (ADR-007). |
 | `check_structure.py` | Project structure enforcement. |
+| `check_techdebt_drift.py` | TECH-DEBT / REG registry drift checker. |
 | `check_translation.py` | 自動化翻譯品質檢查 |
 | `detect_sed_damage.py` | Detect sed -i damage on staged files. |
 | `fix_doc_links.py` | Auto-fix broken MkDocs cross-reference links. |

--- a/scripts/tools/lint/check_techdebt_drift.py
+++ b/scripts/tools/lint/check_techdebt_drift.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""TECH-DEBT / REG registry drift checker.
+
+Cross-references `docs/internal/known-regressions.md` against git log to
+surface drift between recorded status and commit history.
+
+Background
+----------
+v2.8.0 Phase .a Session #16 discovered eight phantom TECH-DEBT entries
+(-002 / -005 / -006 / -008 / -009 / -010 / -013 / -015) whose fixes had
+shipped to main but whose registry status still read `open`. Root cause:
+fix commits did not include a `Resolves TECH-DEBT-XXX` trailer, so the
+registry and git log drifted apart. See dev-rules.md §P1 for the commit
+convention and v2.8.0-planning.md Trap #12 for the Lesson Learned.
+
+This script surfaces two drift classes:
+
+  Class A (loud)  — A commit message references `Resolves TECH-DEBT-XXX`
+                     or `Fixes REG-XXX` but the registry entry still has
+                     status `open` / `in-progress`. Indicates the fix
+                     landed without registry update. `--check` exits 1
+                     when this class has any hits.
+
+  Class B (quiet) — The registry entry has status `resolved` / `fixed`
+                     but no commit in the scan window references it.
+                     Informational only (commit-convention gap, not a
+                     blocker); never fails CI.
+
+Usage
+-----
+  python scripts/tools/lint/check_techdebt_drift.py
+  python scripts/tools/lint/check_techdebt_drift.py --check
+  python scripts/tools/lint/check_techdebt_drift.py --since v2.7.0
+
+Defaults: scans full git history when `--since` is omitted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REGISTRY_PATH = REPO_ROOT / "docs" / "internal" / "known-regressions.md"
+
+# Detail-block heading: `### TECH-DEBT-005：...` or `### REG-003: ...`
+HEADING_RE = re.compile(
+    r"^###\s+(?P<id>(?:TECH-DEBT|REG)-\d+)[\s：:]", re.MULTILINE
+)
+
+# Status cell: `| status | open |` / `| `status` | **resolved** |`
+STATUS_RE = re.compile(
+    r"\|\s*`?status`?\s*\|\s*(?P<status>[^|\n]+?)\s*\|", re.IGNORECASE
+)
+
+# Commit trailer: Resolves / Fixes / Closes TECH-DEBT-XXX or REG-XXX
+TRAILER_RE = re.compile(
+    r"(?:Resolves|Fixes|Closes)\s+((?:TECH-DEBT|REG)-\d+)", re.IGNORECASE
+)
+
+
+def normalize_status(raw: str) -> str:
+    """Strip markdown emphasis markers and lowercase."""
+    return raw.replace("*", "").replace("`", "").strip().lower()
+
+
+def parse_registry(path: Path) -> dict[str, str]:
+    """Extract `{entry_id: normalized_status}` from the registry file.
+
+    Only the first status line inside each detail block is captured —
+    detail blocks are the source of truth; §4 summary bullets are
+    ignored because they duplicate the same data.
+    """
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    result: dict[str, str] = {}
+    headings = list(HEADING_RE.finditer(text))
+    for i, match in enumerate(headings):
+        entry_id = match.group("id")
+        start = match.end()
+        end = headings[i + 1].start() if i + 1 < len(headings) else len(text)
+        block = text[start:end]
+        sm = STATUS_RE.search(block)
+        if sm:
+            result[entry_id] = normalize_status(sm.group("status"))
+    return result
+
+
+def parse_git_log(since: str | None) -> dict[str, list[str]]:
+    """Return `{entry_id: [short_sha, ...]}` from Resolves/Fixes trailers."""
+    rev_range = f"{since}..HEAD" if since else "HEAD"
+    cmd = ["git", "log", rev_range, "--pretty=%H%x00%B%x00%x00"]
+    try:
+        output = subprocess.check_output(
+            cmd, text=True, stderr=subprocess.DEVNULL, cwd=REPO_ROOT
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return {}
+    refs: dict[str, list[str]] = {}
+    for record in output.split("\x00\x00"):
+        record = record.strip("\n\x00 \t")
+        if not record:
+            continue
+        sha, _, body = record.partition("\x00")
+        for tm in TRAILER_RE.finditer(body):
+            refs.setdefault(tm.group(1).upper(), []).append(sha[:7])
+    return refs
+
+
+def detect_drift(
+    registry: dict[str, str], refs: dict[str, list[str]]
+) -> tuple[list[tuple[str, str, list[str]]], list[str]]:
+    """Return (class_a, class_b) drift lists.
+
+    class_a: (id, registry_status, [commits])
+    class_b: [id]
+    """
+    open_states = {"open", "in-progress", "in progress"}
+    resolved_states = {"resolved", "fixed"}
+    class_a: list[tuple[str, str, list[str]]] = []
+    class_b: list[str] = []
+    for entry_id, status in registry.items():
+        commits = refs.get(entry_id, [])
+        if status in open_states and commits:
+            class_a.append((entry_id, status, commits))
+        elif status in resolved_states and not commits:
+            class_b.append(entry_id)
+    return class_a, class_b
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check drift between known-regressions.md and git log."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 if any Class A drift is found (CI mode).",
+    )
+    parser.add_argument(
+        "--since",
+        default=None,
+        help="Restrict git log scan to commits after this rev (e.g. v2.7.0).",
+    )
+    args = parser.parse_args()
+
+    registry = parse_registry(REGISTRY_PATH)
+    refs = parse_git_log(args.since)
+    class_a, class_b = detect_drift(registry, refs)
+
+    if not registry:
+        # Registry is maintainer-local / gitignored in many forks; treat as
+        # informational rather than fatal.
+        print(f"known-regressions.md not found at {REGISTRY_PATH}; nothing to check.")
+        return 0
+
+    scope = f"since {args.since}" if args.since else "full history"
+    print(
+        f"Scanned {len(registry)} registry entries against git log ({scope}); "
+        f"{len(refs)} unique ids referenced in commit trailers."
+    )
+
+    if class_a:
+        print("\nClass A drift — commit resolves but registry still open:")
+        for entry_id, status, commits in sorted(class_a):
+            print(f"  {entry_id}  status={status}  commits={', '.join(commits)}")
+
+    if class_b:
+        print("\nClass B drift — registry resolved/fixed but no commit trailer:")
+        print("(informational only; older fixes pre-date the §S6 convention)")
+        for entry_id in sorted(class_b):
+            print(f"  {entry_id}")
+
+    if not class_a and not class_b:
+        print("OK: 0 drift detected.")
+
+    if args.check and class_a:
+        print("\nClass A drift is blocking. Update registry status or commit message.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
feat(dx): codify Trap #12 three-layer defense

Three artifacts that together close the TECH-DEBT registry / git-log
drift class first observed in v2.8.0 Phase .a Session #16 (8 phantom
TECH-DEBT entries with shipped fixes but registry still `open`).

Defense layers
- CI workflow: commitlint workflow now also fires on PR title `edited`
  events, so amending a wrong-scope title re-runs commitlint without
  needing close/reopen as a workaround.
- Convention: dev-rules.md new section P1 mandates `Resolves <ID>`
  trailer (`TECH-DEBT-XXX` / `REG-XXX` / `Trap #N`) on commits that fix
  any tracked item.
- Lint: scripts/tools/lint/check_techdebt_drift.py cross-checks the
  registry against git-log trailers. Class A drift (commit references
  trailer but registry still open) blocks via --check; Class B (registry
  resolved but no trailer) is informational only.

Bonus codify
- dev-rules.md new section P2: planning.md Session Ledger row capped at
  5 lines / 200 chars. v2.8.0 Phase .a Session ledger had grown to
  ~50KB and was the single biggest driver of context-window pressure
  for Claude in long sessions. P3 spells out the existing automation >
  rule > playbook > working-log preference order.

Pre-commit hook id `check-techdebt-drift` is wired manual-stage so
local maintainers can opt-in via `pre-commit run --hook-stage manual
check-techdebt-drift`. Not auto-staged because the registry file is
gitignored / maintainer-local.

Files changed:
- .github/workflows/commitlint.yaml      (add `edited` to pull_request.types)
- scripts/tools/lint/check_techdebt_drift.py  (new)
- .pre-commit-config.yaml                (manual hook entry)
- docs/internal/dev-rules.md             (new section P + version row)

Resolves Trap #12
