### PR TITLE
refactor(jsx): Hub dynamic counts + Internal phase + reclassify (PR-7/11)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -629,6 +629,8 @@ lint-portal: ## da-portal 整套 lint：jsx-loader-compat / undefined-tokens / p
 	@PYTHONIOENCODING=utf-8 python3 scripts/tools/lint/lint_jsx_babel.py --ci --strict-linecount
 	@echo "==> tool-registry.yaml ↔ jsx parity"
 	@python3 scripts/tools/lint/check_tool_registry_jsx_parity.py
+	@echo "==> Hub UI badge drift (no hardcoded counts)"
+	@python3 scripts/tools/lint/check_hub_badge_drift.py
 
 .PHONY: lint-new-script
 lint-new-script: ## Run all CLI/SAST conventions on a single new lint script (PR-portal-6) — usage: make lint-new-script SCRIPT=scripts/tools/lint/check_foo.py

--- a/docs/assets/tool-registry.yaml
+++ b/docs/assets/tool-registry.yaml
@@ -1018,9 +1018,14 @@ tools:
     en: Release Notes Generator
     zh: 發布說明產生器
   file: interactive/tools/release-notes-generator.jsx
+  # PR-portal-7: re-tagged from `audience: [platform, sre]` to
+  # `[maintainer]` and `journey_phase: reference` to `internal`.
+  # The tool produces da-platform release notes from CHANGELOG —
+  # used only by the team SHIPPING the platform, not by tenants /
+  # SREs operating the platform. Lives under collapsed "Internal /
+  # Maintainer Tools" Hub section.
   audience:
-  - platform
-  - sre
+  - maintainer
   icon: chart
   tags:
   - release
@@ -1034,7 +1039,7 @@ tools:
   - deployment-wizard
   - health-dashboard
   - platform-health
-  journey_phase: reference
+  journey_phase: internal
   hub_section: advanced
   appears_in: []
 - key: threshold-heatmap

--- a/docs/assets/tool-registry.yaml
+++ b/docs/assets/tool-registry.yaml
@@ -793,8 +793,16 @@ tools:
     en: ROI Calculator
     zh: 採用效益試算器
   file: interactive/tools/roi-calculator.jsx
+  # PR-portal-7 audit: re-tagged from `audience: [platform]` +
+  # `journey_phase: monitor` to `[maintainer]` + `internal`. Tool
+  # asks for `hourlyRate` ($75 default), `oncallStaff`, manual
+  # onboard minutes — pure decision-maker / sales business case for
+  # justifying platform adoption to management. Real platform
+  # engineers operating tenants don't compute their own salary ×
+  # hours-saved. Lives under collapsed "Internal / Maintainer Tools"
+  # Hub section.
   audience:
-  - platform
+  - maintainer
   icon: wizard
   tags:
   - roi
@@ -810,15 +818,21 @@ tools:
   - self-service-portal
   hub_section: advanced
   appears_in: []
-  journey_phase: monitor
+  journey_phase: internal
 - key: migration-roi-calculator
   title:
     en: Migration ROI Calculator
     zh: 遷移效益試算器
   file: interactive/tools/migration-roi-calculator.jsx
+  # PR-portal-7 audit: re-tagged from `audience: [platform, sre]` +
+  # `journey_phase: deploy` to `[maintainer]` + `internal`. Tool
+  # asks for `hourlyRate` and outputs "annual savings + break-even
+  # months" — project-justification language for engineering
+  # management, not migration mechanics for SREs actually running
+  # the migration. Lives under collapsed "Internal / Maintainer
+  # Tools" Hub section.
   audience:
-  - platform
-  - sre
+  - maintainer
   icon: wizard
   tags:
   - migration
@@ -834,7 +848,7 @@ tools:
   - migration-simulator
   hub_section: advanced
   appears_in: []
-  journey_phase: deploy
+  journey_phase: internal
 - key: cost-estimator
   title:
     en: Cost Estimator

--- a/docs/interactive/index.html
+++ b/docs/interactive/index.html
@@ -896,7 +896,7 @@
   <!-- platform-demo (interactive/tools/platform-demo.jsx) -->
   <a class="card" data-audience="platform,domain,tenant" href="interactive/tools/platform-demo.jsx">Platform Demo</a>
   <!-- roi-calculator (interactive/tools/roi-calculator.jsx) -->
-  <a class="card" data-audience="platform" href="interactive/tools/roi-calculator.jsx">ROI Calculator</a>
+  <a class="card" data-audience="maintainer" href="interactive/tools/roi-calculator.jsx">ROI Calculator</a>
   <!-- self-service-portal (interactive/tools/self-service-portal.jsx) -->
   <a class="card" data-audience="platform,domain,tenant" href="interactive/tools/self-service-portal.jsx">Tenant Self-Service Portal</a>
   <!-- multi-tenant-comparison (interactive/tools/multi-tenant-comparison.jsx) -->
@@ -910,7 +910,7 @@
   <!-- operator-setup-wizard (interactive/tools/operator-setup-wizard.jsx) -->
   <a class="card" data-audience="platform,sre" href="interactive/tools/operator-setup-wizard.jsx">Operator Setup Wizard</a>
   <!-- migration-roi-calculator (interactive/tools/migration-roi-calculator.jsx) -->
-  <a class="card" data-audience="platform,sre" href="interactive/tools/migration-roi-calculator.jsx">Migration ROI Calculator</a>
+  <a class="card" data-audience="maintainer" href="interactive/tools/migration-roi-calculator.jsx">Migration ROI Calculator</a>
   <!-- cost-estimator (interactive/tools/cost-estimator.jsx) -->
   <a class="card" data-audience="platform,sre,management" href="interactive/tools/cost-estimator.jsx">Cost Estimator</a>
   <!-- release-notes-generator (interactive/tools/release-notes-generator.jsx) -->

--- a/docs/interactive/index.html
+++ b/docs/interactive/index.html
@@ -734,7 +734,7 @@
     <div class="section-header">
       <div class="section-title">
         <span aria-hidden="true">🚀</span> Deploy
-        <span class="journey-phase-badge deploy" id="deploy-badge">8 Tools</span>
+        <span class="journey-phase-badge deploy" id="deploy-badge">{N} Tools</span>
       </div>
     </div>
     <div class="cards" id="deploy-cards"></div>
@@ -745,7 +745,7 @@
     <div class="section-header">
       <div class="section-title">
         <span aria-hidden="true">⚙️</span> Configure
-        <span class="journey-phase-badge configure" id="configure-badge">10 Tools</span>
+        <span class="journey-phase-badge configure" id="configure-badge">{N} Tools</span>
       </div>
     </div>
     <div class="cards" id="configure-cards"></div>
@@ -756,7 +756,7 @@
     <div class="section-header">
       <div class="section-title">
         <span aria-hidden="true">📊</span> Monitor
-        <span class="journey-phase-badge monitor" id="monitor-badge">6 Tools</span>
+        <span class="journey-phase-badge monitor" id="monitor-badge">{N} Tools</span>
       </div>
     </div>
     <div class="cards" id="monitor-cards"></div>
@@ -767,7 +767,7 @@
     <div class="section-header">
       <div class="section-title">
         <span aria-hidden="true">🔧</span> Troubleshoot
-        <span class="journey-phase-badge troubleshoot" id="troubleshoot-badge">6 Tools</span>
+        <span class="journey-phase-badge troubleshoot" id="troubleshoot-badge">{N} Tools</span>
       </div>
     </div>
     <div class="cards" id="troubleshoot-cards"></div>
@@ -777,12 +777,26 @@
   <div style="margin-bottom: 48px;">
     <div class="section-header">
       <div class="section-title">
-        <span aria-hidden="true">📚</span> Reference
-        <span class="journey-phase-badge reference" id="reference-badge">2 Tools</span>
+        <span aria-hidden="true">📚</span> <span id="phase-title-reference">Reference</span>
+        <span class="journey-phase-badge reference" id="reference-badge">{N} Tools</span>
       </div>
     </div>
     <div class="cards" id="reference-cards"></div>
   </div>
+
+  <!-- INTERNAL phase (PR-portal-7) — maintainer-only tools, collapsed by default -->
+  <details style="margin-bottom: 48px;">
+    <summary style="cursor: pointer; padding: var(--da-space-2, 8px) 0;">
+      <span class="section-title" style="display: inline-flex; align-items: center; gap: var(--da-space-2, 8px);">
+        <span aria-hidden="true">🔧</span> <span id="phase-title-internal">Internal / Maintainer Tools</span>
+        <span class="journey-phase-badge reference" id="internal-badge">{N} Tools</span>
+      </span>
+    </summary>
+    <p style="margin: var(--da-space-2, 8px) 0 var(--da-space-3, 12px) 0; font-size: var(--da-font-size-sm, 14px); color: var(--da-color-fg, #6b7280);" id="internal-blurb">
+      Tools used by the platform release / maintenance team — not part of the tenant or SRE journey.
+    </p>
+    <div class="cards" id="internal-cards"></div>
+  </details>
 
   <!-- Documentation links -->
   <div style="margin-bottom: 32px;">
@@ -900,7 +914,7 @@
   <!-- cost-estimator (interactive/tools/cost-estimator.jsx) -->
   <a class="card" data-audience="platform,sre,management" href="interactive/tools/cost-estimator.jsx">Cost Estimator</a>
   <!-- release-notes-generator (interactive/tools/release-notes-generator.jsx) -->
-  <a class="card" data-audience="platform,sre" href="interactive/tools/release-notes-generator.jsx">Release Notes Generator</a>
+  <a class="card" data-audience="maintainer" href="interactive/tools/release-notes-generator.jsx">Release Notes Generator</a>
   <!-- threshold-heatmap (interactive/tools/threshold-heatmap.jsx) -->
   <a class="card" data-audience="platform,domain,sre" href="interactive/tools/threshold-heatmap.jsx">Threshold Heatmap</a>
   <!-- component-health (interactive/tools/component-health.jsx) -->
@@ -927,7 +941,7 @@
   var i18n = {
     en: {
       'hero-title': 'Dynamic Alerting — Interactive Tools Hub',
-      'hero-desc': 'Explore 32 tools organized by your user journey. Build, configure, monitor, and troubleshoot with guided flows and interactive utilities.',
+      'hero-desc': 'Explore {N} tools organized by your user journey. Build, configure, monitor, and troubleshoot with guided flows and interactive utilities.',
       'qa-wizard': 'Getting Started',
       'qa-playground': 'YAML Validator',
       'qa-platform-health': 'Platform Health',
@@ -939,11 +953,15 @@
       'analytics-empty': 'No usage data yet. Start any Guided Flow to see progress analytics.',
       'builder-title': 'Build Custom Flow',
       'builder-btn-label': 'Launch Custom Flow',
-      'deploy-badge': '8 Tools',
-      'configure-badge': '10 Tools',
-      'monitor-badge': '6 Tools',
-      'troubleshoot-badge': '6 Tools',
-      'reference-badge': '2 Tools',
+      'deploy-badge': '{N} Tools',
+      'configure-badge': '{N} Tools',
+      'monitor-badge': '{N} Tools',
+      'troubleshoot-badge': '{N} Tools',
+      'reference-badge': '{N} Tools',
+      'internal-badge': '{N} Tools',
+      'phase-title-reference': 'Reference',
+      'phase-title-internal': 'Internal / Maintainer Tools',
+      'internal-blurb': 'Tools used by the platform release / maintenance team — not part of the tenant or SRE journey.',
       'docs-title': 'Documentation',
       'link-readme-text': 'README',
       'link-arch-text': 'Architecture',
@@ -956,7 +974,7 @@
     },
     zh: {
       'hero-title': '動態告警平台 — 互動工具中心',
-      'hero-desc': '探索 32 個按用戶旅程組織的工具。使用引導式流程和互動工具進行構建、配置、監控和故障排除。',
+      'hero-desc': '探索 {N} 個按用戶旅程組織的工具。使用引導式流程和互動工具進行構建、配置、監控和故障排除。',
       'qa-wizard': '入門精靈',
       'qa-playground': 'YAML 驗證器',
       'qa-platform-health': '平台健康',
@@ -968,11 +986,15 @@
       'analytics-empty': '尚無使用紀錄。開始任一引導式流程後即顯示進度分析。',
       'builder-title': '構建自訂流程',
       'builder-btn-label': '啟動自訂流程',
-      'deploy-badge': '8 個工具',
-      'configure-badge': '10 個工具',
-      'monitor-badge': '6 個工具',
-      'troubleshoot-badge': '6 個工具',
-      'reference-badge': '2 個工具',
+      'deploy-badge': '{N} 個工具',
+      'configure-badge': '{N} 個工具',
+      'monitor-badge': '{N} 個工具',
+      'troubleshoot-badge': '{N} 個工具',
+      'reference-badge': '{N} 個工具',
+      'internal-badge': '{N} 個工具',
+      'phase-title-reference': '參考資料',
+      'phase-title-internal': '內部 / 維運團隊工具',
+      'internal-blurb': '平台發版 / 維運團隊使用的工具 — 不在租戶或 SRE 操作流程內。',
       'docs-title': '文檔',
       'link-readme-text': '讀我檔案',
       'link-arch-text': '架構',
@@ -991,6 +1013,13 @@
   }
 
   // Apply i18n to all static elements with matching IDs (REG-001 fix)
+  // PR-portal-7: phase counts populated by renderTools() after the
+  // tool-registry fetch resolves. Read by __applyHubI18n to substitute
+  // {N} placeholders in *-badge + hero-desc strings so the badge text
+  // reflects the actual rendered card count instead of a stale literal.
+  window.__hubPhaseCounts = {};
+  window.__hubTotalCount = 0;
+
   // Exposed globally so the lang-toggle init script can call it after setting __DA_HUB_LANG
   window.__applyHubI18n = function() {
     var lang = window.__DA_HUB_LANG || 'en';
@@ -998,14 +1027,31 @@
     Object.keys(strings).forEach(function(key) {
       var el = document.getElementById(key);
       if (el) {
+        var text = strings[key];
+        // PR-portal-7: substitute {N} for *-badge (per-phase count)
+        // and hero-desc (total tools count). Source of truth is the
+        // tool-registry fetch via renderTools(); see __hubPhaseCounts
+        // and __hubTotalCount populated below.
+        if (text.indexOf('{N}') !== -1) {
+          var n;
+          if (key === 'hero-desc') {
+            n = window.__hubTotalCount;
+          } else if (/^([a-z]+)-badge$/.test(key)) {
+            var phase = key.replace(/-badge$/, '');
+            n = window.__hubPhaseCounts[phase];
+          }
+          if (typeof n === 'number') {
+            text = text.replace('{N}', String(n));
+          }
+        }
         // For footer-text, preserve structure (contains child elements)
         if (key === 'footer-text') {
           var textNode = el.firstChild;
           if (textNode && textNode.nodeType === 3) {
-            textNode.textContent = strings[key] + ' \u2014 ';
+            textNode.textContent = text + ' \u2014 ';
           }
         } else {
-          el.textContent = strings[key];
+          el.textContent = text;
         }
       }
     });
@@ -1016,7 +1062,11 @@
 
   // Render tools by journey phase
   function renderTools(tools) {
-    var phases = { deploy: [], configure: [], monitor: [], troubleshoot: [], reference: [] };
+    // PR-portal-7: 6th phase 'internal' for maintainer-only tools
+    // (release-notes-generator etc.) that don't belong in the main
+    // tenant/SRE journey but still need a discovery surface for the
+    // platform team. Hidden inside a collapsed <details> below.
+    var phases = { deploy: [], configure: [], monitor: [], troubleshoot: [], reference: [], internal: [] };
 
     tools.forEach(function(tool) {
       var phase = tool.journey_phase || 'reference';
@@ -1024,6 +1074,19 @@
         phases[phase].push(tool);
       }
     });
+
+    // PR-portal-7: populate window.__hubPhaseCounts + total so
+    // __applyHubI18n can substitute {N} placeholders in badge labels
+    // and hero-desc. Also drives the new check_hub_badge_drift lint.
+    window.__hubPhaseCounts = {};
+    window.__hubTotalCount = 0;
+    Object.keys(phases).forEach(function(phase) {
+      window.__hubPhaseCounts[phase] = phases[phase].length;
+      window.__hubTotalCount += phases[phase].length;
+    });
+    if (typeof window.__applyHubI18n === 'function') {
+      window.__applyHubI18n();
+    }
 
     Object.keys(phases).forEach(function(phase) {
       var container = document.getElementById(phase + '-cards');

--- a/docs/interactive/tools/migration-roi-calculator.jsx
+++ b/docs/interactive/tools/migration-roi-calculator.jsx
@@ -1,7 +1,7 @@
 ---
 title: "Migration ROI Calculator"
 tags: [migration, roi, promql, conversion]
-audience: [platform-engineer, sre]
+audience: [maintainer]
 version: v2.7.0
 lang: en
 related: [roi-calculator, operator-setup-wizard, migration-simulator]

--- a/docs/interactive/tools/release-notes-generator.jsx
+++ b/docs/interactive/tools/release-notes-generator.jsx
@@ -1,7 +1,7 @@
 ---
 title: "Release Notes Generator"
 tags: [release, changelog, automation, communication]
-audience: [platform-engineer, sre]
+audience: [maintainer]
 version: v2.7.0
 lang: en
 related: [deployment-wizard, health-dashboard, platform-health]

--- a/docs/interactive/tools/roi-calculator.jsx
+++ b/docs/interactive/tools/roi-calculator.jsx
@@ -1,7 +1,7 @@
 ---
 title: "ROI Calculator"
 tags: [roi, cost, adoption, evaluation]
-audience: [platform-engineer]
+audience: [maintainer]
 version: v2.7.0
 lang: en
 related: [capacity-planner, health-dashboard, alert-simulator]

--- a/docs/internal/doc-map.en.md
+++ b/docs/internal/doc-map.en.md
@@ -61,6 +61,10 @@ lang: en
 | `docs/integration/operator-prometheus-integration.md` (.en.md) | Platform Engineers | Operator Prometheus Integration Guide |
 | `docs/integration/operator-shadow-monitoring.md` (.en.md) | Platform Engineers | Operator Shadow Monitoring Strategy |
 | `docs/integration/prometheus-operator-integration.md` (.en.md) | Platform Engineers | Prometheus Operator Integration Guide (Hub) |
+| `docs/interactive/tools/_common/components/EmptyState.jsx` | All | _common — EmptyState |
+| `docs/interactive/tools/_common/components/ErrorBoundary.jsx` | All | _common — ErrorBoundary |
+| `docs/interactive/tools/_common/components/Loading.jsx` | All | _common — Loading |
+| `docs/interactive/tools/_common/README.md` | All | `_common/` — Shared Hooks, Utils, and Components for Portal Tools |
 | `docs/interactive/tools/alert-builder.jsx` | Platform Engineers, SREs, Tenants | Alert Builder Wizard |
 | `docs/interactive/tools/alert-noise-analyzer.jsx` | platform, Domain Experts (DBA) | Alert Noise Analyzer |
 | `docs/interactive/tools/alert-simulator.jsx` | Domain Experts (DBA), Tenants | Alert Simulator |
@@ -84,6 +88,7 @@ lang: en
 | `docs/interactive/tools/multi-tenant-comparison.jsx` | platform, Domain Experts (DBA) | Multi-Tenant Comparison |
 | `docs/interactive/tools/notification-previewer.jsx` | Platform Engineers, Tenants | Notification Template Editor |
 | `docs/interactive/tools/onboarding-checklist.jsx` | Tenants, Platform Engineers, Domain Experts (DBA) | Onboarding Checklist Generator |
+| `docs/interactive/tools/operator-setup-wizard/components/StepReview.jsx` | All | Operator Setup Wizard — Step 5: Review & Generate |
 | `docs/interactive/tools/operator-setup-wizard.jsx` | Platform Engineers, SREs, DevOps | Operator Setup Wizard |
 | `docs/interactive/tools/platform-demo.jsx` | Platform Engineers, Domain Experts (DBA), Tenants | Platform Demo |
 | `docs/interactive/tools/platform-health.jsx` | Platform Engineers | Platform Health Dashboard |
@@ -91,7 +96,7 @@ lang: en
 | `docs/interactive/tools/portal-shared.jsx` | Platform Engineers | Portal Shared Module |
 | `docs/interactive/tools/promql-tester.jsx` | Platform Engineers, Domain Experts (DBA) | Prometheus Query Tester |
 | `docs/interactive/tools/rbac-setup-wizard.jsx` | Platform Engineers, SREs | RBAC Setup Wizard |
-| `docs/interactive/tools/release-notes-generator.jsx` | Platform Engineers, SREs | Release Notes Generator |
+| `docs/interactive/tools/release-notes-generator.jsx` | maintainer | Release Notes Generator |
 | `docs/interactive/tools/roi-calculator.jsx` | Platform Engineers | ROI Calculator |
 | `docs/interactive/tools/routing-trace.jsx` | Platform Engineers, SREs | Routing Trace Wizard |
 | `docs/interactive/tools/RoutingTraceTab.jsx` | Platform Engineers, Tenants | Routing Trace Tab |

--- a/docs/internal/doc-map.en.md
+++ b/docs/internal/doc-map.en.md
@@ -83,7 +83,7 @@ lang: en
 | `docs/interactive/tools/glossary.jsx` | Platform Engineers, Domain Experts (DBA), Tenants | Interactive Glossary |
 | `docs/interactive/tools/health-dashboard.jsx` | Tenants, Platform Engineers | Tenant Health Dashboard |
 | `docs/interactive/tools/master-onboarding.jsx` | Platform Engineers, SREs, Tenants | Master Onboarding — Dual Entry |
-| `docs/interactive/tools/migration-roi-calculator.jsx` | Platform Engineers, SREs | Migration ROI Calculator |
+| `docs/interactive/tools/migration-roi-calculator.jsx` | maintainer | Migration ROI Calculator |
 | `docs/interactive/tools/migration-simulator.jsx` | Platform Engineers | Migration Dry-Run Simulator |
 | `docs/interactive/tools/multi-tenant-comparison.jsx` | platform, Domain Experts (DBA) | Multi-Tenant Comparison |
 | `docs/interactive/tools/notification-previewer.jsx` | Platform Engineers, Tenants | Notification Template Editor |
@@ -97,7 +97,7 @@ lang: en
 | `docs/interactive/tools/promql-tester.jsx` | Platform Engineers, Domain Experts (DBA) | Prometheus Query Tester |
 | `docs/interactive/tools/rbac-setup-wizard.jsx` | Platform Engineers, SREs | RBAC Setup Wizard |
 | `docs/interactive/tools/release-notes-generator.jsx` | maintainer | Release Notes Generator |
-| `docs/interactive/tools/roi-calculator.jsx` | Platform Engineers | ROI Calculator |
+| `docs/interactive/tools/roi-calculator.jsx` | maintainer | ROI Calculator |
 | `docs/interactive/tools/routing-trace.jsx` | Platform Engineers, SREs | Routing Trace Wizard |
 | `docs/interactive/tools/RoutingTraceTab.jsx` | Platform Engineers, Tenants | Routing Trace Tab |
 | `docs/interactive/tools/rule-pack-detail.jsx` | Platform Engineers, Domain Experts (DBA) | Rule Pack Detail Viewer |

--- a/docs/internal/doc-map.md
+++ b/docs/internal/doc-map.md
@@ -96,7 +96,7 @@ lang: zh
 | `docs/interactive/tools/portal-shared.jsx` | Platform Engineers | Portal Shared Module |
 | `docs/interactive/tools/promql-tester.jsx` | Platform Engineers, Domain Experts (DBA) | Prometheus Query Tester |
 | `docs/interactive/tools/rbac-setup-wizard.jsx` | Platform Engineers, SREs | RBAC Setup Wizard |
-| `docs/interactive/tools/release-notes-generator.jsx` | Platform Engineers, SREs | Release Notes Generator |
+| `docs/interactive/tools/release-notes-generator.jsx` | maintainer | Release Notes Generator |
 | `docs/interactive/tools/roi-calculator.jsx` | Platform Engineers | ROI Calculator |
 | `docs/interactive/tools/routing-trace.jsx` | Platform Engineers, SREs | Routing Trace Wizard |
 | `docs/interactive/tools/RoutingTraceTab.jsx` | Platform Engineers, Tenants | Routing Trace Tab |

--- a/docs/internal/doc-map.md
+++ b/docs/internal/doc-map.md
@@ -83,7 +83,7 @@ lang: zh
 | `docs/interactive/tools/glossary.jsx` | Platform Engineers, Domain Experts (DBA), Tenants | Interactive Glossary |
 | `docs/interactive/tools/health-dashboard.jsx` | Tenants, Platform Engineers | Tenant Health Dashboard |
 | `docs/interactive/tools/master-onboarding.jsx` | Platform Engineers, SREs, Tenants | Master Onboarding — Dual Entry |
-| `docs/interactive/tools/migration-roi-calculator.jsx` | Platform Engineers, SREs | Migration ROI Calculator |
+| `docs/interactive/tools/migration-roi-calculator.jsx` | maintainer | Migration ROI Calculator |
 | `docs/interactive/tools/migration-simulator.jsx` | Platform Engineers | Migration Dry-Run Simulator |
 | `docs/interactive/tools/multi-tenant-comparison.jsx` | platform, Domain Experts (DBA) | Multi-Tenant Comparison |
 | `docs/interactive/tools/notification-previewer.jsx` | Platform Engineers, Tenants | Notification Template Editor |
@@ -97,7 +97,7 @@ lang: zh
 | `docs/interactive/tools/promql-tester.jsx` | Platform Engineers, Domain Experts (DBA) | Prometheus Query Tester |
 | `docs/interactive/tools/rbac-setup-wizard.jsx` | Platform Engineers, SREs | RBAC Setup Wizard |
 | `docs/interactive/tools/release-notes-generator.jsx` | maintainer | Release Notes Generator |
-| `docs/interactive/tools/roi-calculator.jsx` | Platform Engineers | ROI Calculator |
+| `docs/interactive/tools/roi-calculator.jsx` | maintainer | ROI Calculator |
 | `docs/interactive/tools/routing-trace.jsx` | Platform Engineers, SREs | Routing Trace Wizard |
 | `docs/interactive/tools/RoutingTraceTab.jsx` | Platform Engineers, Tenants | Routing Trace Tab |
 | `docs/interactive/tools/rule-pack-detail.jsx` | Platform Engineers, Domain Experts (DBA) | Rule Pack Detail Viewer |

--- a/docs/internal/tool-map.en.md
+++ b/docs/internal/tool-map.en.md
@@ -134,6 +134,7 @@ lang: en
 | `check_glossary_coverage.py` | 術語表覆蓋率檢查 |
 | `check_hardcode_tenant.py` | Detect hardcoded tenant literals in PromQL label selectors (Rule #2). |
 | `check_head_blob_hygiene.py` | Inspect committed HEAD blobs for corruption. |
+| `check_hub_badge_drift.py` | detect hardcoded tool counts in the Hub UI (PR-portal-7). |
 | `check_i18n_coverage.py` | check_i18n_coverage.py |
 | `check_includes_sync.py` | Check that Chinese and English include snippets stay in sync. |
 | `check_jsx_i18n.py` | JSX 工具 i18n 完整性 lint |

--- a/docs/internal/tool-map.md
+++ b/docs/internal/tool-map.md
@@ -134,6 +134,7 @@ lang: zh
 | `check_glossary_coverage.py` | 術語表覆蓋率檢查 |
 | `check_hardcode_tenant.py` | Detect hardcoded tenant literals in PromQL label selectors (Rule #2). |
 | `check_head_blob_hygiene.py` | Inspect committed HEAD blobs for corruption. |
+| `check_hub_badge_drift.py` | detect hardcoded tool counts in the Hub UI (PR-portal-7). |
 | `check_i18n_coverage.py` | check_i18n_coverage.py |
 | `check_includes_sync.py` | Check that Chinese and English include snippets stay in sync. |
 | `check_jsx_i18n.py` | JSX 工具 i18n 完整性 lint |

--- a/scripts/tools/lint/check_hub_badge_drift.py
+++ b/scripts/tools/lint/check_hub_badge_drift.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""check_hub_badge_drift.py — detect hardcoded tool counts in the Hub UI (PR-portal-7).
+
+Why this exists
+---------------
+Pre-PR-portal-7, `docs/interactive/index.html` had per-phase Hub badge
+counts hardcoded in two places: the i18n string table (`*-badge: '8
+Tools'`) and the static HTML body (`<span id="reference-badge">2
+Tools</span>`). These drifted from the tool-registry.yaml ground truth
+over many releases — the user spotted it as "Reference 2 Tools" badge
+above 3 actual cards. PR-portal-7 replaced the literals with `{N}`
+placeholders that get substituted at render time from the live
+phase-count cache.
+
+This lint locks that change in. Any future edit that re-introduces a
+hardcoded `\\d+ Tools` (EN) or `\\d+ 個工具` (ZH) on a `*-badge` or
+`hero-desc` line is flagged.
+
+What it flags
+-------------
+On `docs/interactive/index.html`:
+
+1. **Hardcoded `\\d+ Tools` next to a `*-badge` id or in a *-badge
+   i18n value** — the badge text must use the `{N}` placeholder.
+2. **Hardcoded `\\d+ Tools` in the `hero-desc` i18n value** — the
+   total tool count must come from the live registry length.
+3. **Hardcoded `\\d+ 個工具`** equivalents (ZH side).
+
+What it does NOT flag
+---------------------
+- Counts in comments / explanatory text
+- Counts in unrelated i18n strings (only `*-badge` + `hero-desc`)
+- The literal `{N}` placeholder itself
+
+Allowed exemption: per-line `<!-- hub-badge-drift: ignore -->` (3-line
+lookback, mirrors the convention in check_undefined_tokens.py).
+
+Usage
+-----
+  python3 scripts/tools/lint/check_hub_badge_drift.py
+
+Exit codes:
+  0 = no hardcoded counts found
+  1 = at least one violation
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HUB_HTML = REPO_ROOT / "docs" / "interactive" / "index.html"
+
+# A hardcoded count adjacent to a `*-badge` id/key OR inside hero-desc.
+# Patterns intentionally narrow — only catch the actual drift surface.
+_RE_HARDCODED_BADGE_HTML = re.compile(
+    r'id="[a-z]+-badge"[^>]*>\s*\d+\s+(Tools|個工具)'
+)
+_RE_HARDCODED_BADGE_I18N = re.compile(
+    r"'[a-z]+-badge'\s*:\s*['\"]\d+\s+(Tools|個工具)"
+)
+_RE_HARDCODED_HERO_I18N = re.compile(
+    r"'hero-desc'\s*:\s*['\"][^'\"]*?\b\d+\s+(tools|個[^'\"]*工具)"
+)
+
+_IGNORE_MARKER = "<!-- hub-badge-drift: ignore -->"
+_IGNORE_LOOKBACK_LINES = 3
+
+
+def _line_is_ignored(lines: list[str], idx: int) -> bool:
+    """True if any of the previous N lines carry the ignore marker."""
+    start = max(0, idx - _IGNORE_LOOKBACK_LINES)
+    return any(_IGNORE_MARKER in lines[i] for i in range(start, idx))
+
+
+def _display_path(path: Path) -> str:
+    """Render path relative to REPO_ROOT when possible, else absolute.
+
+    Tests scan synthetic files outside the repo (tmp_path); production
+    runs scan REPO_ROOT/docs/interactive/index.html. Both must format
+    cleanly without crashing.
+    """
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def scan_hub(path: Path = HUB_HTML) -> list[str]:
+    """Return list of violation messages (empty if clean)."""
+    if not path.exists():
+        return [f"ERROR: {path} not found"]
+
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    violations: list[str] = []
+    display = _display_path(path)
+
+    for i, line in enumerate(lines):
+        line_no = i + 1
+        if _line_is_ignored(lines, i):
+            continue
+
+        for rx, label in (
+            (_RE_HARDCODED_BADGE_HTML, "static HTML *-badge"),
+            (_RE_HARDCODED_BADGE_I18N, "i18n *-badge value"),
+            (_RE_HARDCODED_HERO_I18N, "i18n hero-desc tool count"),
+        ):
+            if rx.search(line):
+                violations.append(
+                    f"{display}:{line_no} hardcoded "
+                    f"count in {label} — use {{N}} placeholder; counts "
+                    f"are populated by renderTools() at fetch-time."
+                )
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Detect hardcoded tool counts in the Hub UI "
+            "(docs/interactive/index.html). Counts must use the {N} "
+            "placeholder substituted by renderTools() at fetch-time."
+        ),
+    )
+    parser.parse_args()
+
+    violations = scan_hub()
+    if not violations:
+        print(f"OK: {_display_path(HUB_HTML)} has no hardcoded badge counts.")
+        return 0
+
+    print(f"FAIL: {len(violations)} hardcoded badge count(s):", file=sys.stderr)
+    for v in violations:
+        print(f"  - {v}", file=sys.stderr)
+    print(
+        "\nFix: replace the literal `N Tools` / `N 個工具` with `{N} Tools` "
+        "/ `{N} 個工具`. The Hub i18n applier substitutes from the "
+        "window.__hubPhaseCounts cache populated by renderTools().",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/lint/test_check_hub_badge_drift.py
+++ b/tests/lint/test_check_hub_badge_drift.py
@@ -1,0 +1,162 @@
+"""Unit tests for check_hub_badge_drift.py (PR-portal-7).
+
+Lint that detects hardcoded `N Tools` / `N 個工具` counts in the Hub
+UI (`docs/interactive/index.html`). The whole point: prevent the
+silent drift the user spotted (Reference badge said "2 Tools" while
+the rendered card grid had 3 cards).
+
+Tests cover:
+  - Live repo passes (post-PR-portal-7 state)
+  - Synthetic violations get flagged (HTML body + i18n EN + i18n ZH)
+  - {N} placeholder is the legitimate form (NOT flagged)
+  - Ignore marker suppresses on the next 3 lines
+  - Counts in unrelated i18n strings are NOT flagged
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_TOOLS_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "scripts", "tools", "lint"
+)
+sys.path.insert(0, _TOOLS_DIR)
+
+import check_hub_badge_drift  # noqa: E402
+
+
+def _scan(tmp_path, content):
+    """Write a synthetic Hub HTML and scan it."""
+    f = tmp_path / "index.html"
+    f.write_text(content, encoding="utf-8")
+    return check_hub_badge_drift.scan_hub(f)
+
+
+# ---------------------------------------------------------------------------
+# Live repo state (post-PR-portal-7 must be clean)
+# ---------------------------------------------------------------------------
+
+
+class TestLiveRepoIsClean:
+    def test_real_hub_passes(self):
+        """The shipped index.html (after PR-portal-7) must have no
+        hardcoded counts. If this test fails, someone re-introduced
+        a literal — the regression target.
+        """
+        violations = check_hub_badge_drift.scan_hub()
+        assert violations == [], (
+            "Hub regressed to hardcoded counts:\n  "
+            + "\n  ".join(violations)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Violation detection — synthetic inputs
+# ---------------------------------------------------------------------------
+
+
+class TestStaticHtmlBadgeFlagged:
+    def test_en_badge_flagged(self, tmp_path):
+        violations = _scan(tmp_path, '<span id="reference-badge">2 Tools</span>\n')
+        assert any("static HTML *-badge" in v for v in violations)
+
+    def test_zh_badge_flagged(self, tmp_path):
+        violations = _scan(tmp_path, '<span id="reference-badge">2 個工具</span>\n')
+        assert any("static HTML *-badge" in v for v in violations)
+
+    def test_with_extra_attributes(self, tmp_path):
+        """Real HTML often has extra attributes — class etc. Lint must
+        match across the attribute string."""
+        violations = _scan(
+            tmp_path,
+            '<span class="journey-phase-badge reference" id="reference-badge">3 Tools</span>\n',
+        )
+        assert any("static HTML *-badge" in v for v in violations)
+
+
+class TestI18nBadgeFlagged:
+    def test_en_i18n_value_flagged(self, tmp_path):
+        violations = _scan(tmp_path, "      'reference-badge': '2 Tools',\n")
+        assert any("i18n *-badge value" in v for v in violations)
+
+    def test_zh_i18n_value_flagged(self, tmp_path):
+        violations = _scan(tmp_path, "      'reference-badge': '2 個工具',\n")
+        assert any("i18n *-badge value" in v for v in violations)
+
+
+class TestHeroDescFlagged:
+    def test_en_hero_desc_flagged(self, tmp_path):
+        violations = _scan(
+            tmp_path, "      'hero-desc': 'Explore 32 tools across 5 phases',\n"
+        )
+        assert any("hero-desc" in v for v in violations)
+
+    def test_zh_hero_desc_flagged(self, tmp_path):
+        violations = _scan(
+            tmp_path, "      'hero-desc': '探索 32 個按用戶旅程組織的工具',\n"
+        )
+        assert any("hero-desc" in v for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# Legitimate forms NOT flagged
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceholderForm:
+    def test_n_placeholder_html_not_flagged(self, tmp_path):
+        violations = _scan(tmp_path, '<span id="reference-badge">{N} Tools</span>\n')
+        assert violations == []
+
+    def test_n_placeholder_i18n_not_flagged(self, tmp_path):
+        violations = _scan(tmp_path, "      'reference-badge': '{N} Tools',\n")
+        assert violations == []
+
+    def test_n_placeholder_hero_not_flagged(self, tmp_path):
+        violations = _scan(
+            tmp_path, "      'hero-desc': 'Explore {N} tools',\n"
+        )
+        assert violations == []
+
+
+class TestUnrelatedCountsNotFlagged:
+    def test_count_in_other_i18n_string(self, tmp_path):
+        """Counts in non-badge i18n strings (e.g. someone's footnote)
+        are NOT this lint's concern."""
+        violations = _scan(
+            tmp_path, "      'random-key': 'See 5 examples',\n"
+        )
+        assert violations == []
+
+    def test_count_in_html_body_outside_badge(self, tmp_path):
+        violations = _scan(tmp_path, "<p>You have 7 unread messages.</p>\n")
+        assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# Ignore marker
+# ---------------------------------------------------------------------------
+
+
+class TestIgnoreMarker:
+    def test_marker_on_same_line_block(self, tmp_path):
+        """Marker within 3 lines above suppresses the violation."""
+        content = (
+            "<!-- hub-badge-drift: ignore -->\n"
+            '<span id="reference-badge">5 Tools</span>\n'
+        )
+        violations = _scan(tmp_path, content)
+        assert violations == []
+
+    def test_marker_4_lines_above_does_NOT_suppress(self, tmp_path):
+        content = (
+            "<!-- hub-badge-drift: ignore -->\n"
+            "line 2\n"
+            "line 3\n"
+            "line 4\n"
+            '<span id="reference-badge">5 Tools</span>\n'
+        )
+        violations = _scan(tmp_path, content)
+        assert len(violations) == 1


### PR DESCRIPTION
## Summary

PR-7 of the 11-PR refactor sweep. Closes the two user-spotted observations from the PR-1..6 review:

1. Reference badge says "2 Tools" but renders 3 cards
2. Release Notes Generator is in da-portal but isn't actually a tool any tenant / SRE running the platform would use — it's for the team SHIPPING the platform

Both trace to the same root: Hub UI has no audience-aware curation AND its tool counts are hardcoded literals that drift from the `tool-registry.yaml` ground truth.

**Updated after owner audit** — 2 more tools (`roi-calculator`, `migration-roi-calculator`) reclassified to `internal` based on the decision rule below.

## Drift caught (badge counts)

Real distribution vs hardcoded badges (post all reclassifications):

| Phase | Hardcoded (was) | Actual (will display) |
|-------|----------------|--------|
| Deploy | 8 | **12** |
| Configure | 10 | **13** |
| Monitor | 6 | **7** |
| Troubleshoot | 6 | 6 ✓ |
| Reference | 2 | 2 |
| **Internal (new)** | — | **3** |
| **Total (hero)** | **32** | **43** |

Badges will jump on first load post-merge.

## Decision rule for "operator vs maintainer/sales tool"

Look at the **inputs**:
- Operational config (replicas, retention, scrape interval, tenant count) → operator tool
- Business numbers (hourly rate, FTE count, monthly storms) → maintainer/sales tool

## Reclassified to `audience: [maintainer]` + `journey_phase: internal`

| Tool | Reason |
|------|--------|
| **release-notes-generator** | Used only by team SHIPPING da-platform; tenants don't generate da release notes |
| **roi-calculator** | Asks for `$75/hr` rate, oncall staff, manual onboard minutes; outputs annual $ savings → pure adoption-justification calculator for management |
| **migration-roi-calculator** | Asks for `$/hr` + maintenance hours; outputs "annual savings + break-even months" → project-justification language for engineering management, not migration mechanics for the SRE actually doing it |

Decision rationale recorded as YAML comment on each registry entry so future readers don't re-litigate.

## Kept under operator audience (audit decision)

| Tool | Why kept |
|------|----------|
| **cost-estimator** | Asks for `tenants, packs, scrapeInterval, retentionDays, replicas, mode` — all OPERATIONAL. Does NOT ask for hourly rate. Real SRE question "add 5 tenants → how much more cost?" makes it a legitimate capacity-sizing tool. Already had `management` in audience tag reflecting dual use. Left as `[platform, sre, management]` + `journey_phase: deploy`. |

## Other changes (Hub UI)

1. **Dynamic phase counts + total** — replace hardcoded `*-badge: 'N Tools'` (5 phases × 2 langs = 10 i18n strings + 5 static HTML spans) and hero `'Explore 32 tools'` (2 langs) with `{N}` placeholders. `__applyHubI18n()` substitutes from `window.__hubPhaseCounts` + `window.__hubTotalCount` populated by `renderTools()` after the registry fetch resolves.

2. **6th journey phase `internal`** — collapsed `<details>` section below Reference labeled "Internal / Maintainer Tools" with a blurb explaining the audience.

3. **`check_hub_badge_drift.py` lint** (~110 LOC + 15 unit tests) — detects hardcoded `\d+ Tools` / `\d+ 個工具` in 3 forms. Allows `{N}` placeholder; supports per-line `<!-- hub-badge-drift: ignore -->` marker. Wired into `make lint-portal`.

## Test plan

- [x] All 38 pre-commit hooks green
- [x] 15/15 dogfood tests for `check_hub_badge_drift.py` pass
- [x] **New lint passes 9/9 conventions on first attempt** — validates the PR-6 `make lint-new-script` workflow (0 CI fix cycles needed vs PR-5's 4)
- [x] `tool-consistency-check` clean post-reclassify (3 tools touched in 3 sites each = 9 sync points)
- [x] `check_hub_badge_drift.py` exit 0 on real Hub
- [x] Doc-map + tool-map regenerated
- [x] `make pr-preflight` — READY (38/38, 0 behind main, no scope drift)
- [ ] CI green (Playwright Smoke Tests will visually verify badge counts)

## Roadmap

| PR | Scope | Status |
|----|-------|--------|
| #203-#207 | PR-1..5 | ✅ all merged |
| [#208](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/208) | PR-6 — Lint friction unblockers | ✅ merged |
| **PR-7** (this) | Hub dynamic counts + Internal phase + reclassify 3 tools | ⬅ here |
| PR-8 | `_common/{Loading,EmptyState}` adoption sweep | next |
| PR-9 | `portal-shared.jsx` shim conversion (uses PR-6 allowlist) | depends on PR-6 ✓ |
| PR-10 | 3 sibling setup wizard decomposition (uses PR-6 allowlist) | depends on PR-6 ✓ |
| PR-11 | Subtree ErrorBoundaries | depends on PR-2/8/10 |

## Risk

**Low.** Hub render path is purely additive. Reclassified tools still accessible via direct URL (`?component=release-notes-generator` etc.) and discoverable via the Internal section toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
