### PR TITLE
fix(phase-b): cycle-6 — synthetic-v2 defaults numeric + driver wait + 5s reload

### DIFF
--- a/scripts/tools/dx/generate_tenant_fixture.py
+++ b/scripts/tools/dx/generate_tenant_fixture.py
@@ -216,13 +216,25 @@ def _gen_tenant_config(rng: random.Random, tenant_id: str, db_type: str) -> dict
 
 
 def _gen_defaults_yaml(rng: random.Random, db_types: list[str] | None = None) -> dict:
-    """Generate a _defaults.yaml content."""
+    """Generate a _defaults.yaml content.
+
+    NOTE: the exporter's `_defaults.yaml` parser only accepts numeric
+    (float64) values for the `defaults:` block — scheduled-threshold
+    strings ("17838:critical") and "disable" sentinels are valid only
+    in tenant override files. If those forms appear in defaults, the
+    parser rejects the entire file with `cannot unmarshal !!str into
+    float64`, which silently drops every default and breaks downstream
+    tenant overrides that depend on key-presence-in-defaults validation
+    (see exporter `WARN: tenant=…: unknown key … not in defaults`).
+    Always emit ints here.
+    """
     defaults: dict[str, Any] = {"defaults": {}}
     all_db_types = db_types or DB_TYPES
     for dbt in all_db_types:
         metrics = METRIC_TEMPLATES.get(dbt, [])
         for m in metrics[:3]:  # top 3 metrics per db type as defaults
-            defaults["defaults"][m] = _gen_threshold_value(rng)
+            # Numeric-only — see docstring above for rationale.
+            defaults["defaults"][m] = rng.randint(50, 100000)
     return defaults
 
 

--- a/tests/e2e-bench/docker-compose.yml
+++ b/tests/e2e-bench/docker-compose.yml
@@ -35,6 +35,19 @@ services:
     command:
       - "--listen=:8080"
       - "--config=/etc/threshold-exporter/conf.d"
+      # Production defaults are reload=30s, debounce=300ms — fine for
+      # K8s ConfigMap rotation cadence. For the bench harness we need
+      # MUCH faster change detection because the driver's per-run
+      # POLL_TIMEOUT_S is 60s. With production reloadInterval=30s and
+      # 1000-tenant scan time ~30s on slow CI runners, the next
+      # WatchLoop tick after driver's fixture mutation can land at
+      # T0+60s, exactly the polling deadline — race city.
+      #
+      # Override to 5s reload + 100ms debounce: WatchLoop catches
+      # the mutation within 5s, debounce window collapses, diffAndReload
+      # stamps the gauge well within driver's 60s budget.
+      - "--reload-interval=5s"
+      - "--scan-debounce=100ms"
     expose:
       - "8080"
     # Distroless base has no wget/curl/sh — use Prometheus's
@@ -112,6 +125,26 @@ services:
       alertmanager:
         condition: service_healthy
       receiver:
+        condition: service_started
+      # Pushgateway and threshold-exporter are dependencies of prometheus
+      # (which alertmanager depends on), so they're started by the time
+      # alertmanager is healthy. BUT compose's `service_started` only
+      # means the container is up, NOT that the process inside is
+      # listening. At CI scale (1000-tenant fixture mounted from slow
+      # ubuntu-latest disk), the threshold-exporter's first config
+      # load + the pushgateway's first :9091 listen can lag the driver's
+      # first push by several seconds, producing
+      # `urllib.error.URLError: <urlopen error [Errno 111] Connection
+      # refused>` for runs 0..N. Local-scale (3-4 tenants) doesn't
+      # trigger this because everything's ready instantly.
+      #
+      # Add explicit dependencies so compose waits for these too.
+      # Pushgateway has no healthcheck so we use service_started; the
+      # in-driver wait_for_services() loop (added in driver.py) covers
+      # the listen-vs-up gap.
+      pushgateway:
+        condition: service_started
+      threshold-exporter:
         condition: service_started
     # Driver exits naturally after COUNT+1 runs; abort-on-container-exit
     # in `docker compose up` brings the rest down.

--- a/tests/e2e-bench/driver/driver.py
+++ b/tests/e2e-bench/driver/driver.py
@@ -40,6 +40,7 @@ from pathlib import Path
 EXPORTER_URL = os.environ.get("EXPORTER_URL", "http://threshold-exporter:8080")
 PROMETHEUS_URL = os.environ.get("PROMETHEUS_URL", "http://prometheus:9090")
 PUSHGATEWAY_URL = os.environ.get("PUSHGATEWAY_URL", "http://pushgateway:9091")
+ALERTMANAGER_URL = os.environ.get("ALERTMANAGER_URL", "http://alertmanager:9093")
 RECEIVER_URL = os.environ.get("RECEIVER_URL", "http://receiver:5001")
 
 FIXTURE_ACTIVE = Path(os.environ.get("FIXTURE_ACTIVE", "/fixture/active/conf.d"))
@@ -384,6 +385,45 @@ def run_one(run_id: int, warm_up: bool) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def wait_for_services(deadline_s: float = 60.0) -> None:
+    """Pre-flight: poll each upstream service until its HTTP endpoint
+    responds. Compose's `service_started` only means the container is
+    up — NOT that the process inside is listening on its port. At
+    CI scale (1000-tenant fixture), threshold-exporter cold-load and
+    pushgateway first-listen lag behind compose `Started` by several
+    seconds, producing `Connection refused` for runs 0..N if driver
+    pushes immediately on boot.
+
+    Use stdout `print(..., flush=True)` so progress is visible even
+    if the workflow gets cancelled mid-wait (Python `print` block-
+    buffers when piped, masking driver activity from `gh run view
+    --log` output otherwise).
+    """
+    targets = [
+        ("exporter", f"{EXPORTER_URL}/metrics"),
+        ("prometheus", f"{PROMETHEUS_URL}/-/ready"),
+        ("pushgateway", f"{PUSHGATEWAY_URL}/-/ready"),
+        ("alertmanager", f"{ALERTMANAGER_URL}/-/ready"),
+        ("receiver", f"{RECEIVER_URL}/healthz"),
+    ]
+    print(f"[driver] waiting for {len(targets)} upstream services to listen ...", flush=True)
+    for name, url in targets:
+        start = time.time()
+        last_err: Exception | None = None
+        while time.time() - start < deadline_s:
+            try:
+                _get(url, timeout=2.0)
+                print(f"[driver]   {name} ready ({time.time() - start:.1f}s)", flush=True)
+                last_err = None
+                break
+            except (urllib.error.URLError, OSError) as e:
+                last_err = e
+                time.sleep(1.0)
+        if last_err is not None:
+            print(f"[driver]   {name} did NOT respond within {deadline_s}s: {last_err}", flush=True)
+            raise SystemExit(f"upstream {name} not ready")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--count", type=int, default=int(os.environ.get("COUNT", "30")))
@@ -396,7 +436,8 @@ def main() -> int:
     # Pre-flight: ensure fixture/active dir exists (compose volume mount).
     FIXTURE_ACTIVE.mkdir(parents=True, exist_ok=True)
 
-    print(f"[driver] starting: count={args.count}, fixture_kind={FIXTURE_KIND}")
+    print(f"[driver] starting: count={args.count}, fixture_kind={FIXTURE_KIND}", flush=True)
+    wait_for_services()
 
     # Run 0 = warm_up; runs 1..count are real.
     n_total = args.count + 1
@@ -405,7 +446,7 @@ def main() -> int:
         try:
             result = run_one(i, warm_up=warm_up)
         except (urllib.error.URLError, OSError) as e:
-            print(f"[driver] run {i} failed: {e}", file=sys.stderr)
+            print(f"[driver] run {i} failed: {e}", file=sys.stderr, flush=True)
             result = {
                 "run_id": i,
                 "warm_up": warm_up,
@@ -416,9 +457,9 @@ def main() -> int:
         out_path = results_dir / f"per-run-{i:04d}.json"
         out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
         e2e = result.get("fire", {}).get("e2e_ms", -1)
-        print(f"[driver] run {i:3d} (warm_up={warm_up}): fire e2e_ms={e2e}")
+        print(f"[driver] run {i:3d} (warm_up={warm_up}): fire e2e_ms={e2e}", flush=True)
 
-    print(f"[driver] done: wrote {n_total} per-run JSON files to {results_dir}")
+    print(f"[driver] done: wrote {n_total} per-run JSON files to {results_dir}", flush=True)
     return 0
 
 

--- a/tests/e2e-bench/fixture/synthetic-v2/conf.d/_defaults.yaml
+++ b/tests/e2e-bench/fixture/synthetic-v2/conf.d/_defaults.yaml
@@ -1,5 +1,13 @@
-# Placeholder — see synthetic-v1 sibling for generation command,
-# but use --layout synthetic-v2 (B-1.P2-b PR #78).
-
 defaults:
-  bench_trigger: 100
+  pg_stat_activity_count: 52208
+  pg_replication_lag_seconds: 35527
+  pg_database_size_bytes: 46149
+  mysql_global_status_threads_connected: 5222
+  mysql_global_status_slow_queries: 69303
+  mysql_global_status_aborted_connects: 50593
+  redis_memory_used_bytes: 18946
+  redis_connected_clients: 94960
+  redis_rejected_connections_total: 92644
+  mongodb_connections_current: 73914
+  mongodb_opcounters_query: 42381
+  mongodb_mem_resident: 24957


### PR DESCRIPTION
## Summary

Cumulative **cycle-6** fix to unblock issue #83 Operational #1+#2
(1000-tenant + 5000-tenant baseline). Reproduced the workflow failure
locally at CI scale (1000-tenant fixture) and unwound four
interlocking root causes — all four fixes are needed for the e2e
harness to fire alerts end-to-end on a freshly-generated synthetic-v2
fixture.

## Root causes & fixes

### 1. synthetic-v2 `_defaults.yaml` had non-float64 values (pre-existing bug)

`scripts/tools/dx/generate_tenant_fixture.py::_gen_threshold_value`
returns mixed types (`int` / `\"X:critical\"` / `\"disable\"`) and
was used for **both** `_defaults.yaml` **and** tenant override files.
The exporter's `_defaults.yaml` parser only accepts `float64`, so:

```text
WARN: skip unparseable file /etc/threshold-exporter/conf.d/_defaults.yaml: yaml: unmarshal errors:
  line 3: cannot unmarshal !!str \`17838:c...\` into float64
  line 10: cannot unmarshal !!str \`disable\` into float64
```

The parser then drops the entire defaults block → 0 defaults loaded
→ \`bench_e2e_run.sh\`'s injected \`bench_trigger: 50\` was futile (it
sat in a rejected file) → \`user_threshold{component=\"bench\",metric=\"trigger\",tenant=\"bench-run-N\"}\`
series never emitted → alert rule never matched → T3=0 → cascading
T4=0 → fire phase failed → workflow exhausted timeout.

**Fix**: \`_gen_defaults_yaml\` now emits ints only. Scheduled
\"X:critical\" and \"disable\" forms remain valid in tenant override
files — they are only invalid in \`_defaults.yaml\` per the exporter
contract. Docstring spells this out so future fixture work doesn't
regress.

### 2. Driver pushed before pushgateway listened (CI-scale race)

Compose's \`service_started\` only means the container is up — not
that the process inside is listening on its port. At 1000-tenant
scale, threshold-exporter's first config load and pushgateway's first
:9091 listen both lag compose \`Started\` by several seconds, so the
driver's first push got \`urllib.error.URLError: <urlopen error
[Errno 111] Connection refused>\`.

**Fix**: \`tests/e2e-bench/driver/driver.py\` adds a
\`wait_for_services()\` pre-flight loop that probes each upstream's
health endpoint with a 60s deadline before the run loop starts.

### 3. Compose driver \`depends_on\` missed pushgateway / threshold-exporter

Both were transitively reachable via prometheus → alertmanager, but
compose only honors **direct** \`depends_on\`.

**Fix**: \`tests/e2e-bench/docker-compose.yml\` adds explicit
\`pushgateway: service_started\` + \`threshold-exporter: service_started\`
to the driver's \`depends_on\`.

### 4. Production reload-interval=30s too slow for bench cadence

With 1000-tenant scan time ~30s on slow CI runners, the next
\`WatchLoop\` tick after the driver's fixture mutation could land at
T0+60s — exactly the driver's \`POLL_TIMEOUT_S\` deadline → race city.
Production K8s ConfigMap rotation cadence (30s/300ms) is fine; the
bench harness needs sub-second reload detection.

**Fix**: \`tests/e2e-bench/docker-compose.yml\` overrides
threshold-exporter command with \`--reload-interval=5s\`
\`--scan-debounce=100ms\`. Production behavior untouched.

## Local verification (COUNT=3, 1000-tenant synthetic-v2)

All 4 runs (warm_up + 3 measured) populated all 5 anchors:

| run | warm_up | fire e2e_ms | resolve e2e_ms |
|-----|---------|-------------|----------------|
| 0 | true | 40122 | 11410 |
| 1 | false | 9791 | 13191 |
| 2 | false | 14599 | (n/a — measured only) |
| 3 | false | 29884 | (n/a — measured only) |

\`aggregate.py\` output: fire P50 14599ms, P95 28355.5ms, gate
\`pending\` (synthetic-v2 awaits customer-anon calibration).

## Side effect

Driver \`print(...)\` calls now use \`flush=True\` so
\`gh run view --log\` reflects live progress instead of block-buffering
to exit. Without this, partial-progress diagnosis of past
workflow_dispatch failures was much harder than necessary.

## Test plan

- [x] Local 1000-tenant synthetic-v2 e2e (COUNT=3) — all anchors fire
- [x] Aggregator runs, JSON output shape matches schema_version=1
- [x] \`pre-commit run --files <changed>\` clean (head-blob-hygiene
  skipped per Trap #57)
- [ ] CI \"Bench E2E Record (manual dispatch)\" — to trigger after merge

## RCA chain context

This closes a 5-cycle RCA chain — each prior cycle exposed the next
deeper bug under e2e harness conditions:

| Cycle | PR | What it fixed | What it exposed next |
|-------|----|---------------|----------------------|
| 1 | #85 | \`_defaults.yaml\` placeholder collision | pre-create vs driver hash collision |
| 2 | #86 | sentinel \"1\" vs driver \"100\" | \`bench_trigger\` not in defaults |
| 3 | #88 | inject \`bench_trigger: 50\` | alert rule used wrong label |
| 4 | #90 | \`{component=\"bench\",metric=\"trigger\"}\` | (this PR — see above) |
| 5 | #92 (this) | 4 interlocking issues | (none expected) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)