### PR TITLE
refactor(exporter): decompose ConfigManager god-object (PR-5/5)

### DIFF
--- a/components/threshold-exporter/app/config.go
+++ b/components/threshold-exporter/app/config.go
@@ -27,86 +27,81 @@ import (
 // In directory mode, ConfigManager supports incremental hot-reload (v2.1.0):
 // per-file SHA-256 tracking + parsed config cache → only changed files are
 // re-parsed on each reload cycle, then all cached partials are merged.
+// flatScanState bundles the v2.1.0 incremental-reload caches used by the
+// flat-mode scanner (`scanDirFileHashes` + `IncrementalLoad`). Per-file
+// SHA-256 + parsed partial config + mtime fast-path stat. nil maps when
+// the manager is in single-file mode or has not yet completed its first
+// directory scan.
+type flatScanState struct {
+	hashes  map[string]string          // filename → SHA-256
+	configs map[string]ThresholdConfig // filename → parsed partial config
+	mtimes  map[string]fileStat        // filename → mtime+size for quick skip (v2.1.0)
+}
+
+// hierarchyState bundles the v2.7.0+ ADR-017/018 hierarchical-mode caches.
+// `enabled` is auto-detected on first load: if scanDirHierarchical finds
+// at least one `_defaults.yaml` at any depth AND the top-level scan path
+// is a directory, we keep hierarchical state populated alongside the flat
+// state. A reload always produces both views so a legacy flat caller
+// (fullDirLoad) stays correct.
+//
+// When `enabled` is false, all maps/graph are nil and diffAndReload falls
+// back to IncrementalLoad (flat path).
+//
+// All fields atomic-swap together at the end of diffAndReload under
+// `ConfigManager.mu.Lock()`. A desync between, e.g., `hashes[X]=H_new`
+// and `parsedDefaults[X]=parse(H_old)` would cause
+// classifyDefaultsNoOpEffect (Issue #61) to compute against the wrong
+// baseline. See `installNewHierarchyState` in config_debounce.go.
+//
+// Memory: ~432 `_defaults.yaml` × ~2KB parsed dict ≈ 1MB at the
+// 1000-tenant baseline; scales linearly with tree size.
+type hierarchyState struct {
+	enabled        bool
+	tenantSources  map[string]string          // tenantID → absolute tenant file path
+	hashes         map[string]string          // absolute Clean path → 64-char SHA-256
+	mtimes         map[string]fileStat        // absolute Clean path → mtime+size
+	mergedHashes   map[string]string          // tenantID → 16-char merged_hash
+	graph          *InheritanceGraph          // defaults↔tenants dependency map
+	parsedDefaults map[string]map[string]any  // absolute Clean path → parsed defaults dict
+}
+
+// debouncerState bundles the v2.7.0 Phase 3 burst-coalescing fields.
+// `window` controls fsnotify storm absorption (50-200ms K8s ConfigMap
+// symlink rotation + safety margin). 0 disables debouncing and restores
+// the v2.6.0 behavior (immediate reload per detected diff).
+//
+// `mu` is a separate mutex from `ConfigManager.mu` so a long-running
+// reload doesn't block trigger registration; trigger accumulation is
+// fast (just append to pendingReasons + reset timer).
+type debouncerState struct {
+	window         time.Duration
+	timer          *time.Timer // current pending reload; nil when idle
+	mu             sync.Mutex  // guards timer + pendingReasons
+	pendingReasons []string    // accumulates reload triggers during a window
+	fired          uint64      // count of fires; read via DebounceFiredCount()
+}
+
 type ConfigManager struct {
-	path     string // file path or directory path
-	isDir    bool   // true = directory mode
-	mu       sync.RWMutex
-	config   *ThresholdConfig
-	loaded   bool
+	path       string // file path or directory path
+	isDir      bool   // true = directory mode
+	mu         sync.RWMutex
+	config     *ThresholdConfig
+	loaded     bool
 	lastReload time.Time
 	lastHash   string // SHA-256 composite hash for change detection
-
-	// Incremental reload state (directory mode only, v2.1.0)
-	fileHashes  map[string]string          // filename → SHA-256
-	fileConfigs map[string]ThresholdConfig // filename → parsed partial config
-	fileMtimes  map[string]fileStat        // filename → mtime+size for quick skip (v2.1.0)
 
 	// Config info metric state (v2.3.0)
 	configSource string // "configmap", "operator", or "git-sync"
 	gitCommit    string // git commit hash from .git-revision file, or ""
 
-	// Hierarchical scan state (v2.7.0, ADR-017/018 — Phase 3+5)
-	//
-	// hierarchical mode is auto-detected on first load: if scanDirHierarchical
-	// finds at least one _defaults.yaml at any depth AND the top-level scan
-	// path is a directory, we keep hierarchical state populated alongside the
-	// flat fileHashes above. A reload always produces both views so a legacy
-	// flat caller (fullDirLoad) stays correct.
-	//
-	// When hierarchicalMode is false, all three maps/graph are nil and
-	// diffAndReload falls back to IncrementalLoad (flat path).
-	hierarchicalMode bool
-	// tenantSources maps tenantID → absolute tenant file path. Updated on
-	// every hierarchical scan; used by Resolve(tenantID) for /effective.
-	tenantSources map[string]string
-	// hierarchyHashes is keyed by absolute Clean path and stores the full
-	// 64-char SHA-256 hex of each scanned YAML (tenant + defaults). Used to
-	// diff which files changed between scans in Phase 3.
-	hierarchyHashes map[string]string
-	// hierarchyMtimes parallels hierarchyHashes for mtime-based fast path
-	// (forward-compat with scanDirHierarchical's priorMtimes arg).
-	hierarchyMtimes map[string]fileStat
-	// mergedHashes is the user-facing 16-char merged_hash per tenant, keyed
-	// by tenantID. Computed by diffAndReload on every dirty tenant. The
-	// /effective handler reads this to avoid recomputing on each request.
-	mergedHashes map[string]string
-	// inheritanceGraph records defaults↔tenants dependencies. Swapped
-	// atomically on reload (pointer swap; the graph itself is immutable
-	// once built). nil when hierarchicalMode is false.
-	inheritanceGraph *InheritanceGraph
-	// parsedDefaults caches the *parsed-and-normalized* dict of every
-	// _defaults.yaml file in the tree (key = absolute Clean path, same
-	// keying as hierarchyHashes). Required by Issue #61 to distinguish
-	// effect=shadowed from effect=cosmetic in the blast-radius
-	// histogram: the noOp branch needs to know which keys actually
-	// moved between prior and current scan, which file-hash alone can't
-	// answer (comment-only edits move the file hash but not any key).
-	//
-	// MUST atomic-swap together with hierarchyHashes — a desync between
-	// "we know file X has hash H_new" and "parsed cache for X is H_old"
-	// would cause changedDefaultsKeys to compute against the wrong
-	// baseline. Both are installed under m.mu.Lock() in
-	// populateHierarchyState (cold start) and diffAndReload (incremental).
-	//
-	// Memory: ~432 _defaults files × ~2KB parsed dict ≈ 1MB at the
-	// 1000-tenant baseline; scales linearly with tree size.
-	parsedDefaults map[string]map[string]any
-
-	// Debounce state (v2.7.0 Phase 3)
-	//
-	// debounceWindow bundles multiple fsnotify-ish bursts (tick-initiated
-	// diffs, manual SIGHUP, etc.) into a single reload. 0 disables debouncing
-	// and restores the v2.6.0 behavior (immediate reload on detected diff).
-	debounceWindow time.Duration
-	debounceTimer  *time.Timer // current pending reload; nil when idle
-	debounceMu     sync.Mutex  // guards debounceTimer + pendingReasons
-	// pendingReasons accumulates reload triggers during a debounce window so
-	// the terminal diffAndReload can emit counter increments per-reason (see
-	// collector.go da_config_reload_trigger_total). Cleared on fire + Close.
-	pendingReasons []string
-	// debounceFired is bumped by the timer goroutine each time a debounce
-	// fires. Tests read this via DebounceFiredCount() to assert batching.
-	debounceFired uint64
+	// Sub-struct field groups — v2.8.0 PR-5 decomposed the original
+	// 14-mixed-fields ConfigManager into named concerns. Field accesses
+	// across the codebase use `m.flat.X` / `m.hierarchy.X` / `m.debounce.X`
+	// for clarity at the call site.
+	flat      flatScanState
+	hierarchy hierarchyState
+	debounce  debouncerState
 }
 
 // DefaultDebounceWindow is the default burst-coalescing window applied by
@@ -129,9 +124,9 @@ func NewConfigManagerWithDebounce(path string, debounceWindow time.Duration) *Co
 	isDir := err == nil && info.IsDir()
 
 	return &ConfigManager{
-		path:           path,
-		isDir:          isDir,
-		debounceWindow: debounceWindow,
+		path:     path,
+		isDir:    isDir,
+		debounce: debouncerState{window: debounceWindow},
 	}
 }
 
@@ -456,7 +451,7 @@ func (m *ConfigManager) IncrementalLoad() error {
 	}
 
 	m.mu.RLock()
-	hasCache := m.fileHashes != nil && len(m.fileHashes) > 0
+	hasCache := m.flat.hashes != nil && len(m.flat.hashes) > 0
 	m.mu.RUnlock()
 
 	if !hasCache {
@@ -465,8 +460,8 @@ func (m *ConfigManager) IncrementalLoad() error {
 
 	// Phase 1: scan per-file hashes with mtime guard (cheap — stat + skip unchanged)
 	m.mu.RLock()
-	oldH := m.fileHashes
-	oldM := m.fileMtimes
+	oldH := m.flat.hashes
+	oldM := m.flat.mtimes
 	prevHash := m.lastHash
 	m.mu.RUnlock()
 
@@ -483,8 +478,8 @@ func (m *ConfigManager) IncrementalLoad() error {
 
 	// Phase 2: diff per-file hashes → identify changed/added/removed
 	m.mu.RLock()
-	oldHashes := m.fileHashes
-	oldConfigs := m.fileConfigs
+	oldHashes := m.flat.hashes
+	oldConfigs := m.flat.configs
 	m.mu.RUnlock()
 
 	var changed, added, removed []string
@@ -616,9 +611,9 @@ func (m *ConfigManager) IncrementalLoad() error {
 	m.loaded = true
 	m.lastReload = time.Now()
 	m.lastHash = compositeHash
-	m.fileHashes = newHashes
-	m.fileConfigs = newConfigs
-	m.fileMtimes = newMtimes
+	m.flat.hashes = newHashes
+	m.flat.configs = newConfigs
+	m.flat.mtimes = newMtimes
 	m.mu.Unlock()
 
 	// Refresh config source detection (v2.3.0) — git-sync may rotate .git-revision
@@ -700,9 +695,9 @@ func (m *ConfigManager) fullDirLoad() error {
 	m.loaded = true
 	m.lastReload = time.Now()
 	m.lastHash = compositeHash
-	m.fileHashes = perFileHashes
-	m.fileConfigs = fileConfigs
-	m.fileMtimes = perFileMtimes
+	m.flat.hashes = perFileHashes
+	m.flat.configs = fileConfigs
+	m.flat.mtimes = perFileMtimes
 	m.mu.Unlock()
 
 	// Detect config source mode and git commit (v2.3.0)
@@ -775,14 +770,14 @@ func (m *ConfigManager) populateHierarchyState() error {
 	// somewhere. Pure-flat trees keep hierarchicalMode=false, letting
 	// WatchLoop take the v2.6.0 IncrementalLoad path.
 	if len(defaults) > 0 {
-		m.hierarchicalMode = true
+		m.hierarchy.enabled = true
 	}
-	m.tenantSources = tenants
-	m.hierarchyHashes = hashes
-	m.hierarchyMtimes = mtimes
-	m.mergedHashes = newMergedHashes
-	m.inheritanceGraph = graph
-	m.parsedDefaults = newParsedDefaults
+	m.hierarchy.tenantSources = tenants
+	m.hierarchy.hashes = hashes
+	m.hierarchy.mtimes = mtimes
+	m.hierarchy.mergedHashes = newMergedHashes
+	m.hierarchy.graph = graph
+	m.hierarchy.parsedDefaults = newParsedDefaults
 	m.mu.Unlock()
 	return nil
 }
@@ -987,12 +982,12 @@ func (m *ConfigManager) WatchLoop(interval time.Duration, stopCh <-chan struct{}
 // changed=true call triggerDebouncedReload(reason).
 func (m *ConfigManager) detectChange() (bool, string, error) {
 	m.mu.RLock()
-	oldH := m.fileHashes
-	oldM := m.fileMtimes
+	oldH := m.flat.hashes
+	oldM := m.flat.mtimes
 	prevHash := m.lastHash
-	hierarchical := m.hierarchicalMode
-	priorHierHashes := m.hierarchyHashes
-	priorHierMtimes := m.hierarchyMtimes
+	hierarchical := m.hierarchy.enabled
+	priorHierHashes := m.hierarchy.hashes
+	priorHierMtimes := m.hierarchy.mtimes
 	m.mu.RUnlock()
 
 	if hierarchical {
@@ -1057,12 +1052,12 @@ type EffectiveConfig struct {
 // structured error body instead of 404/500.
 func (m *ConfigManager) Resolve(tenantID string) (*EffectiveConfig, bool) {
 	m.mu.RLock()
-	srcPath, known := m.tenantSources[tenantID]
+	srcPath, known := m.hierarchy.tenantSources[tenantID]
 	var chain []string
-	if m.inheritanceGraph != nil {
-		chain = append(chain, m.inheritanceGraph.TenantDefaults[tenantID]...)
+	if m.hierarchy.graph != nil {
+		chain = append(chain, m.hierarchy.graph.TenantDefaults[tenantID]...)
 	}
-	cachedHash := m.mergedHashes[tenantID]
+	cachedHash := m.hierarchy.mergedHashes[tenantID]
 	m.mu.RUnlock()
 
 	if !known {

--- a/components/threshold-exporter/app/config_bench_test.go
+++ b/components/threshold-exporter/app/config_bench_test.go
@@ -323,7 +323,7 @@ func BenchmarkMergePartialConfigs_100(b *testing.B) {
 	silenceLogs(b)
 	mgr := NewConfigManager(dir)
 	mgr.fullDirLoad()
-	configs := mgr.fileConfigs
+	configs := mgr.flat.configs
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		mergePartialConfigs(configs)
@@ -422,7 +422,7 @@ func BenchmarkMergePartialConfigs_1000(b *testing.B) {
 	silenceLogs(b)
 	mgr := NewConfigManager(dir)
 	mgr.fullDirLoad()
-	configs := mgr.fileConfigs
+	configs := mgr.flat.configs
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		mergePartialConfigs(configs)

--- a/components/threshold-exporter/app/config_debounce.go
+++ b/components/threshold-exporter/app/config_debounce.go
@@ -68,7 +68,7 @@ const (
 //
 // Behavior:
 //   - First call: starts timer; timer fires diffAndReload after
-//     m.debounceWindow elapsed.
+//     m.debounce.window elapsed.
 //   - Subsequent calls within the window: reset the timer — the reload
 //     slides forward, keeping the total batch bounded by the slowest caller.
 //   - debounceWindow == 0: synchronous fallback. Calls diffAndReload
@@ -79,7 +79,7 @@ const (
 // unfiltered for duplicates — a storm of 10 "source" events is itself a
 // signal and we want to count them as 10 increments.
 func (m *ConfigManager) triggerDebouncedReload(reason string) {
-	if m.debounceWindow <= 0 {
+	if m.debounce.window <= 0 {
 		// Synchronous fallback — useful for v2.6.0 parity tests and for
 		// the initial Load() bootstrap where we don't want to gate startup
 		// on a timer. Observe reload duration so callers using the
@@ -91,12 +91,12 @@ func (m *ConfigManager) triggerDebouncedReload(reason string) {
 		return
 	}
 
-	m.debounceMu.Lock()
-	m.pendingReasons = append(m.pendingReasons, reason)
-	if m.debounceTimer == nil {
+	m.debounce.mu.Lock()
+	m.debounce.pendingReasons = append(m.debounce.pendingReasons, reason)
+	if m.debounce.timer == nil {
 		// First event in this window — arm the timer.
-		m.debounceTimer = time.AfterFunc(m.debounceWindow, m.fireDebounced)
-		m.debounceMu.Unlock()
+		m.debounce.timer = time.AfterFunc(m.debounce.window, m.fireDebounced)
+		m.debounce.mu.Unlock()
 		return
 	}
 	// Subsequent event — reset. Stop() returns false if the timer has already
@@ -105,30 +105,30 @@ func (m *ConfigManager) triggerDebouncedReload(reason string) {
 	// goroutine — the callback's own code path handles that. Stop() racing
 	// with fire is cheap to absorb: we simply let the fired callback swap
 	// the pointer to nil and start fresh on the next call.
-	if m.debounceTimer.Stop() {
+	if m.debounce.timer.Stop() {
 		// Successfully cancelled before fire → safe to re-arm in place.
-		m.debounceTimer.Reset(m.debounceWindow)
+		m.debounce.timer.Reset(m.debounce.window)
 	} else {
 		// Already firing; fireDebounced will observe the newly-appended
 		// reason on the next pass since we hold the mutex and it acquires
 		// the same one. If Stop() returned false AND the timer was already
 		// nil'd by a completed fire, arm a fresh one.
-		if m.debounceTimer == nil {
-			m.debounceTimer = time.AfterFunc(m.debounceWindow, m.fireDebounced)
+		if m.debounce.timer == nil {
+			m.debounce.timer = time.AfterFunc(m.debounce.window, m.fireDebounced)
 		} else {
-			m.debounceTimer.Reset(m.debounceWindow)
+			m.debounce.timer.Reset(m.debounce.window)
 		}
 	}
-	m.debounceMu.Unlock()
+	m.debounce.mu.Unlock()
 }
 
 // recordReason appends to pendingReasons under debounceMu. Exported as a
 // method (not inlined) so the synchronous fallback path and the regular
 // path share identical reason-list semantics.
 func (m *ConfigManager) recordReason(reason string) {
-	m.debounceMu.Lock()
-	m.pendingReasons = append(m.pendingReasons, reason)
-	m.debounceMu.Unlock()
+	m.debounce.mu.Lock()
+	m.debounce.pendingReasons = append(m.debounce.pendingReasons, reason)
+	m.debounce.mu.Unlock()
 }
 
 // fireDebounced is invoked by time.AfterFunc when the debounce window
@@ -137,19 +137,19 @@ func (m *ConfigManager) recordReason(reason string) {
 // then runs diffAndReload without holding the mutex so a long reload does
 // not block new triggers.
 func (m *ConfigManager) fireDebounced() {
-	m.debounceMu.Lock()
+	m.debounce.mu.Lock()
 	// Snapshot reasons and clear state so concurrent triggerDebouncedReload
 	// calls start a fresh window.
-	reasons := m.pendingReasons
-	m.pendingReasons = nil
-	m.debounceTimer = nil
-	m.debounceMu.Unlock()
+	reasons := m.debounce.pendingReasons
+	m.debounce.pendingReasons = nil
+	m.debounce.timer = nil
+	m.debounce.mu.Unlock()
 
 	// v2.8.0 B-3: observe debounce batch size (effectiveness signal)
 	// before the reload so the sample lands even if diffAndReload
 	// errors out. Sample count == fire count by construction.
 	ObserveDebounceBatch(len(reasons))
-	atomic.AddUint64(&m.debounceFired, 1)
+	atomic.AddUint64(&m.debounce.fired, 1)
 	t0 := time.Now()
 	_, _, err := m.diffAndReload()
 	ObserveReloadDuration(time.Since(t0))
@@ -162,16 +162,16 @@ func (m *ConfigManager) fireDebounced() {
 // construction. Test-only accessor; production code should not rely on
 // this for correctness. Uses atomic load so callers don't need the mutex.
 func (m *ConfigManager) DebounceFiredCount() uint64 {
-	return atomic.LoadUint64(&m.debounceFired)
+	return atomic.LoadUint64(&m.debounce.fired)
 }
 
 // PendingDebounceReasons returns a snapshot of the current debounce
 // window's accumulated reasons. Test-only; callers should not mutate.
 func (m *ConfigManager) PendingDebounceReasons() []string {
-	m.debounceMu.Lock()
-	defer m.debounceMu.Unlock()
-	out := make([]string, len(m.pendingReasons))
-	copy(out, m.pendingReasons)
+	m.debounce.mu.Lock()
+	defer m.debounce.mu.Unlock()
+	out := make([]string, len(m.debounce.pendingReasons))
+	copy(out, m.debounce.pendingReasons)
 	return out
 }
 
@@ -185,13 +185,13 @@ func (m *ConfigManager) PendingDebounceReasons() []string {
 // done, we'd need to add a wait group here; for now the 15s HTTP shutdown
 // grace in main.go overshoots any debounce window comfortably.
 func (m *ConfigManager) Close() {
-	m.debounceMu.Lock()
-	if m.debounceTimer != nil {
-		m.debounceTimer.Stop()
-		m.debounceTimer = nil
+	m.debounce.mu.Lock()
+	if m.debounce.timer != nil {
+		m.debounce.timer.Stop()
+		m.debounce.timer = nil
 	}
-	m.pendingReasons = nil
-	m.debounceMu.Unlock()
+	m.debounce.pendingReasons = nil
+	m.debounce.mu.Unlock()
 }
 
 // reloadPriorState bundles every m.* hierarchy field captured under
@@ -243,12 +243,12 @@ func (m *ConfigManager) snapshotPriorState() reloadPriorState {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return reloadPriorState{
-		mtimes:           m.hierarchyMtimes,
-		hashes:           m.hierarchyHashes,
-		mergedHashes:     m.mergedHashes,
-		tenantSources:    m.tenantSources,
-		parsedDefaults:   m.parsedDefaults, // Issue #61
-		hierarchicalMode: m.hierarchicalMode,
+		mtimes:           m.hierarchy.mtimes,
+		hashes:           m.hierarchy.hashes,
+		mergedHashes:     m.hierarchy.mergedHashes,
+		tenantSources:    m.hierarchy.tenantSources,
+		parsedDefaults:   m.hierarchy.parsedDefaults, // Issue #61
+		hierarchicalMode: m.hierarchy.enabled,
 	}
 }
 
@@ -467,13 +467,13 @@ func (m *ConfigManager) installNewHierarchyState(scan reloadScanState, result re
 	}
 
 	m.mu.Lock()
-	m.hierarchicalMode = true
-	m.tenantSources = scan.tenants
-	m.hierarchyHashes = scan.hashes
-	m.hierarchyMtimes = scan.mtimes
-	m.mergedHashes = result.newMergedHashes
-	m.inheritanceGraph = scan.graph
-	m.parsedDefaults = result.newParsedDefaults
+	m.hierarchy.enabled = true
+	m.hierarchy.tenantSources = scan.tenants
+	m.hierarchy.hashes = scan.hashes
+	m.hierarchy.mtimes = scan.mtimes
+	m.hierarchy.mergedHashes = result.newMergedHashes
+	m.hierarchy.graph = scan.graph
+	m.hierarchy.parsedDefaults = result.newParsedDefaults
 	m.mu.Unlock()
 
 	SetLastReloadComplete(time.Now())

--- a/components/threshold-exporter/app/config_debounce_test.go
+++ b/components/threshold-exporter/app/config_debounce_test.go
@@ -188,7 +188,7 @@ func TestDiffAndReload_HierarchicalMode_SourceChange(t *testing.T) {
 		t.Fatalf("first diffAndReload: %v", err)
 	}
 	m.mu.RLock()
-	firstHash := m.mergedHashes["tenant-a"]
+	firstHash := m.hierarchy.mergedHashes["tenant-a"]
 	m.mu.RUnlock()
 	if firstHash == "" {
 		t.Fatalf("expected non-empty merged_hash for tenant-a, got empty")
@@ -213,7 +213,7 @@ func TestDiffAndReload_HierarchicalMode_SourceChange(t *testing.T) {
 	}
 
 	m.mu.RLock()
-	secondHash := m.mergedHashes["tenant-a"]
+	secondHash := m.hierarchy.mergedHashes["tenant-a"]
 	m.mu.RUnlock()
 	if secondHash == firstHash {
 		t.Errorf("merged_hash did not move after source change (both=%s)", firstHash)
@@ -239,7 +239,7 @@ func TestDiffAndReload_DefaultsChangeNoOp(t *testing.T) {
 		t.Fatalf("first diffAndReload: %v", err)
 	}
 	m.mu.RLock()
-	firstHash := m.mergedHashes["tenant-a"]
+	firstHash := m.hierarchy.mergedHashes["tenant-a"]
 	m.mu.RUnlock()
 
 	// Mutate _defaults.yaml but only the shadowed key.
@@ -258,7 +258,7 @@ defaults:
 	}
 
 	m.mu.RLock()
-	secondHash := m.mergedHashes["tenant-a"]
+	secondHash := m.hierarchy.mergedHashes["tenant-a"]
 	m.mu.RUnlock()
 	if secondHash != firstHash {
 		t.Errorf("merged_hash moved on shadowed defaults change (first=%s second=%s)", firstHash, secondHash)
@@ -294,7 +294,7 @@ tenants:
 	}
 
 	m.mu.RLock()
-	hierarchical := m.hierarchicalMode
+	hierarchical := m.hierarchy.enabled
 	m.mu.RUnlock()
 	if hierarchical {
 		t.Errorf("hierarchicalMode should remain false for flat conf.d")
@@ -409,12 +409,12 @@ func TestFireDebounced_EmitsBatchAndDuration(t *testing.T) {
 	// fireDebounced may complete AFTER our withIsolatedMetrics swap. The
 	// S#35 fix asserted "deltaReload == deltaBatch lockstep" but that
 	// claim was WRONG — only batch + DebounceFiredCount() are atomic
-	// (Step 1+2 of fireDebounced under m.debounceMu). Reload is observed
+	// (Step 1+2 of fireDebounced under m.debounce.mu). Reload is observed
 	// AFTER diffAndReload (Step 4), making its leak window much wider:
 	//
 	//   fireDebounced steps:
 	//     1. ObserveDebounceBatch(len(reasons))   ← batch leaks here
-	//     2. atomic.AddUint64(&m.debounceFired)   ← fire counter
+	//     2. atomic.AddUint64(&m.debounce.fired)   ← fire counter
 	//        ----- diffAndReload runs (~ms-100ms) -----
 	//     4. ObserveReloadDuration(elapsed)       ← reload leaks LATE
 	//
@@ -429,7 +429,7 @@ func TestFireDebounced_EmitsBatchAndDuration(t *testing.T) {
 	deltaBatchCount := histogramSampleCount(t, fresh.debounceBatch) - baseBatchCount
 
 	if deltaBatchCount != deltaFire {
-		t.Errorf("batch-fire lockstep violated: deltaBatch=%d != deltaFire=%d (both atomic under m.debounceMu in fireDebounced steps 1+2)", deltaBatchCount, deltaFire)
+		t.Errorf("batch-fire lockstep violated: deltaBatch=%d != deltaFire=%d (both atomic under m.debounce.mu in fireDebounced steps 1+2)", deltaBatchCount, deltaFire)
 	}
 	if deltaReload < deltaFire {
 		t.Errorf("at-least-our-own invariant violated: deltaReload=%d < deltaFire=%d", deltaReload, deltaFire)

--- a/components/threshold-exporter/app/config_hierarchy_bench_test.go
+++ b/components/threshold-exporter/app/config_hierarchy_bench_test.go
@@ -468,8 +468,8 @@ func benchBlastRadiusDefaultsChangeAtSize(b *testing.B, n int) {
 	}
 
 	// Snapshot pre-change merged hashes to diff against post-change.
-	preHashes := make(map[string]string, len(mgr.mergedHashes))
-	for k, v := range mgr.mergedHashes {
+	preHashes := make(map[string]string, len(mgr.hierarchy.mergedHashes))
+	for k, v := range mgr.hierarchy.mergedHashes {
 		preHashes[k] = v
 	}
 
@@ -502,7 +502,7 @@ func benchBlastRadiusDefaultsChangeAtSize(b *testing.B, n int) {
 			// Count tenants whose merged_hash changed on the first iteration.
 			// Subsequent iterations should affect the same set (deterministic).
 			count := 0
-			for k, post := range mgr.mergedHashes {
+			for k, post := range mgr.hierarchy.mergedHashes {
 				if preHashes[k] != post {
 					count++
 				}

--- a/components/threshold-exporter/app/config_hierarchy_integration_test.go
+++ b/components/threshold-exporter/app/config_hierarchy_integration_test.go
@@ -37,10 +37,10 @@ func TestFullDirLoad_PopulatesHierarchyState(t *testing.T) {
 	}
 
 	m.mu.RLock()
-	hierarchical := m.hierarchicalMode
-	tenantCount := len(m.tenantSources)
-	hashCount := len(m.mergedHashes)
-	graph := m.inheritanceGraph
+	hierarchical := m.hierarchy.enabled
+	tenantCount := len(m.hierarchy.tenantSources)
+	hashCount := len(m.hierarchy.mergedHashes)
+	graph := m.hierarchy.graph
 	m.mu.RUnlock()
 
 	if !hierarchical {
@@ -77,7 +77,7 @@ tenants:
 	}
 
 	m.mu.RLock()
-	hierarchical := m.hierarchicalMode
+	hierarchical := m.hierarchy.enabled
 	m.mu.RUnlock()
 
 	if hierarchical {
@@ -165,7 +165,7 @@ func TestWatchLoop_DebouncedReload_DetectsFileChange(t *testing.T) {
 	}
 
 	m.mu.RLock()
-	firstHash := m.mergedHashes["tenant-a"]
+	firstHash := m.hierarchy.mergedHashes["tenant-a"]
 	m.mu.RUnlock()
 	if firstHash == "" {
 		t.Fatalf("expected first merged_hash to be populated by Load")
@@ -196,7 +196,7 @@ tenants:
 	ok := waitFor(t, 3*time.Second, func() bool {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
-		curr := m.mergedHashes["tenant-a"]
+		curr := m.hierarchy.mergedHashes["tenant-a"]
 		return curr != "" && curr != firstHash
 	})
 	close(stopCh)
@@ -204,7 +204,7 @@ tenants:
 
 	if !ok {
 		m.mu.RLock()
-		curr := m.mergedHashes["tenant-a"]
+		curr := m.hierarchy.mergedHashes["tenant-a"]
 		m.mu.RUnlock()
 		t.Errorf("merged_hash did not update via WatchLoop: first=%s current=%s", firstHash, curr)
 	}
@@ -257,13 +257,13 @@ defaults:
 	// Baseline invariant: all 3 tenants populated across every per-tenant map.
 	m.mu.RLock()
 	for _, tid := range []string{"tenant-a", "tenant-b", "tenant-c"} {
-		if _, ok := m.tenantSources[tid]; !ok {
+		if _, ok := m.hierarchy.tenantSources[tid]; !ok {
 			t.Errorf("baseline: tenantSources missing %s", tid)
 		}
-		if _, ok := m.mergedHashes[tid]; !ok {
+		if _, ok := m.hierarchy.mergedHashes[tid]; !ok {
 			t.Errorf("baseline: mergedHashes missing %s", tid)
 		}
-		if m.inheritanceGraph == nil || len(m.inheritanceGraph.TenantDefaults[tid]) == 0 {
+		if m.hierarchy.graph == nil || len(m.hierarchy.graph.TenantDefaults[tid]) == 0 {
 			t.Errorf("baseline: inheritanceGraph.TenantDefaults missing %s", tid)
 		}
 	}
@@ -284,7 +284,7 @@ defaults:
 	ok := waitFor(t, 2*time.Second, func() bool {
 		m.mu.RLock()
 		defer m.mu.RUnlock()
-		_, stillHere := m.tenantSources["tenant-b"]
+		_, stillHere := m.hierarchy.tenantSources["tenant-b"]
 		return !stillHere
 	})
 	if !ok {
@@ -296,29 +296,29 @@ defaults:
 	// (e.g. in GET /api/v1/tenants/tenant-b/effective) will return data
 	// for a tenant that no longer exists.
 	m.mu.RLock()
-	if _, stillHere := m.tenantSources["tenant-b"]; stillHere {
+	if _, stillHere := m.hierarchy.tenantSources["tenant-b"]; stillHere {
 		t.Errorf("tenantSources still has tenant-b")
 	}
-	if _, stillHere := m.mergedHashes["tenant-b"]; stillHere {
+	if _, stillHere := m.hierarchy.mergedHashes["tenant-b"]; stillHere {
 		t.Errorf("mergedHashes still has tenant-b")
 	}
-	if _, stillHere := m.hierarchyHashes["team-a/tenant-b.yaml"]; stillHere {
+	if _, stillHere := m.hierarchy.hashes["team-a/tenant-b.yaml"]; stillHere {
 		t.Errorf("hierarchyHashes still has team-a/tenant-b.yaml")
 	}
-	if _, stillHere := m.hierarchyMtimes["team-a/tenant-b.yaml"]; stillHere {
+	if _, stillHere := m.hierarchy.mtimes["team-a/tenant-b.yaml"]; stillHere {
 		t.Errorf("hierarchyMtimes still has team-a/tenant-b.yaml")
 	}
-	if m.inheritanceGraph == nil {
+	if m.hierarchy.graph == nil {
 		t.Errorf("inheritanceGraph became nil after delete")
-	} else if chain := m.inheritanceGraph.TenantDefaults["tenant-b"]; chain != nil {
+	} else if chain := m.hierarchy.graph.TenantDefaults["tenant-b"]; chain != nil {
 		t.Errorf("inheritanceGraph.TenantDefaults[tenant-b] = %v, want nil", chain)
 	}
 	// Surviving tenants must NOT be collateral damage.
 	for _, tid := range []string{"tenant-a", "tenant-c"} {
-		if _, ok := m.tenantSources[tid]; !ok {
+		if _, ok := m.hierarchy.tenantSources[tid]; !ok {
 			t.Errorf("collateral damage: tenantSources missing surviving %s", tid)
 		}
-		if _, ok := m.mergedHashes[tid]; !ok {
+		if _, ok := m.hierarchy.mergedHashes[tid]; !ok {
 			t.Errorf("collateral damage: mergedHashes missing surviving %s", tid)
 		}
 	}

--- a/components/threshold-exporter/app/config_incremental_test.go
+++ b/components/threshold-exporter/app/config_incremental_test.go
@@ -96,11 +96,11 @@ tenants:
 	if !mgr.IsLoaded() {
 		t.Error("should be loaded after IncrementalLoad")
 	}
-	if len(mgr.fileHashes) != 2 {
-		t.Errorf("expected 2 file hashes, got %d", len(mgr.fileHashes))
+	if len(mgr.flat.hashes) != 2 {
+		t.Errorf("expected 2 file hashes, got %d", len(mgr.flat.hashes))
 	}
-	if len(mgr.fileConfigs) != 2 {
-		t.Errorf("expected 2 file configs, got %d", len(mgr.fileConfigs))
+	if len(mgr.flat.configs) != 2 {
+		t.Errorf("expected 2 file configs, got %d", len(mgr.flat.configs))
 	}
 	cfg := mgr.GetConfig()
 	if cfg.Defaults["mysql_connections"] != 80 {
@@ -180,8 +180,8 @@ tenants:
 	if cfg.Tenants["db-b"]["mysql_connections"].Default != "60" {
 		t.Error("expected tenant db-b with value 60")
 	}
-	if len(mgr.fileHashes) != 2 {
-		t.Errorf("expected 2 file hashes after add, got %d", len(mgr.fileHashes))
+	if len(mgr.flat.hashes) != 2 {
+		t.Errorf("expected 2 file hashes after add, got %d", len(mgr.flat.hashes))
 	}
 }
 
@@ -223,8 +223,8 @@ tenants:
 	if _, exists := cfg.Tenants["db-b"]; exists {
 		t.Error("db-b should be removed")
 	}
-	if len(mgr.fileHashes) != 2 {
-		t.Errorf("expected 2 file hashes after remove, got %d", len(mgr.fileHashes))
+	if len(mgr.flat.hashes) != 2 {
+		t.Errorf("expected 2 file hashes after remove, got %d", len(mgr.flat.hashes))
 	}
 }
 
@@ -273,7 +273,7 @@ tenants:
 		t.Error("should be loaded")
 	}
 	// fileHashes should remain nil (single-file mode doesn't use incremental)
-	if mgr.fileHashes != nil {
+	if mgr.flat.hashes != nil {
 		t.Error("fileHashes should be nil for single-file mode")
 	}
 }
@@ -424,11 +424,11 @@ tenants:
 	if err := mgr.fullDirLoad(); err != nil {
 		t.Fatalf("fullDirLoad failed: %v", err)
 	}
-	if len(mgr.fileHashes) != 2 {
-		t.Errorf("expected 2 file hashes, got %d", len(mgr.fileHashes))
+	if len(mgr.flat.hashes) != 2 {
+		t.Errorf("expected 2 file hashes, got %d", len(mgr.flat.hashes))
 	}
-	if len(mgr.fileConfigs) != 2 {
-		t.Errorf("expected 2 file configs, got %d", len(mgr.fileConfigs))
+	if len(mgr.flat.configs) != 2 {
+		t.Errorf("expected 2 file configs, got %d", len(mgr.flat.configs))
 	}
 }
 
@@ -505,8 +505,8 @@ tenants:
 	}
 
 	// Verify cache consistency
-	if len(mgr.fileHashes) != 4 { // _defaults + db-a + db-c + db-d
-		t.Errorf("expected 4 file hashes, got %d", len(mgr.fileHashes))
+	if len(mgr.flat.hashes) != 4 { // _defaults + db-a + db-c + db-d
+		t.Errorf("expected 4 file hashes, got %d", len(mgr.flat.hashes))
 	}
 }
 
@@ -638,8 +638,8 @@ tenants:
 	}
 
 	// Record cache state for db-b (unchanged file)
-	oldDbBConfig := mgr.fileConfigs["db-b.yaml"]
-	oldDbBHash := mgr.fileHashes["db-b.yaml"]
+	oldDbBConfig := mgr.flat.configs["db-b.yaml"]
+	oldDbBHash := mgr.flat.hashes["db-b.yaml"]
 
 	// Only modify db-a
 	writeTestFile(t, dir, "db-a.yaml", `
@@ -653,10 +653,10 @@ tenants:
 	}
 
 	// db-b's cache entry should remain identical (same hash → not re-parsed)
-	if mgr.fileHashes["db-b.yaml"] != oldDbBHash {
+	if mgr.flat.hashes["db-b.yaml"] != oldDbBHash {
 		t.Error("db-b hash should not change")
 	}
-	newDbBConfig := mgr.fileConfigs["db-b.yaml"]
+	newDbBConfig := mgr.flat.configs["db-b.yaml"]
 	if newDbBConfig.Tenants["db-b"]["mysql_connections"].Default != oldDbBConfig.Tenants["db-b"]["mysql_connections"].Default {
 		t.Error("db-b config should be preserved from cache")
 	}

--- a/components/threshold-exporter/app/config_mixed_mode_test.go
+++ b/components/threshold-exporter/app/config_mixed_mode_test.go
@@ -97,7 +97,7 @@ func TestMixedMode_RootDefaultsCascadeToBoth(t *testing.T) {
 
 	// Both tenants should be discovered.
 	mgr.mu.RLock()
-	graph := mgr.inheritanceGraph
+	graph := mgr.hierarchy.graph
 	mgr.mu.RUnlock()
 	if graph == nil {
 		t.Fatal("inheritanceGraph nil; populateHierarchyState should have built it")
@@ -123,8 +123,8 @@ func TestMixedMode_RootDefaultsCascadeToBoth(t *testing.T) {
 	// merged_hash present for both — proves both went through
 	// computeMergedHash with the chain applied.
 	mgr.mu.RLock()
-	flatHash := mgr.mergedHashes["db-flat"]
-	hierHash := mgr.mergedHashes["db-fin"]
+	flatHash := mgr.hierarchy.mergedHashes["db-flat"]
+	hierHash := mgr.hierarchy.mergedHashes["db-fin"]
 	mgr.mu.RUnlock()
 	if flatHash == "" {
 		t.Error("db-flat: merged_hash empty; root defaults didn't apply")
@@ -411,8 +411,8 @@ tenants:
 	}
 
 	mgr.mu.RLock()
-	preChain := append([]string(nil), mgr.inheritanceGraph.TenantDefaults["db-mig"]...)
-	preHash := mgr.mergedHashes["db-mig"]
+	preChain := append([]string(nil), mgr.hierarchy.graph.TenantDefaults["db-mig"]...)
+	preHash := mgr.hierarchy.mergedHashes["db-mig"]
 	mgr.mu.RUnlock()
 	if len(preChain) != 1 {
 		t.Fatalf("pre-migration: expected 1-element chain (root only), got %d: %v", len(preChain), preChain)
@@ -441,8 +441,8 @@ defaults:
 	}
 
 	mgr.mu.RLock()
-	postChain := mgr.inheritanceGraph.TenantDefaults["db-mig"]
-	postHash := mgr.mergedHashes["db-mig"]
+	postChain := mgr.hierarchy.graph.TenantDefaults["db-mig"]
+	postHash := mgr.hierarchy.mergedHashes["db-mig"]
 	mgr.mu.RUnlock()
 
 	// Tenant still present.
@@ -518,7 +518,7 @@ tenants:
 	}
 
 	mgr.mu.RLock()
-	hier := mgr.hierarchicalMode
+	hier := mgr.hierarchy.enabled
 	mgr.mu.RUnlock()
 	if !hier {
 		t.Fatal("hierarchicalMode should flip to true on first Load (root _defaults.yaml present)")
@@ -536,10 +536,10 @@ tenants:
 	}
 
 	mgr.mu.RLock()
-	stillHier := mgr.hierarchicalMode
-	finStillThere := mgr.mergedHashes["db-fin"] != ""
-	flatStillThere := mgr.mergedHashes["db-flat"] != ""
-	finChain := mgr.inheritanceGraph.TenantDefaults["db-fin"]
+	stillHier := mgr.hierarchy.enabled
+	finStillThere := mgr.hierarchy.mergedHashes["db-fin"] != ""
+	flatStillThere := mgr.hierarchy.mergedHashes["db-flat"] != ""
+	finChain := mgr.hierarchy.graph.TenantDefaults["db-fin"]
 	mgr.mu.RUnlock()
 
 	if !stillHier {

--- a/components/threshold-exporter/app/config_slow_write_stress_test.go
+++ b/components/threshold-exporter/app/config_slow_write_stress_test.go
@@ -134,7 +134,7 @@ func TestSlowWriteTornStateStress_FinalConvergence(t *testing.T) {
 	// Snapshot baseline merged_hash for every tenant we plan to mutate.
 	baseline := make(map[string]string, numFiles)
 	m.mu.RLock()
-	for tid, h := range m.mergedHashes {
+	for tid, h := range m.hierarchy.mergedHashes {
 		baseline[tid] = h
 	}
 	m.mu.RUnlock()
@@ -192,7 +192,7 @@ func TestSlowWriteTornStateStress_FinalConvergence(t *testing.T) {
 	m.mu.RLock()
 	mismatches := 0
 	for tid, prev := range baseline {
-		curr := m.mergedHashes[tid]
+		curr := m.hierarchy.mergedHashes[tid]
 		if curr == "" {
 			t.Errorf("tenant %s: missing merged_hash post-reload", tid)
 			mismatches++


### PR DESCRIPTION
## Summary

**Final** of 5 v2.8.0 code-health refactor PRs. Pure structural decomposition — zero behavior change, zero perf overhead (Go struct embedding has identical memory layout to flat fields).

`ConfigManager` had 14 mixed-concern fields (v2.1.0 flat scanner + v2.7.0 hierarchy scanner + v2.7.0 debouncer all dumped together). PR-5 groups them into 3 named sub-structs.

## New struct shape

```go
type flatScanState struct {
    hashes  map[string]string          // v2.1.0 incremental
    configs map[string]ThresholdConfig
    mtimes  map[string]fileStat
}

type hierarchyState struct {
    enabled        bool                 // v2.7.0+ ADR-017/018
    tenantSources  map[string]string
    hashes         map[string]string
    mtimes         map[string]fileStat
    mergedHashes   map[string]string
    graph          *InheritanceGraph
    parsedDefaults map[string]map[string]any
}

type debouncerState struct {
    window         time.Duration       // v2.7.0 Phase 3
    timer          *time.Timer
    mu             sync.Mutex
    pendingReasons []string
    fired          uint64
}

type ConfigManager struct {
    path, isDir, mu, config, loaded, lastReload, lastHash  // 7 orchestrator
    configSource, gitCommit                                 // v2.3.0
    flat      flatScanState
    hierarchy hierarchyState
    debounce  debouncerState
}
```

## Field-rename mapping

| Old | New |
|-----|-----|
| `m.fileHashes` | `m.flat.hashes` |
| `m.fileConfigs` | `m.flat.configs` |
| `m.fileMtimes` | `m.flat.mtimes` |
| `m.hierarchicalMode` | `m.hierarchy.enabled` |
| `m.tenantSources` | `m.hierarchy.tenantSources` |
| `m.hierarchyHashes` | `m.hierarchy.hashes` |
| `m.hierarchyMtimes` | `m.hierarchy.mtimes` |
| `m.mergedHashes` | `m.hierarchy.mergedHashes` |
| `m.inheritanceGraph` | `m.hierarchy.graph` |
| `m.parsedDefaults` | `m.hierarchy.parsedDefaults` |
| `m.debounceWindow` | `m.debounce.window` |
| `m.debounceTimer` | `m.debounce.timer` |
| `m.debounceMu` | `m.debounce.mu` |
| `m.pendingReasons` | `m.debounce.pendingReasons` |
| `m.debounceFired` | `m.debounce.fired` |

**147 rename sites across 9 files** (production + tests). Mechanical Python rename (avoids dev-rule #11 sed -i ban). Both receiver patterns covered (`m.X` for ConfigManager methods, `mgr.X` for test fixtures). The PR-3-introduced `prior.X` field accesses on `reloadPriorState` are deliberately unchanged — different struct.

## Test plan

- [x] **Build**: `go build -buildvcs=false ./...` (Linux dev container, **worktree path** discipline) — clean
- [x] **Race**: `go test -race -count=1 ./...` — all 9 packages pass (10.5s)
- [x] **Hot-path stress**: `-race -count=10` (TestSlowWriteTornStateStress + TestDebounce + TestDiffAndReload + TestIncrementalLoad + TestWatchLoop + TestComputeMergedHash + TestGoldenParity) — 52.4s, 0 races, 0 flakes
- [x] **Apples-to-apples benchmark** (Windows host, `origin/main` vs PR-5, `count=3`, identical machine state via parallel `git worktree`):
  | Bench | origin/main | PR-5 | Δ |
  |-------|------------:|-----:|---|
  | DiffAndReload_Hierarchical_1000_NoChange | 572 ms | 575 ms | **+0.5%** |
  | DiffAndReload_Hierarchical_2000_NoChange | 1149 ms | 1166 ms | **+1.5%** |
  | DiffAndReload_Hierarchical_5000_NoChange | 2823 ms | 2876 ms | **+1.9%** |
  
  All within ±2% noise envelope. **Struct embedding is free in Go** — `m.flat.hashes` compiles to the same field-offset arithmetic as a top-level `m.fileHashes` would.
- [x] Pre-commit auto hooks pass (38/39; 1 env-only Playwright lint fail — eslint not on this Windows host PATH; passes in CI)
- [x] Pre-push hooks pass (protect-main + preflight + tech-debt registry)

## Risk

**Medium.** Touches every config-related file (9 of them) but only renames field accesses — no logic moves. Mitigation:

1. **Mechanical Python rename** (avoids hand-editing 147 sites + dev-rule #11 sed-i ban)
2. **Build forces correctness** — Go compiler catches every missed rename (would error `m.fileHashes undefined`)
3. **Hot-path stress gate** validates no race regression in the touched code paths
4. **Apples-to-apples benchmark with parallel worktree** confirms zero perf overhead

## v2.8.0 5-PR sequence — COMPLETE 🎉

| PR | Status | Net change |
|----|--------|-----------|
| PR-1 (#195) | ✅ merged | HTTP/main extract + handler isolation |
| PR-2 (#195) | ✅ merged | config_test.go 4008 → 461 LoC (split into 9 subject files <800 LoC each) |
| PR-3 (#196) | ✅ merged | diffAndReload 216 → 44 + 4 helpers; WatchLoop 98 → 40 + detectChange |
| PR-4 (#197) | ✅ merged | collapse pkg/config dup, **-1315 LoC net** |
| PR-5 (this) | ⏳ pending CI | ConfigManager 14 fields → 3 sub-structs |

**Aggregate v2.8.0 release readiness**:
- main.go 248 → 197 LoC (-21%)
- config_test.go 4008 → 461 LoC (-89%, distributed)
- diffAndReload 216 → 44 LoC orchestrator
- WatchLoop 98 → 40 LoC
- app/config_resolve.go DELETED (-750 LoC)
- ~1500 LoC duplication collapsed via type aliases + wrappers
- ConfigManager god-object → 3 named concerns

Net code-health: every component config file now <800 LoC, every helper has a named seam, every concern lives in a clearly-named struct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)