### PR TITLE
fix(phase-c): C-10 PR-5 self-review follow-ups — default output + Markdown table robustness

### DIFF
--- a/components/threshold-exporter/app/cmd/da-batchpr/apply.go
+++ b/components/threshold-exporter/app/cmd/da-batchpr/apply.go
@@ -64,7 +64,9 @@ func parseApplyFlags(args []string, errOut io.Writer) (*applyFlags, error) {
 	fs.BoolVar(&f.dryRun, "dry-run", false, "Run orchestration without git or GitHub API calls.")
 	fs.IntVar(&f.interCallDelayMillis, "inter-call-delay-ms", 0, "Per-item delay (ms) between OpenPR calls.")
 	fs.StringVar(&f.reportPath, "report", "-", "Write the human-readable report to this file ('-' = stdout).")
-	fs.StringVar(&f.resultJSONPath, "result-json", "-", "Write the JSON ApplyResult to this file ('-' = stdout).")
+	fs.StringVar(&f.resultJSONPath, "result-json", "",
+		"Write the JSON ApplyResult to this file ('-' = stdout, empty = skip). "+
+			"Empty default avoids gluing markdown + JSON when --report defaults to stdout.")
 	fs.BoolVar(&f.help, "help", false, "Print usage and exit.")
 	fs.BoolVar(&f.help, "h", false, "Alias for --help.")
 
@@ -159,9 +161,14 @@ func runApply(f *applyFlags, repo batchpr.Repo, stdout, errOut io.Writer, git ba
 		fmt.Fprintf(errOut, "%s apply: write report: %v\n", programName, err)
 		return exitCallerErr
 	}
-	if err := writeJSON(f.resultJSONPath, stdout, result); err != nil {
-		fmt.Fprintf(errOut, "%s apply: write result JSON: %v\n", programName, err)
-		return exitCallerErr
+	// Empty --result-json = skip JSON output. Avoids gluing markdown
+	// + JSON on stdout when both default. Customer opts in via
+	// --result-json out.json or --result-json - explicitly.
+	if f.resultJSONPath != "" {
+		if err := writeJSON(f.resultJSONPath, stdout, result); err != nil {
+			fmt.Fprintf(errOut, "%s apply: write result JSON: %v\n", programName, err)
+			return exitCallerErr
+		}
 	}
 	return exitCodeForApply(result.Summary)
 }
@@ -211,14 +218,14 @@ func renderApplyReport(repo batchpr.Repo, in batchpr.ApplyInput, r *batchpr.Appl
 	for _, it := range r.Items {
 		notes := "—"
 		if it.ErrorMessage != "" {
-			notes = it.ErrorMessage
+			notes = mdCell(it.ErrorMessage)
 		}
 		prCol := "—"
 		if it.PRNumber > 0 {
 			prCol = fmt.Sprintf("[#%d](%s)", it.PRNumber, it.PRURL)
 		}
 		out.WriteString(fmt.Sprintf("| %d | %s | `%s` | %s | %s | %s |\n",
-			it.PlanItemIndex, it.Kind, it.BranchName, it.Status, prCol, notes))
+			it.PlanItemIndex, it.Kind, mdCell(it.BranchName), it.Status, prCol, notes))
 	}
 	out.WriteString("\n")
 
@@ -230,4 +237,21 @@ func renderApplyReport(repo batchpr.Repo, in batchpr.ApplyInput, r *batchpr.Appl
 		out.WriteString("\n")
 	}
 	return out.String()
+}
+
+// mdCell sanitises a string for inclusion in a Markdown table cell.
+// Markdown tables can't carry newlines (they break the row) or
+// unescaped pipes (they introduce phantom columns). We replace
+// newlines with spaces and escape pipes as `\|`. Self-review on
+// PR-5 caught that ErrorMessage values from git/gh stderr can be
+// multi-line — without this helper, a real failure would render an
+// unparseable table.
+func mdCell(s string) string {
+	if s == "" {
+		return s
+	}
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", `\|`)
+	return s
 }

--- a/components/threshold-exporter/app/cmd/da-batchpr/apply_test.go
+++ b/components/threshold-exporter/app/cmd/da-batchpr/apply_test.go
@@ -263,6 +263,147 @@ func TestRunApply_MissingEmitDir(t *testing.T) {
 	}
 }
 
+// --- Default-output behaviour (PR-5 self-review fix) -------------
+
+func TestRunApply_DefaultResultJSONIsSkipped_StdoutIsMarkdownOnly(t *testing.T) {
+	// Pre-fix bug: --result-json defaulted to "-" (stdout), so
+	// running with no overrides glued markdown report + JSON onto
+	// stdout. Fix: default to "" → skip JSON write entirely. This
+	// test pins the new default-output contract.
+	tmp := t.TempDir()
+	planFile := filepath.Join(tmp, "plan.json")
+	mustWriteFile(t, planFile, fixturePlanJSON())
+	emitDir := filepath.Join(tmp, "emit")
+	mustWriteFile(t, filepath.Join(emitDir, "conf.d/_defaults.yaml"), []byte("base"))
+	mustWriteFile(t, filepath.Join(emitDir, "conf.d/tenant-a.yaml"), []byte("override"))
+
+	flags := &applyFlags{
+		planPath:       planFile,
+		emitDir:        emitDir,
+		dryRun:         true,
+		reportPath:     "-", // markdown to stdout (default)
+		resultJSONPath: "",  // empty = skip (new default)
+	}
+	repo := batchpr.Repo{Owner: "o", Name: "r", BaseBranch: "main"}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := runApply(flags, repo, stdout, stderr, &stubGit{}, &stubPR{}, &bytes.Buffer{})
+	if code != exitOK {
+		t.Fatalf("exit code = %d, want %d (stderr: %s)", code, exitOK, stderr.String())
+	}
+	body := stdout.String()
+	if !strings.Contains(body, "# Apply report") {
+		t.Errorf("stdout should contain Markdown report; got %q", body)
+	}
+	// JSON-result was skipped → stdout should NOT contain the
+	// JSON shape (e.g. `"items":` from MarshalIndent output).
+	// A glued markdown+JSON output (the pre-fix behaviour) would
+	// have `"summary": {` from the indented JSON.
+	if strings.Contains(body, `"items":`) || strings.Contains(body, `"summary":`) {
+		t.Errorf("stdout should NOT contain JSON output when --result-json is empty; got %q", body)
+	}
+}
+
+func TestRunApply_ExplicitResultJSONDashWritesJSONToStdout(t *testing.T) {
+	// Customer who explicitly opts into both stdout outputs gets
+	// what they asked for (markdown then JSON, glued — their
+	// problem). Test pins that "-" still works.
+	tmp := t.TempDir()
+	planFile := filepath.Join(tmp, "plan.json")
+	mustWriteFile(t, planFile, fixturePlanJSON())
+	emitDir := filepath.Join(tmp, "emit")
+	mustWriteFile(t, filepath.Join(emitDir, "conf.d/_defaults.yaml"), []byte("base"))
+	mustWriteFile(t, filepath.Join(emitDir, "conf.d/tenant-a.yaml"), []byte("override"))
+
+	flags := &applyFlags{
+		planPath:       planFile,
+		emitDir:        emitDir,
+		dryRun:         true,
+		reportPath:     "-",
+		resultJSONPath: "-", // explicit opt-in to stdout JSON
+	}
+	repo := batchpr.Repo{Owner: "o", Name: "r", BaseBranch: "main"}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := runApply(flags, repo, stdout, stderr, &stubGit{}, &stubPR{}, &bytes.Buffer{})
+	if code != exitOK {
+		t.Fatalf("exit code = %d, want %d (stderr: %s)", code, exitOK, stderr.String())
+	}
+	body := stdout.String()
+	if !strings.Contains(body, "# Apply report") {
+		t.Errorf("stdout should contain Markdown report; got %q", body[:200])
+	}
+	if !strings.Contains(body, `"items":`) {
+		t.Errorf("explicit --result-json - should write JSON to stdout; got %q", body[:200])
+	}
+}
+
+// --- mdCell helper -------------------------------------------------
+
+func TestMdCell_HandlesNewlinesAndPipes(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"plain", "plain"},
+		{"line1\nline2", "line1 line2"},
+		{"win\r\nstyle", "win style"},
+		{"col|with|pipes", `col\|with\|pipes`},
+		{"git error: stderr|stuff\nnext line", `git error: stderr\|stuff next line`},
+	}
+	for _, tc := range cases {
+		got := mdCell(tc.in)
+		if got != tc.want {
+			t.Errorf("mdCell(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRenderApplyReport_MultiLineErrorMessageStaysOnOneRow(t *testing.T) {
+	// Pin: a multi-line ErrorMessage (typical for git/gh stderr)
+	// must not break the Markdown table by introducing newlines
+	// mid-row. Counts the number of `|` row separators between the
+	// table header and the closing newline; should equal exactly
+	// (rows × 7) — 6 columns + 7 pipes per row including the
+	// surrounding ones.
+	repo := batchpr.Repo{Owner: "o", Name: "r", BaseBranch: "main"}
+	in := batchpr.ApplyInput{}
+	r := &batchpr.ApplyResult{
+		Items: []batchpr.ApplyItemResult{
+			{
+				PlanItemIndex: 0,
+				Kind:          batchpr.PlanItemBase,
+				BranchName:    "branch-a",
+				Status:        batchpr.ApplyStatusFailed,
+				ErrorMessage:  "git push: command failed\nstderr: refusing to update\nremote rejected",
+			},
+		},
+	}
+	report := renderApplyReport(repo, in, r)
+	// Find the row containing branch-a; count `|` chars on that line.
+	var rowLine string
+	for _, line := range strings.Split(report, "\n") {
+		if strings.Contains(line, "branch-a") {
+			rowLine = line
+			break
+		}
+	}
+	if rowLine == "" {
+		t.Fatalf("could not find branch-a row in report:\n%s", report)
+	}
+	// 6 columns → 7 pipes per row (one between each + surrounding).
+	if got := strings.Count(rowLine, "|"); got != 7 {
+		t.Errorf("row should have exactly 7 pipes (6 columns); got %d in %q", got, rowLine)
+	}
+	// The error message's newlines should be gone.
+	if strings.Contains(rowLine, "\n") {
+		t.Errorf("row line should not contain newlines; got %q", rowLine)
+	}
+	if !strings.Contains(rowLine, "git push: command failed stderr: refusing") {
+		t.Errorf("row should contain the joined error message; got %q", rowLine)
+	}
+}
+
 // --- AllocateFiles warning ordering ----------------------------
 
 func TestRunApply_AllocateWarningsPrependedNotAppended(t *testing.T) {

--- a/components/threshold-exporter/app/cmd/da-batchpr/main.go
+++ b/components/threshold-exporter/app/cmd/da-batchpr/main.go
@@ -178,7 +178,13 @@ func writeReport(path string, stdout io.Writer, body string) error {
 // load C-9 emit output, and by refresh-source to load patch files.
 //
 // `root` MUST exist and be a directory; missing/file → error.
-// Symlinks are followed (filepath.Walk semantics).
+// Symlinks are NOT followed (filepath.Walk semantics — symlinks to
+// directories appear as regular files with ModeSymlink set and are
+// skipped by the IsDir() check; symlinks to files are read-through
+// because os.ReadFile follows them when the dirent is treated as
+// a regular file). If a customer's emit-dir / patches-dir contains
+// a symlinked subdirectory they expect walked into, they'll need to
+// resolve it before invoking this CLI.
 //
 // Path normalisation: returned keys use forward slashes regardless
 // of host OS (matches the rest of the batchpr / config packages).

--- a/components/threshold-exporter/app/cmd/da-batchpr/refresh.go
+++ b/components/threshold-exporter/app/cmd/da-batchpr/refresh.go
@@ -46,8 +46,9 @@ func parseRefreshFlags(args []string, errOut io.Writer) (*refreshFlags, error) {
 		"Local clone of the target repo (CWD for git ops). Required.")
 	fs.StringVar(&f.reportPath, "report", "-",
 		"Write the Markdown refresh-report to this file ('-' = stdout).")
-	fs.StringVar(&f.resultJSONPath, "result-json", "-",
-		"Write the JSON RefreshResult to this file ('-' = stdout).")
+	fs.StringVar(&f.resultJSONPath, "result-json", "",
+		"Write the JSON RefreshResult to this file ('-' = stdout, empty = skip). "+
+			"Empty default avoids gluing markdown + JSON when --report defaults to stdout.")
 	fs.BoolVar(&f.help, "help", false, "Print usage and exit.")
 	fs.BoolVar(&f.help, "h", false, "Alias for --help.")
 
@@ -96,9 +97,11 @@ func runRefresh(f *refreshFlags, in batchpr.RefreshInput, stdout, errOut io.Writ
 		fmt.Fprintf(errOut, "%s refresh: write report: %v\n", programName, err)
 		return exitCallerErr
 	}
-	if err := writeJSON(f.resultJSONPath, stdout, result); err != nil {
-		fmt.Fprintf(errOut, "%s refresh: write result JSON: %v\n", programName, err)
-		return exitCallerErr
+	if f.resultJSONPath != "" {
+		if err := writeJSON(f.resultJSONPath, stdout, result); err != nil {
+			fmt.Fprintf(errOut, "%s refresh: write result JSON: %v\n", programName, err)
+			return exitCallerErr
+		}
 	}
 	return exitCodeForRefresh(result.Summary)
 }

--- a/components/threshold-exporter/app/cmd/da-batchpr/refresh_source.go
+++ b/components/threshold-exporter/app/cmd/da-batchpr/refresh_source.go
@@ -51,8 +51,9 @@ func parseRefreshSourceFlags(args []string, errOut io.Writer) (*refreshSourceFla
 		"Local clone of the target repo (CWD for git ops). Required.")
 	fs.StringVar(&f.reportPath, "report", "-",
 		"Write the Markdown patch-plan report to this file ('-' = stdout).")
-	fs.StringVar(&f.resultJSONPath, "result-json", "-",
-		"Write the JSON RefreshSourceResult to this file ('-' = stdout).")
+	fs.StringVar(&f.resultJSONPath, "result-json", "",
+		"Write the JSON RefreshSourceResult to this file ('-' = stdout, empty = skip). "+
+			"Empty default avoids gluing markdown + JSON when --report defaults to stdout.")
 	fs.BoolVar(&f.help, "help", false, "Print usage and exit.")
 	fs.BoolVar(&f.help, "h", false, "Alias for --help.")
 
@@ -143,9 +144,11 @@ func runRefreshSource(f *refreshSourceFlags, in batchpr.RefreshSourceInput, stdo
 		fmt.Fprintf(errOut, "%s refresh-source: write report: %v\n", programName, err)
 		return exitCallerErr
 	}
-	if err := writeJSON(f.resultJSONPath, stdout, result); err != nil {
-		fmt.Fprintf(errOut, "%s refresh-source: write result JSON: %v\n", programName, err)
-		return exitCallerErr
+	if f.resultJSONPath != "" {
+		if err := writeJSON(f.resultJSONPath, stdout, result); err != nil {
+			fmt.Fprintf(errOut, "%s refresh-source: write result JSON: %v\n", programName, err)
+			return exitCallerErr
+		}
 	}
 	return exitCodeForRefreshSource(result.Summary)
 }

--- a/components/threshold-exporter/app/internal/batchpr/refresh.go
+++ b/components/threshold-exporter/app/internal/batchpr/refresh.go
@@ -345,12 +345,12 @@ func renderRefreshReport(in RefreshInput, r *RefreshResult) string {
 			notes = fmt.Sprintf("%d conflicted file(s) — manual rebase required",
 				len(it.ConflictedFiles))
 		case RebaseFailed:
-			notes = fmt.Sprintf("step=%s: %s", it.Step, it.ErrorMessage)
+			notes = mdCell(fmt.Sprintf("step=%s: %s", it.Step, it.ErrorMessage))
 		case RebaseDryRun:
 			notes = "would rebase + push + comment"
 		}
 		out.WriteString(fmt.Sprintf("| #%d | `%s` | %s | %s | %s |\n",
-			it.PRNumber, it.BranchName, it.PRState, it.Status, notes))
+			it.PRNumber, mdCell(it.BranchName), it.PRState, it.Status, notes))
 	}
 	out.WriteString("\n")
 
@@ -387,4 +387,20 @@ func renderRefreshReport(in RefreshInput, r *RefreshResult) string {
 		out.WriteString("\n")
 	}
 	return out.String()
+}
+
+// mdCell sanitises a string for inclusion in a Markdown table cell.
+// Markdown tables can't carry newlines (they break the row) or
+// unescaped pipes (they introduce phantom columns). Replace
+// newlines with spaces and escape pipes as `\|`. Used by
+// renderRefreshReport + renderRefreshSourceReport for fields like
+// ErrorMessage that come from git/gh stderr (often multi-line).
+func mdCell(s string) string {
+	if s == "" {
+		return s
+	}
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", `\|`)
+	return s
 }

--- a/components/threshold-exporter/app/internal/batchpr/refresh_source.go
+++ b/components/threshold-exporter/app/internal/batchpr/refresh_source.go
@@ -399,14 +399,14 @@ func renderRefreshSourceReport(in RefreshSourceInput, r *RefreshSourceResult) st
 		notes := "—"
 		switch it.Status {
 		case PatchFailed:
-			notes = fmt.Sprintf("step=%s: %s", it.Step, it.ErrorMessage)
+			notes = mdCell(fmt.Sprintf("step=%s: %s", it.Step, it.ErrorMessage))
 		case PatchDryRun:
 			notes = "would update + commit + push + comment"
 		case PatchSkippedNoChange:
 			notes = "caller's diff was empty for this tenant"
 		}
 		out.WriteString(fmt.Sprintf("| #%d | `%s` | %s | %s | %d | %s |\n",
-			it.PRNumber, it.BranchName, it.PRState, it.Status, it.FilesUpdated, notes))
+			it.PRNumber, mdCell(it.BranchName), it.PRState, it.Status, it.FilesUpdated, notes))
 	}
 	out.WriteString("\n")
 


### PR DESCRIPTION
## Summary

Post-merge self-review on PR #131 (C-10 PR-5 \`da-batchpr\` CLI) caught 3 real UX bugs. This is a small follow-up that fixes all 3 + adds the test that would have caught the most impactful one pre-merge.

## Findings + fixes

### Bug 1 — Default invocation glues markdown + JSON on stdout (Medium UX)

All 3 subcommands defaulted **both** \`--report\` and \`--result-json\` to \`-\` (stdout). Running \`da-batchpr apply ...\` with no overrides produced Markdown report immediately followed by indented JSON, on the same stdout. **Confusing for both human and machine consumers** — markdown breaks JSON parsers; JSON pollutes the human-readable report.

**Fix**: \`--result-json\` default → \`""\` (skip). Customer opts in via \`--result-json out.json\` or \`--result-json -\`.

| Default | Before | After |
|---|---|---|
| \`da-batchpr apply ...\` | markdown + JSON glued on stdout | markdown only on stdout |
| \`... --result-json -\` | markdown + JSON glued on stdout | markdown + JSON glued on stdout (explicit opt-in) |
| \`... --result-json out.json\` | markdown stdout, JSON to file | markdown stdout, JSON to file |

Pinned by:
- \`TestRunApply_DefaultResultJSONIsSkipped_StdoutIsMarkdownOnly\`
- \`TestRunApply_ExplicitResultJSONDashWritesJSONToStdout\`

### Bug 2 — Multi-line \`ErrorMessage\` breaks Markdown tables (Medium UX)

git/gh stderr is often multi-line. Surfaced into per-item \`ErrorMessage\` and rendered into the report's Notes column without sanitisation, the newlines split the table row mid-cell. Real failures would render an unparseable table.

**Fix**: new \`mdCell(s string) string\` helper that replaces newlines (both \`\n\` and \`\r\n\`) with spaces and escapes pipes as \`\|\`. Applied to ErrorMessage + BranchName cells in:

- \`cmd/da-batchpr/apply.go renderApplyReport\` (new in PR-5)
- \`internal/batchpr/refresh.go renderRefreshReport\` (PR-3 pre-existing)
- \`internal/batchpr/refresh_source.go renderRefreshSourceReport\` (PR-4 pre-existing)

Pinned by:
- \`TestMdCell_HandlesNewlinesAndPipes\` — \n / \r\n / pipe / combined / empty / plain
- \`TestRenderApplyReport_MultiLineErrorMessageStaysOnOneRow\` — counts pipes per row to assert table integrity

### Bug 3 — \`walkFilesDir\` comment incorrectly claimed symlinks followed (Low doc)

Comment said \"Symlinks are followed (filepath.Walk semantics)\" but \`filepath.Walk\` does **NOT** follow symlinks — symlinked directories appear as regular files (Walk doesn't recurse into them).

**Fix**: corrected comment to be accurate.

## Test gap that would have caught Bug 1

The original PR-5 tests always passed explicit file paths for both \`--report\` and \`--result-json\`. None exercised the default-stdout behaviour. **Adding the test before merging would have caught the dual-output bug.** Lesson: when a flag has a non-trivial default, write at least one test that exercises the default path.

## Test plan

- [ ] Go tests pass on CI (-race -count=2 already green locally — full threshold-exporter suite + 4 new tests for these fixes)
- [ ] mkdocs strict baseline unchanged
- [ ] \`bump_docs.py --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)