### PR TITLE
refactor(jsx): lint friction unblockers (PR-6/11)

### DIFF
--- a/.sed-damage-allowlist
+++ b/.sed-damage-allowlist
@@ -1,0 +1,17 @@
+# sed-damage-guard exemption list (PR-portal-6)
+#
+# Files listed here are exempted from the >50% shrink check in
+# scripts/tools/lint/detect_sed_damage.py. Use sparingly — only for
+# legitimate refactors that inline-shrink an authoritative module
+# (e.g. converting it into a thin BC re-export shim).
+#
+# Format: one path per line, # for comments. Trailing inline comments
+# supported. Paths are matched verbatim (no glob).
+#
+# NOTE: this list ONLY suppresses the truncation check, not the
+# NUL-byte check (NUL bytes are always damage).
+#
+# Examples (commented out — real entries below):
+#   docs/interactive/tools/portal-shared.jsx  # PR-portal-7 shim conversion
+
+# (no active entries)

--- a/Makefile
+++ b/Makefile
@@ -630,6 +630,29 @@ lint-portal: ## da-portal 整套 lint：jsx-loader-compat / undefined-tokens / p
 	@echo "==> tool-registry.yaml ↔ jsx parity"
 	@python3 scripts/tools/lint/check_tool_registry_jsx_parity.py
 
+.PHONY: lint-new-script
+lint-new-script: ## Run all CLI/SAST conventions on a single new lint script (PR-portal-6) — usage: make lint-new-script SCRIPT=scripts/tools/lint/check_foo.py
+	@# All-in-one local pre-flight for newly-added lint scripts. Mirrors
+	@# the CI-only gates that bit PR-portal-5 four times in a row
+	@# (stderr routing / argparse / SAST / strict-linecount). Run this
+	@# BEFORE the first git push to catch convention violations locally
+	@# instead of in CI.
+	@if [ -z "$(SCRIPT)" ]; then \
+		echo "ERROR: SCRIPT variable required."; \
+		echo "Usage: make lint-new-script SCRIPT=scripts/tools/lint/check_foo.py"; \
+		exit 2; \
+	fi
+	@echo "==> Linting new script: $(SCRIPT)"
+	@echo "==> [1/3] argparse + exit-code conventions"
+	@python3 -m pytest tests/shared/test_tool_exit_codes.py -k "$$(basename $(SCRIPT))" -v --no-header
+	@echo "==> [2/3] SAST conventions (encoding / shell=True / yaml-safe-load / stderr-routing / etc.)"
+	@python3 -m pytest tests/shared/test_sast.py -k "$$(basename $(SCRIPT))" -v --no-header
+	@echo "==> [3/3] tool-map registration check"
+	@python3 scripts/tools/dx/generate_tool_map.py --check || \
+		(echo "Hint: run 'python3 scripts/tools/dx/generate_tool_map.py --generate --lang all' to regenerate" && exit 1)
+	@echo ""
+	@echo "✓ All convention gates pass for $(SCRIPT)"
+
 version-show: ## 顯示目前三條版號線
 	@python3 ./scripts/tools/dx/bump_docs.py --show-current
 

--- a/docs/assets/jsx-loader.html
+++ b/docs/assets/jsx-loader.html
@@ -710,7 +710,9 @@ window.addEventListener('pageshow', function(e) {
    * Returns array of resolved URLs relative to basePath.
    */
   function parseDependencies(source, basePath) {
-    var fmMatch = source.match(/^---\n([\s\S]*?)\n---/);
+    // Closing `---` anchored to its own line — defense-in-depth match
+    //  for the loadDependency / renderJSX strip regexes (PR-portal-6).
+    var fmMatch = source.match(/^---\r?\n([\s\S]*?)\r?\n---\s*(?:\r?\n|$)/);
     if (!fmMatch) return [];
     var depMatch = fmMatch[1].match(/dependencies:\s*\[([^\]]*)\]/);
     if (!depMatch) return [];
@@ -735,8 +737,12 @@ window.addEventListener('pageshow', function(e) {
       if (!r.ok) throw new Error('Dependency HTTP ' + r.status + ': ' + url);
       return r.text();
     }).then(function(code) {
-      // Strip YAML front matter
-      code = code.replace(/^---[\s\S]*?---\s*\n?/, '');
+      // Strip YAML front matter (PR-portal-6: closing `---` must be
+      // its own line — old regex `^---[\s\S]*?---\s*\n?` matched any
+      // `---` substring including the first 3 chars of `------`
+      // separator lines inside `purpose:` blocks → silent parse error
+      // when remaining FM bled into JS code).
+      code = code.replace(/^---\r?\n[\s\S]*?\r?\n---\s*(?:\r?\n|$)/, '');
       // Transform ES imports
       code = transformImports(code);
       // Remove export default (deps register on window globals)
@@ -780,7 +786,9 @@ window.addEventListener('pageshow', function(e) {
 
     // 0) Extract front matter for related tools before stripping
     var frontMatter = '';
-    var fmMatch = source.match(/^---\n([\s\S]*?)\n---/);
+    // Closing `---` anchored to its own line — defense-in-depth match
+    //  for the loadDependency / renderJSX strip regexes (PR-portal-6).
+    var fmMatch = source.match(/^---\r?\n([\s\S]*?)\r?\n---\s*(?:\r?\n|$)/);
     if (fmMatch) frontMatter = fmMatch[1];
     var relatedTools = [];
     var relMatch = frontMatter.match(/related:\s*\[([^\]]*)\]/);
@@ -791,8 +799,9 @@ window.addEventListener('pageshow', function(e) {
       });
     }
 
-    // 1) Strip YAML front matter (--- ... ---)
-    source = source.replace(/^---[\s\S]*?---\s*\n?/, '');
+    // 1) Strip YAML front matter (--- ... ---) — closing `---` must
+    //    be its own line; see loadDependency note above (PR-portal-6).
+    source = source.replace(/^---\r?\n[\s\S]*?\r?\n---\s*(?:\r?\n|$)/, '');
 
     // 2) Replace ES imports with global references (using shared transform)
     source = transformImports(source);

--- a/scripts/tools/lint/detect_sed_damage.py
+++ b/scripts/tools/lint/detect_sed_damage.py
@@ -8,11 +8,33 @@ Pre-commit hook that checks if staged files show signs of sed -i damage:
 This is a DETECTION layer — the prevention layer is vibe-sed-guard.sh.
 The REPAIR layer is fix_file_hygiene.py.
 
+Allowlist for legitimate large refactors (PR-portal-6)
+------------------------------------------------------
+The truncation heuristic (>50% shrink) blocks legitimate refactors that
+inline-shrink a file (e.g. converting an authoritative module into a
+thin BC re-export shim). To allow such a refactor without disabling the
+guard repo-wide, list the file path in `.sed-damage-allowlist` at the
+repo root, one path per line, # for comments.
+
+Allowlist semantics:
+  - ONLY suppresses the truncation check, NOT the NUL-byte check
+    (NUL bytes are always damage, never legitimate)
+  - Path is matched verbatim against the staged path; no glob support
+  - Empty / missing allowlist file → no exemption (default behaviour)
+
 Usage:
     python3 detect_sed_damage.py [files...]
 """
+from __future__ import annotations
+
+import argparse
 import subprocess
 import sys
+from pathlib import Path
+
+# Repo root: this file is at <repo>/scripts/tools/lint/detect_sed_damage.py
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_ALLOWLIST_FILE = _REPO_ROOT / ".sed-damage-allowlist"
 
 
 def get_head_content(path: str) -> bytes | None:
@@ -30,8 +52,38 @@ def get_head_content(path: str) -> bytes | None:
     return None
 
 
-def check_file(path: str) -> list[str]:
+def load_allowlist(path: Path = _ALLOWLIST_FILE) -> set[str]:
+    """Load the truncation-check allowlist from `.sed-damage-allowlist`.
+
+    Returns an empty set if the file is missing — the default behaviour
+    is no exemption.
+
+    Format: one path per line, `#` starts a comment, blank lines ignored.
+    Trailing inline comments (after `#`) are supported.
+    """
+    if not path.exists():
+        return set()
+    allowed: set[str] = set()
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            # Strip inline trailing comment.
+            if "#" in stripped:
+                stripped = stripped.split("#", 1)[0].strip()
+            if stripped:
+                # Normalize separators so allowlist works on both
+                # POSIX and Windows-style staged paths.
+                allowed.add(stripped.replace("\\", "/"))
+    return allowed
+
+
+def check_file(path: str, allowlist: set[str] | None = None) -> list[str]:
     """Check a single file for sed -i damage. Returns list of issues."""
+    if allowlist is None:
+        allowlist = load_allowlist()
+
     issues = []
 
     try:
@@ -41,29 +93,32 @@ def check_file(path: str) -> list[str]:
 
     head_content = get_head_content(path)
 
-    # Check 1: NUL bytes appeared (didn't exist in HEAD)
+    # Check 1: NUL bytes appeared (didn't exist in HEAD).
+    # NEVER suppressed by allowlist — NUL bytes are always damage.
     if b"\x00" in current:
         if head_content is None or b"\x00" not in head_content:
             issues.append(
                 f"NUL bytes detected (not present in HEAD) — likely sed -i damage"
             )
 
-    # Check 2: Significant truncation (file shrank >50%)
+    # Check 2: Significant truncation (file shrank >50%).
+    # Suppressed for paths listed in `.sed-damage-allowlist`.
     if head_content is not None and len(head_content) > 100:
-        ratio = len(current) / len(head_content)
-        if ratio < 0.5:
-            issues.append(
-                f"File truncated to {ratio:.0%} of HEAD size "
-                f"({len(head_content)}→{len(current)} bytes) — "
-                f"possible sed -i on file without EOF newline"
-            )
+        normalized = path.replace("\\", "/")
+        if normalized not in allowlist:
+            ratio = len(current) / len(head_content)
+            if ratio < 0.5:
+                issues.append(
+                    f"File truncated to {ratio:.0%} of HEAD size "
+                    f"({len(head_content)}→{len(current)} bytes) — "
+                    f"possible sed -i on file without EOF newline. "
+                    f"If intentional refactor, add path to .sed-damage-allowlist."
+                )
 
     return issues
 
 
 def main() -> int:
-    import argparse
-
     parser = argparse.ArgumentParser(
         description="Detect sed -i damage on staged files",
     )
@@ -74,9 +129,11 @@ def main() -> int:
     if not files:
         return 0
 
+    allowlist = load_allowlist()
+
     all_issues: dict[str, list[str]] = {}
     for f in files:
-        issues = check_file(f)
+        issues = check_file(f, allowlist=allowlist)
         if issues:
             all_issues[f] = issues
 
@@ -93,6 +150,7 @@ def main() -> int:
     print("修復方式：")
     print("  git checkout HEAD -- <file>    # 還原後用 Read+Edit 重做修改")
     print("  或: fix_file_hygiene.py <file>  # 移除 NUL bytes + 補 EOF newline")
+    print("  或（重構縮減合法）: 把路徑加入 .sed-damage-allowlist")
     print("")
     return 1
 

--- a/scripts/tools/lint/lint_jsx_babel.py
+++ b/scripts/tools/lint/lint_jsx_babel.py
@@ -242,8 +242,13 @@ def _run_line_count_check(filepath: str, source: str) -> list[dict]:
 def _transform_jsx(source: str) -> str:
     """Replicate jsx-loader.html renderJSX() transform pipeline."""
 
-    # 1) Strip YAML front matter
-    source = re.sub(r"^---[\s\S]*?---\s*\n?", "", source)
+    # 1) Strip YAML front matter — closing `---` must be on its own
+    #    line (PR-portal-6). Old `^---[\s\S]*?---\s*\n?` matched any
+    #    `---` substring including the first 3 chars of `------`
+    #    separator lines inside `purpose:` blocks → silent parse error
+    #    when remaining FM bled into JS code. Mirrors jsx-loader.html
+    #    `loadDependency` and `renderJSX` transforms.
+    source = re.sub(r"^---\r?\n[\s\S]*?\r?\n---\s*(?:\r?\n|$)", "", source)
 
     # 2a) React imports: import React, { useState, ... } from 'react'
     source = re.sub(

--- a/tests/lint/test_detect_sed_damage.py
+++ b/tests/lint/test_detect_sed_damage.py
@@ -1,0 +1,201 @@
+"""Unit tests for detect_sed_damage.py (PR-portal-6).
+
+Covers two layers:
+  1. Existing detection logic (NUL bytes appearing, >50% shrink)
+  2. NEW exemption marker via .sed-damage-allowlist (PR-portal-6) —
+     allows legitimate inline shrink refactors to land without
+     disabling the guard repo-wide.
+
+Implementation isolates check_file() from git: pass head_content via
+monkeypatched get_head_content() so tests are hermetic.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_TOOLS_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "scripts", "tools", "lint"
+)
+sys.path.insert(0, _TOOLS_DIR)
+
+import detect_sed_damage  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_head(monkeypatch):
+    """Stub `get_head_content` to return a chosen byte string."""
+    holder: dict[str, bytes | None] = {"value": b""}
+
+    def _stub(_path):
+        return holder["value"]
+
+    monkeypatch.setattr(detect_sed_damage, "get_head_content", _stub)
+    return holder
+
+
+def _write(tmp_path, name, content_bytes):
+    f = tmp_path / name
+    f.write_bytes(content_bytes)
+    return str(f)
+
+
+# ---------------------------------------------------------------------------
+# Existing behaviour — NUL bytes + truncation detection
+# ---------------------------------------------------------------------------
+
+
+class TestNulByteDetection:
+    def test_new_nul_byte_flagged(self, tmp_path, fake_head):
+        fake_head["value"] = b"clean content " * 20  # 280 bytes, no NULs
+        path = _write(tmp_path, "f.txt", b"corrupted\x00content " * 20)
+        issues = detect_sed_damage.check_file(path, allowlist=set())
+        assert any("NUL bytes detected" in i for i in issues)
+
+    def test_existing_nul_byte_not_flagged(self, tmp_path, fake_head):
+        fake_head["value"] = b"binary\x00data " * 20
+        path = _write(tmp_path, "f.bin", b"binary\x00more " * 20)
+        issues = detect_sed_damage.check_file(path, allowlist=set())
+        assert not any("NUL bytes detected" in i for i in issues)
+
+
+class TestTruncationDetection:
+    def test_50pct_shrink_flagged(self, tmp_path, fake_head):
+        fake_head["value"] = b"a" * 1000
+        path = _write(tmp_path, "f.txt", b"a" * 200)  # 20% of HEAD
+        issues = detect_sed_damage.check_file(path, allowlist=set())
+        assert any("truncated" in i for i in issues)
+
+    def test_30pct_shrink_not_flagged(self, tmp_path, fake_head):
+        fake_head["value"] = b"a" * 1000
+        path = _write(tmp_path, "f.txt", b"a" * 700)  # 70% of HEAD
+        issues = detect_sed_damage.check_file(path, allowlist=set())
+        assert not any("truncated" in i for i in issues)
+
+    def test_small_files_skipped(self, tmp_path, fake_head):
+        """Files <100 bytes in HEAD don't trigger the shrink check."""
+        fake_head["value"] = b"tiny"
+        path = _write(tmp_path, "f.txt", b"x")  # 25% but <100B HEAD
+        issues = detect_sed_damage.check_file(path, allowlist=set())
+        assert not any("truncated" in i for i in issues)
+
+    def test_new_file_no_head_no_check(self, tmp_path, fake_head):
+        """File missing from HEAD → no truncation check (treated as new)."""
+        fake_head["value"] = None
+        path = _write(tmp_path, "f.txt", b"new content")
+        issues = detect_sed_damage.check_file(path, allowlist=set())
+        assert not any("truncated" in i for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# NEW: allowlist-based exemption (PR-portal-6)
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistExemption:
+    def test_allowlisted_path_skips_truncation_check(self, tmp_path, fake_head):
+        """The whole point of the allowlist: legitimate large refactor
+        shrinks a file >50% without firing the heuristic.
+        """
+        fake_head["value"] = b"a" * 1000
+        path_str = _write(tmp_path, "shim.jsx", b"a" * 100)  # 10% of HEAD
+        # Allowlist uses path-string match (the way pre-commit passes
+        # paths to the script — relative to repo root). Use the literal
+        # path the test passed in.
+        normalized = path_str.replace("\\", "/")
+        issues = detect_sed_damage.check_file(
+            path_str, allowlist={normalized}
+        )
+        assert not any("truncated" in i for i in issues)
+
+    def test_allowlist_does_not_suppress_nul_bytes(self, tmp_path, fake_head):
+        """NUL bytes are ALWAYS damage — allowlist must not silence
+        them even if path is exempted from the truncation check.
+        """
+        fake_head["value"] = b"clean content " * 20  # no NULs
+        path_str = _write(tmp_path, "shim.jsx", b"data\x00more " * 20)
+        normalized = path_str.replace("\\", "/")
+        issues = detect_sed_damage.check_file(
+            path_str, allowlist={normalized}
+        )
+        assert any("NUL bytes" in i for i in issues)
+
+    def test_non_allowlisted_path_still_flagged(self, tmp_path, fake_head):
+        """Allowlist is per-path — adding `a.jsx` does not exempt `b.jsx`."""
+        fake_head["value"] = b"a" * 1000
+        path_str = _write(tmp_path, "other.jsx", b"a" * 100)  # 10%
+        # Allowlist contains a different path.
+        issues = detect_sed_damage.check_file(
+            path_str, allowlist={"some/other/file.jsx"}
+        )
+        assert any("truncated" in i for i in issues)
+
+    def test_empty_allowlist_default_behaviour(self, tmp_path, fake_head):
+        fake_head["value"] = b"a" * 1000
+        path_str = _write(tmp_path, "f.jsx", b"a" * 100)
+        issues = detect_sed_damage.check_file(path_str, allowlist=set())
+        assert any("truncated" in i for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# Allowlist file parsing
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAllowlist:
+    def test_missing_file_returns_empty(self, tmp_path):
+        absent = tmp_path / "nonexistent"
+        assert detect_sed_damage.load_allowlist(absent) == set()
+
+    def test_simple_paths_parsed(self, tmp_path):
+        f = tmp_path / "allow"
+        f.write_text("a/b.jsx\nc/d.js\n", encoding="utf-8")
+        assert detect_sed_damage.load_allowlist(f) == {"a/b.jsx", "c/d.js"}
+
+    def test_comments_and_blanks_ignored(self, tmp_path):
+        f = tmp_path / "allow"
+        f.write_text(
+            "# comment line\n"
+            "\n"
+            "real/path.jsx\n"
+            "  # indented comment\n"
+            "another/path.js\n",
+            encoding="utf-8",
+        )
+        assert detect_sed_damage.load_allowlist(f) == {
+            "real/path.jsx",
+            "another/path.js",
+        }
+
+    def test_inline_trailing_comment_stripped(self, tmp_path):
+        f = tmp_path / "allow"
+        f.write_text("real/path.jsx  # PR-7 shim\n", encoding="utf-8")
+        assert detect_sed_damage.load_allowlist(f) == {"real/path.jsx"}
+
+    def test_windows_separator_normalized_to_posix(self, tmp_path):
+        f = tmp_path / "allow"
+        f.write_text("docs\\foo\\bar.jsx\n", encoding="utf-8")
+        # Loader normalizes to forward slash so it matches both
+        # POSIX and Windows-style staged paths.
+        assert detect_sed_damage.load_allowlist(f) == {"docs/foo/bar.jsx"}
+
+    def test_real_repo_allowlist_parses_cleanly(self):
+        """The shipped `.sed-damage-allowlist` at repo root must parse
+        without error. Currently it has only commented examples; the
+        set should be empty.
+        """
+        result = detect_sed_damage.load_allowlist()
+        # Don't assert the EXACT set (it'll grow over time); just that
+        # parsing succeeds and returns a set of strings.
+        assert isinstance(result, set)
+        for entry in result:
+            assert isinstance(entry, str)
+            assert "#" not in entry  # comments stripped
+            assert entry.strip() == entry  # leading/trailing ws stripped

--- a/tests/lint/test_lint_jsx_babel_frontmatter.py
+++ b/tests/lint/test_lint_jsx_babel_frontmatter.py
@@ -1,0 +1,123 @@
+"""Unit tests for lint_jsx_babel.py front-matter strip regex (PR-portal-6).
+
+Regression for the bug that bit PR-portal-2 (#204): the front-matter
+strip pattern `^---[\\s\\S]*?---\\s*\\n?` matched any 3-dash substring
+including the first 3 chars of `------` separator lines inside YAML
+`purpose:` blocks. Result: closing `---` "found" early → remaining
+front-matter bled into JS code → silent Babel parse error
+("Invalid left-hand side in prefix operation") at the next non-blank
+line.
+
+Fix anchors closing `---` to its own line:
+  `^---\\r?\\n[\\s\\S]*?\\r?\\n---\\s*(?:\\r?\\n|$)`
+
+Same regex shipped in 3 places — `_transform_jsx` here mirrors
+`docs/assets/jsx-loader.html` `loadDependency` strip + `renderJSX`
+strip; tests here exercise the Python copy as proxy for all three.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_TOOLS_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "scripts", "tools", "lint"
+)
+sys.path.insert(0, _TOOLS_DIR)
+
+from lint_jsx_babel import _transform_jsx  # noqa: E402
+
+
+class TestFrontMatterStrip:
+    """Verify _transform_jsx removes the FM block but preserves body."""
+
+    def test_simple_frontmatter_stripped(self):
+        src = '---\ntitle: x\n---\nconst foo = 1;\n'
+        out = _transform_jsx(src)
+        assert 'title' not in out
+        assert 'const foo = 1;' in out
+
+    def test_purpose_block_with_dash_separator_NOT_consumed(self):
+        """The pre-PR-portal-6 regex bit here. ----- inside purpose:
+        was matched as the closing ---, leaving the rest of the
+        front-matter as code → parse error.
+        """
+        src = (
+            '---\n'
+            'title: x\n'
+            'purpose: |\n'
+            '  Description.\n'
+            '\n'
+            '  Section header\n'
+            '  -----\n'
+            '  More text.\n'
+            '---\n'
+            'const foo = 1;\n'
+        )
+        out = _transform_jsx(src)
+        # Body must be preserved verbatim.
+        assert 'const foo = 1;' in out
+        # Front-matter prose must NOT leak into code.
+        assert 'Description' not in out
+        assert 'Section header' not in out
+        assert 'More text' not in out
+
+    def test_long_dash_separator_in_purpose(self):
+        """Same bug class — 50+ dashes in purpose block also poison
+        the old regex.
+        """
+        src = (
+            '---\n'
+            'title: x\n'
+            'purpose: |\n'
+            '  Description.\n'
+            '  ----------------------------------------\n'
+            '  More.\n'
+            '---\n'
+            'const foo = 1;\n'
+        )
+        out = _transform_jsx(src)
+        assert 'const foo = 1;' in out
+        assert 'Description' not in out
+        assert '----------------------------------------' not in out
+
+    def test_frontmatter_with_yaml_dependencies_block(self):
+        """Real-world shape — multi-line `dependencies:` array inside
+        the FM block.
+        """
+        src = (
+            '---\n'
+            'title: My Tool\n'
+            'dependencies: [\n'
+            '  "_common/hooks/useDebouncedValue.js",\n'
+            '  "_common/components/ErrorBoundary.jsx"\n'
+            ']\n'
+            '---\n'
+            'const Tool = () => null;\n'
+        )
+        out = _transform_jsx(src)
+        assert 'const Tool = () => null;' in out
+        assert 'dependencies' not in out
+
+    def test_no_frontmatter_passes_through(self):
+        src = 'const foo = 1;\n'
+        out = _transform_jsx(src)
+        assert out == 'const foo = 1;\n'
+
+    def test_crlf_line_endings_handled(self):
+        """Files with Windows-style line endings still strip cleanly
+        (regex uses `\\r?\\n` to allow either).
+        """
+        src = '---\r\ntitle: x\r\n---\r\nconst foo = 1;\r\n'
+        out = _transform_jsx(src)
+        assert 'title' not in out
+        assert 'const foo = 1;' in out
+
+    def test_fm_only_no_body_does_not_crash(self):
+        """Edge case: file is pure front-matter, no body."""
+        src = '---\ntitle: x\n---'
+        out = _transform_jsx(src)
+        # Body is empty string; assertion is just "doesn't crash".
+        assert 'title' not in out


### PR DESCRIPTION
## Summary

PR-6 of an 11-PR refactor sweep for **da-portal** — first PR of the second batch (PR-6..11 follow-ups to the PR-1..5 sweep). Three meta-tooling fixes that came out of the v2.8.0 portal refactor and would otherwise keep biting future contributors.

## Changes

### 1. Front-matter strip regex — fixed in 4 places

**Bug**: `^---[\s\S]*?---\s*\n?` matches any 3-dash substring including the first 3 chars of `------` separator lines inside YAML `purpose:` blocks → silent Babel parse error. Cost a CI cycle on [#204](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/204) and silently defeated my first attempt at PR-2's component fixtures.

**Fix**: anchor closing `---` to its own line: `^---\r?\n[\s\S]*?\r?\n---\s*(?:\r?\n|$)`

Applied in 4 sites (3 buggy + 1 defense-in-depth):
- `docs/assets/jsx-loader.html` `loadDependency()` strip
- `docs/assets/jsx-loader.html` `renderJSX()` strip
- `docs/assets/jsx-loader.html` `parseDependencies()` (already partially anchored; tightened closing side)
- `scripts/tools/lint/lint_jsx_babel.py` `_transform_jsx()` strip

**Coverage**: 7 regression tests in `tests/lint/test_lint_jsx_babel_frontmatter.py` exercise the Python copy as proxy for all 4 sites.

### 2. `sed-damage-guard` exemption marker

**Bug**: 50% shrink heuristic blocks legitimate inline-shrink refactors. Forced [#205](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/205) to be additive-only and [#206](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/206) to extract only 1 of 5 step components.

**Fix**: new `.sed-damage-allowlist` at repo root. List paths (one per line, `#` comments) that are exempt from the truncation check. Critically: allowlist **only suppresses truncation**, NEVER NUL-byte detection (NUL bytes are always damage).

**Coverage**: 16 unit tests in `tests/lint/test_detect_sed_damage.py` — both existing detection (NUL + truncation) and new allowlist semantics.

### 3. `make lint-new-script SCRIPT=path/to/foo.py`

**Bug**: PR-5 ([#207](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/207)) ate **4 CI fix cycles** (image-tag drift / stderr routing / argparse missing / strict-linecount) because SAST + exit-code gates only run in CI, not pre-commit.

**Fix**: new Makefile target that pytest-greps `test_tool_exit_codes` + `test_sast` filtered to a single new lint script, plus tool-map registration check. Run **before the first push** for any new lint script.

```bash
make lint-new-script SCRIPT=scripts/tools/lint/check_foo.py
```

(Variable name is `SCRIPT=` not `PATH=` — the latter would clobber shell PATH.)

## Test plan

- [x] All 38 pre-commit hooks green
- [x] 7+16=23 new unit tests pass
- [x] `lint_jsx_babel.py --ci --strict-linecount` exit 0 — same 357 pre-existing static warnings, **no new parse errors** (regex change safe for current JSX corpus)
- [x] SAST + exit-code conventions clean on both modified scripts
- [x] `make pr-preflight` — READY (38/38, 0 behind main, no scope drift)
- [ ] CI green

## Roadmap (updated to 11 PRs)

| PR | Scope | Status |
|----|-------|--------|
| [#203](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/203) | PR-1 — `_common/hooks/` | ✅ merged |
| [#204](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/204) | PR-2 — ErrorBoundary | ✅ merged |
| [#205](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/205) | PR-3 — `_common/data/sim/validation` | ✅ merged |
| [#206](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/206) | PR-4 — operator-wizard split | ✅ merged |
| [#207](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/207) | PR-5 — release hygiene | ✅ merged |
| **PR-6** (this) | Lint friction unblockers | ⬅ here |
| PR-7 (NEW) | Hub UI dynamic counts + audience filter + reclassify maintainer tools | next |
| PR-8 | `_common/{Loading,EmptyState}` adoption | next |
| PR-9 | `portal-shared.jsx` shim conversion | depends on PR-6 marker |
| PR-10 | 3 sibling wizard decomposition | depends on PR-6 marker |
| PR-11 | Subtree ErrorBoundaries | depends on PR-2/8/10 |

## Risk

**Medium.** `jsx-loader.html` regex change runs in **every user's browser on every tool load**. Mitigation: 7 unit tests on the same regex shape via Python; existing JSX corpus parses unchanged (verified via `lint_jsx_babel` exit 0); the new regex is strictly more conservative (rejects more strings, accepts a subset of old) so any test suite relying on old laxer behaviour would already be broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
