### PR TITLE
refactor(exporter): extend benchmark suite with 3 customer-scenario benches (PR-9)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,13 @@ go-bench-clean: ## Go micro-benchmark via bench_wrapper (stdout-clean, -json fil
 		-bench=. -benchmem -count=$${COUNT:-5} -run="^$$" -timeout=15m ./...
 
 .PHONY: benchmark-report
-benchmark-report: ## 1000-scale baseline (17 benches: 8 flat + 5 hierarchical + 4 mixed-mode) → .build/bench-baseline.txt（issue #60 Phase 1, informational; COUNT/BENCHTIME 可覆寫）
+benchmark-report: ## 1000-scale baseline (20 benches: 8 flat + 5 hierarchical + 4 mixed-mode + 1 churn + 2 pkg/config library) → .build/bench-baseline.txt（issue #60 Phase 1, informational; COUNT/BENCHTIME 可覆寫）
 	@mkdir -p .build
 	@echo "[benchmark-report] running 1000-scale baseline (count=$${COUNT:-6}, benchtime=$${BENCHTIME:-3s}; samples 2..N treated as steady-state by Phase 2 median-of-5)"
 	@cd components/threshold-exporter/app && \
 		BENCH_OUT_DIR="$(CURDIR)/.build" \
 		bash $(CURDIR)/scripts/tools/ops/bench_wrapper.sh \
-		-bench='_1000(_|$$)|MixedMode' -benchmem -count=$${COUNT:-6} -run='^$$' \
+		-bench='_1000(_|$$)|MixedMode|Simulate_DeepChain' -benchmem -count=$${COUNT:-6} -run='^$$' \
 		-timeout=20m -benchtime=$${BENCHTIME:-3s} ./...
 	@cp .build/bench.out.txt .build/bench-baseline.txt
 	@echo "[benchmark-report] wrote .build/bench-baseline.txt ($$(wc -l < .build/bench-baseline.txt) lines)"

--- a/components/threshold-exporter/app/config_hierarchy_bench_test.go
+++ b/components/threshold-exporter/app/config_hierarchy_bench_test.go
@@ -437,6 +437,66 @@ func BenchmarkDiffAndReload_Hierarchical_5000_NoChange(b *testing.B) {
 }
 
 // ---------------------------------------------------------------------------
+// v2.8.0 PR-9: 10%-churn benchmark — covers the gap between
+// OneTenantChanged (smallest possible diff) and BlastRadius (mid-tree
+// _defaults change). Real ops scenario: 100 of 1000 tenants change in
+// a single tick, mimicking a daily migration batch or a rolling
+// rebalance. Measures the reload pipeline at the throughput tail:
+// 100 individual file writes + diffAndReload's per-tenant merge loop
+// + atomic-swap with a 100-entry update set.
+// ---------------------------------------------------------------------------
+
+// BenchmarkDiffAndReload_Hierarchical_1000_Churn10pct rewrites 10% of
+// tenant files (deterministic stride-of-10 selection: tenant-0000,
+// tenant-0010, ...) with fresh threshold values per iteration, then
+// runs diffAndReload. Measures the full reload pipeline at a real
+// "many-changed" workload.
+//
+// Naming matches the existing _1000(_|$) regex captured by
+// `make benchmark-report` so nightly bench-record auto-tracks it.
+func BenchmarkDiffAndReload_Hierarchical_1000_Churn10pct(b *testing.B) {
+	dir := buildDirConfigHierarchicalFresh(b, 1000)
+	silenceLogs(b)
+	mgr := NewConfigManager(dir)
+	if err := mgr.fullDirLoad(); err != nil {
+		b.Fatal(err)
+	}
+	// Pre-compute the 100 target file paths (deterministic stride).
+	targetFiles := make([]string, 100)
+	targetIDs := make([]string, 100)
+	leafCardinality := len(benchDomains) * len(benchRegions) * len(benchEnvs)
+	for i := 0; i < 100; i++ {
+		tenantIdx := i * 10
+		leafIdx := tenantIdx % leafCardinality
+		envIdx := leafIdx % len(benchEnvs)
+		regionIdx := (leafIdx / len(benchEnvs)) % len(benchRegions)
+		domainIdx := leafIdx / (len(benchEnvs) * len(benchRegions))
+		tenantName := fmt.Sprintf("tenant-%04d", tenantIdx)
+		targetFiles[i] = filepath.Join(dir,
+			benchDomains[domainIdx], benchRegions[regionIdx], benchEnvs[envIdx],
+			tenantName+".yaml")
+		targetIDs[i] = tenantName
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Rewrite all 100 target files with iteration-specific values
+		// so the file hash actually moves.
+		for j := 0; j < 100; j++ {
+			content := fmt.Sprintf("tenants:\n  %s:\n    mysql_connections: \"%d\"\n    mysql_cpu: \"%d\"\n",
+				targetIDs[j], 50+(i+j)%100, 60+(i+j)%40)
+			if err := os.WriteFile(targetFiles[j], []byte(content), 0o600); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if _, _, err := mgr.diffAndReload(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	reportResourceMetrics(b)
+}
+
+// ---------------------------------------------------------------------------
 // B-8: Blast-radius benchmark
 // ---------------------------------------------------------------------------
 //

--- a/components/threshold-exporter/app/pkg/config/simulate_bench_test.go
+++ b/components/threshold-exporter/app/pkg/config/simulate_bench_test.go
@@ -1,0 +1,164 @@
+package config_test
+
+// Library-side benchmark for SimulateEffective.
+//
+// v2.8.0 PR-8 promoted SimulateEffective to pkg/config; this benchmark
+// validates the per-call cost at a realistic L4 (4-level) defaults
+// chain. cmd/da-guard's predict-flow could call SimulateEffective at
+// per-tenant cardinality — knowing the per-call latency informs whether
+// it's safe to call N=1000 times in a CI gate.
+//
+// Naming pattern matches the Makefile bench regex extension PR-9 adds
+// for `Simulate` (and `Churn10pct` for the app-side bench) so nightly
+// bench-record auto-tracks it.
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/vencil/threshold-exporter/pkg/config"
+)
+
+// BenchmarkSimulate_DeepChain_L4 runs SimulateEffective with a 4-level
+// defaults chain (L0 platform / L1 domain / L2 region / L3 tenant) and
+// a tenant.yaml that overrides 5 keys. Each level's _defaults.yaml has
+// 8 distinct threshold keys so deep-merge actually walks. Total bytes
+// processed per call: ~2 KiB defaults + ~512 B tenant = ~2.5 KiB.
+//
+// Realistic shape: matches what `cmd/da-guard defaults-impact` would
+// see when classifying a tenant in a 4-deep production conf.d.
+func BenchmarkSimulate_DeepChain_L4(b *testing.B) {
+	defaultsL0 := []byte(`defaults:
+  mysql_connections: 80
+  mysql_cpu: 80
+  container_cpu: 80
+  container_memory: 85
+  oracle_sessions_active: 200
+  oracle_tablespace_used_pct: 85
+  redis_memory: 90
+  es_index_store_size_bytes: 107374182400
+`)
+	defaultsL1 := []byte(`defaults:
+  mysql_connections: 75
+  mysql_cpu: 75
+  container_cpu: 75
+  container_memory: 80
+  oracle_sessions_active: 180
+  oracle_tablespace_used_pct: 80
+  redis_memory: 85
+  es_index_store_size_bytes: 85899345920
+`)
+	defaultsL2 := []byte(`defaults:
+  mysql_connections: 70
+  mysql_cpu: 70
+  container_cpu: 70
+  container_memory: 75
+  oracle_sessions_active: 160
+  oracle_tablespace_used_pct: 75
+  redis_memory: 80
+  es_index_store_size_bytes: 64424509440
+`)
+	defaultsL3 := []byte(`defaults:
+  mysql_connections: 65
+  mysql_cpu: 65
+  container_cpu: 65
+  container_memory: 70
+  oracle_sessions_active: 140
+  oracle_tablespace_used_pct: 70
+  redis_memory: 75
+  es_index_store_size_bytes: 53687091200
+`)
+	tenantYAML := []byte(`tenants:
+  tenant-deep:
+    mysql_connections: "60"
+    mysql_cpu: "55:critical"
+    container_cpu: "50"
+    redis_memory: "70"
+    es_index_store_size_bytes: "42949672960"
+`)
+
+	req := config.SimulateRequest{
+		TenantID:          "tenant-deep",
+		TenantYAML:        tenantYAML,
+		DefaultsChainYAML: [][]byte{defaultsL0, defaultsL1, defaultsL2, defaultsL3},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resp, err := config.SimulateEffective(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		// Touch the response so the compiler can't dead-code-eliminate
+		// the call.
+		if !strings.HasPrefix(resp.MergedHash, fmt.Sprintf("%c", resp.MergedHash[0])) {
+			b.Fatal("merged hash empty")
+		}
+	}
+}
+
+// BenchmarkScanFromConfigSource_1000_InMemory builds a 1000-tenant
+// in-memory corpus (4-deep hierarchy, 8-tenant leaves under
+// domain/region/env) and runs ScanFromConfigSource end-to-end:
+// classification + dedup check + InheritanceGraph construction.
+//
+// Customer scenario: cmd/da-guard pre-merge gate validates a
+// candidate conf.d/ corpus held in memory before any disk write.
+// Knowing this baseline lets us answer "can guard validate a
+// 1000-tenant change in <1s?" without going through the disk path.
+//
+// Naming matches the Makefile bench regex _1000(_|$$) so nightly
+// bench-record auto-tracks it.
+func BenchmarkScanFromConfigSource_1000_InMemory(b *testing.B) {
+	const tenantCount = 1000
+	domains := []string{"finance", "logistics", "healthcare", "retail", "media", "infra", "analytics", "iot"}
+	regions := []string{"us-east", "us-west", "eu-central", "eu-west", "ap-northeast", "ap-southeast"}
+	envs := []string{"prod", "staging", "dev"}
+
+	files := make(map[string][]byte, tenantCount+50)
+	files["/sim/_defaults.yaml"] = []byte("defaults:\n  mysql_connections: 80\n  mysql_cpu: 80\n")
+
+	leafCardinality := len(domains) * len(regions) * len(envs)
+	for di, d := range domains {
+		domainPath := "/sim/" + d
+		files[domainPath+"/_defaults.yaml"] = []byte(fmt.Sprintf("defaults:\n  mysql_connections: %d\n", 75-di))
+		for ri, r := range regions {
+			regionPath := domainPath + "/" + r
+			files[regionPath+"/_defaults.yaml"] = []byte(fmt.Sprintf("defaults:\n  mysql_cpu: %d\n", 70-ri))
+			for ei, e := range envs {
+				envPath := regionPath + "/" + e
+				files[envPath+"/_defaults.yaml"] = []byte(fmt.Sprintf("defaults:\n  container_cpu: %d\n", 65-ei))
+			}
+		}
+	}
+
+	for i := 0; i < tenantCount; i++ {
+		leafIdx := i % leafCardinality
+		envIdx := leafIdx % len(envs)
+		regionIdx := (leafIdx / len(envs)) % len(regions)
+		domainIdx := leafIdx / (len(envs) * len(regions))
+		leafPath := fmt.Sprintf("/sim/%s/%s/%s", domains[domainIdx], regions[regionIdx], envs[envIdx])
+		tenantName := fmt.Sprintf("tenant-%04d", i)
+		files[leafPath+"/"+tenantName+".yaml"] = []byte(fmt.Sprintf(
+			"tenants:\n  %s:\n    mysql_connections: \"%d\"\n", tenantName, 50+i%100))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		src := config.NewInMemoryConfigSource(files)
+		tenants, _, _, graph, err := config.ScanFromConfigSource(src, "/sim")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(tenants) != tenantCount {
+			b.Fatalf("got %d tenants, want %d", len(tenants), tenantCount)
+		}
+		// Touch the graph so the compiler can't dead-code-eliminate.
+		if graph == nil || len(graph.TenantDefaults) != tenantCount {
+			b.Fatal("graph missing tenants")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Final of the 4 follow-up code-health PRs (PR-6 through PR-9). Adds 3 benchmarks covering customer scenarios the existing 17-bench nightly suite didn't capture, and updates the Makefile regex so nightly bench-record auto-tracks them.

**17 → 20 benches** in nightly bench-record (8 flat + 5 hierarchical + 4 mixed-mode + **1 churn** + **2 pkg/config library**).

## New benchmarks

### app-side: real ops scenario

`BenchmarkDiffAndReload_Hierarchical_1000_Churn10pct` — rewrites 100 of 1000 tenant files (deterministic stride-of-10 selection) per tick, then runs `diffAndReload`. Fills the gap between `OneTenantChanged` (smallest possible diff) and `BlastRadius` (mid-tree `_defaults` change): real ops scenario where a daily migration batch or rolling rebalance touches 10% of the corpus in a single tick.

Local sample (1 iter): **175 ms / 110 MB / 1.05M allocs** at 1000 scale.

### pkg/config-side: library primitives

PR-8 (#201) promoted `SimulateEffective` + `ScanFromConfigSource` to `pkg/config` but neither had perf data. PR-9 closes that gap:

`BenchmarkSimulate_DeepChain_L4` — single `SimulateEffective` call with a 4-level defaults chain (L0 platform / L1 domain / L2 region / L3 env-leaf) + tenant.yaml overriding 5 keys. Customer scenario: `cmd/da-guard` predict-flow per-tenant cost.
- Local sample: **87 µs / 77 KB / 551 allocs** per call → 87 ms for a 1000-tenant CI gate sweep, easy fit.

`BenchmarkScanFromConfigSource_1000_InMemory` — builds a 1000-tenant in-memory corpus (4-deep, 8-tenant leaves) and runs end-to-end scan: classification + dedup + `InheritanceGraph` construction. Customer scenario: `cmd/da-guard` pre-merge gate validates a candidate `conf.d/` held in memory before disk write.
- Local sample: **8.0 ms / 9.9 MB / 73K allocs** at 1000 scale.

Both pkg/config benches live in **`pkg/config/simulate_bench_test.go`** (NEW file, package `config_test`) — first benchmark file in pkg/config, validates that the library is independently benchmarkable per PR-8's promise.

## Makefile update

```diff
-	-bench='_1000(_|$$)|MixedMode' -benchmem -count=$${COUNT:-6}
+	-bench='_1000(_|$$)|MixedMode|Simulate_DeepChain' -benchmem -count=$${COUNT:-6}
```

Two new benches match the existing `_1000_` suffix pattern; `Simulate_DeepChain_L4` needs the explicit pattern. Help text updated: 17 → 20 benches captured.

## Test plan

- [x] **Build**: `go build -buildvcs=false ./...` (Linux dev container, worktree path) — clean
- [x] **Race**: `go test -race -count=1 ./...` — all 9 packages pass (5.6s)
- [x] Each new bench sanity-validated with `-benchtime=1x` (numbers above)
- [x] Full bench regex captures exactly **20 entries** (verified via `go test -bench='...' -benchtime=1x`)

## Why "test fixture factory" was dropped (vs original PR-9 plan)

Original PR-9 plan also pitched a `pkg/config/testfixtures` builder pattern to replace inline `ThresholdConfig{Defaults: ..., Tenants: ...}` literals across the 9 split test files. **Skipped** because:

1. Without actually migrating the 100+ existing inline literals, the factory is dead code — value is in the migration, not the helper.
2. Migrating 100+ test sites is a 1+ day exercise that primarily churns tests without changing production code; better as a dedicated future PR with scope = migration only.
3. PR-9 with bench-only delivers higher value-per-byte: real customer-scenario coverage that was missing, plus pkg/config's first library-side benchmark file.

## Risk

**Low.** Pure additive bench code — no production source touched. Makefile change is one regex extension.

## v2.8.0 follow-up sequence — COMPLETE 🎉

| PR | Status | Theme |
|----|--------|-------|
| PR-6 (#199) | ✅ merged | emit.go 3-way split |
| PR-7 (#200) | ✅ merged | Loader unify + flat_scanner extract |
| PR-8 (#201) | ✅ merged | pkg/config library maturation |
| **PR-9** (this) | ⏳ open | Bench suite extension |

**Aggregate effect of PR-6 through PR-9**: pkg/config is now a proper self-contained Go library with its own bench file; ConfigManager's hot-reload pipeline has named seams at every layer; nightly bench-record tracks 20 customer-relevant benchmarks instead of 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)