### PR TITLE
fix(phase-b): TestSlowWriteTornStateStress race-flake — quiescence detection rewrite (closes #157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ Breaking / Upgrade 七塊清楚區分），那是目標形狀。
 
 ### Fixed
 
+- **`TestSlowWriteTornStateStress` race-flake hardening — quiescence detection rewrite（v2.8.0, Phase B testing follow-up, [closes #157](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/157)）** — B-7 slow-write torn-state stress 從 v2.8.0 cycle 起 flaked CI 兩次（PR #151 + PR #155 各 1 次），symptom 都是 `sliding debounce violated: fire count = 1 after write 19/2 (expected 0 throughout the burst)`。**這 PR 不修 production code — debounce 沒 bug**；修的是 test 違反了 PR #149 codify 的 testing-playbook lesson §2 anti-pattern：`for { trigger; t.Sleep(jitter) } + assert fireCount == 0` 是 wall-clock 斷言，loaded CI runner overshooting sleep 就會誤判 burst split。
+  - **修法**：完整套用 lesson §2 canonical quiescence pattern：
+    - 移除 mid-burst `fireSnapshots` 抽樣 + 「expected 0 throughout the burst」斷言（這條是 timing claim，不是 contract claim）
+    - 移除 post-settle `time.Sleep(2*window) + assert fireCount == 1`（同樣 timing claim）
+    - 加入新 helper `waitForQuiescence(t, deadline, stableWindow, counterFn)` — 輪詢計數器直到 stableWindow 連續 ms 沒變動，否則 timeout
+    - Post-quiescence assert 三條 contract-stable invariants：(1) `debounceBatch._sum == numFiles`（每個 trigger 都 coalesce 到某個 fire — 抓 lost-trigger）；(2) `merged_hash` 全 tenant 從 baseline 推進（抓 lost-write）；(3) `_count ≤ 2` CI-jitter envelope（外面就是真 broken debounce）
+    - `fireCount` 變 informational logging — 不再硬斷言
+  - **重新命名**：`TestSlowWriteTornStateStress_FinalConvergenceNoTornFires` → `TestSlowWriteTornStateStress_FinalConvergence` — 誠實對應改寫後的合約（drop 「NoTornFires」承諾，因 fireCount 不再硬斷）。File 開頭加段 issue #157 history block 給 future reader 知道改寫 rationale
+  - **驗證**：本機 dev-container `-race -count=10` 全綠（vs. 改寫前 CI 上 ~每 10-15 PR 觸發 1 次）；regression 注入「skip every-other trigger」bug → test FAIL at `_sum=25 != 50`，確認 invariants 仍能抓到 lost-trigger class
+  - **第三條 worked example** 加進 `testing-playbook.md §v2.8.0 Lessons Learned — Race-flake battles` lesson §2 — 跟 PR #79 / #90 兩個 worked example 並列，強化 visibility
+
 - **tenant-api body-content range validation 在邊界 fail-fast（v2.8.0, Phase B Track C C4 deferred, [closes #134](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/134)）** — Track C 期間明示 deferred 至獨立 PR 處理的 C4 項目落地。v2.8.0 之前的 `POST /api/v1/tenants/batch` / `PUT /api/v1/groups/{id}` / `PUT /api/v1/views/{id}` body 只驗 size (≤1MB) + JSON 格式，不驗值範圍 — customer 送 `{"_timeout_ms":"99999999999"}` 之類的 nonsense value，API 直接通過寫進 git，幾分鐘後 downstream（threshold-exporter resolve / GitOps writer YAML parse）才 reject。客戶看到的錯誤訊息位置離犯錯點極遠，debug 成本高，且 bad write 已經進 git 需要 revert PR。
   - **修法**：新增 `components/tenant-api/internal/handler/body_validator.go`，hybrid 設計：
     - **Fixed-shape 欄位**（`Label` / `Description` / `Members`）用 `go-playground/validator/v10` struct tags：`validate:"required,min=1,max=256"` / `validate:"max=4096"` / `validate:"max=1000,dive,min=1,max=256"`

--- a/components/threshold-exporter/app/config_slow_write_stress_test.go
+++ b/components/threshold-exporter/app/config_slow_write_stress_test.go
@@ -56,6 +56,13 @@ import (
 // alternative — `time.Sleep(window + buffer)` — flakes under loaded
 // CI runners. See `docs/internal/testing-playbook.md` §v2.8.0 Lessons
 // Learned — Race-flake battles, lesson §2 for the pattern rationale.
+//
+// Caller pitfall: a counter that NEVER moves (e.g. broken trigger,
+// dead system) also satisfies "unchanged for stableWindow" and the
+// function returns true. Callers MUST follow up with a domain-level
+// "did the expected work happen" check (e.g. `fireCount > 0`) to
+// distinguish "settled at the right value" from "settled at zero
+// because nothing fired".
 func waitForQuiescence(
 	t *testing.T,
 	deadline, stableWindow time.Duration,
@@ -108,7 +115,7 @@ func TestSlowWriteTornStateStress_FinalConvergence(t *testing.T) {
 		maxGap        = 25 * time.Millisecond
 		settleTimeout = 5 * time.Second
 		// stableWindow: how long DebounceFiredCount() must be unchanged
-		// before we declare the system quiescent. Set to ~2× debounceWin
+		// before we declare the system quiescent. Set to ~2.5× debounceWin
 		// so a freshly-trigger'd window still has time to fire+settle
 		// before we sample.
 		stableWindow = 250 * time.Millisecond

--- a/components/threshold-exporter/app/config_slow_write_stress_test.go
+++ b/components/threshold-exporter/app/config_slow_write_stress_test.go
@@ -8,15 +8,14 @@ package main
 // realistic ops scenario: an operator runs `git pull` against a repo
 // that updates 50+ tenant files, where individual file rsync writes
 // land with random inter-arrival jitter (a few ms to a few tens of
-// ms apart). The contract is:
+// ms apart). The contract under test:
 //
-//   * While inter-arrival gaps stay < debounceWindow, the timer keeps
-//     resetting (sliding window), and **no** intermediate fire
-//     happens — i.e. there is never a torn-state reload that observes
-//     half the writes.
-//   * Once writes stop, the next debounce window elapses and exactly
-//     ONE fire converges to the post-write merged_hash for every
-//     tenant whose source moved.
+//   * Every triggerDebouncedReload coalesces into SOME fired window
+//     (no lost triggers). The B-3 batch histogram's `_sum` equals
+//     numFiles regardless of how many windows fired.
+//   * Every mutated tenant's merged_hash advances past its baseline
+//     post-quiescence (no torn-state observation that loses a tenant's
+//     final value).
 //   * No goroutine leaks (Close() drains).
 //
 // Production parameters (planning §B-7): 200 files, 50-500ms gaps.
@@ -24,11 +23,19 @@ package main
 // so CI completes in ~2s but the ratio (gap < window) is preserved.
 //
 // Determinism: rand seeded with a fixed constant. Re-running the test
-// produces identical inter-arrival patterns; flaky? File a real bug.
+// produces identical inter-arrival patterns; observed-state is checked
+// post-quiescence so wall-clock scheduler jitter doesn't flake.
 //
-// This is NOT a benchmark — it asserts correctness, not performance.
-// The reload-duration / debounce-batch histograms added in B-3 are
-// observed as a side effect; we sanity-check them at the end.
+// **History (issue #157)**: this test originally asserted "fire count
+// stays at 0 throughout the burst" + "exactly 1 fire after settle".
+// Both are wall-clock claims — they test scheduler timing, not the
+// debounce contract. On loaded CI runners the burst occasionally split
+// into 2 windows, failing the "exactly 0 / exactly 1" assertions even
+// though final convergence held. PRs #151 + #155 each hit this flake;
+// codified rewrite per testing-playbook §"Race-flake battles" lesson §2
+// (canonical quiescence pattern). The new invariants are stable across
+// runner contention while still catching the genuine bug class
+// (lost-trigger / lost-write).
 
 import (
 	"fmt"
@@ -41,31 +48,71 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// TestSlowWriteTornStateStress_FinalConvergenceNoTornFires writes 50
-// tenant files with random 5-25ms inter-arrival gaps under a 100ms
-// debounce window, and verifies:
+// waitForQuiescence polls counterFn until its observed value is
+// unchanged for stableWindow consecutive ms, or until deadline.
+// Returns true on quiescence, false on timeout.
 //
-//	(1) sliding debounce holds: fire count stays at 0 while writes are
-//	    arriving (because each new write resets the timer).
-//	(2) exactly one fire after writes stop.
-//	(3) every mutated tenant's merged_hash differs from its baseline
-//	    (final state correctly observed).
-//	(4) the B-3 batch histogram observes one sample with sum == #fires
-//	    seen by triggerDebouncedReload (proxy for coalescing efficacy).
-func TestSlowWriteTornStateStress_FinalConvergenceNoTornFires(t *testing.T) {
-	// Window/gap ratio chosen so even a CI runner overshooting a
-	// `time.Sleep(gap)` by ~3× still keeps the inter-arrival under
-	// debounceWin (max gap 25ms × 3 = 75ms < 100ms window). Tightening
-	// gaps further saves no wall-clock time and chokes on scheduler
-	// jitter; loosening the window beyond 100ms adds settle latency
-	// without further margin.
+// Use this for "wait for async work to settle" patterns where the
+// alternative — `time.Sleep(window + buffer)` — flakes under loaded
+// CI runners. See `docs/internal/testing-playbook.md` §v2.8.0 Lessons
+// Learned — Race-flake battles, lesson §2 for the pattern rationale.
+func waitForQuiescence(
+	t *testing.T,
+	deadline, stableWindow time.Duration,
+	counterFn func() uint64,
+) bool {
+	t.Helper()
+	last := counterFn()
+	stableSince := time.Now()
+	timeoutAt := time.Now().Add(deadline)
+	pollInterval := 20 * time.Millisecond
+	for time.Now().Before(timeoutAt) {
+		time.Sleep(pollInterval)
+		now := counterFn()
+		if now != last {
+			last = now
+			stableSince = time.Now()
+			continue
+		}
+		if time.Since(stableSince) >= stableWindow {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSlowWriteTornStateStress_FinalConvergence writes 50 tenant files
+// with random 5-25ms inter-arrival gaps under a 100ms debounce window
+// and verifies the post-quiescence contract:
+//
+//	(1) Every triggerDebouncedReload coalesced into some fired window —
+//	    debounceBatch histogram _sum == numFiles. Catches the
+//	    "lost-trigger" bug class directly.
+//	(2) Every mutated tenant's merged_hash advanced past its baseline
+//	    after quiescence. Catches the "lost-write" bug class (a fire
+//	    that observed an incomplete state and didn't get re-driven).
+//	(3) Final fire count is logged for observability — informational,
+//	    NOT asserted exact (1 = sliding window held throughout;
+//	    2+ = burst legitimately split across windows under load,
+//	    which doesn't violate any contract as long as 1 + 2 hold).
+//	(4) No goroutine leak: Close() drains.
+//
+// Test name retains `TornStateStress` for git-blame continuity even
+// though the rewrite no longer hard-asserts "no torn fires" — see
+// the file-level comment for the issue #157 history.
+func TestSlowWriteTornStateStress_FinalConvergence(t *testing.T) {
 	const (
 		numFiles      = 50
 		debounceWin   = 100 * time.Millisecond
 		minGap        = 5 * time.Millisecond
 		maxGap        = 25 * time.Millisecond
-		settleTimeout = 2 * time.Second
-		seed          = int64(0xB7_5_0_5_0)
+		settleTimeout = 5 * time.Second
+		// stableWindow: how long DebounceFiredCount() must be unchanged
+		// before we declare the system quiescent. Set to ~2× debounceWin
+		// so a freshly-trigger'd window still has time to fire+settle
+		// before we sample.
+		stableWindow = 250 * time.Millisecond
+		seed         = int64(0xB7_5_0_5_0)
 	)
 
 	fresh, _ := withIsolatedMetrics(t)
@@ -89,11 +136,12 @@ func TestSlowWriteTornStateStress_FinalConvergenceNoTornFires(t *testing.T) {
 	}
 
 	rng := rand.New(rand.NewSource(seed))
-	fireSnapshots := make([]uint64, 0, numFiles)
 
-	// Drive the slow-write sequence. After EACH write we sample
-	// DebounceFiredCount(); if the sliding window is honored, every
-	// sample should be 0 — the timer resets faster than it can fire.
+	// Drive the slow-write sequence. We do NOT sample DebounceFiredCount()
+	// during the burst — that introduces wall-clock-timing-fragile
+	// assertions (testing-playbook §Race-flake lesson §2). Post-burst
+	// quiescence detection + per-fire invariants below catch the genuine
+	// bug classes without flaking on runner contention.
 	for i := 0; i < numFiles; i++ {
 		tid := fmt.Sprintf("tenant-%04d", i)
 		path := filepath.Join(dir, "team-a", tid+".yaml")
@@ -102,39 +150,39 @@ func TestSlowWriteTornStateStress_FinalConvergenceNoTornFires(t *testing.T) {
 			t.Fatalf("write tenant %s: %v", tid, err)
 		}
 		// Synthetic fsnotify-equivalent: drive the trigger explicitly so
-		// the test stays deterministic (real fsnotify timing is OS-
-		// dependent and would defeat the seed-based reproducibility).
+		// the test stays deterministic across OS fsnotify implementations.
 		m.triggerDebouncedReload(ReloadReasonSource)
-		fireSnapshots = append(fireSnapshots, m.DebounceFiredCount())
 
 		gap := minGap + time.Duration(rng.Int63n(int64(maxGap-minGap)))
 		time.Sleep(gap)
 	}
 
-	// (1) Before settle: across ALL inter-write samples, fire count
-	// MUST stay 0. Even one nonzero sample means a torn-state fire
-	// observed an incomplete write batch.
-	for i, c := range fireSnapshots {
-		if c != 0 {
-			t.Fatalf("sliding debounce violated: fire count = %d after write %d (expected 0 throughout the burst)", c, i+1)
-		}
+	// Quiescence: wait for DebounceFiredCount() to stabilize, indicating
+	// no further fires are pending. This is the canonical replacement
+	// for "sleep + assert exactly N" per testing-playbook §Race-flake
+	// lesson §2.
+	if !waitForQuiescence(t, settleTimeout, stableWindow, m.DebounceFiredCount) {
+		t.Fatalf("DebounceFiredCount never stabilized within %v "+
+			"(last value: %d) — debounce may be misbehaving",
+			settleTimeout, m.DebounceFiredCount())
+	}
+	fireCount := m.DebounceFiredCount()
+	if fireCount < 1 {
+		t.Fatalf("expected at least 1 fire after settle, got %d", fireCount)
 	}
 
-	// (2) After settle: exactly one fire (window elapses post-final-write).
-	if !waitFor(t, settleTimeout, func() bool {
-		return m.DebounceFiredCount() >= 1
-	}) {
-		t.Fatalf("debounce never fired after settle (count=%d)", m.DebounceFiredCount())
-	}
-	// Tail-sleep so any rogue extra fire is also visible.
-	time.Sleep(2 * debounceWin)
-	if got := m.DebounceFiredCount(); got != 1 {
-		t.Errorf("expected exactly 1 debounce fire after settle, got %d", got)
-	}
+	// (3) Fire-count observability — informational only.
+	t.Logf("debounce fires after quiescence: %d "+
+		"(1 = sliding window held throughout the burst; "+
+		"2+ = burst legitimately split across windows under runner load — "+
+		"both states are contract-compliant as long as invariants below pass)",
+		fireCount)
 
-	// (3) Final convergence: every mutated tenant's merged_hash moved.
+	// (2) Final convergence: every mutated tenant's merged_hash advanced.
+	//     Catches the "lost-write" bug class — a fire that observes an
+	//     incomplete state but doesn't get re-driven would leave at least
+	//     one tenant's hash matching baseline after settle.
 	m.mu.RLock()
-	defer m.mu.RUnlock()
 	mismatches := 0
 	for tid, prev := range baseline {
 		curr := m.mergedHashes[tid]
@@ -144,16 +192,25 @@ func TestSlowWriteTornStateStress_FinalConvergenceNoTornFires(t *testing.T) {
 			continue
 		}
 		if curr == prev {
-			t.Errorf("tenant %s: merged_hash unchanged (baseline=%s); slow-write batch lost a tenant", tid, prev)
+			t.Errorf("tenant %s: merged_hash unchanged (baseline=%s); "+
+				"slow-write batch lost a tenant", tid, prev)
 			mismatches++
 		}
 	}
+	m.mu.RUnlock()
 	if mismatches > 0 {
-		t.Fatalf("slow-write convergence: %d/%d tenants did not advance", mismatches, len(baseline))
+		t.Fatalf("slow-write convergence: %d/%d tenants did not advance",
+			mismatches, len(baseline))
 	}
 
-	// (4) B-3 sanity: exactly one debounce-batch sample with sum equal
-	// to numFiles (every triggerDebouncedReload during the burst).
+	// (1) Batch histogram: every trigger coalesced into SOME fire.
+	//     `_sum` MUST equal numFiles regardless of how many windows
+	//     fired (contract-stable assertion). `_count` is intentionally
+	//     NOT asserted exact — it can legitimately be 1 or 2 under
+	//     loaded CI; both states are compliant per the rewrite rationale
+	//     (see file header for issue #157 history). If `_count > 2` we
+	//     do flag — that's outside the realistic CI-jitter envelope and
+	//     suggests debounce is genuinely misbehaving.
 	reg := prometheus.NewRegistry()
 	if err := reg.Register(fresh.debounceBatch); err != nil {
 		t.Fatalf("register debounceBatch: %v", err)
@@ -165,11 +222,19 @@ func TestSlowWriteTornStateStress_FinalConvergenceNoTornFires(t *testing.T) {
 	for _, fam := range families {
 		for _, metric := range fam.Metric {
 			h := metric.Histogram
-			if h.GetSampleCount() != 1 {
-				t.Errorf("debounceBatch: expected _count=1 (one fired window), got %d", h.GetSampleCount())
-			}
 			if h.GetSampleSum() != float64(numFiles) {
-				t.Errorf("debounceBatch: expected _sum=%d (all triggers coalesced), got %v", numFiles, h.GetSampleSum())
+				t.Errorf("debounceBatch: expected _sum=%d (every trigger "+
+					"coalesced into some fire), got %v",
+					numFiles, h.GetSampleSum())
+			}
+			if h.GetSampleCount() < 1 {
+				t.Errorf("debounceBatch: expected at least 1 fired window, got %d",
+					h.GetSampleCount())
+			}
+			if h.GetSampleCount() > 2 {
+				t.Errorf("debounceBatch: _count=%d exceeds runner-jitter envelope (≤2); "+
+					"debounce may be misbehaving (sliding window not coalescing)",
+					h.GetSampleCount())
 			}
 		}
 	}

--- a/docs/internal/testing-playbook.md
+++ b/docs/internal/testing-playbook.md
@@ -685,6 +685,51 @@ fireCount := m.DebounceFiredCount()
 
 This decouples the test from window-size choice and CI scheduling jitter.
 
+#### Worked example: `TestSlowWriteTornStateStress_FinalConvergence`（PR #158, issue #157）
+
+The B-7 slow-write stress test originally asserted **two** wall-clock claims that lesson §2 prohibits:
+
+1. `for i := 0..N { trigger; t.Sleep(jitter); assert fireCount == 0 }` — "no fire DURING the burst"
+2. `t.Sleep(2 * window); assert fireCount == 1` — "exactly 1 fire AFTER settle"
+
+Both pass under healthy CI but flake when scheduler jitter overshoots a sleep, splitting the 50-write burst into 2 fired windows. PR #151 + #155 each took the flake. After two adjacent occurrences, opened issue #157 and codified the rewrite per this lesson.
+
+**Rewrite shape**:
+
+```go
+// Drive the burst — DO NOT sample fireCount mid-burst.
+for i := 0; i < numFiles; i++ {
+    writeFile(...)
+    m.triggerDebouncedReload(ReloadReasonSource)
+    time.Sleep(jitter)
+}
+
+// Quiescence — fireCount stable for stableWindow consecutive ms.
+if !waitForQuiescence(t, settleTimeout, stableWindow, m.DebounceFiredCount) {
+    t.Fatalf("counter never stabilized — debounce may be broken")
+}
+fireCount := m.DebounceFiredCount()
+t.Logf("debounce fires: %d (informational, not asserted)", fireCount)
+
+// Per-fire invariants — INDEPENDENT of fireCount value:
+// (a) every trigger coalesced into SOME fire
+assert h.GetSampleSum() == numFiles
+// (b) every mutated tenant advanced
+assert mergedHash[tid] != baseline[tid] for all tid
+// (c) fire count not absurd (catches genuinely-broken debounce)
+assert h.GetSampleCount() <= 2  // CI-jitter envelope
+```
+
+**Why `_count <= 2` not `_count == 1`**: a 50-write burst with 5-25ms gaps under a 100ms window legitimately splits into 1 OR 2 fired windows depending on scheduler jitter. Both are contract-compliant. `_count <= 2` is the **CI-jitter envelope** — outside this means debounce is genuinely broken (e.g. window not coalescing). The test FAILS bench injection of "skip every-other trigger" via `_sum=25 != 50` (verified during PR #158 implementation).
+
+**Reusable helper** (`config_slow_write_stress_test.go`):
+
+```go
+func waitForQuiescence(t *testing.T, deadline, stableWindow time.Duration, counterFn func() uint64) bool
+```
+
+Generalizes to any test polling a monotonic counter for "no new events for K ms" semantics.
+
 ### 3. `testutil.CollectAndCount` 對 plain Histogram **回 family count, 不是 sample count**
 
 **Footgun**: `prometheus.testutil.CollectAndCount(h)` for a plain `prometheus.Histogram` returns **1** after registration, regardless of how many `Observe()` calls happened. It returns the number of metric families, not samples.

--- a/docs/internal/testing-playbook.md
+++ b/docs/internal/testing-playbook.md
@@ -685,7 +685,7 @@ fireCount := m.DebounceFiredCount()
 
 This decouples the test from window-size choice and CI scheduling jitter.
 
-#### Worked example: `TestSlowWriteTornStateStress_FinalConvergence`（PR #158, issue #157）
+#### Worked example: `TestSlowWriteTornStateStress_FinalConvergence`（PR #159, issue #157）
 
 The B-7 slow-write stress test originally asserted **two** wall-clock claims that lesson §2 prohibits:
 
@@ -720,7 +720,7 @@ assert mergedHash[tid] != baseline[tid] for all tid
 assert h.GetSampleCount() <= 2  // CI-jitter envelope
 ```
 
-**Why `_count <= 2` not `_count == 1`**: a 50-write burst with 5-25ms gaps under a 100ms window legitimately splits into 1 OR 2 fired windows depending on scheduler jitter. Both are contract-compliant. `_count <= 2` is the **CI-jitter envelope** — outside this means debounce is genuinely broken (e.g. window not coalescing). The test FAILS bench injection of "skip every-other trigger" via `_sum=25 != 50` (verified during PR #158 implementation).
+**Why `_count <= 2` not `_count == 1`**: a 50-write burst with 5-25ms gaps under a 100ms window legitimately splits into 1 OR 2 fired windows depending on scheduler jitter. Both are contract-compliant. `_count <= 2` is the **CI-jitter envelope** — outside this means debounce is genuinely broken (e.g. window not coalescing). The test FAILS bench injection of "skip every-other trigger" via `_sum=25 != 50` (verified during PR #159 implementation).
 
 **Reusable helper** (`config_slow_write_stress_test.go`):
 


### PR DESCRIPTION
## Summary

Phase B testing follow-up. Closes #157.

The B-7 slow-write torn-state stress test flaked CI **twice** in adjacent PRs (#151 + #155), each with the same signature:

```
config_slow_write_stress_test.go:119:
  sliding debounce violated: fire count = 1 after write 19
  (expected 0 throughout the burst)
```

**Not a debounce bug** — debounce works correctly. The test violated the testing-playbook lesson §2 anti-pattern that PR #149 codified: wall-clock assertions inside a write-burst loop. On loaded CI runners, an inter-write `t.Sleep(20ms)` occasionally overshoots to ~150ms (exceeding the 100ms debounce window), causing the burst to legitimately split into 2 fired windows. The "expected 0 throughout the burst" assertion misreads this as a real bug.

Two consecutive flake occurrences hit the threshold codified in PR #149 ("act on the second occurrence"); opened #157, this PR delivers.

## Production code: ZERO changes

This is a **test-only** PR. Debounce production code is untouched.

## Test rewrite

`components/threshold-exporter/app/config_slow_write_stress_test.go`:

| Change | Detail |
|---|---|
| Add `waitForQuiescence` helper | Polls a monotonic counter; returns true when value unchanged for `stableWindow` consecutive ms |
| Drop mid-burst `fireSnapshots` sampling | The "expected 0 throughout the burst" wall-clock claim that flaked |
| Drop post-settle `time.Sleep(2*window) + assert fireCount==1` | Same wall-clock class |
| Replace with quiescence-based wait + 3 contract-stable invariants | See below |
| `fireCount` becomes `t.Logf` | Informational, not asserted exact (1 = sliding window held; 2 = burst split under load — both contract-compliant) |
| Rename test | `_FinalConvergenceNoTornFires` → `_FinalConvergence` (the `NoTornFires` suffix promised something we no longer assert) |
| File-level history block | Issue #157 rationale captured for future readers |

## Three contract-stable invariants

| # | Invariant | Catches |
|---|---|---|
| (1) | `debounceBatch._sum == numFiles` | Lost-trigger class — every trigger coalesced into SOME fire regardless of how many windows fired |
| (2) | Every mutated tenant's `merged_hash` advances past baseline | Lost-write class — fire that observed an incomplete state would leave at least one tenant's hash unchanged |
| (3) | `debounceBatch._count <= 2` | Misbehaving-debounce — under 5-25ms gaps + 100ms window, burst legitimately splits into 1-2 windows. `_count > 2` means sliding window isn't coalescing (real bug) |

## Verification

- [x] **Stability**: `-race -count=10` → **10/10 PASS** in local dev container (vs. ~1-in-10 PR flake rate before)
- [x] **Regression**: injected "skip every-other trigger" bug → test FAIL at `debounceBatch: expected _sum=50, got 25` — confirms invariant (1) catches lost-trigger class. Reverted; clean test passes 3/3
- [x] testing-playbook gains third worked example alongside PR #79 + PR #90 examples (lesson §2)
- [x] `validate_all.py --only versions,changelog,glossary,includes,repo_name,commit_scope --ci` → 6/6
- [ ] CI green on PR

## Why this matters

PR #149 codified the lesson; this PR proves it pays off. The lesson said "act on the second occurrence" of a recurring race-flake — and we did, exactly. testing-playbook now has three worked examples instead of two. Each example makes the next reviewer's pattern-match faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)