### PR TITLE
fix(phase-b): bench pre-create sentinel value differs from driver write

### DIFF
--- a/.github/workflows/bench-e2e-record.yaml
+++ b/.github/workflows/bench-e2e-record.yaml
@@ -50,7 +50,14 @@ jobs:
     name: e2e harness (${{ inputs.fixture_kind }} × ${{ inputs.count }} runs)
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    timeout-minutes: 30
+    # 60 min budget: 1000-tenant typically finishes in ~5-8 min after the
+    # bench-trigger sentinel fix, but 5000-tenant has not been measured
+    # end-to-end on ubuntu-latest yet — could plausibly take 20-30 min
+    # given (a) larger fixture generation, (b) longer per-scan time, (c)
+    # higher chance of compose stack memory pressure. 30 was too tight
+    # (run 24937326270 cancelled). 60 leaves slack without normalizing
+    # an unbounded-cost workflow.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout

--- a/scripts/ops/bench_e2e_run.sh
+++ b/scripts/ops/bench_e2e_run.sh
@@ -96,13 +96,26 @@ cp -r "$FIXTURE_SOURCE_DIR/." fixture/active/conf.d/
 
 # ---------------------------------------------------------------------------
 # Step 3: pre-create bench-run-{0..COUNT} placeholder tenants.
-# ---------------------------------------------------------------------------
-echo "[bench-e2e] pre-creating $((COUNT + 1)) bench-run-* placeholder tenants"
+#
+# Sentinel value (bench_trigger: "1") differs from what driver.py writes
+# during the fire phase (bench_trigger: "100"). This guarantees the
+# first fire-phase fixture write produces a real content-hash diff so
+# `diffAndReload` actually triggers and `last_reload_complete_unixtime_
+# seconds` advances → driver's T2 poll succeeds.
+#
+# History: first CI run (24937326270) wrote "100" here AND in the
+# driver, producing identical bytes. Watcher saw mtime change, scan
+# computed identical hash, no reload triggered → driver polled T2
+# until timeout (60s) for every run, taking ~5 min/run × 6 runs before
+# 30-min workflow timeout cancelled. Per-run-*.json all showed
+# `T2_unix_ns: 0, stage_ab_skipped: true` for fire phase, the
+# diagnostic that pinpointed the bug.
+echo "[bench-e2e] pre-creating $((COUNT + 1)) bench-run-* placeholder tenants (sentinel value differs from driver write)"
 for i in $(seq 0 "$COUNT"); do
     cat > "fixture/active/conf.d/bench-run-${i}.yaml" <<EOF
 tenants:
   bench-run-${i}:
-    bench_trigger: "100"
+    bench_trigger: "1"
 EOF
 done
 


### PR DESCRIPTION
## Summary

Diagnosed via partial artifact from cancelled run [#24937326270](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24937326270). All 6 retrieved per-run JSONs showed:

```json
"fire": {
  "T1_unix_ns": 1777140745000000000,  // scan advanced (+24s)
  "T2_unix_ns": 0,                    // reload NEVER advanced
  "T3_unix_ns": 0, "T4_unix_ns": 0,
  "stage_ab_skipped": true,           // ← incorrectly skipped on FIRE phase
  "e2e_ms": -1
}
```

**Root cause**: [bench_e2e_run.sh](scripts/ops/bench_e2e_run.sh) step 3 pre-created `bench-run-${i}.yaml` with `bench_trigger: "100"` — the SAME content [driver.py](tests/e2e-bench/driver/driver.py) writes during the fire phase. WatchLoop scan saw mtime change but content hash was identical, so `diffAndReload` short-circuited and `last_reload_complete_unixtime_seconds` wasn't stamped. Driver then polled T2 for the full 60s `POLL_TIMEOUT_S`, marked stage AB skipped, moved on.

With 31 runs × ~270s/run (4 polls × 60s each + scrape overhead) the workflow exceeded the 30-min cap after ~6 runs and was cancelled.

## Fix

- **Pre-create now writes `bench_trigger: "1"`** (sentinel)
- Driver continues to write `bench_trigger: "100"` per design §5.2
- First fire-phase write per tenant produces a real content-hash diff → exporter reloads → gauge advances → T2 polls succeed in <5s instead of timing out
- Sentinel `"1"` is still a valid threshold (driver pushes actual=200 which exceeds it; alert semantics unchanged)

**Defense-in-depth**: bumped workflow timeout from 30 → 60 min. 1000-tenant should now finish in ~5-8 min after this fix, but 5000-tenant cold-start hasn't been measured end-to-end on ubuntu-latest. 60 min leaves slack without normalizing an unbounded-cost workflow.

## Why not detected pre-merge

The local sanity sweep in PR #80 ran `make benchmark-report` (Go bench), not `make bench-e2e` (compose stack). The compose-level integration was deferred to first workflow_dispatch on main per design §8.1 — exactly the kind of "first-real-run" surprise §8.1 acknowledges as an accepted cost.

## Test plan

- [x] pre-commit clean (head-blob-hygiene FUSE-skipped per Trap #57)
- [ ] CI green
- [ ] Post-merge: re-run `gh workflow run "Bench E2E Record (manual dispatch)" -f fixture_kind=synthetic-v2 -f count=30 -f fixture_tenant_count=1000` → expect successful aggregate JSON within 10 min, all per-run-*.json showing `T2 > T1 > T0` and `stage_ab_skipped=false` for fire phase
- [ ] Then re-run with `fixture_tenant_count=5000`

## Refs

- cancelled runs: [#24937326270](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24937326270) (1000-tenant), [#24937331615](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24937331615) (5000-tenant)
- [Issue #83](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/83) Task 1+2 (baseline runs blocked on this fix)
- design [§5.1](docs/internal/design/phase-b-e2e-harness.md) (pre-create rationale) + §5.2 (driver fire-phase write spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)