### PR TITLE
feat(phase-c): C-12 Guard PR-3 — cardinality guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ Breaking / Upgrade 七塊清楚區分），那是目標形狀。
 
 ### Added
 
+- **Phase .c — C-12 Dangling Defaults Guard PR-3 — Cardinality guard (v2.8.0)** — guard 第三 (最後) 個檢查層落地。預測每 tenant post-merge 的 metric 數，比對 caller-supplied `CardinalityLimit` (建議值對齊 `DefaultMaxMetricsPerTenant=500` from `config_types.go`)。兩 tier — error 在 `>` limit、warn 在 `>` `WarnRatio×limit` (default 0.8 = 80%)。動機：`config_resolve.go::ResolveAt` runtime 對 over-limit tenants **silently truncate excess + WARN log**，operators 經常 deploy 後才發現某些 alerts 不 fire — guard 把這個失敗模式拉到 pre-merge：
+  - **`checkCardinality(input)` 純函式**（`cardinality.go`）— 單 pass：每 tenant 算 `countMetricKeys(effective)` (skip-list 對齊 ResolveAt 的 `_state_*` / `_silent_*` / `_routing*` / `_severity_dedup` / `_metadata` 5 類 special keys) → 比對 limit → emit error/warn/nothing
+  - **Counting model 是 conservative upper bound** — 不模擬 dimensional regex 展開 (`metric{db=~"db[0-9]+"}` 一 key 會在 runtime 變 N thresholds)，所以 dimensional-heavy tenants 可能被 under-count；其他情況 (tenant override 已 disable 的 metrics、`_critical` suffix overrides) 都對。Trade-off 朝「不誤報」傾斜，限制寫進 `cardinality.go` package header
+  - **Skip-list lock-step 維護**：`isSpecialKey` 與 `config_resolve.go::ResolveAt` 的 skip-list 必須手動 keep in lock-step，新加 `_*` semantic prefix 須兩邊都改。`TestIsSpecialKey_FullCoverage` 14 cases 守關 boundary 行為 (含 `_routing_extra` prefix-match vs `_severity_dedup_extra` exact-match)
+  - **新 `CheckInput` fields**：`CardinalityLimit int` (≤0 disables 整個 check)、`CardinalityWarnRatio float64` (out of [0,1] fallback to 0.8；=1.0 disable warn tier 只報 errors)
+  - **新 2 個 `FindingKind`**：`cardinality_exceeded` (error) / `cardinality_warning` (warn)
+  - **16 new top-level tests / 60 total guard tests** — countMetricKeys / isSpecialKey full coverage + checkCardinality 各 tier (no-op when disabled / below floor / at/above warn floor / at exact boundary / above limit / custom warn ratio / out-of-range ratio fallback / ratio=1.0 disables warn tier) + multi-tenant independence + integration with CheckDefaultsImpact (PassedTenantCount drop)。`-race -count=3` 穩定 1.0s；full suite `-race` 5.6s 無 regression
+  - **PR-3 scope discipline** — 不做：dimensional regex expansion 估算 (need fixture data to calibrate, defer)、ADR-003 cross-ref (planning row 寫的 ADR-003 實際是 Sentinel Alert，cardinality 真正 source 是 `DefaultMaxMetricsPerTenant`，CHANGELOG 註記 honest correction)
+  - **C-12 guard 三層 (schema / routing / cardinality) 全到位** — C-10 PR-2 apply mode 啟動時可呼叫完整 guard
+  - 詳見 planning §12.2 Phase .c row C-12
+
 - **Phase .c — C-12 Dangling Defaults Guard PR-2 — Routing schema guardrails (v2.8.0)** — 給 PR-1 落地的 `internal/guard/` 加 routing-schema 檢查。**Scope redirect 從 planning spec**：planning §C-12 layer (ii) 寫的是「routing tree cycle detection + orphaned route」，但 codebase 實際 `_routing` model 是 *flat per-tenant block* (一 receiver + optional `overrides[]`，無 cross-references) → cycles 結構上不可能、orphans 在嚴格意義上不存在。實作 cycle detector 純屬 theatre。本 PR 改 ship 對此 model 真正能抓 bug 的 5 項檢查：
   - **Unknown receiver type (error)** — `receiver.type` 不在 `{webhook, email, slack, teams, rocketchat, pagerduty}`。Source of truth: `scripts/tools/_lib_constants.py::RECEIVER_TYPES` (Python/Go 共用)
   - **Missing required receiver field (error)** — 每 type 有自己的 required fields (`webhook`→`url`、`slack`→`api_url`、`email`→`to`+`smarthost`、`pagerduty`→`service_key`、`teams`→`webhook_url`、`rocketchat`→`url`)。Empty-string 也算 missing (mirror `generate_alertmanager_routes.py` 的 truthy check)

--- a/components/threshold-exporter/app/internal/guard/cardinality.go
+++ b/components/threshold-exporter/app/internal/guard/cardinality.go
@@ -1,0 +1,166 @@
+package guard
+
+// Cardinality guard — PR-3 of the C-12 Dangling Defaults Guard family.
+//
+// Premise: the runtime in components/threshold-exporter/app/
+// config_resolve.go::ResolveAt enforces a per-tenant ceiling on
+// resolved metric thresholds (DefaultMaxMetricsPerTenant = 500).
+// Tenants over the ceiling have their excess silently truncated
+// with a WARN log line. Two failure modes that motivates this guard:
+//
+//   - A `_defaults.yaml` edit that adds N metrics pushes one or
+//     more tenants past the ceiling. Operators only find out via
+//     the WARN log AFTER deploy — and silent truncation means
+//     some alerts simply stop firing without the tenant noticing.
+//
+//   - A tenant's effective config is already at 95% of the ceiling
+//     and an unrelated defaults edit adds one more metric — the
+//     change passes review because nobody checked headroom.
+//
+// PR-3 catches both pre-merge by predicting the post-merge metric
+// count per tenant.
+//
+// COUNTING MODEL (intentionally a conservative upper bound)
+// ---------------------------------------------------------
+// Predicted metric count per tenant = number of top-level keys in
+// the effective config that aren't "special". Special keys mirror
+// the skip-list in config_resolve.go::ResolveAt (lines 47-54):
+//
+//   - prefix `_state_`         (state filters; ResolveStateFilters)
+//   - prefix `_silent_`        (silent modes; ResolveSilentModes)
+//   - prefix `_routing`        (routing block; ResolveRouting)
+//   - exact match `_severity_dedup` (ADR-001)
+//   - exact match `_metadata`  (ADR-018: never inherited, never resolved)
+//
+// What this counter MISSES:
+//   - Dimensional expansion. A YAML like `redis_keys{db="db0"}` and
+//     `redis_keys{db="db1"}` is two keys (counted as 2) but produces
+//     2 thresholds at runtime — counted correctly by accident. But
+//     a regex-based dimensional rule (`redis_keys{db=~"db[0-9]+"}`)
+//     would expand to N thresholds at runtime that the guard counts
+//     as 1. UNDER-COUNT in this case.
+//
+//   - Tenant-disabled metrics. The effective config is post-merge,
+//     so tenant overrides that explicitly disable a default (YAML
+//     null per ADR-018) are already removed by the merge engine
+//     before the guard sees them. So the count is correctly
+//     post-disable. ✓
+//
+//   - `_critical` suffix overrides. These produce additional
+//     threshold rows at runtime but are stored as separate
+//     top-level keys (e.g. `mysql_connections_critical`), so they
+//     ARE counted. ✓
+//
+// Net direction: the counter UNDER-counts dimensional regex
+// expansions and is exact otherwise. That's the safer bias —
+// guard says "you're at the limit" only when you really might be,
+// and a tenant that the guard says is safe could still hit
+// runtime truncation if they use heavy regex dimensional rules.
+// The CLI wrapper (PR-4) should expose a `--strict-dimensional`
+// flag to fold the regex expansion estimate in once we have the
+// fixture data to calibrate it.
+
+import (
+	"fmt"
+	"strings"
+)
+
+// defaultCardinalityWarnRatio matches the value documented on
+// CheckInput.CardinalityWarnRatio (80%).
+const defaultCardinalityWarnRatio = 0.8
+
+// checkCardinality runs the per-tenant cardinality prediction and
+// emits findings. Returns nothing when CardinalityLimit ≤ 0
+// (caller opted out).
+//
+// The check operates on input.EffectiveConfigs — the same merged
+// per-tenant maps the schema validator (PR-1) reads. No extra
+// caller plumbing required beyond setting CardinalityLimit.
+func checkCardinality(input CheckInput) []Finding {
+	if input.CardinalityLimit <= 0 {
+		return nil
+	}
+	warnRatio := input.CardinalityWarnRatio
+	if warnRatio <= 0 || warnRatio > 1 {
+		warnRatio = defaultCardinalityWarnRatio
+	}
+	// Compute warn floor up front. Use float math so a limit of 100
+	// with ratio 0.8 gives 80 exactly (rather than int-truncating to
+	// 80 either way — both work, but floats make non-integer ratios
+	// like 0.85 round predictably).
+	warnFloor := int(float64(input.CardinalityLimit) * warnRatio)
+
+	tenants := sortedTenantIDs(input.EffectiveConfigs)
+	var out []Finding
+	for _, tenantID := range tenants {
+		count := countMetricKeys(input.EffectiveConfigs[tenantID])
+		switch {
+		case count > input.CardinalityLimit:
+			out = append(out, Finding{
+				Severity: SeverityError,
+				Kind:     FindingCardinalityExceeded,
+				TenantID: tenantID,
+				Field:    "",
+				Message: fmt.Sprintf(
+					"tenant %q: predicted metric count %d exceeds the per-tenant cardinality limit of %d; runtime would silently truncate the excess (config_resolve.go::ResolveAt)",
+					tenantID, count, input.CardinalityLimit),
+			})
+		case count > warnFloor:
+			out = append(out, Finding{
+				Severity: SeverityWarn,
+				Kind:     FindingCardinalityWarning,
+				TenantID: tenantID,
+				Field:    "",
+				Message: fmt.Sprintf(
+					"tenant %q: predicted metric count %d is %d%% of the cardinality limit (%d) — only %d slots before runtime truncation",
+					tenantID, count, percentOf(count, input.CardinalityLimit), input.CardinalityLimit, input.CardinalityLimit-count),
+			})
+		}
+	}
+	return out
+}
+
+// countMetricKeys returns the number of top-level keys in `effective`
+// that the runtime would translate into metric threshold rows. See
+// the package header for the precise skip-list rationale.
+//
+// Purely deterministic over the input map's contents; no map
+// iteration order leaks into the count.
+func countMetricKeys(effective map[string]any) int {
+	n := 0
+	for k := range effective {
+		if isSpecialKey(k) {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// isSpecialKey reports whether `k` is a non-metric top-level key
+// per the skip-list in config_resolve.go::ResolveAt (kept in
+// lock-step manually). Adding a new prefix on the runtime side
+// without updating here would over-count and trigger spurious
+// cardinality findings.
+//
+// CAUTION when editing: any new "_*" semantic prefix added to
+// ResolveAt's loop body needs to land here too.
+func isSpecialKey(k string) bool {
+	if k == "_severity_dedup" || k == "_metadata" {
+		return true
+	}
+	return strings.HasPrefix(k, "_state_") ||
+		strings.HasPrefix(k, "_silent_") ||
+		strings.HasPrefix(k, "_routing")
+}
+
+// percentOf returns ⌊count / limit × 100⌋. Defensive division —
+// callers always pass limit > 0 (checkCardinality returns early
+// when limit ≤ 0), but a zero-divide in a Sprintf path would crash
+// the whole report rather than skip one tenant.
+func percentOf(count, limit int) int {
+	if limit <= 0 {
+		return 0
+	}
+	return int(float64(count) * 100.0 / float64(limit))
+}

--- a/components/threshold-exporter/app/internal/guard/cardinality_test.go
+++ b/components/threshold-exporter/app/internal/guard/cardinality_test.go
@@ -1,0 +1,330 @@
+package guard
+
+import (
+	"strings"
+	"testing"
+)
+
+// fixtureMetrics builds a tenant effective config with `n` non-special
+// metric keys + the special keys we want to ignore. Used by every
+// cardinality test that needs to drive the counter to a specific size.
+func fixtureMetrics(n int, includeSpecial bool) map[string]any {
+	out := make(map[string]any, n+5)
+	for i := 0; i < n; i++ {
+		// Use a string-typed value to mirror what the merge engine
+		// emits for top-level threshold entries — ensures the
+		// counter doesn't accidentally key on value type.
+		out[metricKeyName(i)] = "warning"
+	}
+	if includeSpecial {
+		out["_state_disabled"] = nil
+		out["_silent_test"] = "warning"
+		out["_routing"] = "stub"
+		out["_severity_dedup"] = "enable"
+		out["_metadata"] = map[string]any{"contact": "ops"}
+	}
+	return out
+}
+
+func metricKeyName(i int) string {
+	// Generate distinct keys without colliding with any reserved
+	// prefix. Format keeps test output readable when a finding
+	// references one of these synthetically.
+	return "metric_" + strings.Repeat("x", 1) + intToStr(i)
+}
+
+// intToStr is a tiny helper to avoid pulling strconv into the test
+// file's import surface for a single use.
+func intToStr(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	if neg {
+		return "-" + string(digits)
+	}
+	return string(digits)
+}
+
+// --- countMetricKeys / isSpecialKey -------------------------------
+
+func TestCountMetricKeys_SkipsSpecialPrefixes(t *testing.T) {
+	in := fixtureMetrics(7, true)
+	if got := countMetricKeys(in); got != 7 {
+		t.Errorf("countMetricKeys = %d, want 7 (special keys must be skipped)", got)
+	}
+}
+
+func TestIsSpecialKey_FullCoverage(t *testing.T) {
+	cases := []struct {
+		key  string
+		want bool
+	}{
+		{"mysql_connections", false},
+		{"mysql_connections_critical", false}, // suffix _critical doesn't match prefix _
+		{"_state_disabled", true},
+		{"_state_anything", true},
+		{"_silent_warn", true},
+		{"_silent_", true}, // trailing-empty case is still a state-machine match
+		{"_routing", true},
+		{"_routing_extra", true}, // prefix match
+		{"_severity_dedup", true},
+		{"_metadata", true},
+		{"_severity_dedup_extra", false}, // exact match only
+		{"_metadata_extra", false},       // exact match only
+		{"_unknown", false},              // unknown _-prefix not skipped (counts as metric)
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isSpecialKey(tc.key); got != tc.want {
+			t.Errorf("isSpecialKey(%q) = %v, want %v", tc.key, got, tc.want)
+		}
+	}
+}
+
+// --- checkCardinality dispatch -------------------------------------
+
+func TestCheckCardinality_NoOpWhenLimitZero(t *testing.T) {
+	got := checkCardinality(CheckInput{
+		EffectiveConfigs: map[string]map[string]any{
+			"t1": fixtureMetrics(5000, false), // way over any sensible limit
+		},
+		// CardinalityLimit=0 → check disabled
+	})
+	if len(got) != 0 {
+		t.Errorf("got %d findings with CardinalityLimit=0, want 0 (check disabled)", len(got))
+	}
+}
+
+func TestCheckCardinality_NoOpWhenLimitNegative(t *testing.T) {
+	got := checkCardinality(CheckInput{
+		EffectiveConfigs: map[string]map[string]any{"t1": fixtureMetrics(100, false)},
+		CardinalityLimit: -1,
+	})
+	if len(got) != 0 {
+		t.Errorf("got %d findings with negative CardinalityLimit, want 0", len(got))
+	}
+}
+
+func TestCheckCardinality_BelowWarnFloorIsClean(t *testing.T) {
+	// Limit=100, ratio=0.8 → warn floor = 80. 50 metrics is well
+	// below; expect zero findings.
+	got := checkCardinality(CheckInput{
+		EffectiveConfigs: map[string]map[string]any{"t1": fixtureMetrics(50, false)},
+		CardinalityLimit: 100,
+	})
+	if len(got) != 0 {
+		t.Errorf("got %d findings at 50/100, want 0", len(got))
+	}
+}
+
+func TestCheckCardinality_AboveWarnFloorEmitsWarn(t *testing.T) {
+	// Limit=100, ratio=0.8 → warn floor=80. 90 metrics should warn.
+	got := checkCardinality(CheckInput{
+		EffectiveConfigs: map[string]map[string]any{"t1": fixtureMetrics(90, false)},
+		CardinalityLimit: 100,
+	})
+	if len(got) != 1 {
+		t.Fatalf("got %d findings at 90/100, want 1 warning", len(got))
+	}
+	if got[0].Severity != SeverityWarn {
+		t.Errorf("severity = %q, want warn", got[0].Severity)
+	}
+	if got[0].Kind != FindingCardinalityWarning {
+		t.Errorf("kind = %q, want cardinality_warning", got[0].Kind)
+	}
+	if !strings.Contains(got[0].Message, "90") || !strings.Contains(got[0].Message, "100") {
+		t.Errorf("message %q should mention both 90 and 100", got[0].Message)
+	}
+}
+
+func TestCheckCardinality_AboveLimitEmitsError(t *testing.T) {
+	got := checkCardinality(CheckInput{
+		EffectiveConfigs: map[string]map[string]any{"t1": fixtureMetrics(101, false)},
+		CardinalityLimit: 100,
+	})
+	if len(got) != 1 {
+		t.Fatalf("got %d findings at 101/100, want 1 error", len(got))
+	}
+	if got[0].Severity != SeverityError {
+		t.Errorf("severity = %q, want error", got[0].Severity)
+	}
+	if got[0].Kind != FindingCardinalityExceeded {
+		t.Errorf("kind = %q, want cardinality_exceeded", got[0].Kind)
+	}
+	if !strings.Contains(got[0].Message, "exceeds") {
+		t.Errorf("message %q should mention `exceeds`", got[0].Message)
+	}
+}
+
+func TestCheckCardinality_ExactlyAtLimitIsCleanWarn(t *testing.T) {
+	// Boundary: count == limit. The error fires only when count >
+	// limit (strict), so count == limit emits a WARN (still above
+	// the warn floor 80) but not an error.
+	got := checkCardinality(CheckInput{
+		EffectiveConfigs: map[string]map[string]any{"t1": fixtureMetrics(100, false)},
+		CardinalityLimit: 100,
+	})
+	if len(got) != 1 {
+		t.Fatalf("got %d findings at 100/100, want 1 (warn, not error)", len(got))
+	}
+	if got[0].Severity != SeverityWarn {
+		t.Errorf("severity = %q at exact boundary, want warn (error tier requires strictly > limit)", got[0].Severity)
+	}
+}
+
+func TestCheckCardinality_DefaultWarnRatioIs80(t *testing.T) {
+	// Limit=10, no explicit ratio → default 0.8 → floor 8.
+	// 8 metrics: at floor → no warn (warn fires at strictly >).
+	// 9 metrics: above floor → warn fires.
+	in := CheckInput{
+		EffectiveConfigs: map[string]map[string]any{"t1": fixtureMetrics(8, false)},
+		CardinalityLimit: 10,
+	}
+	if got := checkCardinality(in); len(got) != 0 {
+		t.Errorf("at floor (8/10): got %d findings, want 0", len(got))
+	}
+	in.EffectiveConfigs = map[string]map[string]any{"t1": fixtureMetrics(9, false)}
+	if got := checkCardinality(in); len(got) != 1 {
+		t.Errorf("just above floor (9/10): got %d findings, want 1", len(got))
+	}
+}
+
+func TestCheckCardinality_CustomWarnRatio(t *testing.T) {
+	// Custom ratio 0.5 → floor 50 with limit 100. 60 metrics should
+	// emit a warning even though 60 < 80 (the default floor).
+	got := checkCardinality(CheckInput{
+		EffectiveConfigs:     map[string]map[string]any{"t1": fixtureMetrics(60, false)},
+		CardinalityLimit:     100,
+		CardinalityWarnRatio: 0.5,
+	})
+	if len(got) != 1 || got[0].Severity != SeverityWarn {
+		t.Errorf("custom ratio 0.5: at 60/100 expected 1 warn, got %v", got)
+	}
+}
+
+func TestCheckCardinality_RatioOutOfRangeFallsBackToDefault(t *testing.T) {
+	cases := []float64{-0.1, 0, 1.1, 99}
+	for _, ratio := range cases {
+		got := checkCardinality(CheckInput{
+			EffectiveConfigs:     map[string]map[string]any{"t1": fixtureMetrics(85, false)},
+			CardinalityLimit:     100,
+			CardinalityWarnRatio: ratio,
+		})
+		// With default ratio 0.8 the floor is 80; 85 > 80 → 1 warn.
+		if len(got) != 1 || got[0].Severity != SeverityWarn {
+			t.Errorf("ratio=%v: expected default-ratio behaviour (1 warn), got %v", ratio, got)
+		}
+	}
+}
+
+func TestCheckCardinality_RatioOne_DisablesWarnTier(t *testing.T) {
+	// Ratio = 1.0 means warn floor == limit → only counts strictly
+	// above limit ever fire (as errors). So 99/100 emits zero
+	// findings even though it's "almost full".
+	got := checkCardinality(CheckInput{
+		EffectiveConfigs:     map[string]map[string]any{"t1": fixtureMetrics(99, false)},
+		CardinalityLimit:     100,
+		CardinalityWarnRatio: 1.0,
+	})
+	if len(got) != 0 {
+		t.Errorf("ratio=1.0 at 99/100: expected 0 findings (warn tier off), got %v", got)
+	}
+	// 101 should still error.
+	got = checkCardinality(CheckInput{
+		EffectiveConfigs:     map[string]map[string]any{"t1": fixtureMetrics(101, false)},
+		CardinalityLimit:     100,
+		CardinalityWarnRatio: 1.0,
+	})
+	if len(got) != 1 || got[0].Severity != SeverityError {
+		t.Errorf("ratio=1.0 at 101/100: expected 1 error, got %v", got)
+	}
+}
+
+// --- multi-tenant + integration ------------------------------------
+
+func TestCheckCardinality_PerTenantIndependence(t *testing.T) {
+	got := checkCardinality(CheckInput{
+		EffectiveConfigs: map[string]map[string]any{
+			"safe":    fixtureMetrics(50, false),  // below floor
+			"warned":  fixtureMetrics(85, false),  // between floor + limit
+			"errored": fixtureMetrics(150, false), // above limit
+		},
+		CardinalityLimit: 100,
+	})
+	if len(got) != 2 {
+		t.Fatalf("got %d findings (1 warn + 1 error expected for 3 tenants), want 2", len(got))
+	}
+	severities := map[string]Severity{}
+	for _, f := range got {
+		severities[f.TenantID] = f.Severity
+	}
+	if severities["warned"] != SeverityWarn {
+		t.Errorf("tenant `warned` severity = %q, want warn", severities["warned"])
+	}
+	if severities["errored"] != SeverityError {
+		t.Errorf("tenant `errored` severity = %q, want error", severities["errored"])
+	}
+	if _, present := severities["safe"]; present {
+		t.Errorf("tenant `safe` should not appear in findings; got severity %q", severities["safe"])
+	}
+}
+
+func TestCheckCardinality_IntegratesWithCheckDefaultsImpact(t *testing.T) {
+	// Run via the public entry point to confirm the dispatch wires
+	// correctly + cardinality errors drop the tenant from
+	// PassedTenantCount (per run.go's failingTenants map).
+	r, err := CheckDefaultsImpact(CheckInput{
+		EffectiveConfigs: map[string]map[string]any{
+			"good":    fixtureMetrics(50, false),
+			"too-big": fixtureMetrics(200, false),
+		},
+		CardinalityLimit: 100,
+	})
+	if err != nil {
+		t.Fatalf("CheckDefaultsImpact: %v", err)
+	}
+	if r.Summary.PassedTenantCount != 1 {
+		t.Errorf("PassedTenantCount = %d, want 1 (only `good` should pass)", r.Summary.PassedTenantCount)
+	}
+	// Cardinality error should sort before any warn (errors first
+	// in the global sort).
+	if r.Findings[0].Kind != FindingCardinalityExceeded {
+		t.Errorf("first finding kind = %q, want cardinality_exceeded", r.Findings[0].Kind)
+	}
+}
+
+// --- percentOf utility ---------------------------------------------
+
+func TestPercentOf_HappyPath(t *testing.T) {
+	cases := []struct{ count, limit, want int }{
+		{0, 100, 0},
+		{50, 100, 50},
+		{100, 100, 100},
+		{150, 100, 150},
+		{1, 3, 33}, // truncation
+	}
+	for _, tc := range cases {
+		if got := percentOf(tc.count, tc.limit); got != tc.want {
+			t.Errorf("percentOf(%d,%d) = %d, want %d", tc.count, tc.limit, got, tc.want)
+		}
+	}
+}
+
+func TestPercentOf_ZeroLimitIsSafe(t *testing.T) {
+	// Defensive zero-divide guard — we don't expect callers to ever
+	// hit this (checkCardinality returns early when limit ≤ 0), but
+	// a panic in a Sprintf path would take down the whole report.
+	if got := percentOf(50, 0); got != 0 {
+		t.Errorf("percentOf(50, 0) = %d, want 0 (must not panic, must not divide)", got)
+	}
+}

--- a/components/threshold-exporter/app/internal/guard/run.go
+++ b/components/threshold-exporter/app/internal/guard/run.go
@@ -41,6 +41,7 @@ func CheckDefaultsImpact(input CheckInput) (*GuardReport, error) {
 	findings = append(findings, checkRequiredFields(input)...)
 	findings = append(findings, checkRedundantOverrides(input)...)
 	findings = append(findings, checkRoutingGuardrails(input)...)
+	findings = append(findings, checkCardinality(input)...)
 
 	// Stable sort: errors before warnings, then by tenant id, then
 	// by field path. Within the same (severity, tenant, field) we

--- a/components/threshold-exporter/app/internal/guard/types.go
+++ b/components/threshold-exporter/app/internal/guard/types.go
@@ -47,9 +47,16 @@
 //     actually catch real bugs in this model. See routing.go
 //     header for the full rationale.
 //
+//  4. Cardinality guard (PR-3; see cardinality.go)
+//     Predicts each tenant's post-merge metric count and flags
+//     tenants approaching or exceeding the configured per-tenant
+//     ceiling. Conservative upper-bound counter (doesn't model
+//     dimensional expansion); intent is to catch "this defaults
+//     change blows past the runtime truncation threshold" before
+//     it lands. Two tiers: SeverityWarn at WarnRatio×Limit (80%
+//     by default), SeverityError above Limit.
+//
 // Future PRs in the C-12 family:
-//   - PR-3: Cardinality Guard — post-merge label cardinality must
-//     not exceed ADR-003 thresholds (planning §C-12 layer iii).
 //   - PR-4: CLI subcommand `da-tools guard defaults-impact` plus
 //     YAML parsing convenience layer that runs the actual merge
 //     before invoking this library.
@@ -93,6 +100,10 @@ const (
 	FindingEmptyOverrideMatcher      FindingKind = "empty_override_matcher"
 	FindingDuplicateOverrideMatcher  FindingKind = "duplicate_override_matcher"
 	FindingRedundantOverrideReceiver FindingKind = "redundant_override_receiver"
+
+	// Cardinality findings (PR-3; see cardinality.go).
+	FindingCardinalityExceeded FindingKind = "cardinality_exceeded"
+	FindingCardinalityWarning  FindingKind = "cardinality_warning"
 )
 
 // Finding is one issue the guard surfaced. Stable JSON serialisation
@@ -198,4 +209,23 @@ type CheckInput struct {
 	// stays YAML-agnostic; the CLI wrapper (deferred PR-4) does the
 	// extraction before invoking CheckDefaultsImpact.
 	RoutingByTenant map[string]map[string]any `json:"routing_by_tenant,omitempty"`
+
+	// CardinalityLimit is the per-tenant ceiling the cardinality
+	// check (PR-3) compares each tenant's predicted metric count
+	// against. ≤ 0 disables the cardinality check entirely.
+	//
+	// Mirrors `DefaultMaxMetricsPerTenant = 500` from the main
+	// package's config_types.go — caller should usually pass that
+	// constant or whatever the tenant's deployment overrides it to
+	// (`max_metrics_per_tenant` field at the top of the threshold
+	// config).
+	CardinalityLimit int `json:"cardinality_limit,omitempty"`
+
+	// CardinalityWarnRatio is the fraction of CardinalityLimit that
+	// triggers a Severity=warn finding (the error finding fires at
+	// 100% + 1). Out of [0, 1] or zero defaults to 0.8 — early
+	// warning at 80% gives operators a buffer to act before runtime
+	// truncation kicks in. Set to 1.0 to disable the warning tier
+	// (errors only).
+	CardinalityWarnRatio float64 `json:"cardinality_warn_ratio,omitempty"`
 }


### PR DESCRIPTION
## Summary

Adds the third (final) layer of the C-12 Dangling Defaults Guard. PR-1 shipped Schema + Redundant; PR-2 shipped Routing schema; PR-3 closes the loop with cardinality prediction.

**Why**: `config_resolve.go::ResolveAt` silently truncates per-tenant metrics over `DefaultMaxMetricsPerTenant` (default 500) with a WARN log line. Operators only find out post-deploy, and the truncation means some alerts simply stop firing. PR-3 catches both failure modes pre-merge:

- A `_defaults.yaml` edit that adds N metrics pushes one or more tenants past the ceiling.
- A tenant already at 95% of the ceiling and an unrelated defaults edit adds one more — change passes review because nobody checked headroom.

## Files

- `cardinality.go` — `checkCardinality` + `countMetricKeys` + `isSpecialKey` + `percentOf`
- `cardinality_test.go` — 16 top-level tests (both tiers + boundary + ratio edge cases + multi-tenant independence + integration via `CheckDefaultsImpact`)
- `types.go` — new `CardinalityLimit` + `CardinalityWarnRatio` fields on `CheckInput`; two new `FindingKind` consts
- `run.go` — wire `checkCardinality` into `CheckDefaultsImpact`

## Counting model (intentionally a conservative upper bound)

Predicted metric count per tenant = number of top-level keys in the effective config that aren't "special". Special keys mirror `config_resolve.go::ResolveAt`'s skip-list:

- prefix `_state_` (state filters)
- prefix `_silent_` (silent modes)
- prefix `_routing` (routing block)
- exact `_severity_dedup` (ADR-001)
- exact `_metadata` (ADR-018)

**Misses dimensional regex expansion** (e.g. `redis_keys{db=~"db[0-9]+"}` would expand to N rows at runtime but counts as 1 here). Trade-off intentional: false-negative on heavy-regex tenants is the safer bias than over-reporting. The CLI wrapper (PR-4) should expose a `--strict-dimensional` flag once we have fixture data to calibrate the expansion estimate.

**Honest correction**: planning row §C-12 layer (iii) referenced "ADR-003 thresholds" — ADR-003 is actually Sentinel Alert. The real cardinality threshold is `DefaultMaxMetricsPerTenant` from `config_types.go`. PR-3 mirrors that constant rather than ADR-003.

## Two-tier semantics

- **`Severity=error`**: `count > CardinalityLimit` (strict).
- **`Severity=warn`**: `count > WarnRatio×CardinalityLimit` (default 0.8 → warn floor at 80% of limit).
- Set `WarnRatio=1.0` to disable the warn tier (errors only).
- Set `CardinalityLimit=0` (default) to disable the entire check.

## Test plan

- [x] `go test -race -count=3 ./internal/guard/...` — 60 total guard tests (PR-1's 22 + PR-2's 22 + PR-3's 16), 1.0s stable.
- [x] `go test -race ./...` — full suite green, 5.6s, no regression.
- [x] `go vet` clean. `gofmt -l` clean.
- [ ] Branch CI green.

## Self-review pass — found and fixed pre-commit

- `cardinality.go` originally ended with `var _ = sort.Strings` "to prevent import drift" — the **same dead-code anti-pattern** flagged in PR #91 / #102 / #103 self-reviews. Caught and removed during implementation, not waiting for review. Discipline successfully internalised this time — the lesson now fires in muscle memory.
- `cardinality_test.go` `TestCheckCardinality_ExactlyAtLimitIsCleanWarn` had wonky nested if/else logic that worked correctly but was hard to read. Simplified to a single assertion against `SeverityWarn`.

**Failure-mode trace per helper** (per the methodology learning from PR #103's second-pass review):
- `checkCardinality`: ratio edge cases (0/<0/>1/=1) all behave per `types.go` contract.
- `countMetricKeys`: nil/empty/all-special map all return 0 safely (no panic, semantically correct).
- `isSpecialKey`: prefix vs exact match boundary cases all mirror runtime `ResolveAt` semantics (`_routing_extra` matches, `_severity_dedup_extra` does not).
- `percentOf`: zero-divide guarded; large count fits float64.
- `_critical` suffix overrides: counter correctly mirrors runtime "count base + count critical" path per `config_resolve.go:46-130`.

## C-12 status: all three layers complete

Schema (PR #102) + Routing (PR #103) + Cardinality (this PR). C-10 PR-2 apply mode can invoke the complete guard when it lands.

## PR-3 scope discipline

Deferred:
- **PR-4**: CLI subcommand `da-tools guard defaults-impact` plus YAML parsing convenience layer.
- **PR-5**: GitHub Actions wrapper that posts the rendered Markdown report as a PR comment.
- **Dimensional regex expansion estimate** for the cardinality counter (need fixture data to calibrate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)