### PR TITLE
refactor(exporter): promote simulate + source + inheritance graph to pkg/config (PR-8)

### DIFF
--- a/components/threshold-exporter/app/config_hierarchy.go
+++ b/components/threshold-exporter/app/config_hierarchy.go
@@ -27,10 +27,13 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/vencil/threshold-exporter/pkg/config"
 )
 
 // DuplicateTenantError signals that the same tenant ID was discovered in two
@@ -59,61 +62,6 @@ func (e *DuplicateTenantError) Error() string {
 	return fmt.Sprintf("duplicate tenant ID %q: defined in both %s and %s", e.TenantID, e.PathA, e.PathB)
 }
 
-// InheritanceGraph tracks the defaults↔tenants dependency for a hierarchical
-// conf.d layout (ADR-017). Two maps, one per direction:
-//
-//   - TenantDefaults[tenantID]  → L0..Ln defaults paths (root first, leaf last).
-//     Used by computeMergedHash and the /effective handler.
-//   - DefaultsToTenants[path]   → tenant IDs whose merged_hash depends on this
-//     defaults file. Used by the debounced reload path: when a
-//     _defaults.yaml changes, we look up exactly which tenants need re-hash.
-//
-// All paths stored are absolute + filepath.Clean-ed so equality comparisons are
-// stable across calls. The struct is treated as immutable once built — reload
-// constructs a fresh graph and atomically swaps the pointer on ConfigManager.
-type InheritanceGraph struct {
-	DefaultsToTenants map[string][]string
-	TenantDefaults    map[string][]string
-}
-
-// NewInheritanceGraph returns an empty graph with both directions initialized.
-func NewInheritanceGraph() *InheritanceGraph {
-	return &InheritanceGraph{
-		DefaultsToTenants: make(map[string][]string),
-		TenantDefaults:    make(map[string][]string),
-	}
-}
-
-// AddTenant records a tenant's inheritance chain. defaultsChain MUST be
-// ordered root-first, leaf-last (matching describe_tenant.py after its
-// internal reverse). A defensive copy is made so the caller may reuse the
-// slice.
-func (g *InheritanceGraph) AddTenant(tenantID string, defaultsChain []string) {
-	if g.TenantDefaults == nil {
-		g.TenantDefaults = make(map[string][]string)
-	}
-	if g.DefaultsToTenants == nil {
-		g.DefaultsToTenants = make(map[string][]string)
-	}
-	chain := make([]string, len(defaultsChain))
-	copy(chain, defaultsChain)
-	g.TenantDefaults[tenantID] = chain
-
-	for _, dp := range chain {
-		g.DefaultsToTenants[dp] = append(g.DefaultsToTenants[dp], tenantID)
-	}
-}
-
-// TenantsAffectedBy returns the tenant IDs whose effective config depends on
-// the given _defaults.yaml path. Returns nil when the path is unknown — the
-// caller can distinguish "no tenants inherit this file" vs "unrelated file"
-// via the defaults map returned by scanDirHierarchical.
-func (g *InheritanceGraph) TenantsAffectedBy(defaultsPath string) []string {
-	if g == nil {
-		return nil
-	}
-	return g.DefaultsToTenants[defaultsPath]
-}
 
 // scanDirHierarchical walks a conf.d/ tree collecting every tenant file and
 // every _defaults.yaml file at every nesting depth. It supports flat layouts
@@ -309,14 +257,14 @@ func scanDirHierarchical(rootPath string, priorMtimes map[string]fileStat) (
 	}
 	// Sort for stability. We intentionally don't sort by source path because
 	// tenants in the same file would reshuffle across scans.
-	sortStrings(tenantIDs)
+	sort.Strings(tenantIDs)
 
 	for _, tid := range tenantIDs {
 		srcPath := tenants[tid]
 		dir := filepath.Dir(srcPath)
 		chain, cached := chainCache[dir]
 		if !cached {
-			chain = collectDefaultsChain(dir, absRoot, defaults)
+			chain = config.CollectDefaultsChain(dir, absRoot, defaults)
 			chainCache[dir] = chain
 		}
 		graph.AddTenant(tid, chain)
@@ -330,59 +278,3 @@ func scanDirHierarchical(rootPath string, priorMtimes map[string]fileStat) (
 	return tenants, defaults, hashes, mtimes, graph, nil
 }
 
-// collectDefaultsChain walks from `leafDir` up to `root` (both inclusive),
-// collecting _defaults.yaml at each level. Returns root-first (L0..Ln) order.
-// `defaults` is the set populated by the walker; this spares a second stat
-// call per directory level.
-//
-// Precondition: `leafDir` must be `root` or a descendant. (The walker only
-// visits entries under `root`, so this is always true for real callers.)
-func collectDefaultsChain(leafDir, root string, defaults map[string]bool) []string {
-	var chain []string
-	current := filepath.Clean(leafDir)
-	rootClean := filepath.Clean(root)
-
-	for {
-		// Prefer .yaml over .yml when both exist at the same level (same
-		// precedence rule as describe_tenant.py's iteration order).
-		yamlPath := filepath.Join(current, "_defaults.yaml")
-		ymlPath := filepath.Join(current, "_defaults.yml")
-		if defaults[yamlPath] {
-			chain = append(chain, yamlPath)
-		} else if defaults[ymlPath] {
-			chain = append(chain, ymlPath)
-		}
-
-		if current == rootClean {
-			break
-		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			// Reached filesystem root without hitting rootClean — shouldn't
-			// happen given the precondition, but don't infinite-loop.
-			break
-		}
-		current = parent
-	}
-
-	// Reverse to make chain[0] the top-most (L0) defaults and the last entry
-	// the nearest-to-tenant (Ln). Matches describe_tenant.py line 152.
-	for i, j := 0, len(chain)-1; i < j; i, j = i+1, j-1 {
-		chain[i], chain[j] = chain[j], chain[i]
-	}
-	return chain
-}
-
-// sortStrings is a small local helper so this file doesn't pull in "sort"
-// just for a single call site. Keeping the dependency surface minimal makes
-// it easier to spot accidental coupling when reading diffs.
-func sortStrings(s []string) {
-	// Insertion sort is fine: len(tenants) is typically <1000 and we call
-	// this once per scan. Keeps binary size marginally smaller than pulling
-	// sort.Strings. If profile shows it matters, swap to sort.Strings.
-	for i := 1; i < len(s); i++ {
-		for j := i; j > 0 && s[j-1] > s[j]; j-- {
-			s[j-1], s[j] = s[j], s[j-1]
-		}
-	}
-}

--- a/components/threshold-exporter/app/config_hierarchy_test.go
+++ b/components/threshold-exporter/app/config_hierarchy_test.go
@@ -271,7 +271,7 @@ func TestInheritanceGraph_DefaultsToTenantsOrder(t *testing.T) {
 	// Scanner feeds sorted IDs → result is sorted. Verify the sort helper
 	// produces the shape we expect.
 	ids := []string{"tenant-b", "tenant-a", "tenant-c"}
-	sortStrings(ids)
+	sort.Strings(ids)
 	sortExpect := []string{"tenant-a", "tenant-b", "tenant-c"}
 	if !reflect.DeepEqual(ids, sortExpect) {
 		t.Errorf("sortStrings produced %v, want %v", ids, sortExpect)
@@ -280,7 +280,7 @@ func TestInheritanceGraph_DefaultsToTenantsOrder(t *testing.T) {
 	cross := []string{"c", "a", "b"}
 	sort.Strings(cross)
 	ours := []string{"c", "a", "b"}
-	sortStrings(ours)
+	sort.Strings(ours)
 	if !reflect.DeepEqual(cross, ours) {
 		t.Errorf("local sort diverges from stdlib: stdlib=%v ours=%v", cross, ours)
 	}

--- a/components/threshold-exporter/app/config_simulate_test.go
+++ b/components/threshold-exporter/app/config_simulate_test.go
@@ -5,13 +5,13 @@ package main
 // ============================================================
 //
 // Three layers:
-//   1. SimulateEffective unit tests — basic merge / chain ordering /
+//   1. config.SimulateEffective unit tests — basic merge / chain ordering /
 //      error paths (no HTTP).
 //   2. simulateHandler HTTP tests — request shape, error codes,
 //      content-type contract.
 //   3. **Parity gate** — TestSimulate_VsResolve_ParityHash writes the
 //      same bytes to disk under a tmp dir, lets ConfigManager.Resolve
-//      compute its merged_hash, then calls SimulateEffective with the
+//      compute its merged_hash, then calls config.SimulateEffective with the
 //      identical bytes and asserts byte-identical SourceHash, MergedHash,
 //      DefaultsChain length, and effective Config map. This is the
 //      contract Phase .c relies on: a /simulate response is the same
@@ -27,21 +27,23 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/vencil/threshold-exporter/pkg/config"
 )
 
-// --- Layer 1: SimulateEffective unit tests ---------------------------
+// --- Layer 1: config.SimulateEffective unit tests ---------------------------
 
 func TestSimulate_BasicHierarchy(t *testing.T) {
 	defaults := []byte("defaults:\n  mysql_connections: 80\n  cpu_threshold: 75\n")
 	tenantBytes := []byte("tenants:\n  tenant-a:\n    mysql_connections: \"90\"\n")
 
-	resp, err := SimulateEffective(SimulateRequest{
+	resp, err := config.SimulateEffective(config.SimulateRequest{
 		TenantID:          "tenant-a",
 		TenantYAML:        tenantBytes,
 		DefaultsChainYAML: [][]byte{defaults},
 	})
 	if err != nil {
-		t.Fatalf("SimulateEffective: %v", err)
+		t.Fatalf("config.SimulateEffective: %v", err)
 	}
 	if resp.TenantID != "tenant-a" {
 		t.Errorf("TenantID = %q, want tenant-a", resp.TenantID)
@@ -66,12 +68,12 @@ func TestSimulate_BasicHierarchy(t *testing.T) {
 
 func TestSimulate_NoDefaults(t *testing.T) {
 	tenantBytes := []byte("tenants:\n  tenant-flat:\n    cpu_threshold: 80\n")
-	resp, err := SimulateEffective(SimulateRequest{
+	resp, err := config.SimulateEffective(config.SimulateRequest{
 		TenantID:   "tenant-flat",
 		TenantYAML: tenantBytes,
 	})
 	if err != nil {
-		t.Fatalf("SimulateEffective: %v", err)
+		t.Fatalf("config.SimulateEffective: %v", err)
 	}
 	if len(resp.DefaultsChain) != 0 {
 		t.Errorf("DefaultsChain should be empty, got %v", resp.DefaultsChain)
@@ -89,13 +91,13 @@ func TestSimulate_DeepChainOrdering(t *testing.T) {
 	l1 := []byte("defaults:\n  X: 2\n  Z: 20\n")
 	tenantBytes := []byte("tenants:\n  t1:\n    X: 3\n")
 
-	resp, err := SimulateEffective(SimulateRequest{
+	resp, err := config.SimulateEffective(config.SimulateRequest{
 		TenantID:          "t1",
 		TenantYAML:        tenantBytes,
 		DefaultsChainYAML: [][]byte{l0, l1},
 	})
 	if err != nil {
-		t.Fatalf("SimulateEffective: %v", err)
+		t.Fatalf("config.SimulateEffective: %v", err)
 	}
 	if got := resp.Config["X"]; got != 3 {
 		t.Errorf("X = %v, want 3 (tenant)", got)
@@ -113,17 +115,17 @@ func TestSimulate_DeepChainOrdering(t *testing.T) {
 
 func TestSimulate_TenantNotFound(t *testing.T) {
 	tenantBytes := []byte("tenants:\n  someone-else:\n    foo: 1\n")
-	_, err := SimulateEffective(SimulateRequest{
+	_, err := config.SimulateEffective(config.SimulateRequest{
 		TenantID:   "missing",
 		TenantYAML: tenantBytes,
 	})
-	if err != ErrSimulateTenantNotFound {
-		t.Fatalf("err = %v, want ErrSimulateTenantNotFound", err)
+	if err != config.ErrSimulateTenantNotFound {
+		t.Fatalf("err = %v, want config.ErrSimulateTenantNotFound", err)
 	}
 }
 
 func TestSimulate_EmptyTenantID(t *testing.T) {
-	_, err := SimulateEffective(SimulateRequest{
+	_, err := config.SimulateEffective(config.SimulateRequest{
 		TenantYAML: []byte("tenants:\n  t1:\n    x: 1\n"),
 	})
 	if err == nil || !strings.Contains(err.Error(), "tenant_id is required") {
@@ -132,7 +134,7 @@ func TestSimulate_EmptyTenantID(t *testing.T) {
 }
 
 func TestSimulate_EmptyTenantYAML(t *testing.T) {
-	_, err := SimulateEffective(SimulateRequest{
+	_, err := config.SimulateEffective(config.SimulateRequest{
 		TenantID: "t1",
 	})
 	if err == nil || !strings.Contains(err.Error(), "tenant_yaml is required") {
@@ -141,7 +143,7 @@ func TestSimulate_EmptyTenantYAML(t *testing.T) {
 }
 
 func TestSimulate_MalformedTenantYAML(t *testing.T) {
-	_, err := SimulateEffective(SimulateRequest{
+	_, err := config.SimulateEffective(config.SimulateRequest{
 		TenantID:   "t1",
 		TenantYAML: []byte("tenants:\n  t1:\n    [unclosed-bracket\n"),
 	})
@@ -153,7 +155,7 @@ func TestSimulate_MalformedTenantYAML(t *testing.T) {
 // --- Layer 2: simulateHandler HTTP tests -----------------------------
 
 func TestSimulateHandler_Happy(t *testing.T) {
-	body := SimulateRequest{
+	body := config.SimulateRequest{
 		TenantID:          "tenant-a",
 		TenantYAML:        []byte("tenants:\n  tenant-a:\n    cpu_threshold: 70\n"),
 		DefaultsChainYAML: [][]byte{[]byte("defaults:\n  cpu_threshold: 50\n  mem: 80\n")},
@@ -171,7 +173,7 @@ func TestSimulateHandler_Happy(t *testing.T) {
 		t.Errorf("Content-Type = %q", ct)
 	}
 
-	var resp SimulateResponse
+	var resp config.SimulateResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode resp: %v", err)
 	}
@@ -204,7 +206,7 @@ func TestSimulateHandler_BadJSON(t *testing.T) {
 }
 
 func TestSimulateHandler_TenantNotFound(t *testing.T) {
-	body := SimulateRequest{
+	body := config.SimulateRequest{
 		TenantID:   "ghost",
 		TenantYAML: []byte("tenants:\n  alive:\n    x: 1\n"),
 	}
@@ -221,7 +223,7 @@ func TestSimulateHandler_TenantNotFound(t *testing.T) {
 func TestSimulateHandler_BodyTooLarge(t *testing.T) {
 	// Build an oversized payload: 2 MiB of tenant YAML padding.
 	pad := strings.Repeat("a", 2<<20)
-	body := SimulateRequest{
+	body := config.SimulateRequest{
 		TenantID:   "t1",
 		TenantYAML: []byte("tenants:\n  t1:\n    note: \"" + pad + "\"\n"),
 	}
@@ -251,7 +253,7 @@ func TestSimulateHandler_MalformedDefaults(t *testing.T) {
 	// Defaults bytes that don't parse as YAML must surface as 400 from
 	// the handler — the contract is "preview will fail the same way a
 	// commit would fail".
-	body := SimulateRequest{
+	body := config.SimulateRequest{
 		TenantID:          "t1",
 		TenantYAML:        []byte("tenants:\n  t1:\n    x: 1\n"),
 		DefaultsChainYAML: [][]byte{[]byte("defaults:\n  [unclosed\n")},
@@ -326,13 +328,13 @@ func TestSimulate_VsResolve_ParityHash(t *testing.T) {
 	}
 
 	// Simulate path: same bytes, manually-ordered chain.
-	sim, err := SimulateEffective(SimulateRequest{
+	sim, err := config.SimulateEffective(config.SimulateRequest{
 		TenantID:          "tenant-a",
 		TenantYAML:        tenantBytes,
 		DefaultsChainYAML: [][]byte{l0Bytes, l1Bytes},
 	})
 	if err != nil {
-		t.Fatalf("SimulateEffective: %v", err)
+		t.Fatalf("config.SimulateEffective: %v", err)
 	}
 
 	if disk.SourceHash != sim.SourceHash {
@@ -372,7 +374,7 @@ func TestInMemoryConfigSource_FiltersByRoot(t *testing.T) {
 		"/sim/.hidden.yaml":   []byte("tenants:\n  hidden:\n    x: 4\n"),
 		"/sim/_defaults.yaml": []byte("defaults:\n  x: 0\n"),
 	}
-	src := NewInMemoryConfigSource(files)
+	src := config.NewInMemoryConfigSource(files)
 	out, err := src.YAMLFiles("/sim")
 	if err != nil {
 		t.Fatalf("YAMLFiles: %v", err)
@@ -399,8 +401,8 @@ func TestScanFromConfigSource_DuplicateTenantError(t *testing.T) {
 		"/sim/team-a.yaml": []byte("tenants:\n  shared:\n    x: 1\n"),
 		"/sim/team-b.yaml": []byte("tenants:\n  shared:\n    x: 2\n"),
 	}
-	src := NewInMemoryConfigSource(files)
-	_, _, _, _, err := scanFromConfigSource(src, "/sim")
+	src := config.NewInMemoryConfigSource(files)
+	_, _, _, _, err := config.ScanFromConfigSource(src, "/sim")
 	if err == nil || !strings.Contains(err.Error(), "duplicate tenant ID") {
 		t.Fatalf("err = %v, want duplicate tenant error", err)
 	}

--- a/components/threshold-exporter/app/config_types.go
+++ b/components/threshold-exporter/app/config_types.go
@@ -33,7 +33,17 @@ type (
 	ResolvedSeverityDedup     = config.ResolvedSeverityDedup
 	RoutingConfig             = config.RoutingConfig
 	ConfigInfo                = config.ConfigInfo
+
+	// v2.8.0 PR-8: hierarchy graph promoted to pkg/config so cmd/da-guard
+	// and tenant-api can construct it without importing package main.
+	// app's scanDirHierarchical still owns the disk-walking implementation
+	// (it threads fileStat for mtime fast-path).
+	InheritanceGraph = config.InheritanceGraph
 )
+
+// NewInheritanceGraph re-exports the pkg/config constructor under its
+// historical name so existing app/test callers compile unchanged.
+var NewInheritanceGraph = config.NewInheritanceGraph
 
 // fileStat is app-only — pkg/config has no concept of file mtimes
 // because it's the standalone resolver layer. Kept here next to the

--- a/components/threshold-exporter/app/handler_simulate.go
+++ b/components/threshold-exporter/app/handler_simulate.go
@@ -36,6 +36,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+
+	"github.com/vencil/threshold-exporter/pkg/config"
 )
 
 // simulateMaxBodyBytes caps a single /simulate request body. 1 MiB
@@ -59,7 +61,7 @@ func simulateHandler() http.HandlerFunc {
 		body := http.MaxBytesReader(w, r.Body, simulateMaxBodyBytes)
 		defer body.Close()
 
-		var req SimulateRequest
+		var req config.SimulateRequest
 		dec := json.NewDecoder(body)
 		dec.DisallowUnknownFields()
 		if err := dec.Decode(&req); err != nil {
@@ -79,9 +81,9 @@ func simulateHandler() http.HandlerFunc {
 			return
 		}
 
-		resp, err := SimulateEffective(req)
+		resp, err := config.SimulateEffective(req)
 		if err != nil {
-			if errors.Is(err, ErrSimulateTenantNotFound) {
+			if errors.Is(err, config.ErrSimulateTenantNotFound) {
 				writeSimulateError(w, http.StatusNotFound, err.Error())
 				return
 			}

--- a/components/threshold-exporter/app/pkg/config/inheritance_graph.go
+++ b/components/threshold-exporter/app/pkg/config/inheritance_graph.go
@@ -1,0 +1,123 @@
+package config
+
+// InheritanceGraph + the defaults-chain walker that builds it.
+//
+// v2.8.0 PR-8 promoted these from `app/config_hierarchy.go` so that
+// `pkg/config/source.go` (also new in PR-8) and any future cmd/da-guard
+// or tenant-api consumer can construct the graph without depending on
+// `package main`. The exporter's disk scanner (`scanDirHierarchical`)
+// still lives in app/ because it threads `fileStat` (mtime cache) which
+// is exporter-specific.
+//
+// Semantic rules unchanged from the original definition (parity-pinned
+// against describe_tenant.py + golden fixtures):
+//   - chain is L0..Ln (root first, leaf last) after CollectDefaultsChain
+//     reverses its accumulator
+//   - .yaml wins over .yml when both exist at the same level
+//   - filepath.Clean'd paths so equality compares stable across calls
+
+import "path/filepath"
+
+// InheritanceGraph tracks the defaults↔tenants dependency for a
+// hierarchical conf.d layout (ADR-017).
+//
+//   - TenantDefaults[tenantID]   → L0..Ln defaults paths (root first).
+//     Used by ComputeMergedHash and the /effective handler.
+//   - DefaultsToTenants[path]    → tenant IDs whose merged_hash depends
+//     on this defaults file. Used by the debounced reload path: when
+//     a _defaults.yaml changes we look up exactly which tenants need
+//     re-hash.
+//
+// All paths are absolute + filepath.Clean'd. The struct is treated as
+// immutable once built — reload constructs a fresh graph and atomically
+// swaps the pointer on ConfigManager.
+type InheritanceGraph struct {
+	DefaultsToTenants map[string][]string
+	TenantDefaults    map[string][]string
+}
+
+// NewInheritanceGraph returns an empty graph with both directions
+// initialized.
+func NewInheritanceGraph() *InheritanceGraph {
+	return &InheritanceGraph{
+		DefaultsToTenants: make(map[string][]string),
+		TenantDefaults:    make(map[string][]string),
+	}
+}
+
+// AddTenant records a tenant's inheritance chain. defaultsChain MUST
+// be ordered root-first, leaf-last (matching describe_tenant.py after
+// its internal reverse). A defensive copy is made so the caller may
+// reuse the slice.
+func (g *InheritanceGraph) AddTenant(tenantID string, defaultsChain []string) {
+	if g.TenantDefaults == nil {
+		g.TenantDefaults = make(map[string][]string)
+	}
+	if g.DefaultsToTenants == nil {
+		g.DefaultsToTenants = make(map[string][]string)
+	}
+	chain := make([]string, len(defaultsChain))
+	copy(chain, defaultsChain)
+	g.TenantDefaults[tenantID] = chain
+
+	for _, dp := range chain {
+		g.DefaultsToTenants[dp] = append(g.DefaultsToTenants[dp], tenantID)
+	}
+}
+
+// TenantsAffectedBy returns the tenant IDs whose effective config
+// depends on the given _defaults.yaml path. Returns nil when the path
+// is unknown — the caller can distinguish "no tenants inherit this
+// file" vs "unrelated file" via the defaults map returned by the
+// scanner.
+func (g *InheritanceGraph) TenantsAffectedBy(defaultsPath string) []string {
+	if g == nil {
+		return nil
+	}
+	return g.DefaultsToTenants[defaultsPath]
+}
+
+// CollectDefaultsChain walks from leafDir up to (and including) root,
+// picking the `_defaults.yaml` (or `.yml`) at each level and reversing
+// the accumulator so chain[0] is the top-most (L0) defaults.
+//
+// Both the exporter's disk scanner (scanDirHierarchical in app/) and
+// the in-memory scanFromConfigSource in this package call this helper.
+// `defaults` is the populated set of known _defaults.yaml paths
+// (basename match, set membership only — values are unused).
+func CollectDefaultsChain(leafDir, root string, defaults map[string]bool) []string {
+	var chain []string
+	current := filepath.Clean(leafDir)
+	rootClean := filepath.Clean(root)
+
+	for {
+		// Prefer .yaml over .yml when both exist at the same level
+		// (same precedence rule as describe_tenant.py).
+		yamlPath := filepath.Join(current, "_defaults.yaml")
+		ymlPath := filepath.Join(current, "_defaults.yml")
+		if defaults[yamlPath] {
+			chain = append(chain, yamlPath)
+		} else if defaults[ymlPath] {
+			chain = append(chain, ymlPath)
+		}
+
+		if current == rootClean {
+			break
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			// Reached filesystem root without hitting rootClean —
+			// shouldn't happen given the precondition, but don't loop.
+			break
+		}
+		current = parent
+	}
+
+	// Reverse to make chain[0] the top-most (L0) defaults and the last
+	// entry the nearest-to-tenant (Ln). Matches describe_tenant.py
+	// line 152.
+	for i, j := 0, len(chain)-1; i < j; i, j = i+1, j-1 {
+		chain[i], chain[j] = chain[j], chain[i]
+	}
+	return chain
+}

--- a/components/threshold-exporter/app/pkg/config/simulate.go
+++ b/components/threshold-exporter/app/pkg/config/simulate.go
@@ -1,4 +1,4 @@
-package main
+package config
 
 // ============================================================
 // Simulate primitive (v2.8.0 Phase .c C-7b)
@@ -99,7 +99,7 @@ func SimulateEffective(req SimulateRequest) (*SimulateResponse, error) {
 	//   /sim/lvl1/.../tenant.yaml    ← tenant file (deepest)
 	//
 	// This guarantees collectDefaultsChain (called by
-	// scanFromConfigSource) reproduces exactly the chain the caller
+	// ScanFromConfigSource) reproduces exactly the chain the caller
 	// asked for. We could skip the scan and call computeEffectiveConfig
 	// directly, but going through the scan exercises the same code
 	// path the parity test needs — keeping one road keeps both roads
@@ -116,7 +116,7 @@ func SimulateEffective(req SimulateRequest) (*SimulateResponse, error) {
 	files[tenantPath] = req.TenantYAML
 
 	src := NewInMemoryConfigSource(files)
-	tenants, _, _, graph, err := scanFromConfigSource(src, SimRoot)
+	tenants, _, _, graph, err := ScanFromConfigSource(src, SimRoot)
 	if err != nil {
 		return nil, fmt.Errorf("simulate scan: %w", err)
 	}
@@ -130,18 +130,18 @@ func SimulateEffective(req SimulateRequest) (*SimulateResponse, error) {
 		chainBytes = append(chainBytes, files[dp])
 	}
 
-	merged, err := computeEffectiveConfig(req.TenantYAML, req.TenantID, chainBytes)
+	merged, err := ComputeEffectiveConfig(req.TenantYAML, req.TenantID, chainBytes)
 	if err != nil {
 		return nil, fmt.Errorf("simulate merge: %w", err)
 	}
-	mergedHash, err := computeMergedHash(req.TenantYAML, req.TenantID, chainBytes)
+	mergedHash, err := ComputeMergedHash(req.TenantYAML, req.TenantID, chainBytes)
 	if err != nil {
 		return nil, fmt.Errorf("simulate hash: %w", err)
 	}
 
 	return &SimulateResponse{
 		TenantID:      req.TenantID,
-		SourceHash:    computeSourceHash(req.TenantYAML),
+		SourceHash:    ComputeSourceHash(req.TenantYAML),
 		MergedHash:    mergedHash,
 		DefaultsChain: append([]string(nil), chain...),
 		Config:        merged,

--- a/components/threshold-exporter/app/pkg/config/source.go
+++ b/components/threshold-exporter/app/pkg/config/source.go
@@ -1,4 +1,4 @@
-package main
+package config
 
 // ============================================================
 // ConfigSource abstraction (v2.8.0 Phase .c C-7a)
@@ -21,7 +21,7 @@ package main
 // machinery. It exposes one capability — enumerating the YAML files
 // the merge engine should consider — and leaves the parsing, hashing,
 // dedup, and InheritanceGraph construction in one place
-// (`scanFromConfigSource`). The disk path keeps its own walker
+// (`ScanFromConfigSource`). The disk path keeps its own walker
 // (`scanDirHierarchical`) for production because that walker also
 // records mtimes for debounced-reload change detection — a concern
 // the simulate path doesn't share.
@@ -40,6 +40,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -100,7 +101,7 @@ func (s *InMemoryConfigSource) YAMLFiles(rootPath string) (map[string][]byte, er
 	return out, nil
 }
 
-// scanFromConfigSource is the in-memory cousin of scanDirHierarchical:
+// ScanFromConfigSource is the in-memory cousin of scanDirHierarchical:
 // it takes a corpus from a ConfigSource and produces the same outputs
 // (tenants map, defaults set, per-file hashes, InheritanceGraph) using
 // identical classification + dedup + chain rules.
@@ -108,7 +109,7 @@ func (s *InMemoryConfigSource) YAMLFiles(rootPath string) (map[string][]byte, er
 // This is what the /simulate endpoint calls. Production reload still
 // uses scanDirHierarchical because that path also gathers mtimes for
 // change detection — a concern simulate doesn't share.
-func scanFromConfigSource(src ConfigSource, rootPath string) (
+func ScanFromConfigSource(src ConfigSource, rootPath string) (
 	tenants map[string]string,
 	defaults map[string]bool,
 	hashes map[string]string,
@@ -188,14 +189,14 @@ func scanFromConfigSource(src ConfigSource, rootPath string) (
 	for tid := range tenants {
 		tenantIDs = append(tenantIDs, tid)
 	}
-	sortStrings(tenantIDs)
+	sort.Strings(tenantIDs)
 
 	for _, tid := range tenantIDs {
 		srcPath := tenants[tid]
 		dir := filepath.Dir(srcPath)
 		chain, cached := chainCache[dir]
 		if !cached {
-			chain = collectDefaultsChain(dir, absRoot, defaults)
+			chain = CollectDefaultsChain(dir, absRoot, defaults)
 			chainCache[dir] = chain
 		}
 		graph.AddTenant(tid, chain)


### PR DESCRIPTION
## Summary

PR-4 (#197) made `pkg/config` canonical for resolver / parse / inheritance helpers. PR-8 closes the **library shape**: promote the remaining hierarchy + simulate primitives so `cmd/da-guard`, `tenant-api`, and any future component can import them directly without `package main` or HTTP shell-out.

Net delta: -19 LoC, but the value is library shape — `pkg/config` now usable as a standalone Go module for any cross-component consumer.

## File-level changes

### Created in pkg/config (new files)

| File | LoC | Surface |
|------|----:|---------|
| `inheritance_graph.go` | 123 | `InheritanceGraph` type + `NewInheritanceGraph` + `AddTenant` + `TenantsAffectedBy` + `CollectDefaultsChain` (capital export) |

### Renamed (git rename, ~95% similarity except package decl)

| Before (app/) | After (pkg/config/) | LoC |
|---------------|--------------------|----:|
| `config_source.go` | `source.go` | 206 |
| `config_simulate.go` | `simulate.go` | 149 |

`scanFromConfigSource` → `ScanFromConfigSource` (capitalized for test callers).
Internal calls switched: `computeEffectiveConfig` → `ComputeEffectiveConfig` etc. (already exported by PR-4).

### Updated (app/)

| File | Change |
|------|--------|
| `config_hierarchy.go` | -118 LoC: removed `InheritanceGraph` + 3 methods + `collectDefaultsChain` + `sortStrings`. Internal calls switch to `config.CollectDefaultsChain` + `sort.Strings` (stdlib). |
| `config_types.go` | Added `type InheritanceGraph = config.InheritanceGraph` alias + `var NewInheritanceGraph = config.NewInheritanceGraph`. Existing `*InheritanceGraph` field types in `config.go` / `config_debounce.go` compile unchanged. |
| `handler_simulate.go` | Switch to `config.SimulateRequest` + `config.SimulateEffective` + `config.ErrSimulateTenantNotFound`. Transport stays in app, semantic logic now in pkg/config. |
| `config_simulate_test.go` | Test call sites updated to `config.X` namespace. |
| `config_hierarchy_test.go` | `sortStrings` → `sort.Strings`. |

## Library shape achieved

After PR-8, `pkg/config` is **self-contained** for:

- **Resolution** (PR-4): `ApplyProfiles`, `ResolveAt`, `ResolveStateFiltersAt`, etc.
- **Parse helpers** (PR-4): `ParseHHMM`, `ParseMetricKey`, `ParseKeyWithLabels`, `MatchTimeWindow`, `ClampDuration`, `FormatDuration`, `IsDisabled`, etc.
- **Inheritance helpers** (PR-4): `DeepMerge`, `DeepCopyMap`, `NormalizeYAMLToJSON`, `ExtractDefaultsBlock`, `ExtractTenantRaw`, `CanonicalJSON`, `ComputeEffectiveConfig`, `ComputeMergedHash`, `ComputeSourceHash`.
- **Hierarchy graph** (PR-8): `InheritanceGraph` + `CollectDefaultsChain`.
- **Config source** (PR-8): `ConfigSource` interface + `InMemoryConfigSource` + `ScanFromConfigSource`.
- **Simulate primitive** (PR-8): `SimulateEffective` + types.

`cmd/da-guard`'s `da-tools guard defaults-impact` could now call `config.ScanFromConfigSource` + `config.SimulateEffective` directly instead of shell-out — left as a follow-up since it's a behavior change, not a refactor.

`app/` keeps:
- `ConfigManager` (orchestrator) — disk I/O, watchloop, debounce
- `scanDirHierarchical` — disk-walking scanner with mtime fast-path (uses `fileStat` which is exporter-specific)
- `DuplicateTenantError` — scanner error type
- HTTP handlers
- `flat_scanner.go` (PR-7)

## Test plan

- [x] **Build**: `go build -buildvcs=false ./...` (Linux dev container, worktree path) — clean
- [x] **Vet**: `go vet ./...` — clean
- [x] **Race**: `go test -race -count=1 ./...` — all 9 packages pass (5.7s)
- [x] **Hot-path stress** `-race -count=10` (TestSlowWriteTornStateStress + TestDebounce + TestDiffAndReload + TestComputeMergedHash + TestGoldenParity + **TestSimulate***) — 22.4s, 0 races, 0 flakes. Adding `TestSimulate*` to the gate confirms the moved primitive is byte-equivalent to its app/ ancestor.
- [x] **Apples-to-apples bench** (Windows host, parallel `git worktree add` discipline learned from PR-4):
  | Bench | origin/main | PR-8 | Δ |
  |-------|------------:|-----:|---|
  | DiffAndReload_Hierarchical_1000_NoChange | 398 ms | 399 ms | +0.2% |
  | DiffAndReload_Hierarchical_2000_NoChange | 749 ms | 738 ms | -1.6% |
- [x] **Golden parity** (`TestGoldenParity*`) confirms 16-char `merged_hash` output is byte-equal pre/post promote — same parity-pin discipline as PR-4.

## Risk

**Medium.** Touches scanner + simulate primitives, but:
1. Most code MOVED (git renames at 94-96% similarity preserved by file-rename detection)
2. Type alias keeps existing `*InheritanceGraph` field types unchanged
3. Golden parity test would fail loudly on any merged_hash drift
4. cmd/da-guard already imports pkg/config — its CI stays green confirms binary compatibility

## v2.8.0 follow-up sequence

| PR | Status | Theme |
|----|--------|-------|
| PR-6 (#199) | ✅ merged | emit.go 3-way split |
| PR-7 (#200) | ✅ merged | Loader unify + flat_scanner extract |
| **PR-8** (this) | ⏳ open | pkg/config library maturation |
| PR-9 (next) | pending | Test infra modernization |

🤖 Generated with [Claude Code](https://claude.com/claude-code)