### PR TITLE
fix(phase-b): alert rule label match — exporter splits bench_trigger on first underscore

### DIFF
--- a/components/threshold-exporter/app/config_debounce_test.go
+++ b/components/threshold-exporter/app/config_debounce_test.go
@@ -405,34 +405,40 @@ func TestFireDebounced_EmitsBatchAndDuration(t *testing.T) {
 		t.Fatalf("expected at least 1 fire, got %d (base=%d)", deltaFire, baseFire)
 	}
 
-	// Goroutine-leak race (per S#32 / runs/24935213973): a prior test's
-	// fireDebounced may complete its diffAndReload AFTER our
-	// withIsolatedMetrics swap AND after our baseline snapshot — its
-	// late ObserveReloadDuration / ObserveDebounceBatch then lands on
-	// `fresh`, inflating both deltas by 1. `m.Close()` does NOT wait for
-	// in-flight callbacks (intentional — see config_debounce.go::Close).
+	// Goroutine-leak race (per S#32 / S#35 / S#37): a prior test's
+	// fireDebounced may complete AFTER our withIsolatedMetrics swap. The
+	// S#35 fix asserted "deltaReload == deltaBatch lockstep" but that
+	// claim was WRONG — only batch + DebounceFiredCount() are atomic
+	// (Step 1+2 of fireDebounced under m.debounceMu). Reload is observed
+	// AFTER diffAndReload (Step 4), making its leak window much wider:
 	//
-	// The actually-testable invariants under this race:
-	//   1. deltaReload == deltaBatch (both observed in the same
-	//      fireDebounced critical section, so they leak in lockstep)
-	//   2. deltaReload >= deltaFire (we observed at least our own fires)
-	//   3. when no leak (deltaReload == deltaFire), sum == numTriggers
-	//      exactly (every triggerDebouncedReload coalesced into one fire)
+	//   fireDebounced steps:
+	//     1. ObserveDebounceBatch(len(reasons))   ← batch leaks here
+	//     2. atomic.AddUint64(&m.debounceFired)   ← fire counter
+	//        ----- diffAndReload runs (~ms-100ms) -----
+	//     4. ObserveReloadDuration(elapsed)       ← reload leaks LATE
+	//
+	// PR #90 CI run #24946980383 observed deltaReload=2, deltaBatch=1 —
+	// invalidating the lockstep claim. The truly testable invariants:
+	//   1. deltaBatch == deltaFire (these ARE atomic per fireDebounced)
+	//   2. deltaReload >= deltaFire (we observed at least our own fires;
+	//      prior leak's late ObserveReloadDuration may add more)
+	//   3. when deltaReload == deltaFire AND deltaFire == 1 (no leak
+	//      detected), batch sum == numTriggers exactly.
 	deltaReload := histogramSampleCount(t, fresh.reloadDuration) - baseReload
 	deltaBatchCount := histogramSampleCount(t, fresh.debounceBatch) - baseBatchCount
 
-	if deltaReload != deltaBatchCount {
-		t.Errorf("lockstep invariant violated: deltaReload=%d != deltaBatch=%d (both observed in fireDebounced under same lock)", deltaReload, deltaBatchCount)
+	if deltaBatchCount != deltaFire {
+		t.Errorf("batch-fire lockstep violated: deltaBatch=%d != deltaFire=%d (both atomic under m.debounceMu in fireDebounced steps 1+2)", deltaBatchCount, deltaFire)
 	}
 	if deltaReload < deltaFire {
 		t.Errorf("at-least-our-own invariant violated: deltaReload=%d < deltaFire=%d", deltaReload, deltaFire)
 	}
 
-	// When there's no leak, we can assert the exact sum (numTriggers
-	// coalesced into our one fire). When there's a leak, deltaReload >
-	// deltaFire and the sum includes both our triggers and the leaked
-	// fire's batch — sum-floor (>= numTriggers) is the strongest
-	// assertion possible.
+	// When there's no reload leak (deltaReload == deltaFire) AND we
+	// observed exactly one fire, we can assert batch sum exactly.
+	// Otherwise (reload leak from prior test in flight, or multiple
+	// fires), sum-floor (>= numTriggers) is the strongest assertion.
 	leaked := deltaReload > deltaFire
 	if !leaked && deltaFire == 1 {
 		reg := prometheus.NewRegistry()

--- a/docs/internal/testing-playbook.md
+++ b/docs/internal/testing-playbook.md
@@ -599,7 +599,17 @@ The leaked callback's late `getConfigMetrics()` returns the **NEW** test's `fres
 
 **Insufficient fix (S#32, PR #75)**: snapshot baseline counts at test start, assert deltas. **Doesn't help** if the leak lands BETWEEN snapshot and final read (5-50ms `diffAndReload` window). PR #79 reproduced the same flake despite the baseline-snapshot fix.
 
-**Durable fix (S#35, PR #79 commit `0abc2ff`)**: assert lockstep + `>=` invariants. For a metric pair Set in the same critical section (e.g. `ObserveDebounceBatch` + `ObserveReloadDuration` both in `fireDebounced` after the lock):
+**Insufficient fix (S#35, PR #79 commit `0abc2ff`)**: claimed `deltaReload == deltaBatch` "lockstep" because both are observed in `fireDebounced`. **WRONG** — only `ObserveDebounceBatch` + `atomic.AddUint64(&m.debounceFired)` are atomic (steps 1+2 under `m.debounceMu`). `ObserveReloadDuration` happens AFTER `diffAndReload` (step 4), giving reload a much wider leak window than batch. PR #90 CI run #24946980383 observed `deltaReload=2, deltaBatch=1` — invalidated the lockstep claim.
+
+```text
+fireDebounced timeline (per config_debounce.go):
+  1. ObserveDebounceBatch(len(reasons))    ← batch leaks here
+  2. atomic.AddUint64(&m.debounceFired)    ← per-instance fire counter
+     ----- diffAndReload runs (~ms-100ms) -----
+  4. ObserveReloadDuration(elapsed)        ← reload leaks LATE
+```
+
+**Durable fix (S#37, PR #90)**: assert what's actually atomic + a `>=` lower bound on what isn't. Three invariants:
 
 ```go
 // Capture baseline before triggering our own work.
@@ -613,27 +623,30 @@ deltaFire := m.DebounceFiredCount() - baseFire
 deltaReload := histogramSampleCount(t, fresh.reloadDuration) - baseReload
 deltaBatchCount := histogramSampleCount(t, fresh.debounceBatch) - baseBatchCount
 
-// Lockstep invariant: same critical section ⇒ leak in lockstep.
-if deltaReload != deltaBatchCount {
-    t.Errorf("lockstep violated: deltaReload=%d != deltaBatch=%d", deltaReload, deltaBatchCount)
+// (1) batch + fire ARE atomic per fireDebounced steps 1+2 → lockstep:
+if deltaBatchCount != deltaFire {
+    t.Errorf("batch-fire lockstep violated: deltaBatch=%d != deltaFire=%d", deltaBatchCount, deltaFire)
 }
-// At-least-our-own invariant: we observed >= our own fires.
+// (2) reload is observed AFTER diffAndReload → only `>=` invariant holds:
 if deltaReload < deltaFire {
     t.Errorf("at-least invariant violated: deltaReload=%d < deltaFire=%d", deltaReload, deltaFire)
 }
-// Exact equality only when no leak detected.
+// (3) Exact equality only when no leak detected.
 if deltaReload == deltaFire && deltaFire == 1 {
     // assert sum/count exactly here
 }
 ```
 
-**Verified stable** under `go test -race -count=20` on `TestFireDebounced_EmitsBatchAndDuration` after applying the pattern.
-
 **Reference implementations**: see `components/threshold-exporter/app/config_debounce_test.go::TestFireDebounced_EmitsBatchAndDuration` for the canonical example.
 
 > **Generality note**: the example uses `m.DebounceFiredCount()` which is exporter-specific. The pattern generalizes to **any** Go test that:
 > (a) swaps a global metric instance via a `withIsolated*` helper, AND
-> (b) exercises production code that spawns goroutines / `time.AfterFunc` callbacks whose `Close()` doesn't wait. Substitute `DebounceFiredCount()` with whatever per-instance counter your subject exposes (e.g. tenant-api could use a `RequestCount()` accessor). The lockstep + `>=` invariants hold whenever two metric observations sit in the same critical section in the production callback.
+> (b) exercises production code that spawns goroutines / `time.AfterFunc` callbacks whose `Close()` doesn't wait.
+>
+> Identify which observations sit **inside** vs **after** the critical section in the production callback:
+> - **Inside critical section** (atomic with the per-instance counter): assert `delta == fire`
+> - **After critical section** (separated by I/O / heavy compute): assert `delta >= fire`
+> Substitute `DebounceFiredCount()` with whatever per-instance counter your subject exposes (e.g. tenant-api could use a `RequestCount()` accessor).
 
 ### 2. 時間敏感 test 用 quiescence detection，**不要**「sleep + assert exactly N」
 
@@ -715,8 +728,8 @@ This helper exists at `components/threshold-exporter/app/config_metrics_test.go:
 When reviewing a PR that adds a Go test using `withIsolatedMetrics` + production code with async callbacks (`time.AfterFunc`, goroutine spawn), verify:
 
 - [ ] Snapshot baseline counts at test start (don't rely on `fresh` starting at 0)
-- [ ] Assert lockstep invariants for metric pairs Set in same critical section (`deltaA == deltaB`)
-- [ ] Assert `>=` invariants relative to per-instance `DebounceFiredCount()` etc., not exact equality
+- [ ] **Identify which metric observations are `inside` vs `after` the production critical section** — assert `delta == fire` only for those inside; use `delta >= fire` for those after (e.g. observed post-I/O)
+- [ ] **Do NOT assume two metrics in the same callback function are atomic** — check whether they bracket I/O / heavy compute (which makes their leak windows different sizes)
 - [ ] Use quiescence detection for "wait for fire" (poll + stable-window), not `time.Sleep(window+buffer)` + exact-count assert
 - [ ] If using `testutil.CollectAndCount` on plain `Histogram`, replace with `histogramSampleCount` helper
 

--- a/tests/e2e-bench/alert-rules.yml
+++ b/tests/e2e-bench/alert-rules.yml
@@ -12,19 +12,30 @@
 # label; both metrics carry that label; the join `on(tenant)` aligns
 # them. Alertmanager group_by[tenant] keeps fire/resolve cycles for
 # different runs in separate groups → no dedup interference.
+#
+# Label-emit convention (per collector.go): the exporter splits a
+# config key like `bench_trigger` on the FIRST underscore into:
+#   metric="trigger", component="bench"
+# So `bench_trigger: 50` in `_defaults.yaml` becomes
+#   user_threshold{component="bench",metric="trigger",severity="warning",
+#                  tenant="bench-run-N"} 50
+# NOT `user_threshold{metric="bench_trigger"}` — the original alert
+# rule drafted in design §4.3 used the latter and never matched.
+# Diagnosed via local exporter scrape against a representative fixture
+# during 4th cancelled workflow_dispatch (#24945790974) investigation.
 
 groups:
   - name: e2e-bench
     interval: 5s
     rules:
       - alert: TenantThresholdExceeded
-        # actual > threshold for the same tenant where metric=bench_trigger.
-        # group_left(metric) carries the metric label through for clarity
-        # in the alert annotations.
+        # Match the (component, metric) pair that the exporter actually
+        # emits for `bench_trigger` config key. group_left carries both
+        # labels through so alert annotations can reference them.
         expr: |
           actual_metric_value
-            > on(tenant) group_left(metric)
-          user_threshold{metric="bench_trigger"}
+            > on(tenant) group_left(component, metric)
+          user_threshold{component="bench", metric="trigger"}
         for: 0s
         labels:
           severity: critical


### PR DESCRIPTION
## Summary

**4th diagnosis-fix cycle**. Cumulative chain:

| Cycle | Failed run | Fix PR |
|---|---|---|
| 1 | [#24936869438](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24936869438) — fixture-empty conflict | [#85](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/85) ✅ |
| 2 | [#24937326270](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24937326270) — pre-create vs driver write hash collision | [#86](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/86) ✅ |
| 3 | [#24944542524](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24944542524) — missing bench_trigger default | [#88](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/88) ✅ |
| **4** | [#24945790974](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24945790974) — **alert rule label mismatch** | **THIS PR** |

## Diagnosis

Local exporter scrape against representative fixture revealed:

```
$ curl -s http://localhost:18889/metrics | grep user_threshold.*bench
user_threshold{component="bench",metric="trigger",severity="warning",
               tenant="bench-run-1"} 1
```

The exporter ([`collector.go`](components/threshold-exporter/app/collector.go)) splits a config key on the **FIRST underscore** into `component` and `metric` labels:

| Config key | `component` label | `metric` label |
|---|---|---|
| `bench_trigger` | `"bench"` | `"trigger"` |
| `pg_stat_activity_count` | `"pg"` | `"stat_activity_count"` |
| `mysql_global_status_x` | `"mysql"` | `"global_status_x"` |

The original alert rule from [design §4.3](docs/internal/archive/design/phase-b-e2e-harness.md) was:

```promql
actual_metric_value > on(tenant) group_left(metric)
  user_threshold{metric="bench_trigger"}
```

But the actual emitted series carries `metric="trigger"`, NOT `metric="bench_trigger"`. RHS never matches → alert never fires → driver T3 polls 60s → timeout → cycle.

## Fix

Match what exporter actually emits:

```promql
actual_metric_value
  > on(tenant) group_left(component, metric)
user_threshold{component="bench", metric="trigger"}
```

Plus expanded comment in `alert-rules.yml` documenting the splitting convention so the next reader doesn't fall again.

## Why not detected in design phase

design-phase reviewers (myself + Gemini) focused on architecture (5-anchor model, double-metric alert, `send_resolved` necessity) rather than exact label specifics. The original spec used `metric="bench_trigger"` from memory of metric label semantics, not from inspecting `collector.go`'s actual transformation.

This is **the last diagnostic surface in the 5-anchor chain**:
- T1/T2 unblocked by PR #86
- alert rule emission unblocked by PR #88
- alert rule MATCH unblocked by this PR
- T4 follows naturally from T3 within alertmanager `group_wait: 0s`

## Local verification

```bash
rm -rf /tmp/bench-conf && mkdir /tmp/bench-conf
printf 'defaults:\n  bench_trigger: 50\n' > /tmp/bench-conf/_defaults.yaml
printf 'tenants:\n  bench-run-1:\n    bench_trigger: "1"\n' \
  > /tmp/bench-conf/bench-run-1.yaml
go run components/threshold-exporter/app/. \
  --listen=:18889 --config=/tmp/bench-conf &
curl -s http://localhost:18889/metrics | grep user_threshold.*bench
# → user_threshold{component="bench",metric="trigger",...,tenant="bench-run-1"} 1
```

## Test plan

- [x] Local exporter scrape verifies emitted label set
- [x] pre-commit clean (head-blob-hygiene FUSE-skipped per Trap #57)
- [ ] CI green
- [ ] Post-merge: 5th re-trigger of 1000-tenant baseline; expect aggregate JSON within ~10 min, all per-run-*.json showing `T3 > T2`, `T4 > T3`, `e2e_ms > 0`

## Lesson candidate (future testing-playbook §v2.8.x)

"Verify metric label set against a running exporter, not against config key names — the exporter may transform key → label set in non-obvious ways (e.g. `bench_trigger` → `{component=bench, metric=trigger}`)."

## Refs

- cancelled run [#24945790974](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24945790974) (1000-tenant)
- cancelled run [#24945792691](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/24945792691) (5000-tenant; same root cause)
- [Issue #83](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/83) Task 1+2 still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)