### PR TITLE
feat(phase-b): B-1 Phase 2 PR-1 — exporter gauges + synthetic-v2 fixture + playbook skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ Breaking / Upgrade 七塊清楚區分），那是目標形狀。
 
 ### Added
 
+- **B-1 Phase 2 implementation — PR-1 of 3（v2.8.0 B-1.P2-a + B-1.P2-b + g 骨架）** — e2e alert fire-through harness 的 building blocks。零行為變動，全是新增 metric + 新增 fixture mode + doc skeleton：
+  - **`da_config_last_scan_complete_unixtime_seconds` Gauge（B-1.P2-a）** — set in `scanDirHierarchical` success path；e2e harness 5-anchor 模型的 T1 anchor；production 用 `time() - <gauge> > N` 做 stuck-scanner 偵測。Error path 不 set（保持 stale gauge 與「忘了 emit」可區分）
+  - **`da_config_last_reload_complete_unixtime_seconds` Gauge（B-1.P2-a）** — set strictly post-atomic-swap in `diffAndReload`；e2e harness T2 anchor。同樣 error path 不 set
+  - **`generate_tenant_fixture.py --layout synthetic-v2`（B-1.P2-b）** — Phase 2 主基準 fixture mode，在既有 `hierarchical` layout 上加兩個 realistic-ops 分布：(1) Zipf alpha=1.5 / max_size=6 對 tenant size（多數 1-2 個 threshold override，~15% 4+）；(2) power-law alpha=2.0 / max_depth=3 對 `_metadata` overlay depth（>60% flat、~10% 達 depth=3）。`--seed` reproducible。10 unit tests 含分布 statistical asserts（per S#32 lesson 用 invariant-based 而非 absolute-value）
+  - **`docs/internal/benchmark-playbook.md` §v2.8.0 Phase 2 e2e 章節 skeleton（g）** — ops-view 摘要：5-anchor 量測模型對照表、fixture_kind 三態（synthetic-v1 / synthetic-v2 / customer-anon）+ calibration gate ±30% 操作流程、implementation 7-子項 progress tracker、fixture 產出速查指令。Design SSOT 仍在 `design/phase-b-e2e-harness.md`；本節是 ops 視角 cookbook
+  - **PR-2 / PR-3 預告**：PR-2 = docker-compose stack + host driver；PR-3 = aggregation + Makefile target + workflow + playbook 完整化（以 synthetic-v2 跑出第一份 baseline）
+
 - **Migration playbook — Emergency Rollback Procedures（v2.8.0 B-4，doc-only）** — `docs/scenarios/incremental-migration-playbook.md` + `.en.md` 新增 `Emergency Rollback Procedures` 章節，覆蓋 Phase .c batch-PR pipeline cutover 後的整批退版流程：(1) 退版順序 = merge 順序的嚴格反序（inner tenant PR 先 / outer `_defaults.yaml` 最後 / cascading defaults 按 inner→outer 退）；(2) WatchLoop debounce 驗收 PromQL 對接 v2.8.0 B-3 加入的 `da_config_reload_duration_seconds_count` 與 `da_config_debounce_batch_size`；(3) Staging rehearsal hard gate（cutover 前 2 週）；(4) 退版時間預算表（基於 PR #59 Phase 1 baseline，1000-tenant / 5000-tenant 各四種動作）；(5) 8-項驗證 checklist 含 `merged_hash` 收斂、PromQL counter delta、Alertmanager Silenced 清空。配合 Phase .c C-10 pipeline。工具層 `make rollback-dryrun` / `da-tools batch-pr rollback` 列入 v2.8.x backlog
 - **Issue #76 — pre-tag bench gate 3-phase rollout（issue-only，無 code）** — Spawn task C 落地：開 GitHub issue 規範 Phase 1（已 land PR #65）→ Phase 2（main-only hard gate at 3× median-of-5）→ Phase 3（PR-level after Larger Runners）的 entry conditions、acceptance criteria、Gemini「不要 hard gate」反論點 + PR #59 50% within-run variance 反駁。Phase 2 / 3 實作不在此 issue 範圍
 

--- a/components/threshold-exporter/app/config_debounce.go
+++ b/components/threshold-exporter/app/config_debounce.go
@@ -432,6 +432,11 @@ func (m *ConfigManager) diffAndReload() (reloaded, noOp int, err error) {
 	m.parsedDefaults = newParsedDefaults
 	m.mu.Unlock()
 
+	// v2.8.0 B-1.P2-a: stamp the last-successful-reload gauge for the
+	// e2e harness anchor T2 + production stuck-reloader detection. Stamped
+	// strictly post atomic-swap so the gauge cannot advance ahead of
+	// observable state.
+	SetLastReloadComplete(time.Now())
 	return reloaded, noOp, nil
 }
 

--- a/components/threshold-exporter/app/config_hierarchy.go
+++ b/components/threshold-exporter/app/config_hierarchy.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -290,6 +291,11 @@ func scanDirHierarchical(rootPath string, priorMtimes map[string]fileStat) (
 		graph.AddTenant(tid, chain)
 	}
 
+	// v2.8.0 B-1.P2-a: stamp the last-successful-scan gauge for the e2e
+	// harness anchor T1 + production stuck-scanner detection. Stamped only
+	// on success — error returns above leave the gauge at its previous
+	// value so a transient failure doesn't look like a completion.
+	SetLastScanComplete(time.Now())
 	return tenants, defaults, hashes, mtimes, graph, nil
 }
 

--- a/components/threshold-exporter/app/config_metrics.go
+++ b/components/threshold-exporter/app/config_metrics.go
@@ -72,6 +72,8 @@ type configMetrics struct {
 	blastRadius      *prometheus.HistogramVec // v2.8.0 Issue #61: per-tick (reason,scope,effect) tenants-affected distribution
 	reloadDuration   prometheus.Histogram   // v2.8.0 B-3: end-to-end diffAndReload elapsed (debounce window → atomic swap done)
 	debounceBatch    prometheus.Histogram   // v2.8.0 B-3: count of triggers coalesced per fired window (debounce effectiveness)
+	lastScanComplete   prometheus.Gauge // v2.8.0 B-1.P2-a: wall-clock unix seconds at most-recent successful scanDirHierarchical completion (e2e harness anchor T1; production stuck-detection)
+	lastReloadComplete prometheus.Gauge // v2.8.0 B-1.P2-a: wall-clock unix seconds at most-recent successful diffAndReload completion (e2e harness anchor T2; production stuck-detection)
 }
 
 // Default metric instance used by the production server. Tests that want
@@ -139,6 +141,14 @@ func newConfigMetrics() *configMetrics {
 			// burst — exactly the scenario B-7 stress-tests).
 			Buckets: []float64{1, 2, 5, 10, 25, 50, 100, 250, 500},
 		}),
+		lastScanComplete: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "da_config_last_scan_complete_unixtime_seconds",
+			Help: "Wall-clock unix seconds at the most recent successful scanDirHierarchical completion. Set by the scanner; read by the e2e harness as anchor T1 (B-1 Phase 2). Production use: alert on time() - <gauge> > N for stuck-scanner detection. 0 means scanner has not yet completed a successful scan.",
+		}),
+		lastReloadComplete: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "da_config_last_reload_complete_unixtime_seconds",
+			Help: "Wall-clock unix seconds at the most recent successful diffAndReload completion (post atomic-swap). Set by the reload pipeline; read by the e2e harness as anchor T2 (B-1 Phase 2). Production use: alert on time() - <gauge> > N for stuck-reloader detection. 0 means reloader has not yet completed a successful reload.",
+		}),
 	}
 }
 
@@ -184,6 +194,8 @@ func registerConfigMetrics(reg prometheus.Registerer, m *configMetrics) {
 	reg.MustRegister(m.blastRadius)
 	reg.MustRegister(m.reloadDuration)
 	reg.MustRegister(m.debounceBatch)
+	reg.MustRegister(m.lastScanComplete)
+	reg.MustRegister(m.lastReloadComplete)
 }
 
 // IncParseFailure bumps the parse-failure counter for a specific file
@@ -296,4 +308,25 @@ func ObserveDebounceBatch(n int) {
 		return
 	}
 	getConfigMetrics().debounceBatch.Observe(float64(n))
+}
+
+// SetLastScanComplete records the wall-clock unix seconds at successful
+// scanDirHierarchical completion (v2.8.0 B-1.P2-a). The e2e harness reads
+// this gauge as anchor T1 in the 5-anchor measurement model; production
+// uses `time() - <gauge>` for stuck-scanner alerting.
+//
+// Called only on success — error paths leave the gauge at its previous
+// value so a transient scan failure does not look like a successful
+// completion. Tests that want a clean baseline observe via withIsolatedMetrics.
+func SetLastScanComplete(t time.Time) {
+	getConfigMetrics().lastScanComplete.Set(float64(t.Unix()))
+}
+
+// SetLastReloadComplete records the wall-clock unix seconds at the
+// successful diffAndReload completion (post atomic-swap, v2.8.0 B-1.P2-a).
+// E2E harness reads this gauge as anchor T2.
+//
+// Called only on success path — see SetLastScanComplete docstring.
+func SetLastReloadComplete(t time.Time) {
+	getConfigMetrics().lastReloadComplete.Set(float64(t.Unix()))
 }

--- a/components/threshold-exporter/app/config_metrics_test.go
+++ b/components/threshold-exporter/app/config_metrics_test.go
@@ -356,6 +356,163 @@ func histogramSampleCount(t *testing.T, h prometheus.Histogram) uint64 {
 	return 0
 }
 
+// ============================================================
+// v2.8.0 B-1.P2-a — last-scan-complete + last-reload-complete gauges
+// ============================================================
+
+func TestSetLastScanComplete_StoresUnixSeconds(t *testing.T) {
+	fresh, _ := withIsolatedMetrics(t)
+
+	t0 := time.Now()
+	SetLastScanComplete(t0)
+
+	got := testutil.ToFloat64(fresh.lastScanComplete)
+	if int64(got) != t0.Unix() {
+		t.Errorf("expected gauge=%d, got %d", t0.Unix(), int64(got))
+	}
+}
+
+func TestSetLastReloadComplete_StoresUnixSeconds(t *testing.T) {
+	fresh, _ := withIsolatedMetrics(t)
+
+	t0 := time.Now()
+	SetLastReloadComplete(t0)
+
+	got := testutil.ToFloat64(fresh.lastReloadComplete)
+	if int64(got) != t0.Unix() {
+		t.Errorf("expected gauge=%d, got %d", t0.Unix(), int64(got))
+	}
+}
+
+// TestSetLastScanComplete_MonotonicAdvance verifies that successive Set
+// calls move the gauge forward. The e2e harness depends on this — anchor
+// T1 must advance after every successful scan so the harness can detect
+// "scan completed since T0" by sampling the gauge.
+//
+// Per S#32 lesson: assert deltas / monotonic advance, not exact absolute
+// timing. Two `time.Now().Unix()` values across a 10ms sleep can be
+// equal IF the sleep happens to span no second boundary, so the
+// assertion is `>=` not `>`.
+func TestSetLastScanComplete_MonotonicAdvance(t *testing.T) {
+	fresh, _ := withIsolatedMetrics(t)
+
+	t1 := time.Now()
+	SetLastScanComplete(t1)
+	got1 := testutil.ToFloat64(fresh.lastScanComplete)
+
+	time.Sleep(10 * time.Millisecond)
+	t2 := time.Now()
+	SetLastScanComplete(t2)
+	got2 := testutil.ToFloat64(fresh.lastScanComplete)
+
+	if got2 < got1 {
+		t.Errorf("expected monotonic advance: t1=%v t2=%v gauge1=%v gauge2=%v", t1.Unix(), t2.Unix(), got1, got2)
+	}
+}
+
+// TestScanDirHierarchical_StampsLastScanCompleteOnSuccess verifies the
+// gauge advances after a real scan call. Uses delta-based assertion
+// (per S#32 lesson) — only assert "advanced past scan-start", not
+// "equals exact value".
+func TestScanDirHierarchical_StampsLastScanCompleteOnSuccess(t *testing.T) {
+	fresh, _ := withIsolatedMetrics(t)
+	dir := t.TempDir()
+	writeHierarchicalFixture(t, dir, "90")
+
+	scanStart := time.Now().Unix()
+
+	if _, _, _, _, _, err := scanDirHierarchical(dir, nil); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	got := testutil.ToFloat64(fresh.lastScanComplete)
+	if int64(got) < scanStart {
+		t.Errorf("gauge did not advance past scanStart: scanStart=%d gauge=%d", scanStart, int64(got))
+	}
+}
+
+// TestScanDirHierarchical_DoesNotStampOnError verifies that an error path
+// does NOT advance the gauge — a transient scan failure must look
+// distinct from a successful completion. Pre-set the gauge to a known
+// value, run a failing scan, assert no movement.
+func TestScanDirHierarchical_DoesNotStampOnError(t *testing.T) {
+	fresh, _ := withIsolatedMetrics(t)
+
+	known := time.Unix(1700000000, 0)
+	SetLastScanComplete(known)
+	before := testutil.ToFloat64(fresh.lastScanComplete)
+
+	if _, _, _, _, _, err := scanDirHierarchical("/nonexistent/path/that/does/not/exist", nil); err == nil {
+		t.Fatal("expected error for nonexistent path")
+	}
+
+	after := testutil.ToFloat64(fresh.lastScanComplete)
+	if after != before {
+		t.Errorf("gauge advanced on error path: before=%v after=%v", before, after)
+	}
+}
+
+// TestDiffAndReload_StampsLastReloadCompleteOnSuccess verifies the reload
+// gauge advances after a real diffAndReload (delta-based).
+func TestDiffAndReload_StampsLastReloadCompleteOnSuccess(t *testing.T) {
+	fresh, _ := withIsolatedMetrics(t)
+	dir := t.TempDir()
+	writeHierarchicalFixture(t, dir, "90")
+
+	m := NewConfigManagerWithDebounce(dir, 0)
+	defer m.Close()
+	if err := m.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	reloadStart := time.Now().Unix()
+
+	if _, _, err := m.diffAndReload(); err != nil {
+		t.Fatalf("diffAndReload: %v", err)
+	}
+
+	got := testutil.ToFloat64(fresh.lastReloadComplete)
+	if int64(got) < reloadStart {
+		t.Errorf("gauge did not advance past reloadStart: reloadStart=%d gauge=%d", reloadStart, int64(got))
+	}
+}
+
+// TestDiffAndReload_StampsAfterAtomicSwap verifies the contract "gauge
+// advanced ⇒ observable state already updated" by checking that
+// reload_stamp >= scan_stamp (reload pipeline always scans before
+// swapping; reload-complete is stamped strictly after swap).
+//
+// Direct ordering test (gauge stamped post-swap) would require
+// restructuring production code to expose the swap point. The
+// >= invariant is sufficient because if SetLastReloadComplete were
+// called before the swap, a concurrent reader could observe the
+// gauge advanced while the swap was still in progress — exactly what
+// we want to forbid.
+func TestDiffAndReload_StampsAfterAtomicSwap(t *testing.T) {
+	fresh, _ := withIsolatedMetrics(t)
+	dir := t.TempDir()
+	writeHierarchicalFixture(t, dir, "90")
+
+	m := NewConfigManagerWithDebounce(dir, 0)
+	defer m.Close()
+	if err := m.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if _, _, err := m.diffAndReload(); err != nil {
+		t.Fatalf("diffAndReload: %v", err)
+	}
+
+	scanStamp := int64(testutil.ToFloat64(fresh.lastScanComplete))
+	reloadStamp := int64(testutil.ToFloat64(fresh.lastReloadComplete))
+	if scanStamp == 0 {
+		t.Errorf("scan gauge should be set after diffAndReload, got 0")
+	}
+	if reloadStamp < scanStamp {
+		t.Errorf("reload stamp should be >= scan stamp: scan=%d reload=%d", scanStamp, reloadStamp)
+	}
+}
+
 // TestDiffAndReload_EmitsMetricsForSourceChange ensures the full pipeline
 // (scan → diff → counter increment) hooks up end-to-end.
 func TestDiffAndReload_EmitsMetricsForSourceChange(t *testing.T) {

--- a/docs/internal/benchmark-playbook.md
+++ b/docs/internal/benchmark-playbook.md
@@ -295,6 +295,93 @@ func silenceLogs(b *testing.B) {
 - **Customer sample 校準**：synthetic fixture 分布未必等同客戶 workload；Phase 2 帶客戶 anonymized sample re-run
 - **SLO definitive sign-off**：B-2 hard SLO 需 3+ 輪 customer 環境驗證
 
+---
+
+## v2.8.0 Phase 2 e2e Alert Fire-through (B-1 Phase 2, design + skeleton)
+
+> **Status**: design contract 完成（PR #64 / `design/phase-b-e2e-harness.md`）；implementation 進行中（B-1.P2-a/b 在本 PR 落地，c-g 後續）。本節是 playbook 操作層 skeleton — design doc 是 SSOT，這裡只放 ops 視角的「怎麼跑、看哪幾個數字、customer sample 校準怎麼操作」。
+
+### 5-anchor 量測模型（摘要）
+
+完整 5-anchor 鏈與 stage 拆解見 `design/phase-b-e2e-harness.md` §2.5。Ops 視角速查：
+
+| Anchor | Time | 量測來源 | 對應 stage |
+|---|---|---|---|
+| **T0** | now() | driver 寫 fixture | — |
+| **T1** | exporter `last_scan_complete_unixtime_seconds` 值 | 本 PR (B-1.P2-a) 加的 gauge | A: scan |
+| **T2** | exporter `last_reload_complete_unixtime_seconds` 值 | 本 PR (B-1.P2-a) 加的 gauge | B: reload |
+| **T3** | Prometheus `/api/v1/alerts` `activeAt` | Prom internal time | C: scrape+eval |
+| **T4** | receiver POST timestamp | webhook receiver 記錄 | D: alertmanager dispatch |
+
+stage(s) = T1−T0 (A) / T2−T1 (B) / T3−T2 (C: scrape+eval 不拆分) / T4−T3 (D)
+e2e_ms = T4 − T0
+
+**Ops 為何要會看 T1/T2 兩個 gauge**：
+1. **Production stuck-detection** — `time() - da_config_last_scan_complete_unixtime_seconds > 60` → scanner 卡死（gauge 永不會 backfill 過去值，所以 stale gauge 一定是 stuck，不是「忘了 emit」）
+2. **E2E harness 對齊** — harness driver 寫 fixture 後輪詢這兩個 gauge，看到值大於寫入 timestamp 才往下走。**Driver / exporter 同 kernel clock**（皆在 docker-compose 內）所以無 clock skew 問題
+
+### Fixture kinds & calibration gate
+
+完整 calibration gate 規格見 design doc §6.5。Ops 速查：
+
+| `fixture_kind` | 來源 | `gate_status` 預設 | 用途 |
+|---|---|---|---|
+| `synthetic-v1` | PR #59 `buildDirConfigHierarchical` (uniform 分布) | `pending` | Phase 1 baseline，不再為 Phase 2 主基準 |
+| `synthetic-v2` | 本 PR (B-1.P2-b) `generate_tenant_fixture.py --layout synthetic-v2` (Zipf+power-law 分布) | `pending` | Phase 2 主基準；customer sample 抵達前唯一 baseline；customer sample 抵達後做 ±30% 校準 gate 對照 |
+| `customer-anon` | 客戶 anonymized sample（gitignored, manual 取得） | `pending` → `passed/failed/voided` | Definitive baseline 來源；填回 `synthetic-v2` 校準狀態 |
+
+**Customer sample 校準操作流程**（cutover 前 2 週執行；客戶 fixture 拿到後）：
+
+```bash
+# 1. 把客戶 sample 解壓到 tests/e2e-bench/fixture/customer-anon/conf.d/
+#    (整個 customer-anon/ 目錄 gitignored)
+tar -xzf customer-sample.tar.gz -C tests/e2e-bench/fixture/customer-anon/
+
+# 2. 跑 e2e harness 對 customer-anon (n>=30)
+COUNT=30 E2E_FIXTURE_KIND=customer-anon make bench-e2e  # Makefile target 預定 PR-3 加
+
+# 3. 比對最近一次 synthetic-v2 P95 — gate 通過條件:
+#    customer-anon P95 與 synthetic-v2 P95 差距 ≤30%
+python3 scripts/tools/dx/compare_e2e_baseline.py \
+    --customer bench-results/e2e-customer-anon-*.json \
+    --baseline bench-results/e2e-synthetic-v2-*.json \
+    --threshold-pct 30  # PR-3 預定加的工具
+```
+
+通過後填回 synthetic-v2 對應 run 的 `gate_status: "passed"`（calibration confirmed）；失敗則 `gate_status: "voided"` 並在本節章節加紅框。
+
+**Kill switch**：v2.9.0 cut 前若 customer sample 未抵達，強制 go/no-go review — 要嘛 explicit 接受 synthetic-v2 為定案 baseline（含 fixture 假設文件化），要嘛 rescope phase 2。詳 design doc §6.5 + §11。
+
+### Implementation 進度 tracker
+
+| 子項 | 內容 | 狀態 | PR |
+|---|---|---|---|
+| **B-1.P2-a** | exporter timestamp gauges (`last_{scan,reload}_complete_unixtime_seconds`) | 🟢 | 本 PR |
+| **B-1.P2-b** | `generate_tenant_fixture.py --layout synthetic-v2` (Zipf+power-law) | 🟢 | 本 PR |
+| **B-1.P2-c** | docker-compose stack (exporter + Prometheus + Alertmanager + pushgateway + receiver) | ⬜ | PR-2 |
+| **B-1.P2-d** | host driver (5-anchor 量測 + run isolation + fire+resolve 對稱) | ⬜ | PR-2 |
+| **B-1.P2-e** | n≥30 aggregation + bootstrap 95% CI + output JSON `fixture_kind`/`gate_status` | ⬜ | PR-3 |
+| **B-1.P2-f** | `make bench-e2e` + `bench-e2e-record.yaml` workflow (main only, manual dispatch) | ⬜ | PR-3 |
+| **B-1.P2-g** | playbook 完整章節（含實測數字 + customer-sample calibration flow refinement） | 🟡 (skeleton in this PR) | PR-3 |
+
+### 產出 fixture 速查（B-1.P2-b）
+
+```bash
+# Synthetic-v2 (Zipf+power-law skews; B-1 Phase 2 主基準)
+python3 scripts/tools/dx/generate_tenant_fixture.py \
+    --layout synthetic-v2 --count 1000 --with-defaults \
+    --output tests/e2e-bench/fixture/synthetic-v2/conf.d \
+    --seed 42
+
+# Synthetic-v1 (uniform; PR #59 baseline reuse, 不變)
+python3 scripts/tools/dx/generate_tenant_fixture.py \
+    --layout hierarchical --count 1000 --with-defaults \
+    --output tests/e2e-bench/fixture/synthetic-v1/conf.d \
+    --seed 42
+
+# Customer-anon (manual; 不在 generator 範圍 — 客戶 sample 解壓後直接放)
+```
+
 ### 重跑本 baseline 指令
 
 ```bash

--- a/scripts/tools/dx/generate_tenant_fixture.py
+++ b/scripts/tools/dx/generate_tenant_fixture.py
@@ -295,6 +295,165 @@ def generate_hierarchical(count: int, output_dir: Path, with_defaults: bool, see
     print(f"   Structure: {len(DOMAINS)} domains × {len(REGIONS)} regions × {len(ENVIRONMENTS)} envs")
 
 
+def _zipfian_sizes(count: int, alpha: float, max_size: int, rng: random.Random) -> list[int]:
+    """Sample `count` integers from a discrete Zipf-like distribution.
+
+    Returns a list of "tenant size multipliers" in the range [1, max_size]
+    drawn so that low values dominate (most tenants are small) and high
+    values are rare (few tenants are large). `alpha` controls skew; higher
+    alpha = sharper drop-off. Synthetic-v2 uses alpha=1.5 by design choice
+    (per phase-b-e2e-harness §6.2): close to real ops distribution where
+    a small fraction of tenants accumulate disproportionate threshold
+    overrides while the long tail is near-default.
+
+    Implementation note: uses the inverse-CDF method on a normalized
+    discrete distribution rather than `random.zipfian` (3.12+) so this
+    keeps working on older Python in CI. We cap by max_size to bound
+    test fixture YAML size — true Zipf has unbounded support.
+    """
+    weights = [1.0 / ((i + 1) ** alpha) for i in range(max_size)]
+    total = sum(weights)
+    cdf = []
+    running = 0.0
+    for w in weights:
+        running += w / total
+        cdf.append(running)
+    out = []
+    for _ in range(count):
+        u = rng.random()
+        # bisect-style: find smallest index with cdf >= u
+        for size_idx, threshold in enumerate(cdf):
+            if u <= threshold:
+                out.append(size_idx + 1)
+                break
+        else:
+            out.append(max_size)
+    return out
+
+
+def _power_law_depths(count: int, alpha: float, max_depth: int, rng: random.Random) -> list[int]:
+    """Sample `count` integers in [0, max_depth] from a power-law tail.
+
+    Returns _metadata block depth multipliers — most tenants get 0
+    (flat metadata), a long tail get nested overlays. Distinct from
+    Zipf because here the mass is concentrated at 0; only rare tenants
+    deserve depth >= 1. `alpha` higher = more flat tenants. Synthetic-v2
+    uses alpha=2.0 by default (long-tail per phase-b-e2e-harness §6.2).
+    """
+    out = []
+    for _ in range(count):
+        # Sample depth from power-law: P(d) ∝ 1 / (d+1)^alpha for d in [0, max_depth].
+        # Inverse-CDF closed form is messy; just sample-reject from CDF table.
+        weights = [1.0 / ((d + 1) ** alpha) for d in range(max_depth + 1)]
+        total = sum(weights)
+        u = rng.random()
+        running = 0.0
+        for d, w in enumerate(weights):
+            running += w / total
+            if u <= running:
+                out.append(d)
+                break
+        else:
+            out.append(max_depth)
+    return out
+
+
+def generate_synthetic_v2(count: int, output_dir: Path, with_defaults: bool, seed: int) -> None:
+    """Generate a synthetic-v2 hierarchical fixture with skewed distributions.
+
+    Layered on top of `generate_hierarchical` (same domain/region/env tree)
+    but with two realistic-ops skews per phase-b-e2e-harness design §6.2:
+
+      1. Zipfian tenant size — most tenants override 1-2 thresholds; a
+         small fraction (~5-10%) override 5-10. Implementation: sample
+         a "size multiplier" in [1, 6] via Zipf alpha=1.5 and replicate
+         the threshold dict that many times (up to the available metric
+         template count) to vary YAML body size.
+      2. Power-law _metadata overlay depth — most tenants have flat
+         metadata (depth=0); a long tail (~5%) get depth 1-3 nested
+         overlay blocks (e.g. nested escalation policies, inherited
+         silence schedules). Implementation: sample depth in [0, 3]
+         via power-law alpha=2.0.
+
+    Why these specific distributions: they push the inheritance graph
+    + merged_hash compute through a non-uniform input that better
+    surfaces tail-latency in the e2e harness measurement. Uniform
+    fixtures (synthetic-v1, PR #59) hide variance because every tenant
+    looks alike.
+    """
+    rng = _seed_rng(seed)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    slots: list[tuple[str, str, str]] = []
+    for d in DOMAINS:
+        for r in REGIONS:
+            for e in ENVIRONMENTS:
+                slots.append((d, r, e))
+
+    tenants_per_slot = max(1, count // len(slots))
+    remainder = count - tenants_per_slot * len(slots)
+
+    # Sample skew distributions up-front for the full tenant set.
+    sizes = _zipfian_sizes(count, alpha=1.5, max_size=6, rng=rng)
+    depths = _power_law_depths(count, alpha=2.0, max_depth=3, rng=rng)
+
+    idx = 0
+    domain_db_types: dict[str, list[str]] = {}
+    for slot_i, (domain, region, env) in enumerate(slots):
+        if idx >= count:
+            break
+        n = tenants_per_slot + (1 if slot_i < remainder else 0)
+        slot_dir = output_dir / domain / region / env
+        slot_dir.mkdir(parents=True, exist_ok=True)
+
+        for j in range(n):
+            if idx >= count:
+                break
+            db_type = DB_TYPES[idx % len(DB_TYPES)]
+            tid = f"{domain}-{db_type}-{idx:04d}"
+            tenant_config = {"tenants": {tid: _gen_tenant_config(rng, tid, db_type)}}
+            tenant_config["tenants"][tid]["_metadata"]["domain"] = domain
+            tenant_config["tenants"][tid]["_metadata"]["region"] = region
+            tenant_config["tenants"][tid]["_metadata"]["environment"] = env
+
+            # Zipfian: replicate threshold dict to grow YAML body.
+            # _gen_tenant_config produces a base set of threshold keys; we
+            # add `_extra_threshold_NN` keys to reach the desired multiplier.
+            size_mult = sizes[idx]
+            for extra_i in range(size_mult - 1):
+                extra_key = f"_extra_threshold_{extra_i:02d}"
+                tenant_config["tenants"][tid][extra_key] = _gen_threshold_value(rng)
+
+            # Power-law: deepen _metadata with nested overlay blocks.
+            depth = depths[idx]
+            if depth > 0:
+                meta = tenant_config["tenants"][tid]["_metadata"]
+                cursor = meta
+                for d_i in range(depth):
+                    nested_key = f"_overlay_l{d_i}"
+                    cursor[nested_key] = {
+                        "schedule": rng.choice(["business-hours", "off-hours", "24x7"]),
+                        "escalation_tier": rng.choice(TIERS),
+                    }
+                    cursor = cursor[nested_key]
+
+            _write_yaml(slot_dir / f"{tid}.yaml", tenant_config)
+            domain_db_types.setdefault(domain, []).append(db_type)
+            idx += 1
+
+    if with_defaults:
+        _write_yaml(output_dir / "_defaults.yaml", _gen_defaults_yaml(rng))
+        for domain in DOMAINS:
+            domain_dir = output_dir / domain
+            if domain_dir.exists():
+                db_types_in_domain = list(set(domain_db_types.get(domain, DB_TYPES[:2])))
+                _write_yaml(domain_dir / "_defaults.yaml", _gen_defaults_yaml(rng, db_types_in_domain))
+
+    print(f"✅ Generated {idx} tenant files (synthetic-v2) in {output_dir}")
+    print(f"   Skew: Zipf alpha=1.5 (sizes 1-6), power-law alpha=2.0 (overlay depths 0-3)")
+    print(f"   Distribution: sizes p50={sorted(sizes)[len(sizes)//2]} p99={sorted(sizes)[int(len(sizes)*0.99)] if len(sizes)>1 else sizes[0]}; depths p50={sorted(depths)[len(depths)//2]} p99={sorted(depths)[int(len(depths)*0.99)] if len(depths)>1 else depths[0]}")
+
+
 def _write_yaml(path: Path, data: dict) -> None:
     """Write a dict as YAML. Avoids importing yaml to keep deps minimal."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -363,8 +522,8 @@ def main() -> None:
         help="Number of tenants to generate (common: 100, 500, 1000, 2000)",
     )
     parser.add_argument(
-        "--layout", "-l", choices=["flat", "hierarchical"], default="flat",
-        help="Directory layout mode (default: flat)",
+        "--layout", "-l", choices=["flat", "hierarchical", "synthetic-v2"], default="flat",
+        help="Directory layout mode (default: flat). 'synthetic-v2' is hierarchical layout with Zipf+power-law skews per phase-b-e2e-harness §6.2 (B-1 Phase 2 calibration baseline).",
     )
     parser.add_argument(
         "--output", "-o", type=str, default=None,
@@ -393,6 +552,8 @@ def main() -> None:
 
     if args.layout == "flat":
         generate_flat(args.count, output_dir, args.with_defaults, args.seed)
+    elif args.layout == "synthetic-v2":
+        generate_synthetic_v2(args.count, output_dir, args.with_defaults, args.seed)
     else:
         generate_hierarchical(args.count, output_dir, args.with_defaults, args.seed)
 

--- a/tests/dx/test_generate_tenant_fixture.py
+++ b/tests/dx/test_generate_tenant_fixture.py
@@ -1,0 +1,195 @@
+"""Tests for scripts/tools/dx/generate_tenant_fixture.py.
+
+Coverage focus: synthetic-v2 distribution mode (B-1 Phase 2 calibration
+baseline). Pre-existing flat / hierarchical layouts are exercised
+indirectly via the bench fixtures and don't have dedicated tests yet.
+
+Distribution assertions are statistical, not exact-value: we verify
+shape (Zipf skew ratio, power-law long-tail mass) on a sample size
+large enough that variance is bounded. Per S#32 lesson, prefer
+invariant-based asserts over absolute equality where the underlying
+process is randomized — even with a fixed seed, internal RNG layout
+changes between Python versions could break exact-value asserts.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+TOOL_PATH = REPO_ROOT / "scripts" / "tools" / "dx" / "generate_tenant_fixture.py"
+
+
+@pytest.fixture(scope="module")
+def fixture_module():
+    """Load generate_tenant_fixture.py as a module without putting
+    scripts/tools/dx/ on sys.path globally (avoids polluting import
+    namespaces for sibling tests)."""
+    spec = importlib.util.spec_from_file_location("generate_tenant_fixture", TOOL_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["generate_tenant_fixture"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ============================================================
+# Zipfian / power-law distribution helpers
+# ============================================================
+
+
+def test_zipfian_sizes_dominated_by_small_values(fixture_module):
+    """Zipf alpha=1.5 should put most mass at size=1. We verify
+    that >50% of sampled sizes are 1, and that sizes >= 4 are rare
+    (<10%). Sample size 5000 → variance bounded enough that these
+    inequalities hold across reasonable seed choices.
+    """
+    rng = fixture_module._seed_rng(42)
+    sizes = fixture_module._zipfian_sizes(count=5000, alpha=1.5, max_size=6, rng=rng)
+
+    p_small = sum(1 for s in sizes if s == 1) / len(sizes)
+    p_large = sum(1 for s in sizes if s >= 4) / len(sizes)
+    # Theoretical for Zipf alpha=1.5 / max_size=6: P(X=1)≈0.547, P(X>=4)≈0.154
+    # Bounds chosen with ~30% slack on either side for sample-size jitter
+    # (n=5000 → ~σ ≈ 0.7%; bounds at ±5% are safe).
+    assert p_small > 0.5, f"size=1 should dominate; got {p_small:.3f}"
+    assert p_large < 0.20, f"size>=4 should be a tail; got {p_large:.3f}"
+    # All values within bounds.
+    assert all(1 <= s <= 6 for s in sizes)
+
+
+def test_zipfian_sizes_higher_alpha_more_skewed(fixture_module):
+    """Increasing alpha should sharpen the drop-off — fewer large sizes."""
+    rng_low = fixture_module._seed_rng(123)
+    rng_high = fixture_module._seed_rng(123)
+    low = fixture_module._zipfian_sizes(count=2000, alpha=1.0, max_size=10, rng=rng_low)
+    high = fixture_module._zipfian_sizes(count=2000, alpha=2.5, max_size=10, rng=rng_high)
+    p_high_at_low_alpha = sum(1 for s in low if s >= 5) / len(low)
+    p_high_at_high_alpha = sum(1 for s in high if s >= 5) / len(high)
+    assert p_high_at_high_alpha < p_high_at_low_alpha, (
+        f"higher alpha should reduce p(size>=5): low_alpha={p_high_at_low_alpha:.3f} "
+        f"high_alpha={p_high_at_high_alpha:.3f}"
+    )
+
+
+def test_power_law_depths_long_tail(fixture_module):
+    """Power-law alpha=2.0 should put most mass at depth=0 with a
+    long tail at higher depths. Verify >60% are 0 and depth=3 rare (<10%).
+    """
+    rng = fixture_module._seed_rng(42)
+    depths = fixture_module._power_law_depths(count=5000, alpha=2.0, max_depth=3, rng=rng)
+
+    p_zero = sum(1 for d in depths if d == 0) / len(depths)
+    p_max = sum(1 for d in depths if d == 3) / len(depths)
+    assert p_zero > 0.6, f"depth=0 should dominate; got {p_zero:.3f}"
+    assert p_max < 0.10, f"depth=3 should be rare; got {p_max:.3f}"
+    assert all(0 <= d <= 3 for d in depths)
+
+
+def test_seeded_rng_reproducible(fixture_module):
+    """Same seed → same output. Critical for benchmark reproducibility."""
+    a = fixture_module._zipfian_sizes(
+        count=100, alpha=1.5, max_size=6, rng=fixture_module._seed_rng(42)
+    )
+    b = fixture_module._zipfian_sizes(
+        count=100, alpha=1.5, max_size=6, rng=fixture_module._seed_rng(42)
+    )
+    assert a == b
+
+
+# ============================================================
+# generate_synthetic_v2 end-to-end
+# ============================================================
+
+
+def test_synthetic_v2_creates_hierarchical_tree(fixture_module, tmp_path):
+    """Output dir should mirror generate_hierarchical layout: tenants
+    distributed across domain/region/env subdirectories."""
+    out = tmp_path / "synthetic-v2"
+    fixture_module.generate_synthetic_v2(count=144, output_dir=out, with_defaults=True, seed=42)
+
+    domains = list((out).iterdir())
+    assert len(domains) >= 8  # 8 DOMAINS expected (or fewer if count < slots)
+    # _defaults.yaml at root.
+    assert (out / "_defaults.yaml").exists()
+
+
+def test_synthetic_v2_count_matches_request(fixture_module, tmp_path):
+    """Generated tenant file count == --count, regardless of layout."""
+    out = tmp_path / "synthetic-v2"
+    fixture_module.generate_synthetic_v2(count=200, output_dir=out, with_defaults=False, seed=42)
+
+    tenant_files = [
+        p for p in out.rglob("*.yaml") if p.name != "_defaults.yaml"
+    ]
+    assert len(tenant_files) == 200
+
+
+def test_synthetic_v2_yaml_has_extra_threshold_keys(fixture_module, tmp_path):
+    """At least some tenants should have `_extra_threshold_NN` keys
+    from the Zipfian size>1 sample. Sample size 500 ensures we hit
+    at least a few size>=2 tenants under any reasonable seed.
+    """
+    out = tmp_path / "synthetic-v2"
+    fixture_module.generate_synthetic_v2(count=500, output_dir=out, with_defaults=False, seed=42)
+
+    # Read all tenant files and look for the marker key.
+    found_extra = False
+    for p in out.rglob("*.yaml"):
+        if p.name == "_defaults.yaml":
+            continue
+        text = p.read_text(encoding="utf-8")
+        if "_extra_threshold_" in text:
+            found_extra = True
+            break
+    assert found_extra, "expected at least one tenant with _extra_threshold_NN key (Zipf size>1)"
+
+
+def test_synthetic_v2_yaml_has_overlay_blocks(fixture_module, tmp_path):
+    """At least some tenants should have `_overlay_l0` nested overlay
+    blocks from the power-law depth>0 sample.
+    """
+    out = tmp_path / "synthetic-v2"
+    fixture_module.generate_synthetic_v2(count=500, output_dir=out, with_defaults=False, seed=42)
+
+    found_overlay = False
+    for p in out.rglob("*.yaml"):
+        if p.name == "_defaults.yaml":
+            continue
+        text = p.read_text(encoding="utf-8")
+        if "_overlay_l0" in text:
+            found_overlay = True
+            break
+    assert found_overlay, "expected at least one tenant with _overlay_l0 nested block (power-law depth>0)"
+
+
+def test_synthetic_v2_seed_reproducible(fixture_module, tmp_path):
+    """Same seed → byte-identical fixture trees."""
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    fixture_module.generate_synthetic_v2(count=50, output_dir=a, with_defaults=True, seed=2026)
+    fixture_module.generate_synthetic_v2(count=50, output_dir=b, with_defaults=True, seed=2026)
+
+    files_a = sorted(p.relative_to(a) for p in a.rglob("*.yaml"))
+    files_b = sorted(p.relative_to(b) for p in b.rglob("*.yaml"))
+    assert files_a == files_b
+    for rel in files_a:
+        assert (a / rel).read_bytes() == (b / rel).read_bytes(), f"diverged: {rel}"
+
+
+def test_synthetic_v2_different_seeds_produce_different_trees(fixture_module, tmp_path):
+    """Different seeds → different fixture content (sanity: seeding works)."""
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    fixture_module.generate_synthetic_v2(count=100, output_dir=a, with_defaults=False, seed=1)
+    fixture_module.generate_synthetic_v2(count=100, output_dir=b, with_defaults=False, seed=2)
+
+    # Concatenate all tenant YAML content from each tree; the totals
+    # must differ (extremely unlikely both seeds collapse identically
+    # to same Zipf+power-law samples by accident).
+    blob_a = b"".join(sorted(p.read_bytes() for p in a.rglob("*.yaml")))
+    blob_b = b"".join(sorted(p.read_bytes() for p in b.rglob("*.yaml")))
+    assert blob_a != blob_b


### PR DESCRIPTION
## Summary

PR-1 of 3 in **B-1 Phase 2 e2e alert fire-through harness** rollout (per Option β bundle plan). Pure building blocks; no harness yet, no production behavior change.

| Sub-item | Where | What |
|---|---|---|
| **B-1.P2-a** | [config_metrics.go](components/threshold-exporter/app/config_metrics.go) + [config_hierarchy.go](components/threshold-exporter/app/config_hierarchy.go) + [config_debounce.go](components/threshold-exporter/app/config_debounce.go) | Two new Gauges (`da_config_last_{scan,reload}_complete_unixtime_seconds`) — 5-anchor T1/T2; production stuck-detection bonus |
| **B-1.P2-b** | [scripts/tools/dx/generate_tenant_fixture.py](scripts/tools/dx/generate_tenant_fixture.py) | New `--layout synthetic-v2` mode: hierarchical + Zipf alpha=1.5 size + power-law alpha=2.0 overlay depth |
| **g (skeleton)** | [docs/internal/benchmark-playbook.md](docs/internal/benchmark-playbook.md) | New §v2.8.0 Phase 2 e2e section: 5-anchor model summary, fixture_kind matrix, calibration gate ops flow, 7-subitem tracker |

**Tests added**:
- 7 Go unit tests (delta-based per [§S#32 lesson](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/75)): `Set*StoresUnixSeconds`, `*MonotonicAdvance`, `Stamps*OnSuccess`, `DoesNotStampOnError`, `StampsAfterAtomicSwap`
- 10 Python tests: distribution helpers (Zipf skew, power-law tail, alpha effect, RNG reproducibility) + e2e generator (tree layout, file count, marker keys, seed determinism)

**PR-2 / PR-3 plan** (per Option β):
- PR-2: docker-compose stack + host driver (5-anchor measurement + fire+resolve + run isolation)
- PR-3: aggregation + bootstrap 95% CI + `make bench-e2e` + workflow + playbook completion (first synthetic-v2 baseline land)

## Test plan

- [x] `go test -race -count=2 ./...` clean
- [x] `pytest tests/dx/test_generate_tenant_fixture.py -v` 10/10 pass
- [x] `go vet ./...` clean; pre-commit clean (head-blob-hygiene FUSE-skipped per Trap #57)
- [ ] CI green (will validate on PR)

## Refs

- planning §4 Phase .b B-1 Phase 2
- [design/phase-b-e2e-harness.md](docs/internal/design/phase-b-e2e-harness.md) §2.5 / §2.6 / §6.2 / §6.5
- planning §12.1 row #34 (slim pointer; archive S#34 to follow post-merge)
- PR [#75](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/75) — B-3 metrics that the e2e harness PR-2 will consume

🤖 Generated with [Claude Code](https://claude.com/claude-code)