### PR TITLE
chore(docs): doc-map scope to public docs only; exclude docs/internal/**

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Breaking / Upgrade 七塊清楚區分），那是目標形狀。
 
 ### Changed
 
+- **doc-map scope 收窄為公開文件，`docs/internal/**` 不再 catalog（v2.8.0, [#66](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/66) follow-up）** — `generate_doc_map.py` `SKIP_DIRS` + `_version_patterns.py` `DOC_MAP_SKIP_DIRS` 同步加入 `internal`。理由：catalog 真正的 consumer 是「快速查找公開文件」（AI agent / 開發者 discovery）；internal docs 的 discovery path 是 CLAUDE.md / skills / `vibe-playbook-nav`，不需要 catalog 重複登錄。修掉這個 scope 不一致也順手清掉 `validate_docs_versions.py` 對 `v2.8.0-{planning-archive,tech-debt-decomposition}.md` 的 false-positive `doc-map-coverage` warning（產生器故意排除但驗證器不知道）。doc-map 從 134 → 114 entries；公開文件 count 在 CLAUDE.md L83 + README.md 對應行同步更新並改用「公開文件」措辭以反映 scope 收窄。catalog 自描述的 `doc-map.md` / `tool-map.md` meta-entries 仍由 `SELF_ENTRIES` 手動加入，不受影響
+
 - **GitHub Actions Node 20 → Node 24 sweep（v2.8.0, chore）** — 升級全部 11 個 workflow 用到的 7 個 actions 到當前最新 stable major，避開 2026-06-02 GitHub 強制 Node 24 deadline + 26 週後 Node 20 移除：`actions/checkout@v4 → @v6`（11 處）、`actions/setup-python@v5 → @v6`（6 處）、`actions/setup-go@v5 → @v6`（3 處）、`actions/setup-node@v4 → @v6`（3 處，**確認** repo 未用 yarn/pnpm cache 故 v6「limit auto-cache to npm」breaking 不影響）、`actions/cache@v4 → @v5`、`actions/upload-artifact@v4 → @v7`、`actions/github-script@v7 → @v9`（**確認** repo 3 個 inline script 全使用 `require('fs')` + injected `github.rest.*`，未踩到 v9 移除的 `require('@actions/github')` 路徑）。74 個 reference 全替換；diff 嚴格只動 version tag 不動其他語意。verification path：本 PR 自身 CI run（trigger 多數 PR-level workflow）+ post-merge `gh workflow run bench-record.yaml`、`mkdocs-deploy.yaml` 手動 dispatch（cron/push-only workflow）
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ pre-commit run --hook-stage manual --all-files    # manual-stage
 
 ## 文件 / 工具 / Makefile
 
-- **129 份文件** 對照表 → [`docs/internal/doc-map.md`](docs/internal/doc-map.md)
+- **114 份公開文件** 對照表 → [`docs/internal/doc-map.md`](docs/internal/doc-map.md)（`docs/internal/**` 不入 catalog；那些是 maintainer / AI agent 用的 playbook/planning，由 CLAUDE.md / skills 直接引用）
 - **122 個 Python 工具** → [`docs/internal/tool-map.md`](docs/internal/tool-map.md)；CLI 速查：`da-tools <cmd> --help`
 - **39 個 JSX 互動工具** SOT：[`docs/assets/tool-registry.yaml`](docs/assets/tool-registry.yaml)
 - **Makefile** 必記 Top 7：

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ graph TD
 | [`environments/`](environments/) | CI / local 環境 profile | 跨環境差異配置 |
 | [`scripts/`](scripts/) | Shell 進入點 + `scripts/tools/{ops,dx,lint}` 下 122 個 Python 工具 | 跑工具、lint、開發者體驗 |
 | [`tests/`](tests/) | Python pytest（`test_*.py`）、shell scenario（`scenario-*.sh`）、`e2e/` Playwright、`snapshots/` | 跑測試、加測試 |
-| [`docs/`](docs/) | 129 份文件（雙語），對照表見 [doc-map](docs/internal/doc-map.md) | 讀設計/整合/運維文件 |
+| [`docs/`](docs/) | 114 份公開文件（雙語），對照表見 [doc-map](docs/internal/doc-map.md)；另有 internal playbook/planning 文件不入 catalog | 讀設計/整合/運維文件 |
 | [`operator-manifests/`](operator-manifests/) | `operator_generate.py` 產出的 PrometheusRule 範例（14 個 rule-pack） | 參考 operator 模式的輸出樣板 |
 | [`CLAUDE.md`](CLAUDE.md) | AI Agent 起手式與任務分流表 | agent session 開始前必讀 |
 | [`docs/internal/`](docs/internal/) | 內部 playbook（testing / benchmark / windows-mcp / github-release）與 maps | 排錯、release、跑 benchmark |

--- a/docs/internal/doc-map.md
+++ b/docs/internal/doc-map.md
@@ -102,26 +102,6 @@ lang: zh
 | `docs/interactive/tools/threshold-heatmap.jsx` | Platform Engineers, Domain Experts (DBA), SREs | Threshold Heatmap |
 | `docs/interactive/tools/YamlValidatorTab.jsx` | Platform Engineers, Tenants | YAML Validator Tab |
 | `docs/interactive-tools.md` (.en.md) | All | 互動式工具 |
-| `docs/internal/archive/automation-origins/trap-60-fuse-fsync.md` | maintainers, AI Agent | Trap #60 原 RCA — `generate_doc_map.py` FUSE fsync 中斷 |
-| `docs/internal/archive/automation-origins/trap-61-bom.md` | maintainers, AI Agent | Trap #61 原 RCA — PowerShell BOM 污染 commit message |
-| `docs/internal/archive/lessons-learned.md` | Platform Engineers, SREs, Contributors | Lessons Learned Archive |
-| `docs/internal/benchmark-playbook.md` | Platform Engineers, SREs | Benchmark 操作手冊 (Benchmark Playbook) |
-| `docs/internal/commit-convention.md` | contributors, maintainers | Conventional Commits Guide |
-| `docs/internal/component-health-snapshot.md` | maintainer, ui-engineer | Component Health Snapshot (v2.7.0 Phase .a baseline) |
-| `docs/internal/design/phase-b-e2e-harness.md` | maintainers, Platform Engineers | Phase 2 E2E Harness — Alert Fire-through Latency Design |
-| `docs/internal/design-system-guide.md` | maintainers | Design System Guide |
-| `docs/internal/dev-rules.md` | All | 開發規範 (Development Rules) |
-| `docs/internal/doc-template.md` | All | 文件模板規範 |
-| `docs/internal/dx-tooling-backlog.md` | maintainers, contributors | DX Tooling Backlog |
-| `docs/internal/frontend-quality-backlog.md` | maintainers, AI Agent | 前端品質待辦 (Frontend Quality Backlog) |
-| `docs/internal/github-release-playbook.md` | All | GitHub Release — 操作手冊 (Playbook) |
-| `docs/internal/pitch-deck-talking-points.md` | maintainers, business | Pitch Deck Talking Points — v2.8.0 Phase 1 Baseline |
-| `docs/internal/ssot-language-evaluation.md` | maintainers | SSOT 切換影響評估 |
-| `docs/internal/ssot-migration-pilot-report.md` | maintainers | SSOT 語言遷移 Phase 1 Pilot Report |
-| `docs/internal/test-coverage-matrix.md` | Platform Engineers, SREs | 測試覆蓋矩陣與進階場景 |
-| `docs/internal/test-map.md` | maintainers, AI Agent | 測試架構導覽 (Test Map) |
-| `docs/internal/testing-playbook.md` | All | 測試注意事項 — 排錯手冊 (Testing Playbook) |
-| `docs/internal/windows-mcp-playbook.md` | All | Windows-MCP — Dev Container 操作手冊 (Playbook) |
 | `docs/migration-engine.md` (.en.md) | Platform Engineers, DevOps | AST 遷移引擎架構 |
 | `docs/migration-guide.md` (.en.md) | Tenants, DevOps | Migration Guide — 遷移指南 |
 | `docs/scenarios/advanced-scenarios.md` (.en.md) | Platform Engineers, SREs | 進階場景與測試覆蓋 |

--- a/scripts/tools/dx/generate_doc_map.py
+++ b/scripts/tools/dx/generate_doc_map.py
@@ -84,7 +84,16 @@ SKIP_FILENAME_PREFIXES = ("_",)
 # Directories to skip entirely (adr is conditionally included via --include-adr)
 # rule-packs is skipped because it's a junction/symlink on Windows/Linux pointing
 # to the top-level rule-packs/ dir; its README is added via EXTRA_ENTRIES instead.
-SKIP_DIRS = {"includes", "adr", "rule-packs"}
+#
+# `internal` is skipped (issue #66 follow-up): docs/internal/** are maintainer-
+# and AI-agent-only artifacts (playbooks, planning archives, RCAs, dev rules).
+# They have richer discovery paths via CLAUDE.md, dedicated skills (e.g.
+# `vibe-playbook-nav`), and direct file-system search; the catalog adds no
+# real navigation value over those, and including them mixed public + internal
+# documents in a single count that's not actually meaningful externally. The
+# catalog meta-entries (`doc-map.md`, `tool-map.md` themselves) are still
+# manually added via SELF_ENTRIES so the catalog continues to self-describe.
+SKIP_DIRS = {"includes", "adr", "rule-packs", "internal"}
 
 # Extra non-docs entries (manually curated, appended at end)
 EXTRA_ENTRIES = {

--- a/scripts/tools/lint/_version_patterns.py
+++ b/scripts/tools/lint/_version_patterns.py
@@ -157,8 +157,15 @@ SKIP_RULE_PACK_FILES = {"CHANGELOG.md", "CHANGELOG.en.md", "benchmarks.md",
 # Bilingual number consistency skips these
 SKIP_BILINGUAL_NUMBER_FILES = {"benchmarks.md", "CHANGELOG.md"}
 
-# doc-map coverage check skips these directories and files
-DOC_MAP_SKIP_DIRS = {"includes", "adr", "design-reviews"}
+# doc-map coverage check skips these directories and files.
+#
+# `internal` is skipped (issue #66 follow-up; mirrors generate_doc_map.py
+# SKIP_DIRS): docs/internal/** are explicitly out-of-scope for the public
+# doc catalog. Validator must not flag missing-from-doc-map for internal
+# files; otherwise generator and validator disagree and produce false
+# drift (the v2.8.0-{planning-archive,tech-debt-decomposition}.md cases
+# observed during PR #72 review).
+DOC_MAP_SKIP_DIRS = {"includes", "adr", "design-reviews", "internal"}
 DOC_MAP_SKIP_NAMES = {"tags.md", "CHANGELOG.md", "README-root.md",
                       "doc-map.md", "tool-map.md",
                       "known-regressions.md"}


### PR DESCRIPTION
## Summary

[#66](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/66) follow-up. Surfaced during [#72](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/72) review as 2 false-positive `doc-map-coverage` warnings (validator flagged `v2.8.0-planning-archive.md` and `v2.8.0-tech-debt-decomposition.md` as missing-from-doc-map while generator was intentionally filtering them out — generator and validator disagreed).

## Decision rationale

doc-map's real consumer is **public-doc discovery** for AI agents and developers. Internal docs (`docs/internal/**`) have richer discovery paths via:
- Direct CLAUDE.md links
- Skills (`vibe-playbook-nav`, `vibe-dev-rules`, `vibe-workflow`)
- Direct file-system search (Glob / Grep)

Mixing public + internal in one catalog produces a count number that's not externally meaningful (mostly internal artifacts inflating it). Other consumers checked confirmed nothing depends on internal being catalogued:

| Consumer | Uses doc-map? | Cares about internal? |
|---|---|---|
| MkDocs site | ❌ uses `mkdocs.yml` nav | no |
| Documentation link validation hook | ❌ walks markdown directly | no |
| Bilingual sync hooks | ❌ filename pattern | no |
| `validate_docs_versions.py` doc-map-coverage | ✅ | **was producing false positives on internal** — fixed here |

`SELF_ENTRIES` in `generate_doc_map.py` manually catalogs `doc-map.md` and `tool-map.md` themselves, so the catalog's self-description survives.

## Changes

- `generate_doc_map.py`: `SKIP_DIRS += {"internal"}` with explanatory comment
- `_version_patterns.py`: `DOC_MAP_SKIP_DIRS += {"internal"}` with mirror comment
- `docs/internal/doc-map.md` regenerated: **134 → 114 entries** (-20 internal)
- `CLAUDE.md` L83 + `README.md` L97: count `129 → 114`, wording changed from `N 份文件` → `N 份公開文件` to reflect scope narrowing (internal docs still exist, just not in the catalog)
- `CHANGELOG.md`: `### Changed` entry

## Verification

- [x] `validate_docs_versions.py --ci`: exit 0, "All version references and counts are consistent." (was **2 warnings** before)
- [x] `generate_doc_map.py --check`: clean
- [x] `pre-commit run`: all auto hooks pass (with `head-blob-hygiene` and pre-existing `ad-hoc-git-scripts-check` SKIP'd, both pre-existing project-level issues unrelated to this PR)
- [x] `make pr-preflight` → READY (preflight marker written)

## Out of scope (small follow-up if maintainer cares)

`validate_docs_versions.py`'s `check_doc_file_count_in_docs` uses pattern `(\d+)\s*個文件` but CLAUDE.md L83 + README.md use `N 份文件` (`份` not `個`), so the count drift was **never automatically caught**. I updated the actual count manually here. Widening the pattern to also match `份` is a tiny separate cleanup — flagged in commit message.

## Coordination with PR #72

PR #72 fixes #66 part 2 (CLAUDE.md L57 stale Change Impact Matrix ref). This PR does **not** touch L57; both PRs edit different lines of CLAUDE.md, no conflict either merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)