### PR TITLE
refactor(jsx): extract _common/ shared hooks library (PR-1/5)

### DIFF
--- a/docs/interactive/tools/_common/README.md
+++ b/docs/interactive/tools/_common/README.md
@@ -1,0 +1,139 @@
+# `_common/` — Shared Hooks, Utils, and Components for Portal Tools
+
+> **Purpose** — single home for React hooks / JS utilities / JSX components
+> that more than one interactive tool can reuse. Born in **PR-portal-1**
+> (v2.8.0 refactor sweep) by promoting four generic hooks out of
+> `tenant-manager/hooks/` so other tools can stop re-implementing them.
+>
+> **Why a separate directory** — the previous home (`tenant-manager/`)
+> implied tenant-manager ownership; new tools were either copy-pasting
+> (e.g. `simulate-preview.jsx` had an inline `useDebouncedValue` clone)
+> or skipping reuse entirely. `_common/` removes the ownership signal
+> and gives the jsx-loader a stable mount point.
+
+---
+
+## What lives here (post PR-portal-1)
+
+```
+_common/
+├── README.md                      ← you are here
+└── hooks/
+    ├── useDebouncedValue.js       ← debounce a rapidly-changing value
+    ├── useModalFocusTrap.js       ← modal focus trap + Esc + auto-focus
+    ├── useURLState.js             ← bidirectional state ↔ URLSearchParams
+    └── useVirtualGrid.js          ← fixed-row-height grid virtualizer
+```
+
+Future PRs will add `_common/components/` (ErrorBoundary, Loading,
+EmptyState — PR-portal-2), `_common/data/` (rule-packs, routing-profiles
+— PR-portal-3), `_common/sim/` (alert simulator core — PR-portal-3), and
+`_common/hooks/useWizardSteps.js` + `useTokenLifecycle.js` (PR-portal-4).
+
+---
+
+## How to consume from a JSX tool
+
+1. **Add the dep to your front-matter `dependencies:` block.** Paths are
+   relative to `docs/interactive/tools/`:
+
+   ```jsx
+   ---
+   title: "My Tool"
+   dependencies: [
+     "_common/hooks/useDebouncedValue.js"
+   ]
+   ---
+   ```
+
+2. **Pull the symbol off `window` near the top of your file** (after the
+   `import React from 'react'` line and i18n setup):
+
+   ```js
+   const useDebouncedValue = window.__useDebouncedValue;
+   ```
+
+3. **Use it like any React hook.** No further wiring.
+
+The jsx-loader fetches deps in order, strips front-matter, transforms
+imports, and `(0, eval)(...)` evaluates each. Indirect eval keeps
+`const`/`let` declarations block-scoped, so the only safe way to share
+symbols is the `window.__X = X;` self-registration pattern.
+
+---
+
+## How to add a new shared symbol
+
+`scripts/tools/dx/scaffold_jsx_dep.py` (PR [#160](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/160))
+generates the boilerplate. Override the default tool target with
+`--tool _common`:
+
+```bash
+# Hook
+python3 scripts/tools/dx/scaffold_jsx_dep.py \
+  --tool _common --kind hook --name useFoo
+
+# Component
+python3 scripts/tools/dx/scaffold_jsx_dep.py \
+  --tool _common --kind component --name ErrorBoundary
+
+# Util
+python3 scripts/tools/dx/scaffold_jsx_dep.py \
+  --tool _common --kind util --name parseDuration
+```
+
+The scaffold emits a file with:
+
+- YAML front-matter (`title:` + multi-line `purpose:`)
+- React destructure (`const { useState, useEffect } = React;`)
+- Function/class declaration
+- Tail-line `window.__<Name> = <Name>;` registration
+
+After scaffold:
+
+1. Implement the body
+2. **Add a `purpose:` block that documents closure deps + params + return**
+   (so future readers don't have to read the implementation to know
+   when to use it)
+3. Update this README's tree above
+4. Bump consumers' `dependencies:` arrays + add the `const X = window.__X;`
+   line at the top of each consumer
+
+---
+
+## Naming + ownership rules
+
+- **Hooks** — `useXxx.js`, default-export the hook function, register on
+  `window.__useXxx`. Must be **pure** (no module-scope side effects beyond
+  the registration line).
+- **Components** — `Xxx.jsx`, register on `window.__Xxx`. Must take all
+  state via props (no internal data fetching — that's a hook's job).
+- **Utils** — `xxx.js`, register exported helpers individually
+  (`window.__formatDuration = formatDuration; window.__parseDuration = parseDuration;`).
+  Group only when the pair is always used together.
+- **Don't put tool-specific code here.** If the symbol references a
+  specific API endpoint, fixture, or domain model, it belongs under the
+  owning tool's directory (e.g. `tenant-manager/hooks/useTenantData.js`
+  hits `/api/v1/tenants/search` and stays in `tenant-manager/`).
+
+---
+
+## Lints that protect this directory
+
+| Lint | What it catches |
+|------|-----------------|
+| `check_jsx_loader_compat.py` | Named exports / non-allowlist imports / `require()` calls — anything that breaks indirect eval |
+| `check_jsx_line_count.py` (#152) | Soft cap 1500 / hard cap 2500 LOC per file |
+| `check_undefined_tokens.py` (#85/#86) | `var(--da-*)` references not defined in `design-tokens.css` |
+| `check_jsx_i18n.py` | Untranslated user-facing strings |
+
+All four run via pre-commit (`pre-commit run --all-files`).
+
+---
+
+## History
+
+- **PR-portal-1** (v2.8.0) — directory created; `useDebouncedValue` /
+  `useModalFocusTrap` / `useURLState` / `useVirtualGrid` promoted from
+  `tenant-manager/hooks/`. `simulate-preview.jsx` dropped its inline
+  `useDebouncedValue` clone and switched to the shared one.

--- a/docs/interactive/tools/_common/hooks/useDebouncedValue.js
+++ b/docs/interactive/tools/_common/hooks/useDebouncedValue.js
@@ -1,5 +1,5 @@
 ---
-title: "Tenant Manager — useDebouncedValue hook"
+title: "_common — useDebouncedValue hook"
 purpose: |
   Generic debouncer: takes a rapidly-changing value (e.g. typing in
   a search box) and returns a stable mirror that only updates after

--- a/docs/interactive/tools/_common/hooks/useModalFocusTrap.js
+++ b/docs/interactive/tools/_common/hooks/useModalFocusTrap.js
@@ -1,5 +1,5 @@
 ---
-title: "Tenant Manager — useModalFocusTrap hook"
+title: "_common — useModalFocusTrap hook"
 purpose: |
   Modal focus trap + escape-key + auto-focus management. Hoisted above
   the `if (loading) return` early return in PR #150 (commit 2caddc2)

--- a/docs/interactive/tools/_common/hooks/useURLState.js
+++ b/docs/interactive/tools/_common/hooks/useURLState.js
@@ -1,5 +1,5 @@
 ---
-title: "Tenant Manager — useURLState hook"
+title: "_common — useURLState hook"
 purpose: |
   Bidirectional sync between component state and URLSearchParams —
   enables bookmarkable filter state. Each tracked key maps a URL

--- a/docs/interactive/tools/_common/hooks/useVirtualGrid.js
+++ b/docs/interactive/tools/_common/hooks/useVirtualGrid.js
@@ -1,5 +1,5 @@
 ---
-title: "Tenant Manager — useVirtualGrid"
+title: "_common — useVirtualGrid"
 purpose: |
   Minimal fixed-row-height grid virtualizer. Given a flat `items` array
   laid out as a CSS grid with `columnCount` columns and `rowHeight` px

--- a/docs/interactive/tools/simulate-preview.jsx
+++ b/docs/interactive/tools/simulate-preview.jsx
@@ -5,6 +5,9 @@ audience: [platform-engineer, sre, tenant]
 version: v2.7.0
 lang: en
 related: [tenant-manager, alert-builder, routing-trace, master-onboarding]
+dependencies: [
+  "_common/hooks/useDebouncedValue.js"
+]
 ---
 
 import React, { useState, useEffect, useMemo, useRef } from 'react';
@@ -12,22 +15,15 @@ import React, { useState, useEffect, useMemo, useRef } from 'react';
 /* ── i18n + repo helpers ───────────────────────────────────────────── */
 const t = window.__t || ((zh, en) => en);
 
-/* ── Inline useDebouncedValue (S#94 / C-4 PR-2) ──────────────────────
+/* ── Shared useDebouncedValue (PR-portal-1: promoted to _common/) ────
  *
- * Tenant Manager has its own `useDebouncedValue` hook registered on
- * `window.__useDebouncedValue` via the multi-file pattern (PR-2d).
- * We deliberately don't depend on that here — this tool may load
- * before tenant-manager (or stand alone via direct deep link), and a
- * 8-line hook isn't worth a cross-tool dependency. Same semantics.
+ * Loaded via front-matter `dependencies:` block above; registers as
+ * window.__useDebouncedValue. Pre-PR-portal-1 this file inlined an
+ * 8-line copy because Tenant Manager owned the only hook copy and a
+ * cross-tool dep felt heavyweight. With _common/hooks/ now hosting
+ * the canonical hook, the inline copy is removed.
  * ──────────────────────────────────────────────────────────────────── */
-function useDebouncedValue(value, delayMs) {
-  const [debounced, setDebounced] = useState(value);
-  useEffect(() => {
-    const handle = setTimeout(() => setDebounced(value), delayMs);
-    return () => clearTimeout(handle);
-  }, [value, delayMs]);
-  return debounced;
-}
+const useDebouncedValue = window.__useDebouncedValue;
 
 /* ── URL param helpers (S#94 deep-link pattern reuse) ────────────────
  *

--- a/docs/interactive/tools/tenant-manager.jsx
+++ b/docs/interactive/tools/tenant-manager.jsx
@@ -10,14 +10,14 @@ dependencies: [
   "tenant-manager/styles.js",
   "tenant-manager/utils/yaml-generators.js",
   "tenant-manager/hooks/useTenantData.js",
-  "tenant-manager/hooks/useModalFocusTrap.js",
+  "_common/hooks/useModalFocusTrap.js",
   "tenant-manager/components/GroupSidebar.jsx",
   "tenant-manager/components/ApiNotificationToast.jsx",
   "tenant-manager/components/OverflowBanner.jsx",
   "tenant-manager/components/TenantCard.jsx",
-  "tenant-manager/hooks/useDebouncedValue.js",
-  "tenant-manager/hooks/useURLState.js",
-  "tenant-manager/hooks/useVirtualGrid.js",
+  "_common/hooks/useDebouncedValue.js",
+  "_common/hooks/useURLState.js",
+  "_common/hooks/useVirtualGrid.js",
   "tenant-manager/hooks/useSavedViews.js",
   "tenant-manager/components/SavedViewsPanel.jsx"
 ]

--- a/docs/internal/doc-map.md
+++ b/docs/internal/doc-map.md
@@ -61,6 +61,7 @@ lang: zh
 | `docs/integration/operator-prometheus-integration.md` (.en.md) | Platform Engineers | Operator Prometheus 整合指南 |
 | `docs/integration/operator-shadow-monitoring.md` (.en.md) | Platform Engineers | Operator Shadow Monitoring 策略 |
 | `docs/integration/prometheus-operator-integration.md` (.en.md) | Platform Engineers | Prometheus Operator 整合手冊（Hub） |
+| `docs/interactive/tools/_common/README.md` | All | `_common/` — Shared Hooks, Utils, and Components for Portal Tools |
 | `docs/interactive/tools/alert-builder.jsx` | Platform Engineers, SREs, Tenants | Alert Builder Wizard |
 | `docs/interactive/tools/alert-noise-analyzer.jsx` | platform, Domain Experts (DBA) | Alert Noise Analyzer |
 | `docs/interactive/tools/alert-simulator.jsx` | Domain Experts (DBA), Tenants | Alert Simulator |


### PR DESCRIPTION
## Summary

PR-1 of a 5-PR refactor sweep for **da-portal** before v2.8.0 release.

Promotes 4 generic React hooks out of `tenant-manager/hooks/` into a new `docs/interactive/tools/_common/` directory so any tool can reuse them without copy-pasting:

- `useDebouncedValue.js`  (49 LOC)
- `useModalFocusTrap.js`  (62 LOC)
- `useURLState.js`        (102 LOC)
- `useVirtualGrid.js`     (135 LOC)

## Why

v2.8.0 PR #153 cleaved `tenant-manager.jsx` into a sub-component tree but the hooks lived under `tenant-manager/hooks/` — a path that signaled ownership and discouraged reuse. `simulate-preview.jsx` (S#94 / C-4 PR-2) hit that signal and **inlined an 8-line `useDebouncedValue` clone** with a comment explaining the deliberate non-dependency. That is exactly the duplication a shared library should remove.

## Changes

- `git mv` 4 hook files: `tenant-manager/hooks/*` → `_common/hooks/*`
- `tenant-manager.jsx` front-matter `dependencies:` block: 4 path bumps (tenant-specific hooks `useTenantData` / `useSavedViews` stay)
- `simulate-preview.jsx`: drop inline `useDebouncedValue` clone (-12 lines), add to deps, pick up via `const useDebouncedValue = window.__useDebouncedValue;`
- New: `docs/interactive/tools/_common/README.md` — codifies naming + ownership rules, scaffold command (`scaffold_jsx_dep.py --tool _common`), consumer recipe, lint coverage table
- Each moved hook front-matter `title:` bumped from `Tenant Manager — X` → `_common — X`
- Regen: `docs/internal/doc-map.md`

## Roadmap

| PR | Scope | Status |
|----|-------|--------|
| **PR-1** (this) | Extract `_common/` hooks library | ⬅ here |
| PR-2 | `_common/components/{ErrorBoundary,Loading,EmptyState}` + jsx-loader integration | next |
| PR-3 | Split `portal-shared.jsx` (590 → ~200 LOC) into `_common/data/` + `_common/sim/` | depends on PR-1 |
| PR-4 | Decompose `operator-setup-wizard.jsx` (1252 → < 600 LOC) using PR-2d pattern | depends on PR-1 |
| PR-5 | Tool registry parity lint + version sync (Helm + README v2.7 → v2.8) + CHANGELOG | release gate |

## Test plan

- [x] `pre-commit run` — all 38 hooks green (auto-stage)
- [x] All 14 dep paths in `tenant-manager.jsx` + 1 in `simulate-preview.jsx` resolve on disk
- [x] `simulate-preview.jsx` symbol pickup line (L26) precedes all 3 usages (L110+)
- [x] `make pr-preflight` — READY (38/38 hooks pass, 0 behind main, no scope drift)
- [ ] Playwright `tests/e2e/tenant-manager-deeplink.spec.ts` — covers tenant-manager hooks (focus trap / debounce / URL state / virt) + simulate-preview pre-fill (scenario 5); needs CI to run
- [ ] CI green

## Risk

**Low.** Pure path rename + dep-block path bumps. No behavior change. Window-global registration pattern is unchanged. Worst case: jsx-loader fails to fetch a moved file → console shows a clear "Dependency HTTP 404" error and the affected tool fails to render (Hub + other tools unaffected). PR-2 (next) adds an ErrorBoundary at the loader level so even that worst case becomes a graceful per-tool fallback instead of a white screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
