### PR TITLE
fix(phase-b): register bench_trigger in active _defaults.yaml (unblock T3/T4 anchors)

### DIFF
--- a/scripts/ops/bench_e2e_run.sh
+++ b/scripts/ops/bench_e2e_run.sh
@@ -87,12 +87,69 @@ if [[ "$TENANT_FILE_COUNT" -eq 0 ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Step 2: stage fixture into active/.
+# Step 2: stage fixture into active/ + register bench_trigger metric.
 # ---------------------------------------------------------------------------
 echo "[bench-e2e] staging fixture into fixture/active/conf.d/"
 rm -rf fixture/active/conf.d
 mkdir -p fixture/active/conf.d
 cp -r "$FIXTURE_SOURCE_DIR/." fixture/active/conf.d/
+
+# Register `bench_trigger` in the active root _defaults.yaml — the
+# synthetic-v* generator only knows DB-domain metrics (mysql_*, pg_*,
+# etc.), but our bench-run-{i} tenants override `bench_trigger`. Without
+# a default entry the exporter rejects the override (logs "unknown key
+# bench_trigger not in defaults") and never emits user_threshold{
+# metric="bench_trigger"} → alert rule never matches → driver T3/T4
+# poll forever (60s × 4 polls × 31 runs = workflow timeout territory).
+#
+# Diagnosed via partial artifact from cancelled run #24944542524:
+# per-run-*.json showed T1+T2 advance correctly (PR #86 fix worked) but
+# T3=0, T4=0 → alert never fired → metric absent from Prometheus.
+#
+# `_defaults.yaml` lives at root of conf.d/ (root scope per ADR-018).
+# Append `bench_trigger: 50` if the file already exists; else create it.
+# Value 50 is below driver fire-phase actual=200 (alert fires) and
+# above driver resolve-phase actual=50 (alert resolves) … wait, no:
+# resolve sets actual=50 which is NOT > 50, so alert resolves correctly.
+# Setting default to 50 means bench-run-N tenants without explicit
+# override would also have threshold 50 — irrelevant since each tenant
+# config sets its own override before driver pushes actual.
+DEFAULTS_FILE="fixture/active/conf.d/_defaults.yaml"
+if [[ -f "$DEFAULTS_FILE" ]]; then
+    # File exists from --with-defaults; append bench_trigger to the
+    # `defaults:` block. We use a Python helper for safe YAML write
+    # since we don't have yq/jq guaranteed in this orchestrator.
+    python3 - <<PYEOF
+import sys
+from pathlib import Path
+p = Path("$DEFAULTS_FILE")
+text = p.read_text(encoding="utf-8")
+if "bench_trigger:" in text:
+    print("[bench-e2e] bench_trigger already in _defaults.yaml; skipping")
+    sys.exit(0)
+# Find the 'defaults:' block and append a new key. Simple line-based
+# approach: insert after the 'defaults:' line, indented 2 spaces.
+lines = text.splitlines()
+out = []
+inserted = False
+for line in lines:
+    out.append(line)
+    if not inserted and line.rstrip() == "defaults:":
+        out.append("  bench_trigger: 50")
+        inserted = True
+if not inserted:
+    # No 'defaults:' key found; prepend a fresh block.
+    out = ["defaults:", "  bench_trigger: 50"] + out
+p.write_text("\n".join(out) + "\n", encoding="utf-8")
+print(f"[bench-e2e] registered bench_trigger=50 in {p}")
+PYEOF
+else
+    cat > "$DEFAULTS_FILE" <<EOF
+defaults:
+  bench_trigger: 50
+EOF
+    echo "[bench-e2e] created $DEFAULTS_FILE with bench_trigger=50"
+fi
 
 # ---------------------------------------------------------------------------
 # Step 3: pre-create bench-run-{0..COUNT} placeholder tenants.


### PR DESCRIPTION
## Summary

3rd diagnosis-fix cycle. Cumulative chain:
- PR [#85](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/85) — fixed fixture-empty conflict (run [#24936869438](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24936869438))
- PR [#86](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/86) — fixed pre-create-vs-driver hash collision (run [#24937326270](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24937326270))
- **THIS PR** — fixes missing `bench_trigger` default (run [#24944542524](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24944542524))

## Diagnosis from #24944542524 partial artifact

```json
"fire": {
  "T1_unix_ns": 1777164670000000000,  // scan complete (+28s — CI fs)
  "T2_unix_ns": 1777164671000000000,  // reload complete (+1s) ✓ PR #86 fix worked
  "T3_unix_ns": 0,                    // alert NEVER fired
  "T4_unix_ns": 0,                    // receiver NEVER posted
  "stage_ab_skipped": false           // ✓ PR #86 fix verified
}
```

PR #86 unblocked T1/T2. New bug at T3/T4: alert rule never matches because the `user_threshold{metric="bench_trigger"}` series **doesn't exist**.

**Root cause**: synthetic-v2 generator writes `_defaults.yaml` with DB-domain metrics (`mysql_connections`, `pg_stat_activity_count`, etc.) but **not `bench_trigger`**. When bench-run-{i} tenants override `bench_trigger: "1"`, the exporter's three-state config parser logs *"unknown key bench_trigger not in defaults"* and silently skips. Alert rule has no right-hand side → comparison returns empty → alert never fires → driver T3 timeout 60s × 4 polls × 31 runs → 60-min workflow cap.

## Fix

`bench_e2e_run.sh` step 2 (post-stage) registers `bench_trigger: 50` in the active root `_defaults.yaml`. Idempotent (skips if already present). Inline Python helper preserves existing YAML structure.

**Threshold value 50** chosen because:
- driver fire phase pushes actual=200 → 200 > 50 fires ✓
- driver resolve phase pushes actual=50 → 50 > 50 is false (strict `>`) → resolves ✓
- bench-run-{i} tenants override to `"1"` (placeholder) / `"100"` (driver fire write) — default matters only for tenants without override, which doesn't apply here

**Local smoke test** of the Python helper:
```
before: defaults: { mysql_connections: 80, pg_stat_activity_count: 100 }
after:  defaults: { bench_trigger: 50, mysql_connections: 80, pg_stat_activity_count: 100 }
```

## Why not detected earlier

Each fix unblocks one stage of the 5-anchor chain. Only after T1/T2 work do you discover T3/T4 bugs because previously the driver gave up before reaching them. This is the design §8.1 *"first-real-run surprise"* pattern, just deeper than expected.

The pattern is now exhausted at stage 3 (out of 5). After this fix, T3 should fire and T4 should follow within the alertmanager `group_wait: 0s` window. **If a 4th cycle is needed**, the bug would be in T4 (receiver) or aggregator schema — both have unit tests, so unlikely.

## Test plan

- [x] `bash -n scripts/ops/bench_e2e_run.sh` syntax clean
- [x] Local smoke test of inline Python helper (idempotent + preserves structure)
- [x] pre-commit clean (head-blob-hygiene FUSE-skipped per Trap #57)
- [ ] CI green
- [ ] Post-merge: re-run 1000-tenant `gh workflow run`, expect aggregate JSON within ~10 min, all per-run-*.json showing `T3 > T2`, `T4 > T3`, `e2e_ms > 0`, `stage_ms.C ≥ 0` and `stage_ms.D ≥ 0`

## Refs

- cancelled run [#24944542524](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24944542524) (1000-tenant)
- cancelled run [#24944543848](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24944543848) (5000-tenant; same root cause expected)
- [Issue #83](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/83) Task 1+2 still blocked
- design [§4.3](docs/internal/archive/design/phase-b-e2e-harness.md) (alert rule double-metric model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)