### PR TITLE
feat(dx): code-driven P2 drift enforcement hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,13 @@ repos:
         pass_filenames: false
         files: ^scripts/tools/.*\.py$
 
+      - id: devrules-size-check
+        name: "Guard: dev-rules.md line-count cap (500)"
+        entry: python3 -X utf8 scripts/tools/lint/check_devrules_size.py
+        language: python
+        pass_filenames: false
+        files: ^docs/internal/dev-rules\.md$
+
       - id: doc-map-check
         name: Doc map coverage
         entry: python3 -X utf8 scripts/tools/dx/generate_doc_map.py --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ All notable changes to the **Dynamic Alerting Integrations** project will be doc
 
 ## [Unreleased]
 
+### Added
+
+- **`dev-rules.md §P2` 轉 code-driven enforcement（v2.8.0 Phase .a）**：PR #39/#40 踩坑後的結構性改進——純文字規範（「`gh pr create` 前記得掃 drift」）對 agent 記性依賴過高，改寫為兩個 hook：
+  - **`scripts/tools/lint/check_devrules_size.py`**（pre-commit 硬上限）：`docs/internal/dev-rules.md` 超過 **500 行**即 fail。用意是把 dev-rules.md 的累積量做為「code-driven 遷移壓力反向指標」——文字規範越肥代表越多條目本來就該當 hook 寫掉。新增規則時作者被迫三選一：prune / promote（升 L1/L2 hook）/ archive。放寬 `MAX_LINES` 屬禁忌，需在 PR body 明述理由。
+  - **`scripts/tools/lint/check_pr_scope_drift.py`**（pr-preflight 硬失敗）：偵測兩項——tool-map drift（`generate_tool_map.py --check` 失敗，典型肇因：新增 `scripts/tools/**/*.py` 但沒 regen）+ working-tree dirty（unstaged / uncommitted staged 存在，典型肇因：session 邊改 playbook / CLAUDE.md 忘記 git add）。
+  - **`scripts/tools/dx/pr_preflight.py` 新增 Scope drift phase**：`make pr-preflight` 從 6 項 → **7 項**檢查（branch / behind-main / conflict / local hooks / **scope-drift** / CI / mergeable）。PR merge 前必過。
+  - **`dev-rules.md §P2` 從文字敘述改為 hook pointer**：規則本體即 code，避免「文字規範 → 記性 → 執行」三段 rot。新增 drift 項目時改 code，不改本節。
+
+### Changed
+
+- **`.pre-commit-config.yaml` 新增 `devrules-size-check` hook**：緊鄰 `tool-map-check`，僅在 `docs/internal/dev-rules.md` 變動時觸發。
+- **`Makefile` `pr-preflight` target 描述更新**：反映 7 項檢查範圍（含 scope-drift）。
+- **`dev-rules.md` 大幅瘦身（v2.8.0 Phase .a）**：520 → 487 行，為新 500-line cap 留 buffer。壓縮 §S3 / §S5 的反例+正例 block（資訊保留、用註解合併）。未刪任何規則條文。
+- **CLAUDE.md tool count `114 → 116`**：同步 `docs/internal/tool-map.md` regenerated 計數（ops 46 / dx 29 / lint 40，+2 來自本 PR `check_devrules_size.py` + `check_pr_scope_drift.py`）。`make pr-preflight` 描述同步更新為 7 項。
+
 ### Fixed
 
 - **A-5a `make pr-preflight` / `pre-tag` Chart.yaml path bug（Phase .a A-5a）**：Helm chart 從 `components/threshold-exporter/` 遷至 `helm/threshold-exporter/`（parallels `helm/tenant-api/`）時遺漏 3 處 stale reference，導致 `make version-check` 印 `grep: components/threshold-exporter/Chart.yaml: No such file or directory` warning、`make chart-package` / `chart-push` target 失效：

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,10 +98,10 @@ pre-commit run --hook-stage manual --all-files    # manual-stage
 ## 文件 / 工具 / Makefile
 
 - **129 份文件** 對照表 → [`docs/internal/doc-map.md`](docs/internal/doc-map.md)（含受眾、內容摘要、Change Impact Matrix）
-- **112 個 Python 工具**（`validate_all.py` orchestrator / ops 46 / dx 29 / lint 36，含 2 個 helper module）→ [`docs/internal/tool-map.md`](docs/internal/tool-map.md)；CLI 速查：`da-tools <cmd> --help`；完整 CLI 參考：[`docs/cli-reference.md`](docs/cli-reference.md)
+- **116 個 Python 工具**（`validate_all.py` orchestrator / ops 46 / dx 29 / lint 40，含 2 個 helper module）→ [`docs/internal/tool-map.md`](docs/internal/tool-map.md)；CLI 速查：`da-tools <cmd> --help`；完整 CLI 參考：[`docs/cli-reference.md`](docs/cli-reference.md)
 - **39 個 JSX 互動工具** SOT：[`docs/assets/tool-registry.yaml`](docs/assets/tool-registry.yaml)；變更流程見 [dev-rules.md §互動工具變更 SOP](docs/internal/dev-rules.md#互動工具變更-sop)
 - **Makefile** 完整列表：`make help`。必記 Top 5：
-  - `make pr-preflight` — ⛔ PR merge 前必跑（conflict / CI / hooks / mergeable 六項檢查）
+  - `make pr-preflight` — ⛔ PR merge 前必跑（branch / conflict / hooks / scope-drift / CI / mergeable 七項檢查）
   - `make pre-tag` — ⛔ 打 tag 前必跑（version-check + lint-docs）
   - `make session-cleanup` — session 結束清理（vscode-git / lock / port-forward）
   - `make lint-docs` — 一站式文件 lint

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ git-preflight: ## Git 操作前自動降噪（關閉 VS Code Git + 清理 stale 
 	@bash scripts/session-guards/git_check_lock.sh --clean 2>/dev/null || true
 
 .PHONY: pr-preflight
-pr-preflight: ## PR 收尾前檢查（conflict / CI / hooks / mergeable）
+pr-preflight: ## PR 收尾前檢查（branch / conflict / hooks / scope-drift / CI / mergeable）
 	@python3 scripts/tools/dx/pr_preflight.py $(ARGS)
 
 .PHONY: pr-preflight-quick

--- a/docs/internal/dev-rules.md
+++ b/docs/internal/dev-rules.md
@@ -175,15 +175,16 @@ chmod +x .git/hooks/pre-push
 
 **PR 收尾 SOP（Branch Closing Checklist）**：
 
-merge 前執行 `make pr-preflight`（或 `make pr-preflight-quick` 跳過 local hooks），自動檢查六項：
+merge 前執行 `make pr-preflight`（或 `make pr-preflight-quick` 跳過 local hooks），自動檢查七項：
 
 ```
 ┌─ 1. Branch 身份    確認在 feature branch，非 main
 ├─ 2. Behind main    落後幾個 commit → 建議先 merge main
 ├─ 3. Conflict       dry-run merge 偵測衝突
 ├─ 4. Local hooks    pre-commit run --all-files
-├─ 5. CI 狀態        gh pr checks（含 A/B 分類：pre-existing vs this-PR）
-└─ 6. PR mergeable   GitHub mergeable + review 狀態
+├─ 5. Scope drift    check_pr_scope_drift.py（tool-map + working-tree clean，§P2）
+├─ 6. CI 狀態        gh pr checks（含 A/B 分類：pre-existing vs this-PR）
+└─ 7. PR mergeable   GitHub mergeable + review 狀態
 ```
 
 各 status 的處理方式：
@@ -269,30 +270,17 @@ Phase .a0 token 遷移期間確立的慣例，適用所有 JSX 互動工具。
 
 **為什麼**：axe-core `scrollable-region-focusable` rule 在任何 scrollable 且**無 focusable children** 的元素上觸發，不論是否有 `role="region"`。v2.8.0 Phase .a Day 1 scope check 發現 `notification-previewer.jsx` 雖 Day 5-7 期間移除了 `role="region"`，但 `styles.previewBox` 的 `overflowY: 'auto'` + `maxHeight: '400px'` 仍觸發 axe，印證這是容器本身屬性問題而非 role 問題。
 
-**反例**（v2.7.0 實際踩過）：
+**反 / 正例**（v2.7.0 實際踩過，TECH-DEBT-006 / -009）：
 
 ```jsx
-// ❌ TECH-DEBT-006：threshold-heatmap scrollable heatmap grid 沒有 tabIndex
+// ❌ overflow-auto / overflowY:'auto' 容器無 tabIndex／accessible name
 <div className="... overflow-auto" role="region" aria-label="Heatmap">...</div>
-
-// ❌ TECH-DEBT-009：notification-previewer previewBox 拿掉 role="region" 以為修了，
-//     其實 overflowY:'auto' + maxHeight:'400px' 還是觸發 axe
 <div style={{ overflowY: 'auto', maxHeight: '400px' }} aria-live="polite">...</div>
-```
 
-**正例**（v2.8.0 PR#2 修後）：
-
-```jsx
-// ✅ TECH-DEBT-006 修法
-<div className="... overflow-auto"
-     role="region"
-     aria-label={t('閾值熱力圖', 'Threshold heatmap grid')}
-     tabIndex={0}>...</div>
-
-// ✅ TECH-DEBT-009 修法（雙 previewBox 同模式）
-<div style={{ overflowY: 'auto', maxHeight: '400px' }}
-     aria-live="polite"
-     tabIndex={0}
+// ✅ 補 tabIndex={0} + aria-label (雙語 token)
+<div className="... overflow-auto" role="region" tabIndex={0}
+     aria-label={t('閾值熱力圖', 'Threshold heatmap grid')}>...</div>
+<div style={{ overflowY: 'auto', maxHeight: '400px' }} aria-live="polite" tabIndex={0}
      aria-label={t('通知標題預覽', 'Notification title preview')}>...</div>
 ```
 
@@ -316,26 +304,12 @@ Phase .a0 token 遷移期間確立的慣例，適用所有 JSX 互動工具。
 
 **為什麼**：WCAG 2.1 AA 要求文字對背景達 4.5:1 對比。單一色值在 dark bg 上高對比（白灰系列）→ 同一色值在 light bg 上必然低對比，反之亦然。Phase .a0 PR#1 Day 5 retrospective 踩過這坑（TECH-DEBT-007：`--da-color-hero-muted` 用 `gray-400` 一口氣套在 hero dark bg + card light bg + SVG white bg 上，axe-core 在 multi-tenant-comparison 報出 40 nodes color-contrast 違規）。v2.8.0 Phase .a PR#1c 用 token-split 徹底解決——保留 `--da-color-hero-muted` 給 hero dark bg，新增 `--da-color-tile-muted` 給 tile / card / SVG 永遠亮底的 consumers。
 
-**反例**（TECH-DEBT-007 原始犯案）：
+**反 / 正例**（TECH-DEBT-007：一 token 服務兩種背景 → PR#1c token-split）：
 
 ```css
 /* ❌ 一個 token 服務兩種背景 */
-:root {
-  --da-color-hero-muted: #94a3b8;  /* slate-400 */
-}
-```
+:root { --da-color-hero-muted: #94a3b8; }  /* slate-400 */
 
-```jsx
-// ❌ hero dark bg 用（7.2:1 pass）
-<p style={{ color: 'var(--da-color-hero-muted)', background: '#0f172a' }}>subtitle</p>
-
-// ❌ tile light bg 也用（3.12:1 fail）— 同一 token，不同語意
-<td style={{ color: 'var(--da-color-hero-muted)', background: '#fef3c7' }}>label</td>
-```
-
-**正例**（PR#1c 修後 token-split）：
-
-```css
 /* ✅ 按 bg 語意 split */
 :root {
   --da-color-hero-muted: #94a3b8;  /* Hero dark bg ONLY: 7.2:1 on #0f172a */
@@ -344,10 +318,12 @@ Phase .a0 token 遷移期間確立的慣例，適用所有 JSX 互動工具。
 ```
 
 ```jsx
-// ✅ Hero dark bg
+// ❌ 同一 token 給 dark/light 兩背景（後者 3.12:1 fail）
 <p style={{ color: 'var(--da-color-hero-muted)', background: '#0f172a' }}>subtitle</p>
+<td style={{ color: 'var(--da-color-hero-muted)', background: '#fef3c7' }}>label</td>
 
-// ✅ Tile always-light bg
+// ✅ 分 token，各自符合 4.5:1
+<p style={{ color: 'var(--da-color-hero-muted)', background: '#0f172a' }}>subtitle</p>
 <td style={{ color: 'var(--da-color-tile-muted)', background: '#fef3c7' }}>label</td>
 ```
 
@@ -405,6 +381,15 @@ tools:
 **原因**：沒有 trailer 時 registry 與 git log 失聯，下次 session 會把已修項目當新項目再 audit 一次。
 
 **自動化攔截**：pre-push hook `check-techdebt-drift`（`scripts/tools/lint/check_techdebt_drift.py`）。Class A（trailer 指向仍 `open` 的 ID）exit 1 擋住 push；Class B（registry 已 resolved 但無 trailer）僅印資訊。純文件 / 純 refactor / 跨多項目的批次清理可不寫 trailer，改在 body 用 prose 列 IDs。
+
+### P2. PR Scope Drift（由 `check_pr_scope_drift` hook 強制，v2.8.0 Phase .a 新增）
+
+**規則**：本條無文字敘述——由 `scripts/tools/lint/check_pr_scope_drift.py` 於 `make pr-preflight` 強制執行。偵測項：
+
+1. **Tool count drift**：`bump_docs.py --check` 不通過（CLAUDE.md「N 個 Python 工具」與實際 `scripts/tools/**/*.py` count 不一致）
+2. **Working-tree clean**：準備 merge 的 PR branch 存在未 commit 的修改（`git diff --quiet` + `git diff --cached --quiet` 都必須通過）
+
+設計原則：規則本體即為 hook 程式碼，避免「文字規範 → 記性 → 執行」三段 rot。新增 drift 項目時改 code，不改本節。
 
 ## §A 產出物治理（Planning Artifact Policy，v2.8.0 Phase .a 新增）
 

--- a/docs/internal/tool-map.md
+++ b/docs/internal/tool-map.md
@@ -109,6 +109,7 @@ lang: zh
 | `check_build_completeness.py` | build.sh ↔ COMMAND_MAP 雙向同步檢查。 |
 | `check_cli_coverage.py` | CLI 命令覆蓋率檢查 |
 | `check_design_token_usage.py` | JSX 設計 token 使用完整性 lint |
+| `check_devrules_size.py` | Dev-rules 尺寸上限檢查。 |
 | `check_doc_freshness.py` | 文件新鮮度檢查工具。 |
 | `check_doc_links.py` | 文件間交叉引用一致性檢查 |
 | `check_doc_reading_time.py` | 文件閱讀時間檢查工具。 |
@@ -125,6 +126,7 @@ lang: zh
 | `check_orphan_docs.py` | 孤兒文件偵測 |
 | `check_playbook_freshness.py` | Playbook 知識退火檢查工具。 |
 | `check_portal_i18n.py` | Portal JSX i18n hardcoded string detector |
+| `check_pr_scope_drift.py` | PR scope drift 偵測（pr-preflight 級）。 |
 | `check_repo_name.py` | Prevent wrong repository name in source files. |
 | `check_routing_profiles.py` | Lint routing profiles and domain policies (ADR-007). |
 | `check_structure.py` | Project structure enforcement. |

--- a/scripts/tools/dx/pr_preflight.py
+++ b/scripts/tools/dx/pr_preflight.py
@@ -276,6 +276,31 @@ def check_local_hooks() -> CheckResult:
     )
 
 
+def check_scope_drift() -> CheckResult:
+    """跑 check_pr_scope_drift.py — tool-map 與 working-tree 是否乾淨。
+
+    這是 code-driven §P2 rule 的執行點，偵測 PR 準備 merge 時仍有散落
+    在工作目錄、未納入此 PR commit 的 drift（典型 PR #40 肇因）。
+    """
+    r = run(
+        ["python3", "-X", "utf8", "scripts/tools/lint/check_pr_scope_drift.py"],
+        timeout=60,
+    )
+    if r.returncode == 0:
+        return CheckResult("Scope drift", Status.PASS, "無 drift 訊號")
+
+    # Surface the FAIL summary line (first line of stderr from the hook)
+    tail = (r.stdout + r.stderr).strip().splitlines()
+    headline = next(
+        (ln for ln in tail if "FAIL:" in ln),
+        tail[0] if tail else "(no output)",
+    )
+    detail = "\n".join(
+        ln.strip() for ln in tail if ln.strip().startswith(("FAIL", "PASS"))
+    )[:400]
+    return CheckResult("Scope drift", Status.FAIL, headline, detail=detail)
+
+
 def _classify_ci_failures(failed_checks: list) -> str:
     """A/B 分類：比對 main 最近一次 CI run，判斷失敗是 pre-existing 還是 this-PR 引入。
 
@@ -492,10 +517,13 @@ def main() -> int:
     else:
         report.add(check_local_hooks())
 
-    # 5. CI status
+    # 5. Scope drift (code-driven §P2 rule)
+    report.add(check_scope_drift())
+
+    # 6. CI status
     report.add(check_ci_status(args.pr))
 
-    # 6. PR mergeable
+    # 7. PR mergeable
     report.add(check_pr_mergeable(args.pr))
 
     report.print_summary()

--- a/scripts/tools/lint/check_devrules_size.py
+++ b/scripts/tools/lint/check_devrules_size.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Dev-rules 尺寸上限檢查。
+
+docs/internal/dev-rules.md 是 L4 純文字規範的 SSOT。純文字規則無法
+強制執行、無法版本化測試、只靠 agent 記性——因此本專案將文字規範
+的累積量視為 **code-driven 遷移壓力的反向指標**。
+
+本 hook 當文件超過 MAX_LINES 時硬性 fail，強制作者三選一：
+
+1. **Prune**: 將現有規則壓縮（搬例子到 playbook / 合併重複敘述）
+2. **Promote**: 將一條規則升格為 hook（L4 → L1/L2），把文字移除
+3. **Archive**: 將過期規則移到 version history + archive note
+
+設計意圖：規範總量不隨版本線性膨脹。每次有人想加新規範時被迫回頭
+看「舊的哪些該代碼化掉了？」。
+
+用法：
+  python scripts/tools/lint/check_devrules_size.py
+
+Exit:
+  0 = 通過
+  1 = 超過上限
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# 上限。v2.8.0 Phase .a：500 行硬上限。
+# 調整門檻時需同時修改 CHANGELOG 並在 PR body 寫理由（不可偷偷放寬）。
+MAX_LINES = 500
+
+# 相對於 repo root
+DEV_RULES_PATH = "docs/internal/dev-rules.md"
+
+
+def find_repo_root() -> Path:
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / ".git").exists():
+            return parent
+    # fallback: 本腳本位置
+    return Path(__file__).resolve().parent.parent.parent.parent
+
+
+def main() -> int:
+    repo = find_repo_root()
+    target = repo / DEV_RULES_PATH
+    if not target.exists():
+        print(f"[check_devrules_size] target not found: {target}", file=sys.stderr)
+        return 1
+
+    # 用 bytes + splitlines 計算，跟 `wc -l` 一致（最後一行未換行也算一行）
+    text = target.read_text(encoding="utf-8")
+    # splitlines: POSIX 無 trailing newline 時，最後一行仍算一行
+    line_count = len(text.splitlines())
+
+    if line_count <= MAX_LINES:
+        return 0
+
+    over = line_count - MAX_LINES
+    print(
+        f"[check_devrules_size] FAIL: {DEV_RULES_PATH} has {line_count} lines "
+        f"(limit {MAX_LINES}, over by {over}).",
+        file=sys.stderr,
+    )
+    print(
+        "\n  dev-rules.md is the SSOT for L4 plain-text rules (agent has to read + "
+        "remember).\n  When the file grows this large, the system is drifting away "
+        "from code-driven enforcement.\n\n"
+        "  Pick one:\n"
+        "    1. Prune       — compact examples, move samples to a Playbook\n"
+        "    2. Promote     — turn a rule into a pre-commit / pre-push hook, remove text\n"
+        "    3. Archive     — move dead rules into version-history + archive note\n\n"
+        "  Raising MAX_LINES is a last resort and must be justified in the PR body.\n",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tools/lint/check_devrules_size.py
+++ b/scripts/tools/lint/check_devrules_size.py
@@ -24,6 +24,7 @@ Exit:
 
 from __future__ import annotations
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -45,6 +46,10 @@ def find_repo_root() -> Path:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=f"Fail if {DEV_RULES_PATH} exceeds {MAX_LINES} lines."
+    )
+    parser.parse_args()  # no flags — just enforce unknown-arg rejection
     repo = find_repo_root()
     target = repo / DEV_RULES_PATH
     if not target.exists():

--- a/scripts/tools/lint/check_pr_scope_drift.py
+++ b/scripts/tools/lint/check_pr_scope_drift.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""PR scope drift 偵測（pr-preflight 級）。
+
+設計動機——PR #39/#40 踩坑：merge 後才發現 CLAUDE.md 計數沒 bump、
+有未 commit 的 playbook LL 更新散在工作目錄，被迫另開 mini-PR 處理
+瑣碎 drift。單次 gh pr create + CI rerun + review round-trip 的成本
+遠高於「把相關 drift 塞進同一 commit」的邊界風險。
+
+本 hook 在 `make pr-preflight` 時強制執行，硬性 fail 以下任一：
+
+1. **Tool map drift** — `generate_tool_map.py --check` 不通過。典型肇因：
+   新增 / 移除 `scripts/tools/**/*.py` 但 `docs/internal/tool-map.md`
+   未重新產生（並連帶 CLAUDE.md「N 個 Python 工具」計數漂移）。
+2. **Working-tree dirty** — 準備 merge 的 branch 工作目錄含 unstaged
+   或 uncommitted staged 修改。典型肇因：session 中邊做邊改 playbook /
+   CLAUDE.md 但忘記 git add 進本次 commit。
+
+Exit:
+  0 = 通過
+  1 = 偵測到 drift
+
+說明：本 hook **刻意保守**，只報告高信號項，避免 false-positive 被繞過。
+新增 drift 項目時先把訊號量測明確再加入。
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def find_repo_root() -> Path:
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return Path(__file__).resolve().parent.parent.parent.parent
+
+
+def run(cmd: list[str], cwd: Path) -> tuple[int, str, str]:
+    """Run a subprocess, return (exit, stdout, stderr)."""
+    proc = subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, check=False
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def check_tool_map(repo: Path) -> tuple[bool, str]:
+    """Return (ok, message).
+
+    generate_tool_map.py --check prints a clear "outdated" line and is tightly
+    scoped to scripts/tools/**/*.py vs docs/internal/tool-map.md consistency.
+    Caveat: exits 0 even on drift (known issue with that script). We parse
+    stdout for the failure sentinel instead of relying on exit code.
+    """
+    rc, stdout, stderr = run(
+        ["python3", "scripts/tools/dx/generate_tool_map.py", "--check"], repo
+    )
+    combined = (stdout + stderr).strip()
+    if rc == 0 and "outdated" not in combined.lower():
+        return True, "tool-map --check: PASS"
+    last = combined.splitlines()[-1] if combined else "(no output)"
+    return False, f"tool-map drift: {last}"
+
+
+def check_working_tree_clean(repo: Path) -> tuple[bool, str]:
+    """Both `git diff --quiet` (unstaged) and `git diff --cached --quiet` (staged)
+    must return 0. Untracked files are NOT checked here — they're handled by the
+    author's own discretion (adopt or delete).
+    """
+    rc_unstaged, _, _ = run(["git", "diff", "--quiet"], repo)
+    rc_staged, _, _ = run(["git", "diff", "--cached", "--quiet"], repo)
+    if rc_unstaged == 0 and rc_staged == 0:
+        return True, "working-tree clean (no unstaged / uncommitted staged)"
+
+    rc, stdout, _ = run(["git", "status", "--short"], repo)
+    lines = [ln for ln in stdout.splitlines() if ln and not ln.startswith("??")]
+    preview = "\n".join("    " + ln for ln in lines[:15])
+    return False, (
+        "working-tree has uncommitted changes (should be in this PR or reverted):\n"
+        + preview
+    )
+
+
+def main() -> int:
+    repo = find_repo_root()
+    print("[check_pr_scope_drift] scanning for PR-level drift signals...\n")
+
+    checks = [
+        ("tool-map", check_tool_map(repo)),
+        ("working-tree", check_working_tree_clean(repo)),
+    ]
+
+    failed = [name for name, (ok, _) in checks if not ok]
+    for name, (ok, msg) in checks:
+        prefix = "  PASS" if ok else "  FAIL"
+        print(f"{prefix}  [{name}] {msg}")
+
+    print()
+    if failed:
+        print(
+            "[check_pr_scope_drift] FAIL: "
+            + ", ".join(failed)
+            + "\n\n  Either fold the drift into this PR's commit, or revert it.\n"
+              "  Do NOT open a follow-up mini-PR unless the drift is genuinely\n"
+              "  out of scope (use your judgement, then justify in PR body).",
+            file=sys.stderr,
+        )
+        return 1
+    print("[check_pr_scope_drift] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tools/lint/check_pr_scope_drift.py
+++ b/scripts/tools/lint/check_pr_scope_drift.py
@@ -25,6 +25,7 @@ Exit:
 
 from __future__ import annotations
 
+import argparse
 import subprocess
 import sys
 from pathlib import Path
@@ -84,6 +85,10 @@ def check_working_tree_clean(repo: Path) -> tuple[bool, str]:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail on PR-level drift (tool-map outdated or working-tree dirty)."
+    )
+    parser.parse_args()  # no flags — just enforce unknown-arg rejection
     repo = find_repo_root()
     print("[check_pr_scope_drift] scanning for PR-level drift signals...\n")
 


### PR DESCRIPTION
## Summary

Pivot dev-rules section **P2** from text rule to **code-driven enforcement**. The PR #39/#40 tangent revealed that plain-text dev-rules rely on agent memory and don't actually prevent the mistake they describe — so P2 is now rule-body-IS-the-hook-code.

## What this adds

- `scripts/tools/lint/check_devrules_size.py` — pre-commit hook that fails when `docs/internal/dev-rules.md` exceeds **500 lines**. Back-pressure mechanism: new text rules force authors to prune existing rules, promote to an auto-hook, or archive. Raising `MAX_LINES` requires PR-body justification.
- `scripts/tools/lint/check_pr_scope_drift.py` — `pr-preflight` orchestrator. Fails on tool-map drift OR working-tree dirty. Catches the exact PR #40 scenario: uncommitted changes sitting around that should be folded in rather than opened as a follow-up mini-PR.
- `scripts/tools/dx/pr_preflight.py` — new **Scope drift** phase. `make pr-preflight` now runs **7** checks (was 6).
- `.pre-commit-config.yaml` — registers `devrules-size-check` hook.

## What this changes

- `docs/internal/dev-rules.md` — §P2 rewritten from prose rule to hook pointer. Pruned **520 → 487 lines** under the new 500-line cap; **no rule content deleted**, only example blocks compacted in §S3 and §S5.
- `CLAUDE.md` — tool count **114 → 116** (lint 38 → 40); `pr-preflight` description updated from 6- to 7-check.
- `docs/internal/tool-map.md` — regenerated.
- `Makefile` — `pr-preflight` help text updated.
- `CHANGELOG.md` — Unreleased entries reflect the code-driven pivot.

## Why this matters

Dogfooding: the PR that codifies "scope drift must fold in, not follow up" bundles every related drift (new hooks, registration, Makefile text, CLAUDE count, tool-map regen, CHANGELOG) in **one commit**, per the rule it codifies.

## Test plan

- [x] `pre-commit run --all-files` passes (sandbox hook-gate green)
- [x] New `devrules-size-check` fires when dev-rules.md grows past 500 lines (unit-verified)
- [x] `check_pr_scope_drift.py` catches the dirty-working-tree + tool-map-drift cases
- [ ] CI green
- [ ] Owner review

Refs: dev-rules.md P2, PR #39 post-merge drift
