### PR TITLE
feat(dx): pre-tag benchmark-report Phase 1 of issue #60

### DIFF
--- a/.github/workflows/bench-record.yaml
+++ b/.github/workflows/bench-record.yaml
@@ -1,0 +1,74 @@
+name: Bench Record (nightly)
+
+# Phase 1 of pre-tag benchmark gate (issue #60).
+#
+# Purpose: collect ~28 nightly data points / 4 weeks to characterize empirical
+# variance on GitHub Actions runners. This is informational only — there is NO
+# regression gate at this stage. Phase 2 will introduce a hard gate (3× of
+# median-of-5 baseline, main+release-please only) once stability is measured.
+#
+# Scope:
+#   - Runs only on main (cron + workflow_dispatch from main).
+#   - Bench artifacts retained 90 days for cross-quarter trend review.
+#   - Go version pinned to match ci.yml.
+
+on:
+  schedule:
+    # 03:00 UTC nightly — runner contention typically lowest in this window.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bench-record:
+    name: 1000-tenant baseline (informational)
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go 1.26
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-1.26-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-1.26-
+            ${{ runner.os }}-go-
+
+      - name: Run benchmark-report
+        run: make benchmark-report
+
+      - name: Summarize results
+        if: always()
+        run: |
+          echo "### Bench Record — $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          if [ -f .build/bench-baseline.txt ]; then
+            cat .build/bench-baseline.txt >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "(no bench output produced)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload bench artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-baseline-${{ github.run_id }}
+          path: |
+            .build/bench-baseline.txt
+            .build/bench.raw.jsonl
+            .build/bench.err.log
+          retention-days: 90
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ Breaking / Upgrade 七塊清楚區分），那是目標形狀。
 
 ### Added
 
+- **Pre-tag benchmark report — Phase 1 of issue #60 3-phase rollout（v2.8.0）**
+  - **`make benchmark-report`** — 1000-tenant baseline 基準測試 → `.build/bench-baseline.txt`，使用既有 `bench_wrapper.sh`（A-15）。regex `_1000(_|$)` 涵蓋 13 支 1000-scale benchmarks：8 個 legacy flat（`Benchmark{ResolveSilentModes,FullDirLoad,IncrementalLoad_1000_NoChange,IncrementalLoad_1000_NoChange_MtimeGuard,IncrementalLoad_1000_OneFileChanged,ScanDirFileHashes,ScanDirFileHashes_1000_MtimeGuard,MergePartialConfigs}_1000`）+ 5 個 hierarchical（PR #59 新加：`Benchmark{ScanDirHierarchical,FullDirLoad_Hierarchical,DiffAndReload_Hierarchical_1000_NoChange,DiffAndReload_Hierarchical_1000_OneTenantChanged,BlastRadius_DefaultsChange_Hierarchical}_1000`）。Legacy flat 仍在生產（v2.7.0 fallback path），同 scale 一併 record 給 trend 分析。預設 `-count=6 -benchtime=3s`；第一個 sample 視為 warmup，由下游 median-of-5 分析（Phase 2）丟棄，target 本身 record 全 6 個。`COUNT` / `BENCHTIME` 可覆寫
+  - **`make pre-tag` 串入 `benchmark-report-warn`** — informational only，bench 失敗不阻擋 tag。Phase 1 設計刻意不加 hard gate（issue #60 §Tension：62% CI variance 證據）；maintainer tag 前人眼看 trend
+  - **`.github/workflows/bench-record.yaml`** — nightly 03:00 UTC + `workflow_dispatch`，僅 main，artifact 保留 90 天，`GITHUB_STEP_SUMMARY` 內嵌結果。4 週累積 ~28 點數據作為 Phase 2 entry 條件（hard gate at 3× median-of-5 baseline）的判斷基準
+  - **與 issue #60 acceptance 對照**：(1) Makefile target ✅；(2) pre-tag wiring ✅；(3) `.build/bench-baseline.txt` 輸出 ✅；(4) Go 版本固定 1.26 與 ci.yml SSOT 一致 ✅；(5) nightly schedule 解決「4-week stability」資料缺口 ✅；(6) release-please attachment ⏭️ 延後（current target 寫入 `.build/`，未串接 release notes asset upload；low-effort follow-up）
+  - **不做的事**（明確分階段）：不寫 `benchmarks/baseline.json`（Phase 2）；不加 hard gate（Phase 2）；不引入 `rhysd/github-action-benchmark`（Phase 1 評估後判定 Phase 2 再考慮）；不碰 PR template / commit lint enforcement（Q3 後續獨立工作）；release-please 自動 attach asset（low-priority follow-up）
+  - 詳見 issue #60 / planning §4 Phase .b 離場條件
+
 - **Post-merge housekeeping — PR #59 follow-up drift（v2.8.0）**：PR #59（B-1 Phase 1 + B-8）merge 後例行 drift 收尾，獨立 PR 以保留主 PR diff 純淨：
   - **`docs/internal/test-coverage-matrix.md`** 新增「Tier 2 — Performance Benchmarks」章節 + Phase .b 1000+ tenant baseline 子節，登錄 PR #59 加入 `components/threshold-exporter/app/config_hierarchy_bench_test.go` 的 13 支 hierarchical benchmarks（`Benchmark{ScanDirHierarchical,FullDirLoad_Hierarchical,DiffAndReload_Hierarchical_NoChange,BlastRadius_DefaultsChange_Hierarchical}_{1000,2000,5000}` × 4 patterns + `DiffAndReload_Hierarchical_1000_OneTenantChanged`）：每筆登 Tier / Coverage Target / Last Verified（v2.8.0）；附共用 helpers（`buildDirConfigHierarchical` / `reportResourceMetrics` / `bench*AtSize` 驅動函式）說明 + Phase 1 synthetic baseline disclaimer
   - **`benchmark-playbook.md` `verified-at-version`**：已為 v2.8.0（PR #59 同步更新），本 PR 確認無需 bump

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ pre-commit run --hook-stage manual --all-files    # manual-stage
 
 五線版號（`v*` / `exporter/v*` / `tools/v*` / `portal/v*` / `tenant-api/v*`）。完整步驟、Distribution artifacts、踩坑記錄見 [`docs/internal/github-release-playbook.md`](docs/internal/github-release-playbook.md)。
 
+**Pre-tag 加跑 `make benchmark-report`（v2.8.0, issue #60 Phase 1）**：1000-tenant baseline 寫到 `.build/bench-baseline.txt`，informational only（pre-tag 不阻擋）。Tag 前人眼比上次 trend；異常時延遲 tag 並先在 issue #60 留 comment。Nightly `bench-record` workflow（main only, 90 天 retention）累積 ~28 點數據後評估 Phase 2 hard gate（3× median-of-5）。
+
 ## AI Agent 環境
 
 - **Dev Container**: `docker exec -w /workspaces/vibe-k8s-lab vibe-dev-container <cmd>`（或 `make dc-run`）

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,24 @@ go-bench-clean: ## Go micro-benchmark via bench_wrapper (stdout-clean, -json fil
 		bash $(CURDIR)/scripts/tools/ops/bench_wrapper.sh \
 		-bench=. -benchmem -count=$${COUNT:-5} -run="^$$" -timeout=15m ./...
 
+.PHONY: benchmark-report
+benchmark-report: ## 1000-scale baseline (13 benches: 8 flat + 5 hierarchical) → .build/bench-baseline.txt（issue #60 Phase 1, informational; COUNT/BENCHTIME 可覆寫）
+	@mkdir -p .build
+	@echo "[benchmark-report] running 1000-scale baseline (count=$${COUNT:-6}, benchtime=$${BENCHTIME:-3s}; samples 2..N treated as steady-state by Phase 2 median-of-5)"
+	@cd components/threshold-exporter/app && \
+		BENCH_OUT_DIR="$(CURDIR)/.build" \
+		bash $(CURDIR)/scripts/tools/ops/bench_wrapper.sh \
+		-bench='_1000(_|$$)' -benchmem -count=$${COUNT:-6} -run='^$$' \
+		-timeout=20m -benchtime=$${BENCHTIME:-3s} ./...
+	@cp .build/bench.out.txt .build/bench-baseline.txt
+	@echo "[benchmark-report] wrote .build/bench-baseline.txt ($$(wc -l < .build/bench-baseline.txt) lines)"
+	@echo "[benchmark-report] Phase 1 informational — review trend manually before tagging (issue #60)"
+
+.PHONY: benchmark-report-warn
+benchmark-report-warn: ## benchmark-report 但失敗不阻擋（pre-tag 用，issue #60 Phase 1 informational）
+	@$(MAKE) benchmark-report || \
+		echo "[pre-tag] ⚠ benchmark-report failed (informational, not blocking — issue #60 Phase 1)"
+
 .PHONY: test-alert
 test-alert: ## 硬體故障/服務中斷測試 — Kill process 模擬 Hard Outage (使用: make test-alert TENANT=db-b)
 	@./scripts/test-alert.sh $(TENANT)
@@ -437,10 +455,11 @@ version-check: ## 檢查版號一致性 (CI lint 用)
 	@python3 ./scripts/tools/dx/bump_docs.py --check
 
 .PHONY: pre-tag
-pre-tag: version-check lint-docs playbook-freshness-ll ## ⛔ Pre-tag 品質閘門（所有檢查必須通過才能打 tag）
+pre-tag: version-check lint-docs playbook-freshness-ll benchmark-report-warn ## ⛔ Pre-tag 品質閘門（所有檢查必須通過才能打 tag；benchmark-report informational）
 	@echo ""
 	@echo "============================================================"
 	@echo "  Pre-tag Gate: version-check ✅  lint-docs ✅  playbook-freshness ✅"
+	@echo "  Bench baseline: .build/bench-baseline.txt (informational, issue #60 Phase 1)"
 	@echo "  Safe to create tags."
 	@echo "============================================================"
 


### PR DESCRIPTION
## Summary

Phase 1 of the 3-phase pre-tag benchmark gate rollout proposed in [#60](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/60). Informational only — no hard regression gate at this stage.

## What lands

- **`make benchmark-report`** — runs **13 1000-scale benchmarks** (8 flat legacy + 5 hierarchical from PR #59) via existing `bench_wrapper.sh` (A-15) → writes `.build/bench-baseline.txt`. Defaults `-count=6 -benchtime=3s`; first sample acts as warmup, downstream median-of-5 analysis (Phase 2) discards it. The target itself records all 6 samples. `COUNT` / `BENCHTIME` overridable. Regex `_1000(_|$)` deliberately includes legacy flat path (`scanDirFileHashes`, `IncrementalLoad_*`) which is still production fallback per PR #59 file header.
- **`make pre-tag` calls `benchmark-report-warn`** — informational wrapper, does not block tag on bench failure (Phase 1 design; CI variance evidence in #60 §Tension shows 62% jitter on identical code).
- **`.github/workflows/bench-record.yaml`** — nightly 03:00 UTC + manual dispatch, main only, 90-day artifact retention, results inlined in `GITHUB_STEP_SUMMARY`. ~28 data points / 4 weeks gives the empirical variance baseline needed to evaluate Phase 2 entry (hard gate at 3× median-of-5).
- Doc-as-code sync: `CHANGELOG.md` Unreleased Added entry, `CLAUDE.md` Release-flow note. README.md verified not in scope (no maintainer Makefile section); doc-map.md Change Impact Matrix cited in CLAUDE.md does not actually exist in doc-map.md (separate stale-ref issue, not in this PR's scope).

## Acceptance vs issue #60

| Item | Status |
|---|---|
| (1) Makefile `benchmark-report` target | ✅ |
| (2) `pre-tag` wiring (informational) | ✅ |
| (3) `.build/bench-baseline.txt` output path | ✅ |
| (4) Go version pinned (1.26, matches `ci.yml` SSOT) | ✅ |
| (5) Nightly schedule for 4-week stability data | ✅ (decision B: main only, decision C: 90-day retention) |
| (6) **release-please attachment to GitHub Release** | ⏭️ **deferred — see note below** |

### ⚠️ Scope deviation: release-please attachment deferred

Issue #60 Phase 1 acceptance includes "release-please picks up the file; auto-attached to GitHub Release". This PR does NOT implement that. Reasoning:

- The `make pre-tag` flow writes the file to `.build/bench-baseline.txt`, which is `.gitignore`-d
- Attaching to a GitHub Release requires either (a) modifying `.github/workflows/release.yaml` to upload as release asset, or (b) committing the file under a non-ignored path
- Both add coupling to the existing release workflow that's better reviewed in isolation

**Maintainer**: please confirm deferral is OK, or push back and I'll add the asset-upload step in this PR.

## Out of scope (per phase plan)

- ❌ `benchmarks/baseline.json` — Phase 2
- ❌ Hard regression gate — Phase 2
- ❌ `rhysd/github-action-benchmark` — revisit at Phase 2 (Phase 1 deliberately lightweight)
- ❌ PR template / commit-msg lint enforcement for baseline bumps — separate Q3 follow-up
- ❌ release-please auto-attach (see deviation note above)

## Test plan

- [x] Smoke test: `COUNT=1 BENCHTIME=100ms make benchmark-report` in Dev Container — wrote 13 benchmark records (8 flat + 5 hierarchical) to `.build/bench-baseline.txt` with proper structure
- [x] Makefile dry-run (`make -n benchmark-report` / `make -n pre-tag`) — verified dependency expansion is correct: `version-check` → `lint-docs` → `playbook-freshness-ll` → `benchmark-report-warn` → final summary; `||` shell swallows non-zero so warn-wrapper never blocks
- [x] YAML syntax validated for `bench-record.yaml` (`yaml.safe_load`)
- [x] `make pr-preflight` ✅ (all 6 gates green: branch, behind-main, conflict, local-hooks, scope-drift, CI status — only "PR mergeable" warning is "needs review approval" which is expected pre-approval)
- [x] All 28 applicable pre-commit hooks pass (`head-blob-hygiene` skipped per project's codified `make commit-bypass-hh` pattern — verified passing by direct invocation `python3 scripts/tools/lint/check_head_blob_hygiene.py --ci` <30s)
- [ ] Nightly workflow first run (post-merge, automatic — first run after merge to main on schedule)
- [ ] Visual review of trend file before next tag (manual, per Phase 1 design)

## Self-review notes (force-push v2 after maintainer feedback request)

Initial PR description had an error claim ("5 hierarchical bench") that didn't match actual scope (13 benchmarks via regex). Force-pushed amended commit `ab2de99` with corrected CHANGELOG.md (line lists all 13 by name) and clearer Makefile target description. No functional code change.

Refs #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)