### PR TITLE
fix(lint): harden 4 Phase .a lint scripts — encoding, regex, test harness

### DIFF
--- a/docs/internal/dev-rules.md
+++ b/docs/internal/dev-rules.md
@@ -270,6 +270,8 @@ Phase .a0 token 遷移期間確立的慣例，適用所有 JSX 互動工具。
 
 **為什麼**：axe-core `scrollable-region-focusable` rule 在任何 scrollable 且**無 focusable children** 的元素上觸發，不論是否有 `role="region"`。v2.8.0 Phase .a Day 1 scope check 發現 `notification-previewer.jsx` 雖 Day 5-7 期間移除了 `role="region"`，但 `styles.previewBox` 的 `overflowY: 'auto'` + `maxHeight: '400px'` 仍觸發 axe，印證這是容器本身屬性問題而非 role 問題。
 
+**反例：容器已有 focusable children 時勿再套 `tabIndex={0}`**（v2.8.0 Phase .a 追加補充）：若捲動容器內已經放了會吃 Tab 焦點的元素（`<button>`、`<a href>`、`<input>`、`<select>`、`[tabindex="0"]` 等），**容器自己應走 `tabIndex={-1}`**（或乾脆省略），避免 Tab 序列產生容器→內部元素的雙 stop。axe 在這種情況本來就不會觸發 `scrollable-region-focusable`（容器「有 focusable descendants」）；本規則適用範圍就是「容器是捲動區但內部沒 tabbable 元素」的純資訊顯示區塊（heatmap cells / preview panels）。
+
 **反 / 正例**（v2.7.0 實際踩過，TECH-DEBT-006 / -009）：
 
 ```jsx

--- a/scripts/ops/run_hooks_sandbox.sh
+++ b/scripts/ops/run_hooks_sandbox.sh
@@ -27,6 +27,14 @@
 #   SKIP        — passed through to pre-commit (CSV of hook IDs to skip)
 #   PRECOMMIT_LOG — override log destination (default: _sandbox_hooks.log)
 #
+# Concurrency note:
+#   The default log path (_sandbox_hooks.log) is a single shared file in
+#   the repo root. If two `make win-commit` invocations run in parallel
+#   they will overwrite each other's log and misreport status. Do NOT
+#   run concurrent win-commit / run_hooks_sandbox invocations — either
+#   serialize them, or override PRECOMMIT_LOG per caller:
+#     PRECOMMIT_LOG=_sandbox_hooks.$$.log scripts/ops/run_hooks_sandbox.sh ...
+#
 # Exit codes:
 #   0   All hooks passed
 #   1   At least one hook failed (see log for details)

--- a/scripts/tools/lint/check_techdebt_drift.py
+++ b/scripts/tools/lint/check_techdebt_drift.py
@@ -58,8 +58,10 @@ STATUS_RE = re.compile(
 )
 
 # Commit trailer: Resolves / Fixes / Closes TECH-DEBT-XXX or REG-XXX
+# Trailing `\b` guards against pathological IDs like TECH-DEBT-007x or
+# TECH-DEBT-0071 being sliced to match TECH-DEBT-007 by accident.
 TRAILER_RE = re.compile(
-    r"(?:Resolves|Fixes|Closes)\s+((?:TECH-DEBT|REG)-\d+)", re.IGNORECASE
+    r"(?:Resolves|Fixes|Closes)\s+((?:TECH-DEBT|REG)-\d+)\b", re.IGNORECASE
 )
 
 
@@ -96,8 +98,17 @@ def parse_git_log(since: str | None) -> dict[str, list[str]]:
     rev_range = f"{since}..HEAD" if since else "HEAD"
     cmd = ["git", "log", rev_range, "--pretty=%H%x00%B%x00%x00"]
     try:
+        # encoding + errors="replace" protects against Windows console
+        # codepage (cp950/cp932) surfacing in git output when commit
+        # messages contain CJK — otherwise check_output would raise
+        # UnicodeDecodeError and mask the real drift signal.
         output = subprocess.check_output(
-            cmd, text=True, stderr=subprocess.DEVNULL, cwd=REPO_ROOT
+            cmd,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            stderr=subprocess.DEVNULL,
+            cwd=REPO_ROOT,
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
         return {}

--- a/scripts/tools/lint/validate_planning_session_row.py
+++ b/scripts/tools/lint/validate_planning_session_row.py
@@ -94,11 +94,26 @@ def resolve_targets(args_paths: list[str], glob: str) -> list[Path]:
     return sorted(REPO_ROOT.glob(glob))
 
 
+def _display_path(path: Path) -> Path:
+    """Return a repo-relative path when possible, else the path as-is.
+
+    Using `Path.relative_to` directly crashes if the path is absolute but
+    lives outside REPO_ROOT (e.g. test fixture under tmp_path); we fall
+    back to the original path in that case instead of aborting the report.
+    """
+    if not path.is_absolute():
+        return path
+    try:
+        return path.relative_to(REPO_ROOT)
+    except ValueError:
+        return path
+
+
 def report(offenders_by_path: dict[Path, list[tuple[int, int, str]]], limit: int) -> None:
     for path, offenders in offenders_by_path.items():
         if not offenders:
             continue
-        print(f"\n{path.relative_to(REPO_ROOT) if path.is_absolute() else path}: "
+        print(f"\n{_display_path(path)}: "
               f"{len(offenders)} Session row(s) exceed {limit} chars")
         for lineno, n, preview in offenders:
             print(f"  L{lineno}: {n} chars — {preview}…")

--- a/tests/lint/test_check_devrules_size.py
+++ b/tests/lint/test_check_devrules_size.py
@@ -1,0 +1,92 @@
+"""Smoke tests for check_devrules_size.py — dev-rules.md line-count gate.
+
+Covers:
+  - `find_repo_root` walks parents until a `.git` is found
+  - `find_repo_root` falls back to script-relative path when cwd has no .git
+  - `main` passes when dev-rules.md is at/under MAX_LINES
+  - `main` fails with exit 1 when dev-rules.md exceeds MAX_LINES
+  - `main` fails with exit 1 when dev-rules.md is missing
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_TOOLS_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'scripts', 'tools', 'lint')
+sys.path.insert(0, _TOOLS_DIR)
+
+import check_devrules_size as cds  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# find_repo_root
+# ---------------------------------------------------------------------------
+class TestFindRepoRoot:
+    def test_finds_cwd_ancestor_with_dot_git(self, tmp_path, monkeypatch):
+        # Build: tmp/repo/.git  and  tmp/repo/sub/nested
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        nested = repo / "sub" / "nested"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+        assert cds.find_repo_root() == repo
+
+    def test_fallback_when_no_dot_git(self, tmp_path, monkeypatch):
+        """With no ancestor carrying .git, we fall back to script-parent path.
+        We don't assert the exact fallback path (it depends on where the test
+        runs from) — just that the function returns *something* without crashing.
+        """
+        monkeypatch.chdir(tmp_path)  # tmp_path has no .git anywhere above in test env
+        got = cds.find_repo_root()
+        # Should be a Path, not a crash; on actual repo test env it will hit
+        # the real vibe-k8s-lab .git and return that root, which is also fine.
+        assert got is not None
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+class TestMain:
+    def _setup_fake_repo(self, tmp_path, dev_rules_content):
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        (repo / "docs" / "internal").mkdir(parents=True)
+        if dev_rules_content is not None:
+            (repo / "docs" / "internal" / "dev-rules.md").write_text(
+                dev_rules_content, encoding="utf-8"
+            )
+        return repo
+
+    def test_under_limit_passes(self, tmp_path, monkeypatch):
+        content = "\n".join(f"line {i}" for i in range(100))  # 100 lines
+        repo = self._setup_fake_repo(tmp_path, content)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr("sys.argv", ["check_devrules_size.py"])
+        assert cds.main() == 0
+
+    def test_exactly_at_limit_passes(self, tmp_path, monkeypatch):
+        content = "\n".join(f"line {i}" for i in range(cds.MAX_LINES))
+        repo = self._setup_fake_repo(tmp_path, content)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr("sys.argv", ["check_devrules_size.py"])
+        assert cds.main() == 0
+
+    def test_over_limit_fails(self, tmp_path, monkeypatch, capsys):
+        content = "\n".join(f"line {i}" for i in range(cds.MAX_LINES + 50))
+        repo = self._setup_fake_repo(tmp_path, content)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr("sys.argv", ["check_devrules_size.py"])
+        assert cds.main() == 1
+        err = capsys.readouterr().err
+        assert "FAIL" in err
+        assert "Prune" in err or "Promote" in err or "Archive" in err
+
+    def test_missing_file_fails(self, tmp_path, monkeypatch, capsys):
+        repo = self._setup_fake_repo(tmp_path, dev_rules_content=None)
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr("sys.argv", ["check_devrules_size.py"])
+        assert cds.main() == 1
+        err = capsys.readouterr().err
+        assert "target not found" in err

--- a/tests/lint/test_check_pr_scope_drift.py
+++ b/tests/lint/test_check_pr_scope_drift.py
@@ -1,0 +1,145 @@
+"""Smoke tests for check_pr_scope_drift.py — PR-level drift gate.
+
+Covers:
+  - `run` passes encoding="utf-8" + errors="replace" (regression guard for H3-class
+    Windows cp950/cp932 UnicodeDecodeError on git stderr)
+  - `check_tool_map` parses generate_tool_map.py --check output correctly
+  - `check_working_tree_clean` treats both staged and unstaged diffs as FAIL
+  - `check_working_tree_clean` ignores untracked files (`??`)
+  - `main` returns 0 when both checks pass
+  - `main` returns 1 when any check fails
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_TOOLS_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'scripts', 'tools', 'lint')
+sys.path.insert(0, _TOOLS_DIR)
+
+import check_pr_scope_drift as cpsd  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# run — subprocess encoding contract
+# ---------------------------------------------------------------------------
+class TestRun:
+    def test_uses_utf8_encoding(self, tmp_path):
+        """The whole point of this helper (vs stdlib subprocess.run) is the
+        `encoding="utf-8", errors="replace"` contract. Guard against regression."""
+        with patch("check_pr_scope_drift.subprocess.run") as mock_run:
+            mock_run.return_value = type(
+                "R", (), {"returncode": 0, "stdout": "", "stderr": ""}
+            )()
+            cpsd.run(["echo", "hi"], cwd=tmp_path)
+            _, kwargs = mock_run.call_args
+            assert kwargs["encoding"] == "utf-8"
+            assert kwargs["errors"] == "replace"
+            assert kwargs["capture_output"] is True
+
+
+# ---------------------------------------------------------------------------
+# check_tool_map
+# ---------------------------------------------------------------------------
+class TestCheckToolMap:
+    def test_pass_when_no_outdated_keyword(self, tmp_path):
+        with patch("check_pr_scope_drift.run",
+                   return_value=(0, "tool-map is up to date", "")):
+            ok, msg = cpsd.check_tool_map(tmp_path)
+            assert ok is True
+            assert "PASS" in msg
+
+    def test_fail_when_outdated_in_stdout(self, tmp_path):
+        with patch("check_pr_scope_drift.run",
+                   return_value=(0, "tool-map outdated: 3 entries", "")):
+            ok, msg = cpsd.check_tool_map(tmp_path)
+            assert ok is False
+            assert "drift" in msg.lower()
+
+    def test_fail_when_generator_exit_nonzero(self, tmp_path):
+        with patch("check_pr_scope_drift.run",
+                   return_value=(1, "", "some error")):
+            ok, _ = cpsd.check_tool_map(tmp_path)
+            assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# check_working_tree_clean
+# ---------------------------------------------------------------------------
+class TestWorkingTreeClean:
+    def test_clean_both_passes(self, tmp_path):
+        def fake_run(cmd, cwd):
+            return (0, "", "")
+        with patch("check_pr_scope_drift.run", side_effect=fake_run):
+            ok, msg = cpsd.check_working_tree_clean(tmp_path)
+            assert ok is True
+            assert "clean" in msg
+
+    def test_unstaged_changes_fails(self, tmp_path):
+        calls = {"i": 0}
+        def fake_run(cmd, cwd):
+            calls["i"] += 1
+            if cmd[:2] == ["git", "diff"] and "--cached" not in cmd and "--quiet" in cmd:
+                return (1, "", "")  # unstaged dirty
+            if cmd[:3] == ["git", "diff", "--cached"]:
+                return (0, "", "")
+            if cmd[:2] == ["git", "status"]:
+                return (0, " M file.txt\n", "")
+            return (0, "", "")
+        with patch("check_pr_scope_drift.run", side_effect=fake_run):
+            ok, msg = cpsd.check_working_tree_clean(tmp_path)
+            assert ok is False
+            assert "uncommitted" in msg
+
+    def test_staged_changes_fails(self, tmp_path):
+        def fake_run(cmd, cwd):
+            if cmd[:2] == ["git", "diff"] and "--cached" not in cmd:
+                return (0, "", "")
+            if cmd[:3] == ["git", "diff", "--cached"]:
+                return (1, "", "")  # staged dirty
+            if cmd[:2] == ["git", "status"]:
+                return (0, "M  staged.txt\n", "")
+            return (0, "", "")
+        with patch("check_pr_scope_drift.run", side_effect=fake_run):
+            ok, _ = cpsd.check_working_tree_clean(tmp_path)
+            assert ok is False
+
+    def test_untracked_ignored(self, tmp_path):
+        """`?? untracked_file` lines should be filtered out of the preview, and
+        if diff --quiet returns 0, we're clean regardless of untracked files."""
+        def fake_run(cmd, cwd):
+            if cmd[:2] == ["git", "diff"]:
+                return (0, "", "")
+            return (0, "?? scratch.txt\n", "")
+        with patch("check_pr_scope_drift.run", side_effect=fake_run):
+            ok, _ = cpsd.check_working_tree_clean(tmp_path)
+            assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# main — end-to-end exit code
+# ---------------------------------------------------------------------------
+class TestMain:
+    def test_all_pass_returns_zero(self, capsys, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["check_pr_scope_drift.py"])
+        with patch("check_pr_scope_drift.check_tool_map",
+                   return_value=(True, "tool-map: PASS")), \
+             patch("check_pr_scope_drift.check_working_tree_clean",
+                   return_value=(True, "clean")):
+            rc = cpsd.main()
+            assert rc == 0
+
+    def test_tool_map_fail_returns_one(self, capsys, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["check_pr_scope_drift.py"])
+        with patch("check_pr_scope_drift.check_tool_map",
+                   return_value=(False, "tool-map drift")), \
+             patch("check_pr_scope_drift.check_working_tree_clean",
+                   return_value=(True, "clean")):
+            rc = cpsd.main()
+            assert rc == 1
+            err = capsys.readouterr().err
+            assert "FAIL" in err

--- a/tests/lint/test_check_techdebt_drift.py
+++ b/tests/lint/test_check_techdebt_drift.py
@@ -1,0 +1,166 @@
+"""Smoke tests for check_techdebt_drift.py — registry vs git-log drift detection.
+
+Covers:
+  - `normalize_status` strips markdown emphasis + lowercases
+  - `parse_registry` extracts {id: status} from §TECH-DEBT-XXX headings
+  - `TRAILER_RE` `\\b` hardening: TECH-DEBT-007 does not match TECH-DEBT-0071
+  - `detect_drift` classifies Class A (open-but-resolved) / Class B
+  - `parse_git_log` uses encoding="utf-8" safely on CJK commit bodies
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+_TOOLS_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'scripts', 'tools', 'lint')
+sys.path.insert(0, _TOOLS_DIR)
+
+import check_techdebt_drift as ctd  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# normalize_status
+# ---------------------------------------------------------------------------
+class TestNormalizeStatus:
+    def test_strips_bold_markers(self):
+        assert ctd.normalize_status("**resolved**") == "resolved"
+
+    def test_strips_backticks(self):
+        assert ctd.normalize_status("`open`") == "open"
+
+    def test_lowercases(self):
+        assert ctd.normalize_status("RESOLVED") == "resolved"
+
+    def test_mixed(self):
+        assert ctd.normalize_status("  **`IN-PROGRESS`**  ") == "in-progress"
+
+
+# ---------------------------------------------------------------------------
+# parse_registry
+# ---------------------------------------------------------------------------
+class TestParseRegistry:
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert ctd.parse_registry(tmp_path / "nope.md") == {}
+
+    def test_basic_block(self, tmp_path):
+        f = tmp_path / "reg.md"
+        f.write_text(
+            "# Known regressions\n\n"
+            "### TECH-DEBT-005：some title\n\n"
+            "| field | value |\n"
+            "|---|---|\n"
+            "| `status` | `open` |\n"
+            "| owner | maintainer |\n\n"
+            "### REG-003: another title\n\n"
+            "| `status` | **resolved** |\n",
+            encoding="utf-8",
+        )
+        result = ctd.parse_registry(f)
+        assert result == {"TECH-DEBT-005": "open", "REG-003": "resolved"}
+
+    def test_only_first_status_per_block_captured(self, tmp_path):
+        """detail blocks sometimes repeat the status in §4 summary; only first wins."""
+        f = tmp_path / "reg.md"
+        f.write_text(
+            "### TECH-DEBT-010：...\n\n"
+            "| `status` | resolved |\n"
+            "later restated:\n"
+            "| status | open |\n",
+            encoding="utf-8",
+        )
+        assert ctd.parse_registry(f) == {"TECH-DEBT-010": "resolved"}
+
+
+# ---------------------------------------------------------------------------
+# TRAILER_RE word boundary hardening (L4 fix)
+# ---------------------------------------------------------------------------
+class TestTrailerRegex:
+    def test_matches_plain(self):
+        m = ctd.TRAILER_RE.search("Resolves TECH-DEBT-007 per PR review")
+        assert m and m.group(1) == "TECH-DEBT-007"
+
+    def test_matches_case_insensitive(self):
+        m = ctd.TRAILER_RE.search("fixes reg-003")
+        assert m and m.group(1).upper() == "REG-003"
+
+    def test_multi_digit_id_captured_in_full(self):
+        """Sanity check that the greedy \\d+ captures the full numeric suffix,
+        not a prefix (this held even without the \\b; kept as regression guard)."""
+        m = ctd.TRAILER_RE.search("Resolves TECH-DEBT-0071 hypothetical")
+        assert m and m.group(1) == "TECH-DEBT-0071"
+
+    def test_does_not_match_trailing_junk(self):
+        """The `\\b` hardening's actual job: Resolves TECH-DEBT-007x should
+        not match at all, because `7` -> `x` is not a word boundary.
+        Without `\\b` the regex would wrongly capture TECH-DEBT-007."""
+        m = ctd.TRAILER_RE.search("Resolves TECH-DEBT-007x garbage")
+        assert m is None
+
+
+# ---------------------------------------------------------------------------
+# detect_drift
+# ---------------------------------------------------------------------------
+class TestDetectDrift:
+    def test_class_a_open_with_commit(self):
+        registry = {"TECH-DEBT-005": "open"}
+        refs = {"TECH-DEBT-005": ["abc1234"]}
+        class_a, class_b = ctd.detect_drift(registry, refs)
+        assert class_a == [("TECH-DEBT-005", "open", ["abc1234"])]
+        assert class_b == []
+
+    def test_class_b_resolved_without_commit(self):
+        registry = {"REG-003": "resolved"}
+        refs: dict[str, list[str]] = {}
+        class_a, class_b = ctd.detect_drift(registry, refs)
+        assert class_a == []
+        assert class_b == ["REG-003"]
+
+    def test_neither_when_open_and_no_commit(self):
+        registry = {"TECH-DEBT-020": "open"}
+        class_a, class_b = ctd.detect_drift(registry, {})
+        assert class_a == [] and class_b == []
+
+    def test_neither_when_resolved_with_commit(self):
+        registry = {"TECH-DEBT-007": "resolved"}
+        refs = {"TECH-DEBT-007": ["def5678"]}
+        class_a, class_b = ctd.detect_drift(registry, refs)
+        assert class_a == [] and class_b == []
+
+
+# ---------------------------------------------------------------------------
+# parse_git_log — subprocess UTF-8 hardening (H3 fix)
+# ---------------------------------------------------------------------------
+class TestParseGitLog:
+    def test_subprocess_call_uses_utf8_encoding(self):
+        """Regression guard for H3: subprocess.check_output must pass
+        encoding='utf-8' + errors='replace' so CJK commit bodies do not
+        crash the parser on Windows cp950/cp932 consoles."""
+        cji_body = (
+            "fakesha\x00"
+            "feat(foo): 中文訊息 with 日本語\n\n"
+            "Resolves TECH-DEBT-042\n"
+            "\x00\x00"
+        )
+        with patch("check_techdebt_drift.subprocess.check_output",
+                   return_value=cji_body) as mock_co:
+            refs = ctd.parse_git_log(since=None)
+            assert "TECH-DEBT-042" in refs
+            # Verify the caller actually requested UTF-8 decoding.
+            _, kwargs = mock_co.call_args
+            assert kwargs.get("encoding") == "utf-8"
+            assert kwargs.get("errors") == "replace"
+
+    def test_git_not_found_returns_empty(self):
+        """FileNotFoundError from git missing should degrade gracefully."""
+        with patch("check_techdebt_drift.subprocess.check_output",
+                   side_effect=FileNotFoundError):
+            assert ctd.parse_git_log(since=None) == {}
+
+    def test_git_error_returns_empty(self):
+        with patch("check_techdebt_drift.subprocess.check_output",
+                   side_effect=subprocess.CalledProcessError(1, ["git"])):
+            assert ctd.parse_git_log(since=None) == {}

--- a/tests/lint/test_validate_planning_session_row.py
+++ b/tests/lint/test_validate_planning_session_row.py
@@ -1,0 +1,125 @@
+"""Smoke tests for validate_planning_session_row.py — §12.1 Session Ledger bloat guard.
+
+Covers:
+  - `find_offending_rows` only scans inside §12.1 scope
+  - Divider lines (`| --- | --- |`) are skipped, not flagged as rows
+  - Rows under limit pass; over-limit rows reported with line number + char count
+  - `resolve_targets` falls back to glob when no CLI path given
+  - `main` returns 0 when no planning docs match the glob
+  - `main` returns 1 when at least one row exceeds the limit
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_TOOLS_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'scripts', 'tools', 'lint')
+sys.path.insert(0, _TOOLS_DIR)
+
+import validate_planning_session_row as vpsr  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# find_offending_rows
+# ---------------------------------------------------------------------------
+class TestFindOffendingRows:
+    def _write_planning(self, path, ledger_rows, pre="", post=""):
+        content = (
+            "---\ntitle: fake planning\n---\n\n"
+            f"{pre}"
+            "### 12.1 Session Ledger（Working Log）\n\n"
+            "| Session | Notes |\n"
+            "|---|---|\n"
+        )
+        content += "\n".join(ledger_rows) + "\n"
+        content += f"\n### 12.2 Next section\n\n{post}"
+        path.write_text(content, encoding="utf-8")
+
+    def test_row_under_limit_passes(self, tmp_path):
+        f = tmp_path / "v2.9.0-planning.md"
+        self._write_planning(f, ["| #01 | short summary |"])
+        offenders = vpsr.find_offending_rows(f, limit=2000)
+        assert offenders == []
+
+    def test_row_over_limit_flagged(self, tmp_path):
+        f = tmp_path / "v2.9.0-planning.md"
+        big_row = "| #99 | " + ("x" * 2500) + " |"
+        self._write_planning(f, [big_row])
+        offenders = vpsr.find_offending_rows(f, limit=2000)
+        assert len(offenders) == 1
+        lineno, n, preview = offenders[0]
+        assert n > 2000
+        assert "xxxx" in preview
+
+    def test_divider_lines_not_flagged(self, tmp_path):
+        """A divider `| --- | --- |` must never be reported as a bloated row
+        even if its character length happens to exceed the limit."""
+        f = tmp_path / "v2.9.0-planning.md"
+        big_divider = "|" + ("-" * 2500) + "|"
+        self._write_planning(f, [big_divider])
+        offenders = vpsr.find_offending_rows(f, limit=2000)
+        assert offenders == []
+
+    def test_scope_restricted_to_12_1(self, tmp_path):
+        """Long rows OUTSIDE §12.1 (e.g. a live-tracker table) must be ignored."""
+        f = tmp_path / "v2.9.0-planning.md"
+        content = (
+            "### 12.1 Session Ledger\n\n"
+            "| #01 | short |\n\n"
+            "### 12.2 Live Tracker\n\n"
+            "| 1 | " + ("y" * 3000) + " |\n"
+        )
+        f.write_text(content, encoding="utf-8")
+        offenders = vpsr.find_offending_rows(f, limit=2000)
+        assert offenders == []
+
+    def test_missing_file_returns_empty(self, tmp_path, capsys):
+        offenders = vpsr.find_offending_rows(tmp_path / "nope.md", limit=2000)
+        assert offenders == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_targets
+# ---------------------------------------------------------------------------
+class TestResolveTargets:
+    def test_cli_paths_take_precedence(self):
+        targets = vpsr.resolve_targets(["a.md", "b.md"], "docs/internal/v*.md")
+        assert [t.name for t in targets] == ["a.md", "b.md"]
+
+    def test_empty_falls_back_to_glob(self):
+        # glob against REPO_ROOT — result may be empty in CI clone, either is fine.
+        targets = vpsr.resolve_targets([], "docs/internal/NONEXISTENT-*.md")
+        assert targets == []
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+class TestMain:
+    def test_no_docs_matches_glob_returns_zero(self, tmp_path, capsys):
+        rc = vpsr.main(["--glob", "docs/internal/NONEXISTENT-*.md"])
+        assert rc == 0
+
+    def test_over_limit_returns_one(self, tmp_path):
+        f = tmp_path / "v9.0.0-planning.md"
+        content = (
+            "### 12.1 Session Ledger\n\n"
+            "|s|n|\n|---|---|\n"
+            "| #1 | " + ("z" * 3000) + " |\n"
+        )
+        f.write_text(content, encoding="utf-8")
+        rc = vpsr.main([str(f), "--limit", "2000"])
+        assert rc == 1
+
+    def test_under_limit_returns_zero(self, tmp_path):
+        f = tmp_path / "v9.0.0-planning.md"
+        content = (
+            "### 12.1 Session Ledger\n\n"
+            "|s|n|\n|---|---|\n"
+            "| #1 | short |\n"
+        )
+        f.write_text(content, encoding="utf-8")
+        rc = vpsr.main([str(f), "--limit", "2000"])
+        assert rc == 0


### PR DESCRIPTION
## Summary

Review-driven hardening bundle for 4 v2.8.0 Phase .a Policy-as-Code lint scripts. Came out of a three-round code review (PR #25..#45) that found the new hooks were land-without-tests and carried one encoding latent bug.

## Type of Change

- [x] Bug fix
- [x] CI/CD / Tooling
- [ ] Feature (new functionality)
- [ ] Documentation
- [ ] Refactoring (no behavior change)
- [ ] Release

## What changed

### Fixes (2 scripts)

**`scripts/tools/lint/check_techdebt_drift.py`**
- `parse_git_log`: `subprocess.check_output` now passes `encoding="utf-8", errors="replace"`. Without it, a CJK commit body on a Windows cp950/cp932 console raised `UnicodeDecodeError` and silently masked real drift signal. Matches the pattern already in `check_pr_scope_drift.run()`.
- `TRAILER_RE`: added trailing `\b` so `Resolves TECH-DEBT-007x` no longer spuriously matches `TECH-DEBT-007`.

**`scripts/tools/lint/validate_planning_session_row.py`**
- Extracted `_display_path()` helper with `try/except ValueError`. `Path.relative_to()` crashed when an absolute path lived outside `REPO_ROOT` (pytest `tmp_path` surfaced this latent bug while writing the test harness below).

### Test harness — `tests/lint/`, **44 tests**

| File | Tests | Coverage |
|---|---|---|
| `test_check_techdebt_drift.py` | 18 | normalize_status · parse_registry · TRAILER_RE word-boundary cases · detect_drift Class A/B · parse_git_log UTF-8 regression guard · graceful FileNotFoundError / CalledProcessError |
| `test_validate_planning_session_row.py` | 10 | scope restricted to §12.1 · divider-line skip · over-limit row flagged · glob fallback · `main` exit code |
| `test_check_devrules_size.py` | 6 | `find_repo_root` ancestor walk + script-relative fallback · under / at / over limit · missing file |
| `test_check_pr_scope_drift.py` | 10 | `run()` encoding contract regression guard · `check_tool_map` outdated-keyword parse · `check_working_tree_clean` staged vs unstaged vs untracked-ignored · `main` end-to-end exit code |

### Docs (2)

- **`docs/internal/dev-rules.md` §S3** — counter-example clarifying `tabIndex={0}` applies **only** to scrollable containers **without** focusable descendants; containers with tabbable children should use `tabIndex={-1}` to avoid double focus stops.
- **`scripts/ops/run_hooks_sandbox.sh`** — header adds concurrency warning: the shared `_sandbox_hooks.log` is unsharded, so parallel `make win-commit` invocations overwrite each other's log. Workaround documented: `PRECOMMIT_LOG=_sandbox_hooks.$$.log`.

## Why

v2.8.0 Phase .a PRs #38 / #39 / #40 introduced four pre-commit / pre-push hooks that encode Policy-as-Code for TECH-DEBT drift, planning doc bloat, dev-rules.md size, and PR-scope drift. They shipped without any test coverage and with one cp950/cp932 encoding latent bug — which is ironic because that's exactly the pattern the project's SAST rules (PR #25) were meant to prevent.

This PR restores the invariant: **every new lint script has pytest coverage before it ships**, and subprocess calls defensively decode.

## Scope deliberately NOT in this PR

- **session-init.py JSONL concurrent-append**: the `--stats` parser already does `except json.JSONDecodeError: continue`, so torn lines self-heal. Cross-platform file locking (`fcntl` vs `msvcrt`) complexity > value.
- **`generate_tool_map.py` cp950 `UnicodeEncodeError` on `✅` emoji**: surfaced during smoke-testing this PR, deserves its own fix — `fix(lint): harden generate_tool_map.py console encoding`.
- **SAST rule #6 `input()` block**: no interactive CLI demand right now.

## Review origin

Three-round code review over PRs #25..#45, findings logged in maintainer-local `docs/internal/v2.8.0-day-pr41-45-code-review.md` (gitignored per `v*-day*-*.md` pattern). Three sub-agent claims (`B1 unwired` / `M6 .gitattributes missing` / `M7 Makefile WSL hardcoded`) were retracted after direct code verification.

## Test plan

```bash
# 1. New test harness (expect 44 passed)
python3 -m pytest tests/lint/test_check_techdebt_drift.py \
    tests/lint/test_validate_planning_session_row.py \
    tests/lint/test_check_devrules_size.py \
    tests/lint/test_check_pr_scope_drift.py -v

# 2. Spot-check touched pre-commit hooks
pre-commit run file-hygiene --all-files
pre-commit run devrules-size-check --all-files
pre-commit run check-techdebt-drift --hook-stage pre-push --all-files

# 3. Runtime smoke (both fixed scripts degrade gracefully)
python3 scripts/tools/lint/check_techdebt_drift.py       # exits 0 when registry gitignored
python3 scripts/tools/lint/validate_planning_session_row.py \
    --glob "docs/internal/NONEXISTENT-*.md"              # exits 0 on no match
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
