### PR TITLE
fix(phase-b): bench_e2e_run.sh fixture-empty path conflicts with shipped _defaults.yaml

### DIFF
--- a/scripts/ops/bench_e2e_run.sh
+++ b/scripts/ops/bench_e2e_run.sh
@@ -57,6 +57,9 @@ echo "[bench-e2e] fixture_kind=$FIXTURE_KIND, tenants=$FIXTURE_TENANT_COUNT, run
 # Step 1: ensure fixture for the chosen kind exists.
 # ---------------------------------------------------------------------------
 FIXTURE_SOURCE_DIR="fixture/$FIXTURE_KIND/conf.d"
+# Count tenant YAMLs only (NOT _defaults.yaml — the placeholder
+# `_defaults.yaml` is shipped in PR-2 to give scanner a hierarchical-mode
+# root signal even before generation).
 TENANT_FILE_COUNT=$(find "$FIXTURE_SOURCE_DIR" -name "*.yaml" -not -name "_defaults.yaml" 2>/dev/null | wc -l)
 if [[ "$TENANT_FILE_COUNT" -eq 0 ]]; then
     if [[ "$FIXTURE_KIND" == "customer-anon" ]]; then
@@ -68,7 +71,13 @@ if [[ "$TENANT_FILE_COUNT" -eq 0 ]]; then
     if [[ "$FIXTURE_KIND" == "synthetic-v2" ]]; then
         layout_arg="synthetic-v2"
     fi
-    echo "[bench-e2e] fixture empty — generating $FIXTURE_KIND ($FIXTURE_TENANT_COUNT tenants, seed=$SEED)..."
+    # generate_tenant_fixture.py refuses to write into a non-empty dir
+    # (sane guard against accidental clobber). The shipped placeholder
+    # `_defaults.yaml` would trigger that refusal even though we WANT
+    # to (re)generate. Clear the dir before invoking the generator;
+    # `--with-defaults` will reinstate `_defaults.yaml` correctly.
+    echo "[bench-e2e] fixture empty (only placeholder _defaults.yaml) — clearing + generating $FIXTURE_KIND ($FIXTURE_TENANT_COUNT tenants, seed=$SEED)..."
+    rm -rf "$FIXTURE_SOURCE_DIR"
     python3 "$REPO_ROOT/scripts/tools/dx/generate_tenant_fixture.py" \
         --layout "$layout_arg" \
         --count "$FIXTURE_TENANT_COUNT" \


### PR DESCRIPTION
## Summary

Discovered by [issue #83](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/83) Task 1 first `gh workflow run bench-e2e-record.yaml` attempt. Script-orchestrator-only fix; **needs to merge before #83 baseline runs can complete**.

**Failing run**: [actions/runs/24936869438](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24936869438):

```
⚠️  Output directory fixture/synthetic-v2/conf.d already exists
   and is not empty.
   Use a different --output or remove it first.
make: *** [Makefile:78: bench-e2e] Error 1
```

**Root cause**: [bench_e2e_run.sh](scripts/ops/bench_e2e_run.sh) counts tenant YAMLs only (excludes `_defaults.yaml`) to detect "fixture empty? generate it". But `generate_tenant_fixture.py` refuses to write into a non-empty dir as a sane guard against accidental clobber — and the placeholder `_defaults.yaml` shipped in PR #79 (PR-2 of B-1 Phase 2 rollout) makes the dir non-empty from the generator's perspective. The two tools disagree on what "empty" means.

**Fix**: clear the fixture source dir (`rm -rf`) before invoking the generator. `--with-defaults` will reinstate `_defaults.yaml` correctly as part of generation, so net behavior is identical to a fresh-clone run.

**Safety analysis**: `rm -rf` only fires inside the `if [[ TENANT_FILE_COUNT -eq 0 ]]` branch — user-generated fixtures (with custom seeds) always have tenant YAMLs and never enter this path, so they're never destroyed.

## Side-channel: sanity sweep finding (out-of-band, captured here for durable record)

While PR #85 was being prepared, I ran the deep-review §8 sanity sweep (`make benchmark-report` 1000-tenant flat) inside dev container to verify PR #78 timestamp gauges introduced no regression. Result vs PR #59 baseline:

| Bench | PR #59 baseline | Current dev-container measurement | Diff |
|---|---|---|---|
| `BenchmarkFullDirLoad_Hierarchical_1000` | 237ms | ~278ms (median of 3) | +17% |
| `BenchmarkDiffAndReload_Hierarchical_1000_NoChange` | 189ms | ~309ms (median of 3) | **+63%** |

**Important — not isolated to PR #78**: PR #69 (Issue #61, blast-radius metric) added significant work to `diffAndReload` between PR #59 baseline and PR #78 (parsedDefaults eager parse + `classifyDefaultsNoOpEffect` per-tenant + per-tick group-by emission map). The +63% delta is plausibly cumulative from PR #69 changes.

**Caveats**:
- Dev-container WSL/FUSE measurement has higher noise than ubuntu-latest CI runner
- 3 measurements isn't enough to characterize variance
- Recommendation: kick `bench-record.yaml` nightly workflow on main (after this PR + PR #84 land) for an authoritative number; bisect PR #69 vs PR #78 if numbers really diverge

This finding will also be captured in the S#37 doc-only PR (which closes #83) and in the #83 close comment for traceability.

## Test plan

- [x] pre-commit clean (head-blob-hygiene FUSE-skipped per Trap #57)
- [ ] CI green
- [ ] Post-merge: re-run `gh workflow run "Bench E2E Record (manual dispatch)" -f fixture_kind=synthetic-v2 -f count=30 -f fixture_tenant_count=1000` → expect successful artifact upload (per-run-*.json files)

## Refs

- failing run [#24936869438](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24936869438)
- [Issue #83](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/83) Task 1 (1000-tenant baseline) + Task 3 (sanity sweep)
- PR [#79](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/79) introduced the placeholder `_defaults.yaml`
- PR [#69](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/69) likely contributor to DiffAndReload regression observed in sanity sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)