### PR TITLE
feat(scanner): A-10 hierarchical WatchLoop + A-8b/A-8d test harness (closes #52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ Breaking / Upgrade 七塊清楚區分），那是目標形狀。
 
 ### Added
 
+- **Phase .a Scanner correctness + test harness bundle（v2.8.0, A-10 fix + A-8b + A-8d + LL ext）**
+  - **A-10 product fix — WatchLoop hierarchical scan awareness**（`components/threshold-exporter/app/config.go` WatchLoop block, [Issue #52](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/52)）：root cause — WatchLoop 在 hierarchical mode 下仍用 flat-only `scanDirFileHashes`（`os.ReadDir(dir)` + `IsDir()` skip），看不到 `conf.d/<domain>/<region>/tenant.yaml` 等 nested tenant file 的變動，所以 file 改動**永遠不觸發 reload**；測試靠 `os.Chtimes(now-5s)` 詭技偶然湊效率才 pass。改為在 hierarchical mode 走 `scanDirHierarchical`（recursive）+ per-file hash diff。`TestWatchLoop_DebouncedReload_DetectsFileChange` 從 Chtimes 版本改為直接寫檔觸發，dev container `-race -count=30` → **30/30 PASS**（修前 1/30 flake）
+  - **A-8b `TestScanDirHierarchical_K8sSymlinkLayout`**（planning §12.2）：K8s ConfigMap mount pattern invariant lock — file-symlinks ARE followed (`os.ReadFile` resolves)、dir-symlinks NOT recursed（`filepath.WalkDir` lstat semantics），防止未來 Go stdlib 升級悄悄 regress
+  - **A-8d `TestScanDirHierarchical_MixedValidInvalid` + 新 metric `da_config_parse_failure_total{file_basename}`**：poison-pill chaos — malformed YAML 不污染 sibling 正常 file 的發現 / 掃描；broken file 仍進 hash 表（change detection 可感知 recovery）；**新 Counter** 提供「tenant 檔持續損壞」的 ops observability signal（Gemini R3 #3 原提案，per-file error-skip 邏輯本就存在，這批純加 metric exposure + behavior lock）
+  - **Testing-playbook §v2.8.0 LL #3 extension** — 本地 commit-msg hook（PR #44 C2）**只驗 header**，不驗 body/footer；CI commitlint 多驗 `footer-max-line-length` 等 body 規則。PR #51 self-review commit 本地過、CI 擋（long pytest path 被當 footer），force-push 修。暫時 mitigation + 長期 enforcement 併入 Issue #53
+  - A-8c 已於 PR #51 merge；A-8 family 至此 b/c/d 三件齊。僅 A-8 Golden Parity `hypothesis` 擴充（基礎已在 codebase）還可後續做
+
 - **Phase .a Dev Container enablement bundle（v2.8.0, PR #51 接手: Trap #62 + A-12(v) + A-8c + testing LL）**
   - **Trap #62** `windows-mcp-playbook.md` — dev container mount scope drift workaround（cp-test-revert workflow for editing claude worktree files that need to run in container）
   - **A-12(v) `scripts/session-guards/git_check_lock.sh` hardening** — self-PID + name filter（Trap #58 long-term fix）+ `.git/HEAD` NUL-byte corruption auto-repair（Trap #59 long-term fix）+ dedicated `--check-head` subcommand + 14 pytest cases

--- a/components/threshold-exporter/app/config.go
+++ b/components/threshold-exporter/app/config.go
@@ -846,36 +846,68 @@ func (m *ConfigManager) WatchLoop(interval time.Duration, stopCh <-chan struct{}
 		}
 
 		if m.isDir {
-			// Incremental reload path (v2.1.0): per-file hash check with mtime guard.
-			// scanDirFileHashes uses mtime+size to skip unchanged files (stat-only).
+			// Incremental reload path. Two scan strategies:
+			//   - Flat mode (v2.1.0): scanDirFileHashes of top-level files,
+			//     mtime-guard cheap stat, composite hash compare.
+			//   - Hierarchical mode (v2.8.0 A-10 fix, Issue #52): flat scan
+			//     cannot see nested tenant files (os.ReadDir(dir) + IsDir()
+			//     skip), so changes under conf.d/<domain>/<region>/ would
+			//     NEVER trigger a reload. Use scanDirHierarchical (recursive)
+			//     and diff the per-file hash map against the prior hierarchy
+			//     state for change detection.
 			m.mu.RLock()
 			oldH := m.fileHashes
 			oldM := m.fileMtimes
 			prevHash := m.lastHash
 			hierarchical := m.hierarchicalMode
+			priorHierHashes := m.hierarchyHashes
+			priorHierMtimes := m.hierarchyMtimes
 			m.mu.RUnlock()
 
-			_, compositeHash, _, _, err := scanDirFileHashes(m.path, oldH, oldM)
-			if err != nil {
-				log.Printf("WARN: cannot check config %s: %v", m.path, err)
-				continue
+			var changed bool
+			var reason string
+
+			if hierarchical {
+				_, _, newHashes, _, _, hErr := scanDirHierarchical(m.path, priorHierMtimes)
+				if hErr != nil {
+					log.Printf("WARN: hierarchical scan in WatchLoop failed for %s: %v", m.path, hErr)
+					continue
+				}
+				// Any file added/removed/changed constitutes a change.
+				// O(N) compare, one hash-string compare per file. At
+				// WatchInterval cadence (15s default) with 1000 files this
+				// adds ~1k comparisons/15s — negligible. Disk-read cost is
+				// in scanDirHierarchical itself; mtime-guard optimization
+				// is reserved for Phase 3 (see config_hierarchy.go L132).
+				if len(newHashes) != len(priorHierHashes) {
+					changed = true
+				} else {
+					for k, v := range newHashes {
+						if priorHierHashes[k] != v {
+							changed = true
+							break
+						}
+					}
+				}
+				// diffAndReload will categorize the actual reason via its
+				// per-tenant source/defaults hash compare; WatchLoop just
+				// needs to trigger.
+				reason = ReloadReasonForced
+			} else {
+				_, compositeHash, _, _, err := scanDirFileHashes(m.path, oldH, oldM)
+				if err != nil {
+					log.Printf("WARN: cannot check config %s: %v", m.path, err)
+					continue
+				}
+				changed = (compositeHash != prevHash)
+				reason = ReloadReasonSource
 			}
 
-			if compositeHash != prevHash {
+			if changed {
 				log.Printf("Config changed, scheduling debounced reload...")
 				// v2.7.0: route through debounce even for flat mode so an
 				// ops tool that rapidly rewrites multiple files coalesces
-				// into a single reload. When hierarchicalMode is already
-				// on, diffAndReload handles everything; when still off,
-				// triggerDebouncedReload falls through to IncrementalLoad
-				// via the diffAndReload → IncrementalLoad branch.
-				reason := ReloadReasonSource
-				if hierarchical {
-					// We don't yet know *which* file changed from the
-					// composite hash alone; the actual categorization
-					// happens inside diffAndReload.
-					reason = ReloadReasonForced
-				}
+				// into a single reload.
 				m.triggerDebouncedReload(reason)
 			}
 		} else {

--- a/components/threshold-exporter/app/config_hierarchy.go
+++ b/components/threshold-exporter/app/config_hierarchy.go
@@ -230,6 +230,10 @@ func scanDirHierarchical(rootPath string, priorMtimes map[string]fileStat) (
 		}
 		if perr := yaml.Unmarshal(data, &doc); perr != nil {
 			log.Printf("WARN: cannot parse %s: %v", path, perr)
+			// v2.8.0 A-8d: expose parse failure as a Prometheus counter so
+			// ops can alert on "tenant file persistently broken". label is
+			// basename (not full path) to cap cardinality.
+			IncParseFailure(filepath.Base(path))
 			return nil
 		}
 		if len(doc.Tenants) == 0 {

--- a/components/threshold-exporter/app/config_hierarchy_integration_test.go
+++ b/components/threshold-exporter/app/config_hierarchy_integration_test.go
@@ -185,10 +185,10 @@ tenants:
   tenant-a:
     mysql_connections: "77"
 `)
-	// Bump mtime explicitly so the flat scanDirFileHashes composite hash
-	// picks up the change past its 2s age guard.
-	os.Chtimes(filepath.Join(dir, "team-a", "tenant-a.yaml"),
-		time.Now().Add(-5*time.Second), time.Now().Add(-5*time.Second))
+	// v2.8.0 A-10 fix (Issue #52, PR #54): no longer need `os.Chtimes(past)`
+	// trick — WatchLoop in hierarchical mode now uses scanDirHierarchical
+	// (recursive) instead of flat scanDirFileHashes, so nested tenant file
+	// writes are detected directly via content hash without mtime tricks.
 
 	// Wait up to 3s for the new hash to differ. CI runners under load occasionally
 	// need >1s for the 20ms WatchLoop tick + 10ms debounce + fsync + diff to

--- a/components/threshold-exporter/app/config_hierarchy_test.go
+++ b/components/threshold-exporter/app/config_hierarchy_test.go
@@ -9,9 +9,13 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // writeFile is a test helper that creates the parent dir and writes content.
@@ -277,5 +281,235 @@ func TestInheritanceGraph_DefaultsToTenantsOrder(t *testing.T) {
 	sortStrings(ours)
 	if !reflect.DeepEqual(cross, ours) {
 		t.Errorf("local sort diverges from stdlib: stdlib=%v ours=%v", cross, ours)
+	}
+}
+
+// TestScanDirHierarchical_K8sSymlinkLayout (A-8b, planning §12.2) locks
+// the invariants around Kubernetes ConfigMap mount layouts:
+//
+//   conf.d/                        ← exporter mount root
+//     _defaults.yaml  → real/_defaults.yaml        (file-symlink)
+//     team-a/                                      (real directory)
+//       tenant-a.yaml → ../real/tenant-a.yaml      (file-symlink)
+//     sl-dir/         → real/                      (dir-symlink)
+//     real/                                        (actual content)
+//       _defaults.yaml
+//       tenant-a.yaml
+//       nested-only.yaml                           (only reachable via sl-dir)
+//
+// Go `filepath.WalkDir` under the hood uses `fs.DirEntry` + `Lstat`:
+//   - **file-level symlinks** ARE followed when we call `os.ReadFile(path)`
+//     (ReadFile uses Stat, which resolves symlinks) → content IS read
+//   - **dir-level symlinks** are NOT recursed into (WalkDir sees them as
+//     non-dir leaves via Lstat; we then call os.ReadFile which fails
+//     with "is a directory" and we log+skip)
+//
+// K8s ConfigMap mount pattern flattens to file-level symlinks only
+// (nested keys are legal via `/` in the key name becoming subdirs, but
+// each leaf is a file-symlink). So file-symlinks must work; dir-symlinks
+// must NOT cause double-walk or infinite loops.
+//
+// The production scanner relies on this behavior but never asserts it.
+// Per Gemini R3 #1: invariant under-test → future Go stdlib change could
+// silently regress. This test nails it down.
+func TestScanDirHierarchical_K8sSymlinkLayout(t *testing.T) {
+	// Skip on platforms that can't create symlinks without privilege.
+	// Linux CI (ubuntu-latest) always works; Windows developer-mode
+	// usually has symlinks enabled but CI runners may not.
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires Windows Developer Mode; covered on Linux CI")
+	}
+
+	// Real content lives OUTSIDE the scan root. K8s ConfigMap mount does
+	// the equivalent via `..data/` hidden by the dotfile prefix; here we
+	// just keep the backing dir as a separate tmp to avoid the scanner
+	// walking it directly (which would produce duplicate tenant IDs from
+	// both the real path AND the symlink resolution).
+	tmp := t.TempDir()
+	root := filepath.Join(tmp, "root")
+	backing := filepath.Join(tmp, "backing")
+
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	writeFile(t, filepath.Join(backing, "_defaults.yaml"), `defaults:
+  level: L0
+`)
+	writeFile(t, filepath.Join(backing, "tenant-a.yaml"), `tenants:
+  tenant-a:
+    threshold:
+      cpu: 90
+`)
+	writeFile(t, filepath.Join(backing, "nested-only.yaml"), `tenants:
+  nested-only:
+    threshold:
+      cpu: 95
+`)
+
+	// File-symlink at root: should be followed (K8s-style key mount).
+	if err := os.Symlink(
+		filepath.Join(backing, "_defaults.yaml"),
+		filepath.Join(root, "_defaults.yaml"),
+	); err != nil {
+		t.Fatalf("symlink root file: %v", err)
+	}
+
+	// File-symlink in subdirectory: K8s "team-a/tenant-a.yaml" key format.
+	if err := os.MkdirAll(filepath.Join(root, "team-a"), 0o755); err != nil {
+		t.Fatalf("mkdir team-a: %v", err)
+	}
+	if err := os.Symlink(
+		filepath.Join(backing, "tenant-a.yaml"),
+		filepath.Join(root, "team-a", "tenant-a.yaml"),
+	); err != nil {
+		t.Fatalf("symlink nested file: %v", err)
+	}
+
+	// Dir-symlink: should NOT be recursed into. `nested-only.yaml`
+	// is ONLY reachable via this symlink path — so if we see it in
+	// `tenants`, the scanner mistakenly followed the dir-symlink.
+	if err := os.Symlink(
+		backing,
+		filepath.Join(root, "sl-dir"),
+	); err != nil {
+		t.Fatalf("symlink dir: %v", err)
+	}
+
+	tenants, defaults, hashes, _, graph, err := scanDirHierarchical(root, nil)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	// Invariant #1: root-level file-symlink followed → _defaults.yaml
+	// is registered as a defaults file.
+	if len(defaults) == 0 {
+		t.Errorf("defaults map empty; file-symlink at root not followed")
+	}
+
+	// Invariant #2: subdirectory file-symlink followed → tenant-a
+	// discovered via team-a/tenant-a.yaml path.
+	if _, ok := tenants["tenant-a"]; !ok {
+		t.Errorf("tenant-a missing; nested file-symlink not followed (WalkDir behavior regressed)")
+	}
+
+	// Invariant #3: tenant-a has a non-empty defaults chain (L0 picked up
+	// from the root symlink'd _defaults.yaml).
+	if chain := graph.TenantDefaults["tenant-a"]; len(chain) == 0 {
+		t.Errorf("tenant-a defaults chain empty; _defaults.yaml not in hierarchy")
+	}
+
+	// Invariant #4: dir-symlink NOT recursed — nested-only tenant MUST
+	// NOT appear. If it does, scanner is double-walking (also potential
+	// infinite-loop risk if the symlink pointed at an ancestor).
+	if _, ok := tenants["nested-only"]; ok {
+		t.Errorf("nested-only tenant discovered; scanner recursed into dir-symlink (should skip)")
+	}
+
+	// Invariant #5: exactly 2 yaml hashes (the two file-symlinks resolved).
+	// If we see 3+, either dir-symlink got followed OR the backing dir
+	// is visible inside the scan root.
+	yamlCount := 0
+	for path, h := range hashes {
+		if filepath.Ext(path) == ".yaml" && h != "" {
+			yamlCount++
+		}
+	}
+	if yamlCount != 2 {
+		t.Errorf("yaml hash count = %d, want exactly 2 (the two file-symlinks)", yamlCount)
+	}
+}
+
+// TestScanDirHierarchical_MixedValidInvalid (A-8d, planning §12.2) locks
+// the "poison pill isolation" invariant: a malformed YAML file in the
+// scan tree must not block discovery / hashing of sibling valid files.
+//
+// Also verifies the v2.8.0 A-8d observability metric
+// `da_config_parse_failure_total{file_basename=...}` is incremented
+// so ops can alert on persistently broken tenant files.
+//
+// Per Gemini R3 #3: per-file error-skip already exists in scanner
+// (config_hierarchy.go yaml.Unmarshal warn+return nil). This test nails
+// the behavior down AND exposes the observability hook.
+func TestScanDirHierarchical_MixedValidInvalid(t *testing.T) {
+	root := t.TempDir()
+
+	// Reset metrics so the parseFailures counter is fresh for assertion.
+	// Save+restore rather than nil-out in cleanup — getConfigMetrics does
+	// not re-init after sync.Once fires, so a nil substitution would crash
+	// subsequent tests in the same process.
+	origMetrics := getConfigMetrics()
+	freshMetrics := newConfigMetrics()
+	setConfigMetrics(freshMetrics)
+	t.Cleanup(func() { setConfigMetrics(origMetrics) })
+
+	// Valid sibling — must survive the broken neighbor.
+	writeFile(t, filepath.Join(root, "team-a", "t-good.yaml"), `tenants:
+  t-good:
+    threshold:
+      cpu: 80
+`)
+
+	// Poison pill — unclosed brace, YAML parser will error.
+	writeFile(t, filepath.Join(root, "team-a", "broken.yaml"),
+		"tenants:\n  broken-tenant:\n    threshold: {unclosed\n")
+
+	// Second valid sibling in a different directory — broken.yaml in
+	// team-a must not bleed into team-b scanning.
+	writeFile(t, filepath.Join(root, "team-b", "t-ok.yaml"), `tenants:
+  t-ok:
+    threshold:
+      cpu: 70
+`)
+
+	tenants, _, hashes, _, _, err := scanDirHierarchical(root, nil)
+	if err != nil {
+		t.Fatalf("scan should not return error on per-file parse failure: %v", err)
+	}
+
+	// Invariant #1: valid siblings discovered normally.
+	if _, ok := tenants["t-good"]; !ok {
+		t.Errorf("t-good missing; broken sibling poisoned the scan")
+	}
+	if _, ok := tenants["t-ok"]; !ok {
+		t.Errorf("t-ok (different dir) missing; error propagated across dirs")
+	}
+
+	// Invariant #2: broken tenant NOT discovered (yaml.Unmarshal failed
+	// before `decls` append). Good — we don't want ghost entries.
+	if _, ok := tenants["broken-tenant"]; ok {
+		t.Errorf("broken-tenant should NOT be registered; its YAML didn't parse")
+	}
+
+	// Invariant #3: broken.yaml IS in the hashes map (hash of raw bytes
+	// happens before yaml parse). This is important for change detection
+	// — if a tenant file becomes malformed, subsequent scans should still
+	// notice the hash changed so WatchLoop can trigger a reload attempt.
+	brokenHashFound := false
+	for path, h := range hashes {
+		if filepath.Base(path) == "broken.yaml" && h != "" {
+			brokenHashFound = true
+			break
+		}
+	}
+	if !brokenHashFound {
+		t.Errorf("broken.yaml not in hashes; change detection will miss recovery")
+	}
+
+	// Invariant #4: parse-failure metric incremented exactly once for
+	// the broken file's basename. Pulls counter value via the test-only
+	// collector API.
+	ch := make(chan prometheus.Metric, 1)
+	freshMetrics.parseFailures.WithLabelValues("broken.yaml").Collect(ch)
+	close(ch)
+	var count float64
+	for m := range ch {
+		var dto dto.Metric
+		if err := m.Write(&dto); err != nil {
+			t.Fatalf("metric.Write: %v", err)
+		}
+		count = dto.GetCounter().GetValue()
+	}
+	if count != 1 {
+		t.Errorf("da_config_parse_failure_total{file_basename=broken.yaml} = %v, want 1", count)
 	}
 }

--- a/components/threshold-exporter/app/config_metrics.go
+++ b/components/threshold-exporter/app/config_metrics.go
@@ -46,6 +46,7 @@ type configMetrics struct {
 	scanDuration     prometheus.Histogram
 	reloadTriggers   *prometheus.CounterVec
 	defaultsNoop     prometheus.Counter
+	parseFailures    *prometheus.CounterVec // v2.8.0 A-8d: per-file YAML parse failures
 }
 
 // Default metric instance used by the production server. Tests that want
@@ -76,6 +77,10 @@ func newConfigMetrics() *configMetrics {
 			Name: "da_config_defaults_change_noop_total",
 			Help: "Count of _defaults.yaml changes that did NOT move any dependent tenant's merged_hash (ADR-018 'quiet defaults edit').",
 		}),
+		parseFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "da_config_parse_failure_total",
+			Help: "Count of per-file YAML parse failures during hierarchical scan (v2.8.0 A-8d). Label 'file_basename' lets ops pin down which tenant or defaults file is broken. Alert: >5/h for any single basename = page ops.",
+		}, []string{"file_basename"}),
 	}
 }
 
@@ -116,6 +121,17 @@ func registerConfigMetrics(reg prometheus.Registerer, m *configMetrics) {
 	reg.MustRegister(m.scanDuration)
 	reg.MustRegister(m.reloadTriggers)
 	reg.MustRegister(m.defaultsNoop)
+	reg.MustRegister(m.parseFailures)
+}
+
+// IncParseFailure bumps the parse-failure counter for a specific file
+// basename. Called from scanDirHierarchical whenever yaml.Unmarshal
+// returns an error for a non-_-prefixed tenant file. file_basename
+// (not full path) is used as the label to keep cardinality bounded
+// in practice — same tenant name across domains sums to one series.
+// v2.8.0 A-8d (Issue #52-adjacent observability gap from Gemini R3).
+func IncParseFailure(fileBasename string) {
+	getConfigMetrics().parseFailures.WithLabelValues(fileBasename).Inc()
 }
 
 // ObserveScanDuration starts a timer and returns a stop function that

--- a/docs/internal/testing-playbook.md
+++ b/docs/internal/testing-playbook.md
@@ -562,6 +562,8 @@ Phase .a0 已將主要互動工具加 `data-testid`（wizard、playground、conf
 4. commit message 必須記錄：(a) 哪個 hook 被跳過、(b) 原因（引 Trap #N）、(c) 手動補跑了哪些 hook 確認通過
 5. **長期 enforcement** 追蹤於 [Issue #53](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/53)（narrow `--no-verify` bypass）
 
+> **Extension（PR #51 self-review 新發現）**：本地 `commit-msg` hook（PR #44 C2 安裝的 `scripts/hooks/commit-msg` → `pr_preflight.py --check-commit-msg`）**只驗 header**（type / scope / header length），**不驗 body / footer**。CI commitlint 多驗 `footer-max-line-length ≤ 100`、`footer-leading-blank` 等 body 規則；long pytest path / long file list 塞在 commit message 末段會被 commitlint 當 footer → 觸發 `footer-max-line-length`。PR #51 self-review commit 踩到：local 過、CI 擋、force-push-with-lease 修。**暫時 mitigation**：commit body 的 long command 改寫 `pytest <a> <b> <c>` 放在非末段、或多行斷 ≤ 100 chars。**長期 enforcement**：`pr_preflight.py --check-commit-msg` 擴充 footer 規則（沿用 `.commitlintrc.yaml` 的 `footer-max-line-length` config），併入 [Issue #53](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/53)。
+
 ### 4. Dev Container mount scope（Trap #62 連帶工作流）
 
 Dev Container 只 bind-mount 主 worktree（`C:\Users\vencs\vibe-k8s-lab\`），claude worktree 的 Edit **不會進 container**。詳 `windows-mcp-playbook.md` Trap #62。**Go test / Playwright E2E** 在 claude worktree 做 Edit 後，一律走：


### PR DESCRIPTION
## Summary

Closes [#52](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/52) at product layer + completes the A-8 test harness family. 4 items bundled under scanner/reload correctness theme; all need Dev Container for Go test verification. Continuation of PR #49/#50/#51 Phase .a chain.

## A-10 (Issue #52) real RCA — not the initially-suspected atomic-swap empty window

The Issue #52 opening narrative blamed `config_debounce.go` atomic-swap having an empty window between "clear old map entries" and "populate new map entries". Deep-read of the swap site (L346-353) shows it's **pointer replacement under write lock** — no empty window there.

**Actual root cause**: `WatchLoop`'s change-detection path used **flat-only** `scanDirFileHashes`:

```go
// config.go L858 (before fix)
_, compositeHash, _, _, err := scanDirFileHashes(m.path, oldH, oldM)
if compositeHash != prevHash { m.triggerDebouncedReload(reason) }
```

`scanDirFileHashes` uses `os.ReadDir(dir)` + `IsDir()` skip → only hashes **top-level** files. With hierarchical fixtures like:

```
conf.d/
  _defaults.yaml        ← flat scan sees this
  team-a/tenant-a.yaml  ← flat scan IGNORES (inside directory)
```

Writes to `team-a/tenant-a.yaml` never change the flat composite hash → **`triggerDebouncedReload` never fires**.

`TestWatchLoop_DebouncedReload_DetectsFileChange` was passing ~29/30 times in dev container by accident — likely some filesystem side-effect bumping `_defaults.yaml` mtime. The `os.Chtimes(now-5s)` trick in the test was a futile attempt to stabilize around the real bug.

### Fix

In hierarchical mode, use `scanDirHierarchical` (recursive) + per-file hash diff:

```go
if hierarchical {
    _, _, newHashes, _, _, hErr := scanDirHierarchical(m.path, priorHierMtimes)
    if len(newHashes) != len(priorHierHashes) { changed = true }
    else { for k, v := range newHashes {
        if priorHierHashes[k] != v { changed = true; break }
    }}
} else {
    // flat path unchanged
}
```

Cost: O(N) string compare per tick. At 15s WatchInterval with 1000 files = ~67 compares/sec. Disk-read cost is in `scanDirHierarchical` (mtime-guard optimization reserved for Phase 3).

### Test

`TestWatchLoop_DebouncedReload_DetectsFileChange` rewritten to drop `os.Chtimes(past)` entirely. Content hash differs naturally on write. **Dev container `-race -count=30` → 30/30 PASS** (previously 1/30 FAIL).

## A-8b — `TestScanDirHierarchical_K8sSymlinkLayout`

Locks invariants around K8s ConfigMap mount pattern:
- **file-symlinks ARE followed** (`os.ReadFile` resolves through) → content hashed
- **dir-symlinks NOT recursed** (`filepath.WalkDir` lstat semantics) → no double-walk or infinite-loop risk
- bounded hash count (exactly 2 file-symlinks resolved, no bleeding from backing dir)

Fixture places `backing/` OUTSIDE scan root so scanner only sees symlinks (matches K8s `..data/` hidden-prefix pattern). 5 invariants asserted. Gemini R3 #1 original proposal.

## A-8d — `TestScanDirHierarchical_MixedValidInvalid` + `da_config_parse_failure_total`

Poison-pill chaos test:
- malformed YAML in `team-a/broken.yaml` does NOT block sibling discovery (`t-good` same dir + `t-ok` different dir)
- broken file still in hashes map → change-detection can sense recovery
- **NEW Prometheus metric** `da_config_parse_failure_total{file_basename}` Counter, incremented once per yaml.Unmarshal failure

Product change: 8 lines in `config_metrics.go` (struct field + `IncParseFailure` helper + Register) + 2 lines in `config_hierarchy.go` (call site on parse-fail path). Per Gemini R3 #3 original proposal (per-file error-skip logic already exists; this PR adds observability).

## Testing-playbook §v2.8.0 LL #3 extension

PR #51 self-review commit `4c6c9a0` hit commitlint CI on `footer-max-line-length`: body contained a long pytest command commitlint treated as footer. **Local `commit-msg` hook (PR #44 C2) only validates HEADER, not body/footer** — rules like `footer-max-line-length` fire only in CI.

Added as extension to existing LL #3. Long-term enforcement (expand local validator to cover body rules) deferred to [Issue #53](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/53).

## Test plan

- [x] Dev Container: `go test -race -count=30 TestWatchLoop_DebouncedReload_DetectsFileChange` → **30/30 PASS (2.807s)**
- [x] Dev Container: `go test -race -count=5 'TestScanDirHierarchical_(K8sSymlinkLayout|MixedValidInvalid)'` → **10/10 PASS (1.029s)**
- [x] Dev Container: `go test -race ./...` (full exporter suite) → **ok 4.015s**, zero regression vs post-PR-#51 baseline
- [x] Cowork: `pre-commit run --files <staged>` — 31/31 fast hooks green (`SKIP=head-blob-hygiene` per Trap #57)
- [x] `validate_docs_versions --ci` / `generate_tool_map --check` / `generate_doc_map --check` — all green
- [x] `bump_playbook_versions --to v2.8.0 --check` — all 4 playbooks already at v2.8.0

## Notes for reviewer

**Dev Container workflow used** (Trap #62 pattern):
```bash
cp <claude-worktree-path> <main-worktree-path>
docker exec vibe-dev-container bash -c "cd /workspaces/... && go test ..."
cd /c/Users/vencs/vibe-k8s-lab && git checkout -- <paths>  # revert main worktree
```

**Why A-10 fix belongs here not in a standalone PR**: the test rewrite (drop `os.Chtimes` trick) is coupled with the product fix — without hierarchical scan awareness, the test would still flake. Keeping them together keeps the red→green signal clean.

**Issue #52 will auto-close on merge** via "closes #52" in the commit message trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)