### PR TITLE
feat(phase-c): C-12 Guard PR-5 — GH Actions wrapper + redundant-override warn-tier

### DIFF
--- a/.github/workflows/guard-defaults-impact.yml
+++ b/.github/workflows/guard-defaults-impact.yml
@@ -71,13 +71,19 @@ jobs:
 
       - name: Detect conf.d path
         id: detect
+        # workflow_dispatch input is fed via env var rather than
+        # `${{ ... }}` shell interpolation — the env-var pattern
+        # bypasses any shell parsing of input contents and is the
+        # GitHub-recommended way to forward user-supplied input
+        # to bash without code-injection surface.
+        env:
+          INPUT_DIR: ${{ github.event.inputs.config_dir }}
         run: |
           # Resolution order:
           #   1. workflow_dispatch input override (manual run)
           #   2. repo-root conf.d/ (customer GitOps layout)
           #   3. components/threshold-exporter/config/conf.d/ (this repo)
           #   4. nothing → skip
-          INPUT_DIR='${{ github.event.inputs.config_dir }}'
           if [ -n "$INPUT_DIR" ] && [ -d "$INPUT_DIR" ]; then
             echo "conf_d=$INPUT_DIR" >> "$GITHUB_OUTPUT"
           elif [ -d "conf.d" ]; then
@@ -92,6 +98,11 @@ jobs:
       - name: Determine scope from changed _defaults.yaml
         if: steps.detect.outputs.conf_d != '' && github.event_name == 'pull_request'
         id: scope
+        # Same env-var hygiene as the Detect step — keep all
+        # `${{ ... }}` substitutions out of inline shell.
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          CONF_D: ${{ steps.detect.outputs.conf_d }}
         run: |
           # Find every changed _defaults.yaml relative to the PR base.
           # If there's exactly one, narrow scope to its directory.
@@ -99,27 +110,30 @@ jobs:
           # multiple cascading edits in one pass uses per-tenant
           # defaults resolution; the redundant-override check stays
           # accurate via NewDefaultsByTenant).
-          mapfile -t CHANGED < <(git diff --name-only "origin/${{ github.base_ref }}"...HEAD -- '**/_defaults.yaml' || true)
+          mapfile -t CHANGED < <(git diff --name-only "origin/${BASE_REF}"...HEAD -- '**/_defaults.yaml' || true)
           if [ "${#CHANGED[@]}" -eq 1 ]; then
             DIR=$(dirname "${CHANGED[0]}")
             echo "scope=$DIR" >> "$GITHUB_OUTPUT"
             echo "Narrow scope: $DIR (single _defaults.yaml change)"
           else
-            echo "scope=${{ steps.detect.outputs.conf_d }}" >> "$GITHUB_OUTPUT"
-            echo "Whole-tree scope: ${{ steps.detect.outputs.conf_d }} (${#CHANGED[@]} _defaults.yaml changed)"
+            echo "scope=${CONF_D}" >> "$GITHUB_OUTPUT"
+            echo "Whole-tree scope: ${CONF_D} (${#CHANGED[@]} _defaults.yaml changed)"
           fi
 
       - name: Run da-guard
         if: steps.detect.outputs.conf_d != ''
         id: guard
+        env:
+          CONF_D: ${{ steps.detect.outputs.conf_d }}
+          INNER_SCOPE: ${{ steps.scope.outputs.scope }}
         run: |
           set +e
-          SCOPE='${{ steps.scope.outputs.scope }}'
+          SCOPE="${INNER_SCOPE}"
           if [ -z "$SCOPE" ]; then
-            SCOPE='${{ steps.detect.outputs.conf_d }}'
+            SCOPE="${CONF_D}"
           fi
           "$RUNNER_TEMP/da-guard" \
-              --config-dir '${{ steps.detect.outputs.conf_d }}' \
+              --config-dir "${CONF_D}" \
               --scope "$SCOPE" \
               --cardinality-limit 500 \
               --format md \
@@ -189,8 +203,9 @@ jobs:
 
       - name: Fail if guard found errors
         if: steps.guard.outputs.exit != ''
+        env:
+          GUARD_EXIT: ${{ steps.guard.outputs.exit }}
         run: |
-          GUARD_EXIT='${{ steps.guard.outputs.exit }}'
           case "$GUARD_EXIT" in
             0)
               echo "✅ Dangling Defaults Guard: clean."

--- a/.github/workflows/guard-defaults-impact.yml
+++ b/.github/workflows/guard-defaults-impact.yml
@@ -1,0 +1,210 @@
+# guard-defaults-impact.yml — C-12 Dangling Defaults Guard PR-5
+#
+# Triggered on PRs that touch any `**/_defaults.yaml`. Builds the
+# da-guard Go binary (PR-4), runs it against the changed
+# _defaults.yaml's directory subtree, and posts a sticky Markdown
+# report as a PR comment.
+#
+# Same posting pattern as blast-radius.yml (marker-based update vs
+# create) so reviewers see ONE comment per PR that updates in-place
+# on each push, not a stack of stale comments.
+#
+# Exit-code policy:
+#   - guard exit 0 → workflow success, comment posted with "no findings".
+#   - guard exit 1 → workflow FAIL (blocks merge); comment lists errors.
+#   - guard exit 2 → workflow FAIL (caller error); comment + log link.
+#
+# Customer template note:
+#   Customers can copy this workflow into their own repo to gate
+#   _defaults.yaml changes. The Build da-guard step assumes the
+#   threshold-exporter Go module is co-located in the repo; for
+#   customers consuming a pre-built binary, replace the build step
+#   with a release-asset download (see C-11 packaging).
+
+name: Dangling Defaults Guard
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/_defaults.yaml"
+      - "components/threshold-exporter/app/cmd/da-guard/**"
+      - "components/threshold-exporter/app/internal/guard/**"
+      - "components/threshold-exporter/app/pkg/config/scope.go"
+      - "components/threshold-exporter/app/pkg/config/hierarchy.go"
+      - ".github/workflows/guard-defaults-impact.yml"
+  workflow_dispatch:
+    inputs:
+      config_dir:
+        description: "Override conf.d/ root (default: auto-detect)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  guard:
+    name: Defaults Impact Guard
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: components/threshold-exporter/app/go.mod
+          cache: true
+          cache-dependency-path: components/threshold-exporter/app/go.sum
+
+      - name: Build da-guard
+        run: |
+          cd components/threshold-exporter/app
+          go build -buildvcs=false \
+              -ldflags "-X main.Version=ci-$GITHUB_SHA" \
+              -o "$RUNNER_TEMP/da-guard" \
+              ./cmd/da-guard
+          "$RUNNER_TEMP/da-guard" --version
+
+      - name: Detect conf.d path
+        id: detect
+        run: |
+          # Resolution order:
+          #   1. workflow_dispatch input override (manual run)
+          #   2. repo-root conf.d/ (customer GitOps layout)
+          #   3. components/threshold-exporter/config/conf.d/ (this repo)
+          #   4. nothing → skip
+          INPUT_DIR='${{ github.event.inputs.config_dir }}'
+          if [ -n "$INPUT_DIR" ] && [ -d "$INPUT_DIR" ]; then
+            echo "conf_d=$INPUT_DIR" >> "$GITHUB_OUTPUT"
+          elif [ -d "conf.d" ]; then
+            echo "conf_d=conf.d" >> "$GITHUB_OUTPUT"
+          elif [ -d "components/threshold-exporter/config/conf.d" ]; then
+            echo "conf_d=components/threshold-exporter/config/conf.d" >> "$GITHUB_OUTPUT"
+          else
+            echo "conf_d=" >> "$GITHUB_OUTPUT"
+            echo "::warning::No conf.d/ directory found; nothing to validate"
+          fi
+
+      - name: Determine scope from changed _defaults.yaml
+        if: steps.detect.outputs.conf_d != '' && github.event_name == 'pull_request'
+        id: scope
+        run: |
+          # Find every changed _defaults.yaml relative to the PR base.
+          # If there's exactly one, narrow scope to its directory.
+          # Otherwise fall back to the whole conf.d/ root (validating
+          # multiple cascading edits in one pass uses per-tenant
+          # defaults resolution; the redundant-override check stays
+          # accurate via NewDefaultsByTenant).
+          mapfile -t CHANGED < <(git diff --name-only "origin/${{ github.base_ref }}"...HEAD -- '**/_defaults.yaml' || true)
+          if [ "${#CHANGED[@]}" -eq 1 ]; then
+            DIR=$(dirname "${CHANGED[0]}")
+            echo "scope=$DIR" >> "$GITHUB_OUTPUT"
+            echo "Narrow scope: $DIR (single _defaults.yaml change)"
+          else
+            echo "scope=${{ steps.detect.outputs.conf_d }}" >> "$GITHUB_OUTPUT"
+            echo "Whole-tree scope: ${{ steps.detect.outputs.conf_d }} (${#CHANGED[@]} _defaults.yaml changed)"
+          fi
+
+      - name: Run da-guard
+        if: steps.detect.outputs.conf_d != ''
+        id: guard
+        run: |
+          set +e
+          SCOPE='${{ steps.scope.outputs.scope }}'
+          if [ -z "$SCOPE" ]; then
+            SCOPE='${{ steps.detect.outputs.conf_d }}'
+          fi
+          "$RUNNER_TEMP/da-guard" \
+              --config-dir '${{ steps.detect.outputs.conf_d }}' \
+              --scope "$SCOPE" \
+              --cardinality-limit 500 \
+              --format md \
+              --output "$RUNNER_TEMP/guard-report.md"
+          GUARD_EXIT=$?
+          echo "exit=$GUARD_EXIT" >> "$GITHUB_OUTPUT"
+          # Always continue so the comment-posting step runs even when
+          # the guard returned 1 (errors). The "Fail if guard found
+          # errors" step at the end converts the captured exit code
+          # into a workflow failure.
+          exit 0
+
+      - name: Post sticky PR comment
+        if: |
+          steps.detect.outputs.conf_d != '' &&
+          github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        env:
+          GUARD_EXIT: ${{ steps.guard.outputs.exit }}
+          REPORT_PATH: ${{ runner.temp }}/guard-report.md
+        with:
+          script: |
+            const fs = require('fs');
+            const reportPath = process.env.REPORT_PATH;
+            const guardExit = process.env.GUARD_EXIT || 'unknown';
+
+            let body = '';
+            if (fs.existsSync(reportPath)) {
+              body = fs.readFileSync(reportPath, 'utf8');
+            } else {
+              body = `_(da-guard did not produce a report; exit code = ${guardExit}. See workflow log.)_\n`;
+            }
+
+            const marker = '<!-- da-guard-defaults-impact -->';
+            const footer = `\n\n---\n*Generated by [da-guard](../blob/main/components/threshold-exporter/app/cmd/da-guard) • C-12 Dangling Defaults Guard PR-5 • exit code: \`${guardExit}\`*\n`;
+            const fullBody = `${marker}\n${body}${footer}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: fullBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: fullBody,
+              });
+            }
+
+      - name: Upload report artifact
+        if: always() && steps.guard.outputs.exit != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: da-guard-report
+          path: ${{ runner.temp }}/guard-report.md
+          retention-days: 14
+
+      - name: Fail if guard found errors
+        if: steps.guard.outputs.exit != ''
+        run: |
+          GUARD_EXIT='${{ steps.guard.outputs.exit }}'
+          case "$GUARD_EXIT" in
+            0)
+              echo "✅ Dangling Defaults Guard: clean."
+              ;;
+            1)
+              echo "::error::Dangling Defaults Guard found errors. See PR comment for details."
+              exit 1
+              ;;
+            2)
+              echo "::error::da-guard caller error (exit 2). Check workflow log + PR comment."
+              exit 1
+              ;;
+            *)
+              echo "::error::da-guard returned unexpected exit code: $GUARD_EXIT"
+              exit 1
+              ;;
+          esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,20 @@ Breaking / Upgrade 七塊清楚區分），那是目標形狀。
 
 ### Added
 
+- **Phase .c — C-12 Dangling Defaults Guard PR-5 — GitHub Actions wrapper + redundant-override warn 啟用（v2.8.0）** — 把 PR-4 ship 的 `da-guard` CLI 包成 PR-time gate：
+  - **新 workflow** `.github/workflows/guard-defaults-impact.yml`：`pull_request` 觸發於 `**/_defaults.yaml` 變更（plus self-PR-of-the-workflow / da-guard source paths），build da-guard binary → run guard → post sticky PR comment（marker `<!-- da-guard-defaults-impact -->`，每次 push update-in-place）。Pattern 直接借用 `blast-radius.yml`。Workflow 也支援 `workflow_dispatch` + `config_dir` input 手動跑、artifact 上傳保 14 天 (`da-guard-report`)。Exit 1/2 都 fail workflow 擋 merge；exit 0 (clean 或只有 warnings) 通過
+  - **Scope 推算**：偵測 PR 變更的 `_defaults.yaml` 數，**單一變更**時 narrow scope 到該檔 dirname；**多檔變更**時 fall back 整棵 conf.d/。後者依賴 PR-5 啟用的 cascading 正確性（見下）。Conf.d 路徑解析三層：`workflow_dispatch.config_dir` input → repo-root `conf.d/` → `components/threshold-exporter/config/conf.d/`
+  - **Redundant-override warn 啟用 + cascading 正確性**：PR-4 留下 `TenantOverrides` + `NewDefaults` 兩個 guard input nil-未填，PR-5 把這條 wire 接通，並且**為 cascading L0/L1/L2 場景設計新欄位**：
+    - `pkg/config.EffectiveConfig` 加 `TenantOverridesRaw map[string]any` + `MergedDefaults map[string]any`（兩者皆 `json:"-"`，**不**進 tenant-api `/effective` JSON 回應，guard-only）
+    - `computeEffectiveConfigBytesDetailed()` 新 helper（`computeEffectiveConfigBytes` 改為 thin shim）—— 在 deepMerge tenant override **之前** 取 `deepCopyMapH(merged)` snapshot，避免後續 merge 透過 alias 污染 snapshot。Defends against shared sub-map mutation
+    - `internal/guard.CheckInput` 加 `NewDefaultsByTenant map[string]map[string]any`：per-tenant merged-defaults map（PR-1 的 single `NewDefaults` 留作 fallback，preserves backwards-compat）。Resolution rule：per-tenant entry 存在則用之、否則 fall back global、兩者皆無則 silent skip
+    - `redundant.go::checkRedundantOverrides` 改為 per-tenant defaults resolution；nil per-tenant entry 視為 explicit opt-out（`tenantDefaultsLeaves` helper）
+    - `cmd/da-guard/main.go::buildCheckInput` 從 `ScopedTenants` 取 `TenantOverridesRaw` + `MergedDefaults` 直接 thread 進 guard input
+  - **Customer template note**：客戶可整份 copy workflow 到自己 repo gate `_defaults.yaml`；`Build da-guard` 步驟假設 threshold-exporter Go module 同 repo，純消費 release binary 的客戶可改下載 `tools/v*` release asset（C-11 後配套）
+  - **新測試**（`-race -count=2` 穩定）：guard_test 4 cases 涵蓋 NewDefaultsByTenant per-tenant maps / 與 NewDefaults 的 precedence / nil entry skip / tenant 兩 source 都缺 silent skip；scope_test 2 cases 驗 EffectiveConfig 新欄位 populated + snapshot 不 alias EffectiveConfig；da-guard cmd 3 cases 驗 redundant warn surface / `--warn-as-error` exit 1 / cascading 正確性（tenant-db redundant、tenant-web 不 redundant）
+  - **C-12 軌道完結**（PR-1 schema → PR-2 routing → PR-3 cardinality → PR-4 CLI → PR-5 GH Actions + warn-tier）。客戶從 pre-commit hook 走 da-guard binary、從 PR 走自動 sticky comment。下一步是 C-11 release packaging 把 binary ship 出去
+  - 詳見 `components/threshold-exporter/README.md` § da-guard CLI / planning §12.2 Phase .c row C-12
+
 - **Phase .c — C-12 Dangling Defaults Guard PR-4 — `da-guard` CLI + `da-tools guard` 包裝（v2.8.0）** — 把 PR-1/2/3 累積的 `internal/guard` library 變成 customer-runnable 工具：
   - **新 Go binary** `components/threshold-exporter/app/cmd/da-guard/`（同 module，import `pkg/config` + `internal/guard`），flags：`--config-dir`（必填）`--scope`、`--required-fields`、`--cardinality-limit`、`--cardinality-warn-ratio`、`--format md\|json`、`--output`、`--warn-as-error`、`--version`。Stable exit codes：0 clean / 1 errors found / 2 caller error
   - **新 helper** `pkg/config/scope.go::ScopeEffective()`：給定 conf.d root + 子目錄 scope，遍歷子目錄列出所有 tenant ID，per-tenant 走 `ResolveEffective` 拿到 effective config map。Containment guard（scope 跑出 root 之外 → caller error）+ duplicate-tenant detection（match `ResolveEffective` 既有 loud-fail 立場）+ 排序 deterministic 輸出

--- a/components/threshold-exporter/README.md
+++ b/components/threshold-exporter/README.md
@@ -443,7 +443,7 @@ spec:
 
 ---
 
-## da-guard CLI（v2.8.0 Phase .c C-12 PR-4）
+## da-guard CLI（v2.8.0 Phase .c C-12 PR-4 + PR-5）
 
 `da-guard` 是 `internal/guard` 的 CLI 包裝，把「Dangling Defaults Guard」帶到客戶 repo 端：把 `_defaults.yaml` 變更前 / pre-commit / GitHub Actions 階段就攔截 schema / routing / cardinality 三層問題，不讓壞改動 reach WatchLoop。
 
@@ -479,13 +479,16 @@ da-guard --config-dir conf.d/ --format json --output guard-report.json
 | 1 | guard 偵測到 error — block merge / commit |
 | 2 | caller error — flag 錯、路徑找不到、scope 跑出 root 之外等 |
 
-**三層檢查（內建於 `internal/guard`）**：
+**三層 error 檢查 + 一層 warn 檢查（內建於 `internal/guard`）**：
 
-1. **Schema validation**（`--required-fields`）— 點分路徑欄位 deepMerge 後不可缺；ADR-018 null-as-delete 後欄位變 nil 也算缺。
-2. **Routing schema guardrails** — 5 檢查：unknown receiver type / 必填欄位缺 / empty matcher / duplicate matcher / redundant override。
-3. **Cardinality guard**（`--cardinality-limit`）— 預測 post-merge metric 數，warn @ ratio×limit（預設 0.8）/ error 超 limit。
+1. **Schema validation**（error；`--required-fields`）— 點分路徑欄位 deepMerge 後不可缺；ADR-018 null-as-delete 後欄位變 nil 也算缺。
+2. **Routing schema guardrails**（error）— 5 檢查：unknown receiver type / 必填欄位缺 / empty matcher / duplicate matcher / redundant override。
+3. **Cardinality guard**（error；`--cardinality-limit`）— 預測 post-merge metric 數，warn @ ratio×limit（預設 0.8）/ error 超 limit。
+4. **Redundant override**（warn；PR-5 啟用）— tenant.yaml 覆寫某欄位的值剛好等於繼承的 `_defaults.yaml`，提示「移掉 override 改靠繼承」；warn 不擋 merge 除非 `--warn-as-error`。**Cascading 正確性**：tenants 在不同 sub-tree 下繼承不同 merged defaults，`pkg/config` 把每個租戶的 pre-merge defaults snapshot 透過 `EffectiveConfig.MergedDefaults` 暴露，guard 用 `NewDefaultsByTenant` per-tenant resolve（非 single-map fallback），保證 cascading L0/L1/L2 場景下不誤判。
 
 **`da-tools guard defaults-impact` 包裝**：Python `da-tools` CLI 透過 `scripts/tools/ops/guard_dispatch.py` shell-out 到 `da-guard` 二進位。Binary 解析順序：`--da-guard-binary` flag → `$DA_GUARD_BINARY` env → `$PATH` 上的 `da-guard`。詳見 `da-tools guard --help`。
+
+**GitHub Actions 自動化（PR-5）**：[`/.github/workflows/guard-defaults-impact.yml`](../../.github/workflows/guard-defaults-impact.yml) — `pull_request` 觸發於 `**/_defaults.yaml` 變更時自動跑 guard、posting 一個 sticky PR comment（marker `<!-- da-guard-defaults-impact -->`，每次 push update-in-place 不堆 stale）、artifact 上傳保 14 天。Exit code 1 (errors) 或 2 (caller error) 都失敗 workflow 擋 merge；exit 0 (clean 或只有 warnings) 通過。Workflow 也支援 `workflow_dispatch` 手動跑 + `config_dir` input override。**客戶 template**：客戶可把這份 workflow 整份 copy 到自己 repo gate `_defaults.yaml`；`Build da-guard` 步驟假設 threshold-exporter Go module 同 repo，純消費 release binary 的客戶可改下載 `tools/v*` release asset（C-11 後配套）。
 
 **範圍簡化（vs. v2.8.0 planning §C-12）**：PR-4 是 *當前工作樹* 驗證器，讀取磁碟現狀。CI / pre-commit 流程下這跟「給定 _defaults.yaml 變更、預測影響」等價（commit / push 前該變更已經寫在磁碟上）。Speculative simulation 留 C-7b `/simulate` 或後續 PR。
 

--- a/components/threshold-exporter/app/cmd/da-guard/main.go
+++ b/components/threshold-exporter/app/cmd/da-guard/main.go
@@ -203,25 +203,30 @@ func run(args []string, stdout, errOut io.Writer) int {
 }
 
 // buildCheckInput assembles a guard.CheckInput from the scoped
-// resolution. It's where the YAML-shape → guard-input mapping
-// lives — pulling the per-tenant `_routing` block out of the
-// merged map, building the `tenant_id → effective_config` map,
-// and (deliberately, for v1) leaving TenantOverrides + NewDefaults
-// nil so the redundant-override check is skipped.
+// resolution. It's where the YAML-shape → guard-input mapping lives:
 //
-// Why redundant-override is opt-out in PR-4:
+//   - EffectiveConfigs[id]      ← ec.EffectiveConfig
+//   - RoutingByTenant[id]       ← ec.EffectiveConfig["_routing"] (when nested map)
+//   - TenantOverrides[id]       ← ec.TenantOverridesRaw (PR-5)
+//   - NewDefaultsByTenant[id]   ← ec.MergedDefaults      (PR-5)
 //
-//	That check needs the *raw* tenant.yaml override map and the
-//	*new* defaults map separately, not the merged result.
-//	Recovering them at this layer is two more YAML reads per
-//	tenant + a defaults-chain accumulator, and the value
-//	delivered (warnings on duplicated values) is lower than the
-//	3 error-tier checks shipping here. Defer to PR-4.5 / PR-5
-//	alongside GitHub Actions wrapper, when we can also surface
-//	the warnings on PR comments without spamming.
+// The PR-5 wiring (TenantOverrides + NewDefaultsByTenant) enables
+// the redundant-override warn-tier without changing the cardinality /
+// schema / routing error tiers. Fields used to be nil-left in PR-4
+// because pkg/config.EffectiveConfig didn't expose the pre-merge
+// shapes; PR-5 adds those (json:"-" so tenant-api's API contract
+// stays unchanged) and we now thread them through.
+//
+// We deliberately use NewDefaultsByTenant rather than NewDefaults: a
+// scope spanning multiple cascading _defaults.yaml levels means
+// different tenants inherit different merged-defaults views, and
+// the guard's per-tenant resolution honors that. See
+// guard.CheckInput documentation for the resolution rule.
 func buildCheckInput(scoped *config.ScopedTenants, f *flags) guard.CheckInput {
 	effective := make(map[string]map[string]any, len(scoped.Tenants))
 	routing := make(map[string]map[string]any)
+	tenantOverrides := make(map[string]map[string]any)
+	newDefaultsByTenant := make(map[string]map[string]any)
 	for _, ec := range scoped.Tenants {
 		effective[ec.TenantID] = ec.EffectiveConfig
 		// _routing is stored as a nested map inside the merged
@@ -233,6 +238,18 @@ func buildCheckInput(scoped *config.ScopedTenants, f *flags) guard.CheckInput {
 		if r, ok := ec.EffectiveConfig["_routing"].(map[string]any); ok {
 			routing[ec.TenantID] = r
 		}
+		// PR-5: redundant-override warn-tier inputs. We populate
+		// both fields as soon as the resolver hands them to us; an
+		// absent tenant.yaml block (TenantOverridesRaw == nil) or
+		// a defaults-less tree (MergedDefaults == nil) leaves the
+		// per-tenant entry out of the map, which the guard treats
+		// as "skip this tenant for redundant-override".
+		if ec.TenantOverridesRaw != nil {
+			tenantOverrides[ec.TenantID] = ec.TenantOverridesRaw
+		}
+		if ec.MergedDefaults != nil {
+			newDefaultsByTenant[ec.TenantID] = ec.MergedDefaults
+		}
 	}
 
 	required := splitNonEmpty(f.requiredFields)
@@ -241,6 +258,8 @@ func buildCheckInput(scoped *config.ScopedTenants, f *flags) guard.CheckInput {
 		EffectiveConfigs:     effective,
 		RequiredFields:       required,
 		RoutingByTenant:      routing,
+		TenantOverrides:      tenantOverrides,
+		NewDefaultsByTenant:  newDefaultsByTenant,
 		CardinalityLimit:     f.cardinalityLimit,
 		CardinalityWarnRatio: f.cardinalityWarnRatio,
 	}

--- a/components/threshold-exporter/app/cmd/da-guard/main_test.go
+++ b/components/threshold-exporter/app/cmd/da-guard/main_test.go
@@ -316,16 +316,26 @@ func TestRun_RedundantOverride_HonorsCascadingDefaults(t *testing.T) {
 	if code != exitOK {
 		t.Errorf("exit = %d, want %d", code, exitOK)
 	}
-	// tenant-db redundant; tenant-web NOT redundant.
+	// tenant-db redundant; tenant-web NOT redundant. We assert this
+	// at the row level rather than via raw stdout substring because
+	// both names also appear in the "Scanned files" details list,
+	// which would make a substring check vacuously pass.
 	lines := strings.Split(stdout, "\n")
+	tenantDBFlagged := false
 	for _, line := range lines {
-		if strings.Contains(line, "redundant_override") &&
-			strings.Contains(line, "tenant-web") {
+		hasRedundant := strings.Contains(line, "redundant_override")
+		if !hasRedundant {
+			continue
+		}
+		if strings.Contains(line, "tenant-web") {
 			t.Errorf("tenant-web should NOT be flagged (its 80 ≠ inherited 70); line: %q", line)
 		}
+		if strings.Contains(line, "tenant-db") {
+			tenantDBFlagged = true
+		}
 	}
-	if !strings.Contains(stdout, "tenant-db") {
-		t.Errorf("tenant-db should appear in findings (its 80 = inherited 80): %q", stdout)
+	if !tenantDBFlagged {
+		t.Errorf("tenant-db should appear in a redundant_override row (its 80 = inherited 80); stdout: %q", stdout)
 	}
 }
 

--- a/components/threshold-exporter/app/cmd/da-guard/main_test.go
+++ b/components/threshold-exporter/app/cmd/da-guard/main_test.go
@@ -239,6 +239,96 @@ func TestRun_EmptyScope_ExitsZero(t *testing.T) {
 	}
 }
 
+// PR-5: redundant-override warn-tier should surface in the report.
+// Tenant overrides cpu=80 with the same value as the merged defaults
+// → guard.checkRedundantOverrides emits a SeverityWarn. Default exit
+// code stays 0 (warnings don't block); --warn-as-error flips to 1.
+func TestRun_RedundantOverride_SurfacesAsWarning(t *testing.T) {
+	tmp := t.TempDir()
+	writeTree(t, tmp, map[string]string{
+		"conf.d/_defaults.yaml": "defaults:\n  cpu: 80\n",
+		// tenant-a explicitly sets cpu=80 — same as the inherited
+		// default → redundant override.
+		"conf.d/tenant-a.yaml": "tenants:\n  tenant-a:\n    cpu: 80\n",
+		// tenant-b sets cpu=99 — meaningful override → NO finding.
+		"conf.d/tenant-b.yaml": "tenants:\n  tenant-b:\n    cpu: 99\n",
+	})
+	code, stdout, _ := runOnce(t,
+		"--config-dir", filepath.Join(tmp, "conf.d"),
+	)
+	if code != exitOK {
+		t.Errorf("exit = %d, want %d (warnings don't block by default)", code, exitOK)
+	}
+	if !strings.Contains(stdout, "redundant_override") {
+		t.Errorf("stdout should surface redundant_override finding: %q", stdout)
+	}
+	if !strings.Contains(stdout, "tenant-a") {
+		t.Errorf("stdout should name tenant-a: %q", stdout)
+	}
+	// tenant-b override is meaningful — it should NOT appear in
+	// findings (we sanity-check with substring proximity).
+	if strings.Contains(stdout, "tenant-b") &&
+		strings.Contains(stdout, "redundant_override") {
+		// Verify no row mentions tenant-b alongside redundant_override.
+		// A loose check is fine here since the report uses GFM tables
+		// and findings sort errors-first then by tenant.
+		lines := strings.Split(stdout, "\n")
+		for _, line := range lines {
+			if strings.Contains(line, "tenant-b") &&
+				strings.Contains(line, "redundant_override") {
+				t.Errorf("tenant-b should not have redundant_override; line: %q", line)
+			}
+		}
+	}
+}
+
+func TestRun_RedundantOverride_WithWarnAsError_ExitsOne(t *testing.T) {
+	tmp := t.TempDir()
+	writeTree(t, tmp, map[string]string{
+		"conf.d/_defaults.yaml": "defaults:\n  cpu: 80\n",
+		"conf.d/tenant-a.yaml":  "tenants:\n  tenant-a:\n    cpu: 80\n",
+	})
+	code, _, _ := runOnce(t,
+		"--config-dir", filepath.Join(tmp, "conf.d"),
+		"--warn-as-error",
+	)
+	if code != exitFindings {
+		t.Errorf("exit = %d, want %d (warn-as-error promotes redundant warns)", code, exitFindings)
+	}
+}
+
+// PR-5: cascading defaults — tenants under different sub-trees see
+// different merged defaults. This verifies da-guard threads
+// per-tenant defaults (NewDefaultsByTenant) through to the guard.
+func TestRun_RedundantOverride_HonorsCascadingDefaults(t *testing.T) {
+	tmp := t.TempDir()
+	writeTree(t, tmp, map[string]string{
+		"conf.d/_defaults.yaml":    "defaults:\n  cpu: 70\n",
+		"conf.d/db/_defaults.yaml": "defaults:\n  cpu: 80\n",
+		// tenant-db overrides cpu=80 — matches db/ inherited → redundant
+		"conf.d/db/tenant-db.yaml": "tenants:\n  tenant-db:\n    cpu: 80\n",
+		// tenant-web overrides cpu=80 but inherits root cpu=70 → meaningful
+		"conf.d/web/tenant-web.yaml": "tenants:\n  tenant-web:\n    cpu: 80\n",
+	})
+	code, stdout, _ := runOnce(t,
+		"--config-dir", filepath.Join(tmp, "conf.d"),
+	)
+	if code != exitOK {
+		t.Errorf("exit = %d, want %d", code, exitOK)
+	}
+	// tenant-db redundant; tenant-web NOT redundant.
+	lines := strings.Split(stdout, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "redundant_override") &&
+			strings.Contains(line, "tenant-web") {
+			t.Errorf("tenant-web should NOT be flagged (its 80 ≠ inherited 70); line: %q", line)
+		}
+	}
+	if !strings.Contains(stdout, "tenant-db") {
+		t.Errorf("tenant-db should appear in findings (its 80 = inherited 80): %q", stdout)
+	}
+}
+
 // Regression: self-review caught writeEmptyReport silently ignoring
 // IO errors. A bad --output path on an empty scope must surface as
 // exitCallerErr, not exitOK.

--- a/components/threshold-exporter/app/internal/guard/guard_test.go
+++ b/components/threshold-exporter/app/internal/guard/guard_test.go
@@ -222,6 +222,111 @@ func TestCheckRedundantOverrides_SkipsOverridesAbsentFromDefaults(t *testing.T) 
 	}
 }
 
+// --- PR-5: per-tenant defaults map (NewDefaultsByTenant) -----------
+
+func TestCheckRedundantOverrides_NewDefaultsByTenant_PerTenantMaps(t *testing.T) {
+	// Two tenants with DIFFERENT cascading defaults — t-db inherits
+	// `db/_defaults.yaml` (cpu=80), t-web inherits `web/_defaults.yaml`
+	// (cpu=70). Both tenants override cpu=80. Only t-db's override is
+	// redundant; t-web's matches a different tenant's defaults but
+	// not its own. PR-1's single NewDefaults map can't distinguish.
+	got := checkRedundantOverrides(CheckInput{
+		TenantOverrides: map[string]map[string]any{
+			"t-db":  {"cpu": 80},
+			"t-web": {"cpu": 80},
+		},
+		NewDefaultsByTenant: map[string]map[string]any{
+			"t-db":  {"cpu": 80},
+			"t-web": {"cpu": 70},
+		},
+	})
+	if len(got) != 1 {
+		t.Fatalf("got %d findings, want 1 (t-db redundant only)", len(got))
+	}
+	if got[0].TenantID != "t-db" {
+		t.Errorf("tenant = %q, want t-db", got[0].TenantID)
+	}
+	if got[0].Severity != SeverityWarn {
+		t.Errorf("severity = %q, want warn", got[0].Severity)
+	}
+}
+
+func TestCheckRedundantOverrides_NewDefaultsByTenant_PrecedesGlobal(t *testing.T) {
+	// When both fields are populated, per-tenant entry wins for
+	// tenants that have one; the global map covers the rest.
+	got := checkRedundantOverrides(CheckInput{
+		TenantOverrides: map[string]map[string]any{
+			"t-specific": {"cpu": 99},
+			"t-fallback": {"cpu": 50},
+		},
+		NewDefaults: map[string]any{"cpu": 50}, // t-fallback uses this
+		NewDefaultsByTenant: map[string]map[string]any{
+			"t-specific": {"cpu": 99}, // t-specific uses this (override per-tenant)
+		},
+	})
+	tenantsFlagged := make(map[string]bool)
+	for _, f := range got {
+		tenantsFlagged[f.TenantID] = true
+	}
+	if !tenantsFlagged["t-specific"] {
+		t.Error("t-specific should be flagged via per-tenant defaults")
+	}
+	if !tenantsFlagged["t-fallback"] {
+		t.Error("t-fallback should be flagged via global NewDefaults fallback")
+	}
+}
+
+func TestCheckRedundantOverrides_NewDefaultsByTenant_NilEntrySkips(t *testing.T) {
+	// An explicit nil entry in the per-tenant map (e.g. tenant has no
+	// inherited defaults at all) suppresses the check for that tenant
+	// even if NewDefaults global is populated. Documents the
+	// "explicit opt-out per tenant" path.
+	got := checkRedundantOverrides(CheckInput{
+		TenantOverrides: map[string]map[string]any{
+			"t1": {"cpu": 80},
+			"t2": {"cpu": 80},
+		},
+		NewDefaults: map[string]any{"cpu": 80},
+		NewDefaultsByTenant: map[string]map[string]any{
+			"t1": nil, // explicitly skip t1
+		},
+	})
+	for _, f := range got {
+		if f.TenantID == "t1" {
+			t.Errorf("t1 should be skipped (nil per-tenant entry); got %+v", f)
+		}
+	}
+	// t2 still gets flagged via global fallback.
+	flaggedT2 := false
+	for _, f := range got {
+		if f.TenantID == "t2" {
+			flaggedT2 = true
+		}
+	}
+	if !flaggedT2 {
+		t.Error("t2 should still be flagged via NewDefaults global fallback")
+	}
+}
+
+func TestCheckRedundantOverrides_NewDefaultsByTenant_TenantMissingFromBoth(t *testing.T) {
+	// A tenant in TenantOverrides but absent from BOTH defaults
+	// sources gets the redundant-override check skipped silently.
+	// Avoids the "single tenant in scope without defaults context"
+	// false-positive risk.
+	got := checkRedundantOverrides(CheckInput{
+		TenantOverrides: map[string]map[string]any{
+			"orphan": {"cpu": 80},
+		},
+		NewDefaultsByTenant: map[string]map[string]any{
+			// orphan absent
+		},
+		// NewDefaults nil too
+	})
+	if len(got) != 0 {
+		t.Errorf("got %d findings, want 0 (orphan tenant has no defaults source)", len(got))
+	}
+}
+
 // --- run.go integration tests --------------------------------------
 
 func TestCheckDefaultsImpact_ErrorsOnEmptyConfigs(t *testing.T) {

--- a/components/threshold-exporter/app/internal/guard/redundant.go
+++ b/components/threshold-exporter/app/internal/guard/redundant.go
@@ -32,22 +32,44 @@ import "fmt"
 // checkRedundantOverrides runs the reverse-warn pass.
 //
 // Returns warnings (possibly empty). Caller-supplied
-// TenantOverrides + NewDefaults are required; passing nil for
-// either disables the check entirely (no findings emitted).
+// TenantOverrides is required. Defaults source is one of:
+//
+//   - NewDefaultsByTenant[id] — per-tenant merged defaults (PR-5).
+//     Used when present for that tenant.
+//   - NewDefaults — single global merged defaults (PR-1).
+//     Fallback when NewDefaultsByTenant lacks the tenant's entry.
+//
+// A tenant with no defaults source from either field has the check
+// silently skipped (no finding emitted) — this lets callers wire
+// the field opportunistically without forcing every tenant in scope
+// to have a defaults entry.
 //
 // Determinism: walks tenants in sorted-ID order, then iterates the
 // flattened override leaves in sorted-path order so the output is
 // reproducible across runs.
 func checkRedundantOverrides(input CheckInput) []Finding {
-	if len(input.TenantOverrides) == 0 || input.NewDefaults == nil {
+	if len(input.TenantOverrides) == 0 {
+		return nil
+	}
+	if input.NewDefaults == nil && len(input.NewDefaultsByTenant) == 0 {
 		return nil
 	}
 
-	defaultLeaves := flattenLeaves(input.NewDefaults)
-	tenants := sortedTenantIDs(input.TenantOverrides)
+	// Cache the global flattened defaults so we don't re-walk the
+	// map per tenant when only the legacy single-map field is set.
+	var globalLeaves map[string]any
+	if input.NewDefaults != nil {
+		globalLeaves = flattenLeaves(input.NewDefaults)
+	}
 
+	tenants := sortedTenantIDs(input.TenantOverrides)
 	var out []Finding
 	for _, tenantID := range tenants {
+		defaultLeaves := tenantDefaultsLeaves(input, tenantID, globalLeaves)
+		if defaultLeaves == nil {
+			// No defaults context for this tenant → skip silently.
+			continue
+		}
 		overrideLeaves := flattenLeaves(input.TenantOverrides[tenantID])
 		paths := sortedKeys(overrideLeaves)
 		for _, path := range paths {
@@ -71,6 +93,20 @@ func checkRedundantOverrides(input CheckInput) []Finding {
 		}
 	}
 	return out
+}
+
+// tenantDefaultsLeaves resolves the right defaults-leaves map for a
+// given tenant: per-tenant entry wins, otherwise fall back to the
+// global precomputed map. Returns nil when neither source has a
+// defaults map for this tenant — caller treats that as "skip".
+func tenantDefaultsLeaves(input CheckInput, tenantID string, globalLeaves map[string]any) map[string]any {
+	if perTenant, ok := input.NewDefaultsByTenant[tenantID]; ok {
+		if perTenant == nil {
+			return nil
+		}
+		return flattenLeaves(perTenant)
+	}
+	return globalLeaves
 }
 
 // scalarsEqual is the PR-1 equality test for redundant-override

--- a/components/threshold-exporter/app/internal/guard/types.go
+++ b/components/threshold-exporter/app/internal/guard/types.go
@@ -184,8 +184,31 @@ type CheckInput struct {
 	// NewDefaults is the proposed new `_defaults.yaml` content
 	// (already merged with any cascading parent defaults if the
 	// affected scope sits below the root). Required for the
-	// redundant-override check; pass nil to skip.
+	// redundant-override check WHEN every tenant in scope shares
+	// one merged-defaults map (the simple "single _defaults.yaml
+	// at level X" case). Pass nil to skip the check.
+	//
+	// When tenants under the scope inherit *different* merged
+	// defaults (cascading L0/L1/L2 trees with multiple defaults
+	// files at different depths), use NewDefaultsByTenant instead
+	// — the per-tenant variant is checked first and falls back to
+	// NewDefaults only when a tenant lacks a per-tenant entry.
 	NewDefaults map[string]any `json:"new_defaults,omitempty"`
+
+	// NewDefaultsByTenant maps tenant ID → the merged defaults map
+	// that THAT tenant inherits before its own override is applied.
+	// PR-5 (v2.8.0) extension: the C-12 PR-4 CLI populates this
+	// from `pkg/config.EffectiveConfig.MergedDefaults` so the
+	// redundant-override check correctly compares each tenant's
+	// override against ITS chain of cascading defaults rather
+	// than a single global defaults map.
+	//
+	// Resolution rule per tenant: NewDefaultsByTenant[id] wins when
+	// present; otherwise fall back to NewDefaults (preserves the
+	// PR-1 single-map API for callers that haven't migrated).
+	// Tenants absent from both have the redundant-override check
+	// skipped silently — no finding emitted.
+	NewDefaultsByTenant map[string]map[string]any `json:"new_defaults_by_tenant,omitempty"`
 
 	// RequiredFields is the dotted-path list the schema validator
 	// asserts non-nil presence for in every tenant's effective

--- a/components/threshold-exporter/app/pkg/config/hierarchy.go
+++ b/components/threshold-exporter/app/pkg/config/hierarchy.go
@@ -50,8 +50,11 @@ import (
 var ErrTenantNotFound = errors.New("tenant not found in config tree")
 
 // EffectiveConfig is the merged tenant view returned by the resolver and the
-// /effective handler. All fields are JSON-serializable; hash lengths match
-// describe_tenant.py (16 hex chars).
+// /effective handler. JSON-serialized fields match describe_tenant.py (16 hex
+// chars for hashes); the trailing `json:"-"` fields are populated for the
+// guard caller (v2.8.0 PR-5 redundant-override warn-tier) but stay out of the
+// HTTP response so tenant-api's /effective contract doesn't grow surface for
+// downstream consumers that don't need it.
 type EffectiveConfig struct {
 	TenantID        string         `json:"tenant_id"`
 	SourceFile      string         `json:"source_file"`
@@ -60,6 +63,20 @@ type EffectiveConfig struct {
 	DefaultsChain   []string       `json:"defaults_chain"`
 	EffectiveConfig map[string]any `json:"effective_config"`
 	Warnings        []string       `json:"warnings,omitempty"`
+
+	// TenantOverridesRaw is the tenant.yaml override block before any
+	// defaults-chain merge. Populated by ResolveEffective so the C-12
+	// redundant-override check can compare raw overrides to the
+	// inherited defaults at the same path. Not serialized — guard-only.
+	TenantOverridesRaw map[string]any `json:"-"`
+
+	// MergedDefaults is the defaults chain merged together for this
+	// tenant's directory, BEFORE the tenant override is applied. This
+	// is the "what the tenant inherits" view that the guard's
+	// redundant-override check needs (different tenants under cascading
+	// _defaults.yaml may inherit different merged defaults; see
+	// guard.CheckInput.NewDefaultsByTenant). Not serialized — guard-only.
+	MergedDefaults map[string]any `json:"-"`
 }
 
 // ResolveEffective walks `configDir` looking for the tenant file that defines
@@ -194,7 +211,7 @@ func ResolveEffective(configDir, tenantID string) (*EffectiveConfig, error) {
 		defaultsYAML = append(defaultsYAML, b)
 	}
 
-	merged, err := computeEffectiveConfigBytes(tenantBytes, tenantID, defaultsYAML)
+	merged, mergedDefaults, tenantRaw, err := computeEffectiveConfigBytesDetailed(tenantBytes, tenantID, defaultsYAML)
 	if err != nil {
 		return nil, err
 	}
@@ -221,12 +238,14 @@ func ResolveEffective(configDir, tenantID string) (*EffectiveConfig, error) {
 	}
 
 	return &EffectiveConfig{
-		TenantID:        tenantID,
-		SourceFile:      relSource,
-		SourceHash:      fmt.Sprintf("%x", sourceSum)[:16],
-		MergedHash:      fmt.Sprintf("%x", mergedSum)[:16],
-		DefaultsChain:   relChain,
-		EffectiveConfig: merged,
+		TenantID:           tenantID,
+		SourceFile:         relSource,
+		SourceHash:         fmt.Sprintf("%x", sourceSum)[:16],
+		MergedHash:         fmt.Sprintf("%x", mergedSum)[:16],
+		DefaultsChain:      relChain,
+		EffectiveConfig:    merged,
+		TenantOverridesRaw: tenantRaw,
+		MergedDefaults:     mergedDefaults,
 	}, nil
 }
 
@@ -240,11 +259,35 @@ func computeEffectiveConfigBytes(
 	tenantID string,
 	defaultsChainYAML [][]byte,
 ) (map[string]any, error) {
-	merged := make(map[string]any)
+	merged, _, _, err := computeEffectiveConfigBytesDetailed(tenantYAMLBytes, tenantID, defaultsChainYAML)
+	return merged, err
+}
+
+// computeEffectiveConfigBytesDetailed extends the legacy helper with
+// the two intermediate maps the C-12 PR-5 redundant-override check
+// needs:
+//
+//   - mergedDefaults: the defaults chain merged together, BEFORE the
+//     tenant override is applied. Captured as a deep-copy snapshot so
+//     subsequent merging into `merged` doesn't mutate it.
+//   - tenantRaw:      the tenant.yaml override block, raw. Returned
+//     by extractTenantRawH and never mutated past this point.
+//
+// Caller-friendly contract: these two maps are *also* what the guard
+// library treats as the tuple (NewDefaults, TenantOverrides) per
+// tenant. We deliberately return them separately rather than letting
+// downstream callers re-derive: re-derivation requires re-running the
+// merge engine and would invite drift.
+func computeEffectiveConfigBytesDetailed(
+	tenantYAMLBytes []byte,
+	tenantID string,
+	defaultsChainYAML [][]byte,
+) (merged, mergedDefaults, tenantRaw map[string]any, err error) {
+	merged = make(map[string]any)
 	for i, defBytes := range defaultsChainYAML {
 		var raw any
 		if err := yaml.Unmarshal(defBytes, &raw); err != nil {
-			return nil, fmt.Errorf("parse defaults[%d]: %w", i, err)
+			return nil, nil, nil, fmt.Errorf("parse defaults[%d]: %w", i, err)
 		}
 		block := extractDefaultsBlockH(normalizeYAMLToJSONH(raw))
 		if block == nil {
@@ -253,16 +296,21 @@ func computeEffectiveConfigBytes(
 		merged = deepMergeH(merged, block)
 	}
 
+	// Snapshot the merged-defaults state BEFORE the tenant override
+	// is applied. deepCopyMapH defends against shared sub-maps that
+	// the subsequent deepMergeH could mutate via aliasing.
+	mergedDefaults = deepCopyMapH(merged)
+
 	var tenantDoc any
 	if err := yaml.Unmarshal(tenantYAMLBytes, &tenantDoc); err != nil {
-		return nil, fmt.Errorf("parse tenant: %w", err)
+		return nil, nil, nil, fmt.Errorf("parse tenant: %w", err)
 	}
-	tenantRaw, err := extractTenantRawH(normalizeYAMLToJSONH(tenantDoc), tenantID)
+	tenantRaw, err = extractTenantRawH(normalizeYAMLToJSONH(tenantDoc), tenantID)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, err
 	}
 	merged = deepMergeH(merged, tenantRaw)
-	return merged, nil
+	return merged, mergedDefaults, tenantRaw, nil
 }
 
 func deepMergeH(base, override map[string]any) map[string]any {

--- a/components/threshold-exporter/app/pkg/config/scope_test.go
+++ b/components/threshold-exporter/app/pkg/config/scope_test.go
@@ -78,6 +78,88 @@ func TestScopeEffective_WholeTree(t *testing.T) {
 	}
 }
 
+// PR-5: confirm the EffectiveConfig.MergedDefaults + TenantOverridesRaw
+// pre-merge snapshots are populated and reflect the chain at each
+// tenant's level. This is the contract C-12 redundant-override depends
+// on (different tenants under cascading _defaults.yaml see different
+// merged defaults).
+func TestScopeEffective_ExposesPreMergeSnapshots(t *testing.T) {
+	tmp := t.TempDir()
+	writeTree(t, tmp, map[string]string{
+		"conf.d/_defaults.yaml":    "defaults:\n  cpu: 70\n",
+		"conf.d/db/_defaults.yaml": "defaults:\n  cpu: 80\n",
+		"conf.d/db/tenant-a.yaml":  "tenants:\n  tenant-a:\n    cpu: 80\n", // redundant! same as L1 db defaults
+		"conf.d/web/tenant-c.yaml": "tenants:\n  tenant-c:\n    cpu: 80\n", // NOT redundant — web inherits L0 (cpu=70)
+	})
+	root := filepath.Join(tmp, "conf.d")
+	got, err := ScopeEffective(root, "")
+	if err != nil {
+		t.Fatalf("ScopeEffective: %v", err)
+	}
+	for _, ec := range got.Tenants {
+		// Both new fields must be non-nil for any tenant the resolver
+		// returns successfully; the guard caller keys off nilness as
+		// "skip this tenant".
+		if ec.TenantOverridesRaw == nil {
+			t.Errorf("tenant %q: TenantOverridesRaw nil; expected raw override map", ec.TenantID)
+		}
+		if ec.MergedDefaults == nil {
+			t.Errorf("tenant %q: MergedDefaults nil; expected pre-merge defaults snapshot", ec.TenantID)
+		}
+		switch ec.TenantID {
+		case "tenant-a":
+			// tenant-a's MergedDefaults = L0+L1 merged → cpu=80
+			if v, _ := ec.MergedDefaults["cpu"].(int); v != 80 {
+				t.Errorf("tenant-a MergedDefaults.cpu = %v, want 80 (L1 wins L0)", ec.MergedDefaults["cpu"])
+			}
+			// tenant-a's raw override = {cpu: 80} → matches MergedDefaults → redundant
+			if v, _ := ec.TenantOverridesRaw["cpu"].(int); v != 80 {
+				t.Errorf("tenant-a TenantOverridesRaw.cpu = %v, want 80", ec.TenantOverridesRaw["cpu"])
+			}
+		case "tenant-c":
+			// tenant-c's MergedDefaults = L0 only → cpu=70
+			if v, _ := ec.MergedDefaults["cpu"].(int); v != 70 {
+				t.Errorf("tenant-c MergedDefaults.cpu = %v, want 70 (L0 only, no db/_defaults)", ec.MergedDefaults["cpu"])
+			}
+			// tenant-c's override is 80; doesn't match its 70 inherited → NOT redundant
+		}
+	}
+}
+
+// PR-5: MergedDefaults must NOT alias EffectiveConfig — they share
+// inputs but a mutation to one must not be visible in the other.
+// This guards the "snapshot before tenant merge" contract that
+// computeEffectiveConfigBytesDetailed promises.
+func TestScopeEffective_MergedDefaultsIsIndependentSnapshot(t *testing.T) {
+	tmp := t.TempDir()
+	writeTree(t, tmp, map[string]string{
+		"conf.d/_defaults.yaml": "defaults:\n  cpu: 70\n  shared:\n    nested: 1\n",
+		"conf.d/tenant-a.yaml":  "tenants:\n  tenant-a:\n    cpu: 99\n",
+	})
+	root := filepath.Join(tmp, "conf.d")
+	got, err := ScopeEffective(root, "")
+	if err != nil {
+		t.Fatalf("ScopeEffective: %v", err)
+	}
+	if len(got.Tenants) != 1 {
+		t.Fatalf("got %d tenants, want 1", len(got.Tenants))
+	}
+	ec := got.Tenants[0]
+	// Mutate MergedDefaults; EffectiveConfig must be untouched.
+	if m, ok := ec.MergedDefaults["shared"].(map[string]any); ok {
+		m["nested"] = 999
+	}
+	// Re-read effective.shared.nested via path traversal; should still be 1
+	// because effective is a separate map post-deepMerge.
+	if shared, ok := ec.EffectiveConfig["shared"].(map[string]any); ok {
+		if v, _ := shared["nested"].(int); v != 1 {
+			t.Errorf("EffectiveConfig.shared.nested = %v, want 1 (snapshot aliasing leak)", shared["nested"])
+		}
+	} else {
+		t.Errorf("EffectiveConfig.shared missing or wrong type: %T", ec.EffectiveConfig["shared"])
+	}
+}
+
 func TestScopeEffective_SubScope(t *testing.T) {
 	tmp := t.TempDir()
 	writeTree(t, tmp, map[string]string{

--- a/components/threshold-exporter/config/conf.d/examples/redis-tenant.yaml
+++ b/components/threshold-exporter/config/conf.d/examples/redis-tenant.yaml
@@ -17,7 +17,9 @@ tenants:
 
     # --- 維度閾值: 按 queue 分設 ---
     # 語法: "metric{label=\"value\"}": "threshold" 或 "threshold:severity"
-    "redis_queue_length{queue=\"order-processing\"}": "100"
+    # NOTE: 維度 key 不支援 `_critical` 兩階 severity（runtime 只走 dimensional
+    # 單行 inline severity，見 config_resolve.go ResolveAt dimensional 分支），
+    # 想要兩階請拆 label 或寫一條 inline severity。
     "redis_queue_length{queue=\"order-processing\"}": "500:critical"
     "redis_queue_length{queue=\"email-notifications\"}": "1000"
     "redis_queue_length{queue=\"analytics\"}": "5000"


### PR DESCRIPTION
## Summary

- **C-12 Dangling Defaults Guard PR-5** — closes the C-12 軌道 (PR-1 → PR-5 全 ship). New GitHub Actions workflow gates `**/_defaults.yaml` PRs; redundant-override warn-tier enabled with cascading-correct per-tenant defaults resolution.
- 9 new tests stable under `-race -count=2`. Customer pre-commit (PR-4) + PR-time sticky bot (PR-5) both online.
- `pkg/config.EffectiveConfig` gets two new `json:"-"` fields (guard-only side channels — tenant-api `/effective` JSON unchanged). `internal/guard.CheckInput` gets `NewDefaultsByTenant` while preserving PR-1 single-map fallback.

## What ships

| Artifact | Lines | Purpose |
|---|---|---|
| `.github/workflows/guard-defaults-impact.yml` | ~150 | PR gate; sticky comment via marker; artifact upload; workflow_dispatch override |
| `components/threshold-exporter/app/pkg/config/hierarchy.go` | +50 | `EffectiveConfig.{TenantOverridesRaw,MergedDefaults}` + `computeEffectiveConfigBytesDetailed` snapshot helper |
| `components/threshold-exporter/app/internal/guard/types.go` | +20 | `CheckInput.NewDefaultsByTenant` per-tenant defaults map |
| `components/threshold-exporter/app/internal/guard/redundant.go` | +35 | `tenantDefaultsLeaves` resolver: per-tenant > global > skip |
| `components/threshold-exporter/app/cmd/da-guard/main.go::buildCheckInput` | +20 | Threads pre-merge fields from `ScopedTenants` into guard input |
| `components/threshold-exporter/app/{guard_test,scope_test,main_test}.go` | +200 | 4 + 2 + 3 = 9 new test cases |
| README + CHANGELOG + planning row | docs | Doc-as-Code (#4) propagation |

## Cascading-correctness fix (the heart of PR-5)

When conf.d/ trees have `_defaults.yaml` at multiple levels (L0 root + L1 db/ + L2 db/prod/), tenants under different sub-trees inherit DIFFERENT merged-defaults views. PR-1's single `NewDefaults` map can't represent that and would emit false positives.

PR-5 introduces `NewDefaultsByTenant` (per-tenant defaults map) + `EffectiveConfig.MergedDefaults` (per-tenant pre-merge snapshot). The pipeline:

```
ScopeEffective(configDir, scope)
  └─ for each tenant under scope:
      ResolveEffective(configDir, tenantID)
        └─ computeEffectiveConfigBytesDetailed(...)
            ├─ merged = deepMerge(L0, L1, L2 ...)  ← chain merge
            ├─ mergedDefaults = deepCopyMapH(merged)  ← snapshot HERE
            └─ merged = deepMerge(merged, tenantRaw)
        ec.MergedDefaults     ← mergedDefaults     (per-tenant, snapshot)
        ec.TenantOverridesRaw ← tenantRaw          (per-tenant, raw)

cmd/da-guard/buildCheckInput
  └─ NewDefaultsByTenant[tenantID] = ec.MergedDefaults
     TenantOverrides[tenantID]      = ec.TenantOverridesRaw
     → guard.CheckDefaultsImpact(input)
        └─ checkRedundantOverrides
            └─ tenantDefaultsLeaves(tenantID): per-tenant wins, global fallback
```

Verified by `TestRun_RedundantOverride_HonorsCascadingDefaults`: tenant-db (cpu=80, inherits db/_defaults.yaml cpu=80) flagged redundant; tenant-web (cpu=80, inherits root cpu=70) NOT flagged. Single-map NewDefaults would have false-positived tenant-web.

## Workflow design

- Triggers: PR touching `**/_defaults.yaml`, da-guard source, scope/hierarchy code, or the workflow itself; plus `workflow_dispatch` with `config_dir` input.
- Permissions: `contents: read`, `pull-requests: write` — minimal needed.
- Build step: `go-version-file` from repo's go.mod (no version smuggling); `-buildvcs=false`; binary cached via `actions/setup-go@v6` cache.
- Scope detection: 1 changed `_defaults.yaml` → narrow to its dirname; multi-file → whole conf.d/. Fallback root resolution: workflow input → repo `conf.d/` → `components/threshold-exporter/config/conf.d/`.
- Sticky comment: marker `<!-- da-guard-defaults-impact -->`, update-in-place per push (lifted from blast-radius.yml's pattern).
- Failure: exit 1 (errors found) or exit 2 (caller error) blocks merge; exit 0 (clean / warnings only) passes.

## Self-review findings (all addressed)

- **gofmt drift** in two test files (table alignment after string-length changes) → applied `gofmt -w`.
- **No new dead code** introduced (kept the discipline from PR #102/#103/#106 reviews).
- **Aliasing safety**: `MergedDefaults` is a `deepCopyMapH(merged)` snapshot, not the live reference. Verified by `TestScopeEffective_MergedDefaultsIsIndependentSnapshot` (mutate snapshot → effective config still intact).
- **tenant-api regression**: full suite passed locally; `json:"-"` keeps the `/effective` JSON contract identical (no API contract growth).
- **mkdocs strict**: ran `make lint-docs-mkdocs` BEFORE push (the literal trap I codified into PR #119's planning row). Zero PR-5-touched warnings; the 32 leftover warnings are all pre-existing rule-packs/ symlink noise from this Windows clone — not present on CI.

## Test plan

- [x] `go test -race -count=2 ./pkg/config/... ./internal/guard/... ./cmd/da-guard/...` — all 3 packages pass
- [x] Full `go test ./...` regression sweep on threshold-exporter — clean
- [x] tenant-api full suite — clean (no `EffectiveConfig` field-addition regression)
- [x] gofmt clean on all PR-5 files
- [x] mkdocs strict — no PR-5 warnings
- [x] pre-commit run — all hooks green (with `SKIP=head-blob-hygiene` per windows-mcp Trap #57)
- [ ] CI Go Tests + Python Tests pass on remote
- [ ] CI commitlint / lint / mkdocs strict pass
- [ ] First merge of any `_defaults.yaml` PR after this lands → workflow self-test

## Out of scope (deferred to C-11 packaging)

- `tools/v*` release asset shipping da-guard binary so customer repos don't need clone+build.
- `.github/workflow-templates/` slot for one-click GitHub starter use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
