### PR TITLE
refactor(jsx): promote portal-shared catalog into _common/ modules (PR-3/5)

### DIFF
--- a/docs/interactive/tools/_common/data/routing-profiles.js
+++ b/docs/interactive/tools/_common/data/routing-profiles.js
@@ -1,0 +1,74 @@
+---
+title: "_common — Routing profiles, domain policies, defaults"
+purpose: |
+  In-browser mirror of the four-layer routing model defined in ADR-007:
+  L1 platform defaults → L2 routing profile → L3 tenant override → L4
+  platform-enforced. The actual resolution lives in
+  `_common/sim/alert-engine.js` (`resolveRoutingLayers`); this file
+  owns just the data tables.
+
+  Three exported tables:
+    - ROUTING_DEFAULTS  — L1 baseline that every tenant inherits
+    - ROUTING_PROFILES  — L2 named bundles (team-sre-apac, etc.)
+    - DOMAIN_POLICIES   — domain-level constraints (allow/forbid lists,
+                          max repeat_interval) used by the validator
+
+  Pre-PR-portal-3 these were inline in portal-shared.jsx. Splitting
+  them out lets future tools (notification-previewer, alert-noise-
+  analyzer, etc.) read the catalog without dragging in the validator
+  + simulator surface.
+
+  Public API:
+    window.__ROUTING_DEFAULTS
+    window.__ROUTING_PROFILES
+    window.__DOMAIN_POLICIES
+
+  Closure deps: none. Pure data.
+
+  Backward compatibility: portal-shared.jsx re-exports these on
+  window.__portalShared unchanged.
+---
+
+const ROUTING_DEFAULTS = {
+  receiver_type: 'webhook',
+  group_by: ['alertname', 'tenant'],
+  group_wait: '30s',
+  group_interval: '5m',
+  repeat_interval: '4h',
+};
+
+const ROUTING_PROFILES = {
+  'team-sre-apac': {
+    receiver_type: 'slack', group_wait: '30s', group_interval: '5m', repeat_interval: '4h',
+  },
+  'team-dba-global': {
+    receiver_type: 'webhook', group_wait: '1m', group_interval: '10m', repeat_interval: '8h',
+  },
+  'domain-finance-tier1': {
+    receiver_type: 'pagerduty', group_wait: '30s', group_interval: '5m', repeat_interval: '1h',
+  },
+};
+
+const DOMAIN_POLICIES = {
+  finance: {
+    description: 'Finance domain compliance',
+    tenants: ['db-a', 'db-b'],
+    constraints: {
+      allowed_receiver_types: ['pagerduty', 'email', 'opsgenie'],
+      forbidden_receiver_types: ['slack', 'webhook'],
+      max_repeat_interval: '1h',
+    },
+  },
+  ecommerce: {
+    description: 'E-commerce domain standards',
+    tenants: ['db-c', 'db-d'],
+    constraints: {
+      allowed_receiver_types: ['slack', 'pagerduty', 'email', 'webhook'],
+      max_repeat_interval: '12h',
+    },
+  },
+};
+
+window.__ROUTING_DEFAULTS = ROUTING_DEFAULTS;
+window.__ROUTING_PROFILES = ROUTING_PROFILES;
+window.__DOMAIN_POLICIES = DOMAIN_POLICIES;

--- a/docs/interactive/tools/_common/data/rule-packs.js
+++ b/docs/interactive/tools/_common/data/rule-packs.js
@@ -1,0 +1,79 @@
+---
+title: "_common — Rule Pack catalog accessor"
+purpose: |
+  Single source of truth for the in-browser Rule Pack catalog (DB /
+  middleware / runtime defaults + metric lists + display labels) and
+  the helper that flattens defaults into a [{key, pack, label, ...}]
+  list for autocomplete / validation.
+
+  Layered fallback at module-eval time:
+    1. window.__platformData.rulePacks  — if `make platform-data`
+       generated assets/platform-data.json and jsx-loader pre-fetched
+       it (production deployment path)
+    2. inline catalog below — last-resort offline / standalone bundle
+       (lets a JSX file be opened from disk for quick smoke testing)
+
+  Pre-PR-portal-3 this lived in portal-shared.jsx tied to the alert
+  builder / validator / simulator UI components. Pulling it into
+  _common/data/ lets new tools (capacity-planner, multi-tenant-
+  comparison, etc.) consume it without dragging the React component
+  surface along.
+
+  Public API:
+    window.__RULE_PACK_DATA            map of packId to {label, category, defaults, metrics, ...}
+    window.__CATEGORY_LABELS           map of category to i18n thunk
+    window.__getAllMetricKeys(packs)   flatten defaults to [{key, pack, label, value, unit, desc}]
+
+  Closure deps: none. Pure data + one helper.
+
+  Backward compatibility: portal-shared.jsx re-exports these on
+  window.__portalShared verbatim, so the 4 existing consumers
+  (self-service-portal + 3 Tab files) need no changes.
+---
+
+const t = window.__t || ((zh, en) => en);
+
+const RULE_PACK_DATA = window.__platformData?.rulePacks || {
+  mariadb: { label: 'MariaDB/MySQL', category: 'database', defaults: { mysql_connections: { value: 80, unit: 'count', desc: 'Max connections warning' }, mysql_cpu: { value: 80, unit: '%', desc: 'CPU threads rate warning' } }, metrics: ['connections', 'cpu', 'memory', 'slow_queries', 'replication_lag', 'query_errors'] },
+  postgresql: { label: 'PostgreSQL', category: 'database', defaults: { pg_connections: { value: 80, unit: '%', desc: 'Connection usage warning' }, pg_replication_lag: { value: 30, unit: 'seconds', desc: 'Replication lag warning' } }, metrics: ['connections', 'cache_hit', 'query_time', 'disk_usage', 'replication_lag'] },
+  redis: { label: 'Redis', category: 'database', defaults: { redis_memory_used_bytes: { value: 4294967296, unit: 'bytes', desc: 'Memory usage warning' }, redis_connected_clients: { value: 200, unit: 'count', desc: 'Connected clients warning' } }, metrics: ['memory', 'evictions', 'connected_clients', 'keyspace_hits'] },
+  mongodb: { label: 'MongoDB', category: 'database', defaults: { mongodb_connections_current: { value: 300, unit: 'count', desc: 'Current connections warning' }, mongodb_repl_lag_seconds: { value: 10, unit: 'seconds', desc: 'Replication lag warning' } }, metrics: ['connections', 'memory', 'page_faults', 'replication'] },
+  elasticsearch: { label: 'Elasticsearch', category: 'database', defaults: { es_jvm_memory_used_percent: { value: 85, unit: '%', desc: 'JVM heap usage warning' }, es_filesystem_free_percent: { value: 15, unit: '%', desc: 'Disk free space warning' } }, metrics: ['heap', 'unassigned_shards', 'cluster_health', 'indexing_rate'] },
+  oracle: { label: 'Oracle', category: 'database', defaults: { oracle_sessions_active: { value: 200, unit: 'count', desc: 'Active sessions warning' }, oracle_tablespace_used_percent: { value: 85, unit: '%', desc: 'Tablespace usage warning' } }, metrics: ['sessions', 'tablespace', 'wait_events', 'redo_log'] },
+  db2: { label: 'DB2', category: 'database', defaults: { db2_connections_active: { value: 200, unit: 'count', desc: 'Active connections warning' }, db2_bufferpool_hit_ratio: { value: 0.95, unit: 'ratio', desc: 'Bufferpool hit ratio warning' } }, metrics: ['connections', 'bufferpool', 'tablespace', 'lock_waits'] },
+  clickhouse: { label: 'ClickHouse', category: 'database', defaults: { clickhouse_queries_rate: { value: 500, unit: 'qps', desc: 'Query rate warning' }, clickhouse_active_connections: { value: 200, unit: 'count', desc: 'Active connections warning' } }, metrics: ['queries', 'merges', 'replicated_lag', 'memory'] },
+  kafka: { label: 'Kafka', category: 'messaging', defaults: { kafka_consumer_lag: { value: 1000, unit: 'messages', desc: 'Consumer lag warning' }, kafka_under_replicated_partitions: { value: 0, unit: 'count', desc: 'Under-replicated partitions' }, kafka_broker_count: { value: 3, unit: 'count', desc: 'Min broker count' }, kafka_active_controllers: { value: 1, unit: 'count', desc: 'Min active controllers' }, kafka_request_rate: { value: 10000, unit: 'msg/s', desc: 'Message rate warning' } }, metrics: ['consumer_lag', 'broker_active', 'controller', 'isr_shrink', 'under_replicated'] },
+  rabbitmq: { label: 'RabbitMQ', category: 'messaging', defaults: { rabbitmq_queue_messages: { value: 100000, unit: 'messages', desc: 'Queue depth warning' }, rabbitmq_node_mem_percent: { value: 80, unit: '%', desc: 'Node memory usage warning' }, rabbitmq_connections: { value: 1000, unit: 'count', desc: 'Connection count warning' }, rabbitmq_consumers: { value: 5, unit: 'count', desc: 'Min consumer count' }, rabbitmq_unacked_messages: { value: 10000, unit: 'messages', desc: 'Unacked messages warning' } }, metrics: ['queue_depth', 'consumers', 'memory', 'disk_free', 'connections'] },
+  jvm: { label: 'JVM', category: 'runtime', defaults: { jvm_gc_pause: { value: 0.5, unit: 'seconds/5m', desc: 'GC pause duration warning' }, jvm_memory: { value: 80, unit: '%', desc: 'Heap usage warning' }, jvm_threads: { value: 500, unit: 'count', desc: 'Active thread count warning' } }, metrics: ['gc_pause', 'heap_usage', 'thread_pool', 'class_loading'] },
+  nginx: { label: 'Nginx', category: 'webserver', defaults: { nginx_connections: { value: 1000, unit: 'count', desc: 'Active connections warning' }, nginx_request_rate: { value: 5000, unit: 'req/s', desc: 'Request rate warning' }, nginx_waiting: { value: 200, unit: 'count', desc: 'Waiting connections warning' } }, metrics: ['active_connections', 'request_rate', 'connection_backlog'] },
+  kubernetes: { label: 'Kubernetes', category: 'infrastructure', defaults: { container_cpu: { value: 80, unit: '%', desc: 'Container CPU % of limit' }, container_memory: { value: 85, unit: '%', desc: 'Container memory % of limit' } }, metrics: ['pod_restart', 'cpu_limit', 'memory_limit', 'pvc_usage'] },
+  operational: { label: 'Operational', category: 'infrastructure', required: true, defaults: {}, metrics: ['exporter_health', 'config_reload'] },
+  platform: { label: 'Platform', category: 'infrastructure', required: true, defaults: {}, metrics: ['threshold_metric_count', 'recording_rule_health', 'scrape_success'] },
+};
+
+const CATEGORY_LABELS = {
+  database: () => t('資料庫', 'Databases'),
+  messaging: () => t('訊息佇列', 'Messaging'),
+  runtime: () => t('運行環境', 'Runtime'),
+  webserver: () => t('網頁伺服器', 'Web Servers'),
+  infrastructure: () => t('基礎設施', 'Infrastructure'),
+};
+
+function getAllMetricKeys(selectedPacks) {
+  const keys = [];
+  const packs = selectedPacks && selectedPacks.length > 0
+    ? selectedPacks
+    : Object.keys(RULE_PACK_DATA);
+  for (const packId of packs) {
+    const pack = RULE_PACK_DATA[packId];
+    if (!pack || !pack.defaults) continue;
+    for (const [key, meta] of Object.entries(pack.defaults)) {
+      keys.push({ key, pack: packId, label: pack.label, ...meta });
+    }
+  }
+  return keys;
+}
+
+window.__RULE_PACK_DATA = RULE_PACK_DATA;
+window.__CATEGORY_LABELS = CATEGORY_LABELS;
+window.__getAllMetricKeys = getAllMetricKeys;

--- a/docs/interactive/tools/_common/sim/alert-engine.js
+++ b/docs/interactive/tools/_common/sim/alert-engine.js
@@ -1,0 +1,310 @@
+---
+title: "_common — Alert engine: validation + simulation + routing resolver"
+purpose: |
+  Pure-function alerting engine pulled out of portal-shared.jsx so
+  multi-tool flows (alert simulator UI / self-service portal /
+  notification previewer) can share one canonical implementation.
+
+  Three exported functions, all stateless:
+
+  generateSampleYaml(packs, withProfile)
+    Emit a starter tenant.yaml string from selected Rule Pack
+    defaults. Used to seed the YAML editor on first load.
+
+  validateConfig(config, packs)
+    Lint a parsed tenant config against the validation constants
+    (RECEIVER_TYPES / TIMING_GUARDRAILS / RESERVED_KEYS) + cross-
+    references to Rule Pack metric keys + DOMAIN_POLICIES. Returns
+    {issues: [{level, field, msg}]}.
+
+  simulateAlerts(config, metricValues)
+    Given current metric readings, compute which alerts fire and at
+    what severity. Returns array of {metric, current, threshold,
+    critical_threshold, firing, critical_firing, severity, ...}.
+
+  resolveRoutingLayers(config)
+    Apply the four-layer routing model (ADR-007): L1 platform
+    defaults → L2 routing profile → L3 tenant override → L4 platform-
+    enforced. Returns {layers: [...], resolved: <final>}.
+
+  Closure deps: reads window.__t, window.__RULE_PACK_DATA,
+  window.__getAllMetricKeys, window.__RECEIVER_TYPES,
+  window.__RESERVED_KEYS, window.__RESERVED_PREFIXES,
+  window.__TIMING_GUARDRAILS, window.__ROUTING_DEFAULTS,
+  window.__ROUTING_PROFILES, window.__DOMAIN_POLICIES. Pulled at
+  call time so consumers loaded after the data files see them.
+
+  Backward compatibility: portal-shared.jsx re-exports all 4
+  functions on window.__portalShared unchanged.
+---
+
+function generateSampleYaml(selectedPacks, withProfile) {
+  const t = window.__t || ((zh, en) => en);
+  const RULE_PACK_DATA = window.__RULE_PACK_DATA || {};
+
+  const lines = [`# ${t('從 Rule Pack 自動產生的 Tenant YAML', 'Auto-generated tenant YAML from Rule Packs')}`];
+  for (const packId of selectedPacks) {
+    const pack = RULE_PACK_DATA[packId];
+    if (!pack || !pack.defaults || Object.keys(pack.defaults).length === 0) continue;
+    lines.push(`\n# --- ${pack.label} ---`);
+    for (const [key, meta] of Object.entries(pack.defaults)) {
+      lines.push(`${key}: "${meta.value}"  # ${meta.desc}`);
+    }
+  }
+  lines.push('');
+  if (withProfile) {
+    lines.push('_routing_profile: team-sre-apac');
+  } else {
+    lines.push(`_routing:`);
+    lines.push(`  receiver_type: webhook`);
+    lines.push(`  webhook_url: https://hooks.example.com/alerts`);
+    lines.push(`  group_by: [alertname, severity]`);
+    lines.push(`  group_wait: "30s"`);
+    lines.push(`  repeat_interval: "4h"`);
+  }
+  lines.push('');
+  lines.push(`_metadata:`);
+  lines.push(`  runbook_url: https://runbooks.example.com/my-tenant`);
+  lines.push(`  owner: platform-team`);
+  lines.push(`  tier: production`);
+  return lines.join('\n');
+}
+
+function validateConfig(config, selectedPacks) {
+  const t = window.__t || ((zh, en) => en);
+  const getAllMetricKeys = window.__getAllMetricKeys;
+  const RECEIVER_TYPES = window.__RECEIVER_TYPES || [];
+  const RESERVED_KEYS = window.__RESERVED_KEYS || new Set();
+  const RESERVED_PREFIXES = window.__RESERVED_PREFIXES || [];
+  const TIMING_GUARDRAILS = window.__TIMING_GUARDRAILS || {};
+  const ROUTING_PROFILES = window.__ROUTING_PROFILES || {};
+  const DOMAIN_POLICIES = window.__DOMAIN_POLICIES || {};
+  const parseDuration = window.__parseDuration;
+
+  const issues = [];
+  const info = [];
+  const knownMetrics = new Set((getAllMetricKeys ? getAllMetricKeys(selectedPacks) : []).map(m => m.key));
+
+  for (const [key, val] of Object.entries(config)) {
+    if (key.startsWith('_')) continue;
+    if (val === 'disable') {
+      info.push({ level: 'info', field: key,
+        msg: t('已禁用此指標', 'Metric disabled') });
+      continue;
+    }
+    const numVal = parseFloat(val);
+    if (!isNaN(numVal)) {
+      const LARGE_VALUE_PATTERNS = ['bytes', 'connections', 'lag', 'rate', 'messages',
+        'threads', 'count', 'queue', 'consumers', 'controllers', 'broker', 'sessions',
+        'partitions', 'queries', 'waiting'];
+      const isLargeValueMetric = LARGE_VALUE_PATTERNS.some(p => key.includes(p));
+      if (numVal > 100 && !isLargeValueMetric) {
+        issues.push({ level: 'warning', field: key,
+          msg: t(`閾值 ${numVal} 超過 100，確認是否正確`, `Threshold ${numVal} exceeds 100, verify if correct`) });
+      }
+      if (numVal < 0) {
+        issues.push({ level: 'error', field: key,
+          msg: t(`閾值 ${numVal} < 0，無效`, `Threshold ${numVal} < 0, invalid`) });
+      }
+    }
+    if (selectedPacks && selectedPacks.length > 0 && knownMetrics.size > 0) {
+      const isCriticalVariant = key.endsWith('_critical');
+      const baseKey = isCriticalVariant ? key.replace(/_critical$/, '') : key;
+      if (!knownMetrics.has(baseKey) && !knownMetrics.has(key)) {
+        issues.push({ level: 'info', field: key,
+          msg: t(`此 metric key 不在已選 Rule Pack 的預設清單中`, `Metric key not found in selected Rule Pack defaults`) });
+      }
+    }
+  }
+
+  const routing = config._routing;
+  if (routing && typeof routing === 'object') {
+    const rtype = routing.receiver_type;
+    if (rtype && !RECEIVER_TYPES.includes(rtype)) {
+      issues.push({ level: 'error', field: '_routing.receiver_type',
+        msg: t(`不支援的 receiver 類型: ${rtype}`, `Unsupported receiver type: ${rtype}`) });
+    }
+    const webhookUrl = routing.webhook_url;
+    if (rtype === 'webhook' && webhookUrl) {
+      try {
+        const parsed = new URL(webhookUrl);
+        if (!['http:', 'https:'].includes(parsed.protocol)) {
+          issues.push({ level: 'error', field: '_routing.webhook_url',
+            msg: t('僅允許 http/https URL', 'Only http/https URLs allowed') });
+        } else if (parsed.protocol !== 'https:') {
+          issues.push({ level: 'error', field: '_routing.webhook_url',
+            msg: t('生產環境必須使用 HTTPS — HTTP 會導致告警通知明文傳輸', 'Production requires HTTPS — HTTP transmits alert notifications in plaintext') });
+        }
+      } catch (e) {
+        issues.push({ level: 'error', field: '_routing.webhook_url',
+          msg: t('無效的 URL 格式', 'Invalid URL format') });
+      }
+    }
+    for (const [param, guard] of Object.entries(TIMING_GUARDRAILS)) {
+      const val = routing[param];
+      if (val) {
+        const secs = parseDuration ? parseDuration(val) : null;
+        if (secs !== null) {
+          if (secs < guard.min) {
+            issues.push({ level: 'warning', field: `_routing.${param}`,
+              msg: t(`${val} 低於下限 ${guard.min}s`, `${val} below minimum ${guard.min}s`) });
+          }
+          if (secs > guard.max) {
+            issues.push({ level: 'warning', field: `_routing.${param}`,
+              msg: t(`${val} 超過上限 ${guard.max}s`, `${val} exceeds maximum ${guard.max}s`) });
+          }
+        }
+      }
+    }
+  }
+
+  const profileRef = config._routing_profile;
+  if (profileRef) {
+    if (!ROUTING_PROFILES[profileRef]) {
+      issues.push({ level: 'error', field: '_routing_profile',
+        msg: t(`路由 profile "${profileRef}" 不存在`, `Routing profile "${profileRef}" not found`) });
+    } else {
+      info.push({ level: 'info', field: '_routing_profile',
+        msg: t(`使用路由 profile: ${profileRef}`, `Using routing profile: ${profileRef}`) });
+    }
+  }
+
+  const resolvedReceiverType = routing
+    ? (routing.receiver_type || (profileRef && ROUTING_PROFILES[profileRef]?.receiver_type))
+    : (profileRef && ROUTING_PROFILES[profileRef]?.receiver_type);
+  if (resolvedReceiverType) {
+    for (const [domain, policy] of Object.entries(DOMAIN_POLICIES)) {
+      const constraints = policy.constraints || {};
+      if (constraints.forbidden_receiver_types?.includes(resolvedReceiverType)) {
+        issues.push({ level: 'warning', field: '_domain_policy',
+          msg: t(`domain "${domain}" 禁止使用 ${resolvedReceiverType}`,
+                 `Domain "${domain}" forbids receiver type: ${resolvedReceiverType}`) });
+      }
+      if (constraints.allowed_receiver_types &&
+          !constraints.allowed_receiver_types.includes(resolvedReceiverType)) {
+        issues.push({ level: 'warning', field: '_domain_policy',
+          msg: t(`domain "${domain}" 不允許 ${resolvedReceiverType}`,
+                 `Domain "${domain}" does not allow receiver type: ${resolvedReceiverType}`) });
+      }
+    }
+  }
+
+  if (config._metadata && typeof config._metadata === 'object') {
+    if (!config._metadata.runbook_url) {
+      issues.push({ level: 'info', field: '_metadata.runbook_url',
+        msg: t('建議配置 runbook URL', 'Consider adding runbook URL') });
+    }
+  }
+
+  for (const key of Object.keys(config)) {
+    if (key.startsWith('_')) {
+      if (!RESERVED_KEYS.has(key) && !RESERVED_PREFIXES.some(p => key.startsWith(p))) {
+        issues.push({ level: 'warning', field: key,
+          msg: t(`未知的保留字 key: ${key}`, `Unknown reserved key: ${key}`) });
+      }
+    }
+  }
+
+  return { issues: [...issues, ...info] };
+}
+
+function simulateAlerts(config, metricValues) {
+  const alerts = [];
+
+  for (const [metric, val] of Object.entries(metricValues)) {
+    const threshold = config[metric];
+    if (!threshold || threshold === 'disable') {
+      alerts.push({
+        metric, current: val.current, threshold: null, critical_threshold: null,
+        firing: false, critical_firing: false, severity: threshold === 'disable' ? 'disabled' : 'no-threshold',
+        unit: val.unit, packLabel: val.packLabel,
+      });
+      continue;
+    }
+
+    const thresholdNum = parseFloat(threshold);
+    if (isNaN(thresholdNum)) continue;
+
+    const currentVal = val.current;
+    const firing = currentVal >= thresholdNum;
+
+    const critKey = `${metric}_critical`;
+    const critThreshold = config[critKey] ? parseFloat(config[critKey]) : null;
+    const critFiring = critThreshold !== null && currentVal >= critThreshold;
+
+    alerts.push({
+      metric, current: currentVal, threshold: thresholdNum,
+      critical_threshold: critThreshold, firing, critical_firing: critFiring,
+      severity: critFiring ? 'critical' : (firing ? 'warning' : 'ok'),
+      unit: val.unit, packLabel: val.packLabel,
+    });
+  }
+
+  return alerts;
+}
+
+function resolveRoutingLayers(config) {
+  const t = window.__t || ((zh, en) => en);
+  const ROUTING_DEFAULTS = window.__ROUTING_DEFAULTS || {};
+  const ROUTING_PROFILES = window.__ROUTING_PROFILES || {};
+
+  const layers = [];
+
+  const L1 = { ...ROUTING_DEFAULTS };
+  layers.push({
+    layer: 1, name: '_routing_defaults',
+    label: t('平台預設', 'Platform Defaults'),
+    values: { ...L1 }, overrides: {}, source: 'platform',
+  });
+
+  const profileRef = config._routing_profile;
+  const profile = profileRef ? ROUTING_PROFILES[profileRef] : null;
+  const L2 = { ...L1 };
+  const L2overrides = {};
+  if (profile) {
+    for (const [k, v] of Object.entries(profile)) {
+      if (v !== undefined && v !== L2[k]) {
+        L2overrides[k] = { from: L2[k], to: v };
+        L2[k] = v;
+      }
+    }
+  }
+  layers.push({
+    layer: 2,
+    name: profileRef ? `routing_profiles[${profileRef}]` : t('（未指定 profile）', '(no profile)'),
+    label: t('路由 Profile', 'Routing Profile'),
+    values: { ...L2 }, overrides: L2overrides,
+    source: profileRef ? 'profile' : 'skip',
+  });
+
+  const routing = config._routing;
+  const L3 = { ...L2 };
+  const L3overrides = {};
+  if (routing && typeof routing === 'object') {
+    for (const [k, v] of Object.entries(routing)) {
+      if (v !== undefined && k !== 'overrides' && v !== L3[k]) {
+        L3overrides[k] = { from: L3[k], to: v };
+        L3[k] = v;
+      }
+    }
+  }
+  layers.push({
+    layer: 3, name: '_routing',
+    label: t('租戶覆蓋', 'Tenant Override'),
+    values: { ...L3 }, overrides: L3overrides,
+    source: routing ? 'tenant' : 'skip',
+  });
+
+  layers.push({
+    layer: 4, name: '_routing_enforced',
+    label: t('平台強制 (NOC)', 'Platform Enforced (NOC)'),
+    values: { ...L3 }, overrides: {}, source: 'enforced',
+  });
+
+  return { layers, resolved: L3 };
+}
+
+window.__generateSampleYaml = generateSampleYaml;
+window.__validateConfig = validateConfig;
+window.__simulateAlerts = simulateAlerts;
+window.__resolveRoutingLayers = resolveRoutingLayers;

--- a/docs/interactive/tools/_common/validation/constants.js
+++ b/docs/interactive/tools/_common/validation/constants.js
@@ -1,0 +1,59 @@
+---
+title: "_common — Validation constants"
+purpose: |
+  Shared validation constants for tenant config + routing rules:
+  reserved keys, key prefixes, supported receiver types + per-receiver
+  required fields, timing guardrails (group_wait / repeat_interval
+  bounds), and the YAML parser's safety limits (UNSAFE_KEYS,
+  MAX_YAML_SIZE).
+
+  Pre-PR-portal-3 lived inline in portal-shared.jsx. Splitting lets
+  the validator (alert-engine.js) and the YAML parser (yaml-parser.js)
+  share the constants without circular-loading the rest of the
+  validator surface.
+
+  Public API:
+    window.__RESERVED_KEYS         Set of reserved tenant keys (_silent_mode, _metadata, ...)
+    window.__RESERVED_PREFIXES     Array of reserved key prefixes (_state_, _routing)
+    window.__RECEIVER_TYPES        Array of supported notification receiver types
+    window.__RECEIVER_REQUIRED     map of receiver_type to required field names
+    window.__TIMING_GUARDRAILS     map of timing param to bounds {min, max, unit}
+    window.__UNSAFE_KEYS           Set of prototype-pollution keys parser must reject
+    window.__MAX_YAML_SIZE         Hard cap (100KB) on parser input length
+
+  Closure deps: none. Pure data.
+
+  Backward compatibility: portal-shared.jsx re-exports all of these on
+  window.__portalShared unchanged.
+---
+
+const RESERVED_KEYS = new Set([
+  '_silent_mode', '_namespaces', '_metadata', '_profile',
+  '_routing_defaults', '_routing_profile', '_domain_policy', '_instance_mapping'
+]);
+
+const RESERVED_PREFIXES = ['_state_', '_routing'];
+
+const RECEIVER_TYPES = ['webhook', 'email', 'slack', 'teams', 'rocketchat', 'pagerduty'];
+
+const RECEIVER_REQUIRED = {
+  webhook: ['url'], email: ['to', 'smarthost'], slack: ['api_url'],
+  teams: ['webhook_url'], rocketchat: ['url'], pagerduty: ['service_key'],
+};
+
+const TIMING_GUARDRAILS = {
+  group_wait: { min: 5, max: 300, unit: 's' },
+  group_interval: { min: 5, max: 300, unit: 's' },
+  repeat_interval: { min: 60, max: 259200, unit: 's' },
+};
+
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const MAX_YAML_SIZE = 100000;
+
+window.__RESERVED_KEYS = RESERVED_KEYS;
+window.__RESERVED_PREFIXES = RESERVED_PREFIXES;
+window.__RECEIVER_TYPES = RECEIVER_TYPES;
+window.__RECEIVER_REQUIRED = RECEIVER_REQUIRED;
+window.__TIMING_GUARDRAILS = TIMING_GUARDRAILS;
+window.__UNSAFE_KEYS = UNSAFE_KEYS;
+window.__MAX_YAML_SIZE = MAX_YAML_SIZE;

--- a/docs/interactive/tools/_common/validation/yaml-parser.js
+++ b/docs/interactive/tools/_common/validation/yaml-parser.js
@@ -1,0 +1,119 @@
+---
+title: "_common — YAML parser + duration helper"
+purpose: |
+  Lightweight YAML subset parser tailored for the tenant config shape
+  (top-level scalars + one or two levels of nested objects under
+  _routing / _metadata). Plus a parseDuration helper that turns
+  "30s" / "5m" / "2h" / "1d" into seconds.
+
+  Why a custom parser instead of js-yaml: portal is zero-build /
+  Babel-standalone-in-browser; pulling js-yaml would either inflate
+  the vendor bundle (~70KB) or require an additional CDN dep that
+  air-gapped deployments cannot fetch. The tenant subset we accept
+  is small enough to roll by hand; everything more complex (anchors,
+  multi-doc, complex flows) belongs server-side.
+
+  Public API:
+    window.__parseDuration(str)   parse '30s' / '5m' / '2h' / '1d' to seconds (or null)
+    window.__parseYaml(text)      parse tenant YAML to {config, errors}
+
+  Behaviour notes:
+    parseYaml hard-rejects > MAX_YAML_SIZE chars and returns errors
+    array. UNSAFE_KEYS (__proto__, constructor, prototype) are
+    silently dropped to mitigate prototype pollution. Inline values
+    in [a, b, c] form parse to a JS array of trimmed strings.
+    Indented children of _routing / _metadata flatten one extra
+    level — enough for `_routing.webhook_url` etc.
+
+  Closure deps:
+    Reads window.__t (i18n thunk), window.__UNSAFE_KEYS,
+    window.__MAX_YAML_SIZE. Pulled at call time so test harnesses
+    that swap globals between renders see updated values.
+
+  Backward compatibility: portal-shared.jsx re-exports parseDuration
+  + parseYaml on window.__portalShared unchanged.
+---
+
+function parseDuration(str) {
+  if (!str) return null;
+  const m = String(str).match(/^(\d+\.?\d*)([smhd])$/);
+  if (!m) return null;
+  const multi = { s: 1, m: 60, h: 3600, d: 86400 };
+  return parseFloat(m[1]) * (multi[m[2]] || 1);
+}
+
+function parseYaml(text) {
+  const t = window.__t || ((zh, en) => en);
+  const UNSAFE_KEYS = window.__UNSAFE_KEYS || new Set(['__proto__', 'constructor', 'prototype']);
+  const MAX_YAML_SIZE = window.__MAX_YAML_SIZE || 100000;
+
+  const errors = [];
+  if (text.length > MAX_YAML_SIZE) {
+    return { config: {}, errors: [t('YAML 超過大小限制（100KB）', 'YAML exceeds size limit (100KB)')] };
+  }
+  const config = {};
+  let currentKey = null;
+  let currentObj = null;
+
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.replace(/\s+#(?![^"']*["'][^"']*$).*$/, '').trimEnd();
+    if (!trimmed || trimmed.trim() === '') continue;
+
+    const lineIndent = line.search(/\S/);
+    const content = trimmed.trim();
+
+    const kvMatch = content.match(/^([^:]+?):\s+(.+)$/);
+    const objMatch = content.match(/^([^:]+?):\s*$/);
+
+    if (lineIndent === 0 && kvMatch) {
+      const key = kvMatch[1].trim();
+      if (UNSAFE_KEYS.has(key)) continue;
+      let val = kvMatch[2].trim();
+      if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+      if (val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+      if (val.startsWith('[') && val.endsWith(']')) {
+        val = val.slice(1, -1).split(',').map(s => s.trim().replace(/"/g, '').replace(/'/g, ''));
+      }
+      config[key] = val;
+      currentKey = null;
+      currentObj = null;
+    } else if (lineIndent === 0 && objMatch) {
+      const key = objMatch[1].trim();
+      if (UNSAFE_KEYS.has(key)) continue;
+      config[key] = {};
+      currentKey = key;
+      currentObj = config[key];
+    } else if (currentKey && lineIndent > 0 && kvMatch) {
+      const key = kvMatch[1].trim();
+      let val = kvMatch[2].trim();
+      if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+      if (val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+      if (val.startsWith('[') && val.endsWith(']')) {
+        val = val.slice(1, -1).split(',').map(s => s.trim().replace(/"/g, '').replace(/'/g, ''));
+      }
+
+      if (currentKey === '_routing' || currentKey === '_metadata') {
+        const depth = Math.floor(lineIndent / 2) - 1;
+        if (depth === 0) {
+          currentObj[key] = val;
+        } else if (depth === 1 && typeof currentObj[Object.keys(currentObj).pop()] === 'object') {
+          const parentKey = Object.keys(currentObj).pop();
+          if (typeof currentObj[parentKey] === 'object') {
+            currentObj[parentKey][key] = val;
+          }
+        }
+      }
+    } else if (currentKey && lineIndent > 0 && objMatch) {
+      const key = objMatch[1].trim();
+      if (currentObj) {
+        currentObj[key] = {};
+      }
+    }
+  }
+  return { config, errors };
+}
+
+window.__parseDuration = parseDuration;
+window.__parseYaml = parseYaml;


### PR DESCRIPTION
## Summary

PR-3 of a 5-PR refactor sweep for **da-portal** before v2.8.0 release. Stacks alongside [#203](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/203) (merged) + [#204](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/204) (in flight).

Adds **5 new modules** under `docs/interactive/tools/_common/` that own the catalog data + helpers currently inline in `portal-shared.jsx` (590 LOC). Each module self-registers on `window.__X` so future tools can pull individual symbols without dragging the whole portal-shared React component surface along.

## Why this is additive only

The original PR-3 plan was to convert `portal-shared.jsx` into a thin BC re-export shim (590 → 191 LOC). The `sed-damage-guard` pre-commit lint blocks > 50% in-place file shrinkage as suspected sed-i damage — there is no per-file allowlist or override marker. So PR-3 is split:

- **This PR (PR-3)** — purely additive: 5 new `_common/` modules, `portal-shared.jsx` untouched. Existing 4 consumers (self-service-portal + 3 Tab files) keep using `window.__portalShared` and need zero changes.
- **Follow-up** — flip `portal-shared.jsx` into the shim once these modules have proven stable in CI/e2e (and probably with explicit lint bypass annotation).

## Changes

| File | LOC | Purpose |
|------|-----|---------|
| `_common/data/rule-packs.js` | 80 | `RULE_PACK_DATA` + `CATEGORY_LABELS` + `getAllMetricKeys`; `window.__platformData.rulePacks` fallback preserved |
| `_common/data/routing-profiles.js` | 75 | `ROUTING_DEFAULTS` + `ROUTING_PROFILES` + `DOMAIN_POLICIES` (ADR-007 four-layer routing data) |
| `_common/validation/constants.js` | 60 | `RESERVED_KEYS` / `RESERVED_PREFIXES` / `RECEIVER_TYPES` / `RECEIVER_REQUIRED` / `TIMING_GUARDRAILS` / `UNSAFE_KEYS` / `MAX_YAML_SIZE` |
| `_common/validation/yaml-parser.js` | 120 | `parseDuration` + `parseYaml`; reads constants off `window` per-call |
| `_common/sim/alert-engine.js` | 310 | `generateSampleYaml` + `validateConfig` + `simulateAlerts` + `resolveRoutingLayers` (pure functions; data + constants pulled per-call) |

Each module's front-matter follows the **PR-2 fixup conventions** (no `---` separators inside `purpose:`, plain `Name:` headers) so the YAML closing `---` regex doesn't eat documentation prose.

Function bodies are byte-for-byte ports from `portal-shared.jsx` (verified with `diff` against the original).

## Test plan

- [x] All 38 pre-commit hooks green on the 5 new files
- [x] `python3 scripts/tools/lint/lint_jsx_babel.py --ci --strict-linecount` exit 0 (the 357 advisory warnings are pre-existing on main, untouched)
- [x] `make pr-preflight` — READY (38/38 hooks pass, 0 behind main, no scope drift)
- [x] `portal-shared.jsx` unchanged — `git diff origin/main -- portal-shared.jsx` is empty
- [ ] CI green (Lint, Smoke Tests, etc.)

## Roadmap

| PR | Scope | Status |
|----|-------|--------|
| [#203](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/203) | Extract `_common/hooks/` library | ✅ merged |
| [#204](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/204) | `_common/components/` + jsx-loader ErrorBoundary | 🟡 in flight |
| **PR-3** (this) | `_common/data/` + `_common/validation/` + `_common/sim/` modules | ⬅ here |
| PR-4 | Decompose `operator-setup-wizard.jsx` (1252 → < 600 LOC) using PR-2d pattern | next |
| PR-5 | Tool registry parity lint + version sync (Helm + README v2.7 → v2.8) + CHANGELOG | release gate |

## Risk

**Low.** Pure addition. The 5 new modules can be loaded in isolation or alongside `portal-shared.jsx` (idempotent — last write wins on `window.__X` keys, but values are identical, so order doesn't matter). No consumer changes mean no behavioural risk to the live tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
