### PR TITLE
refactor(jsx): adopt _common/{Loading,EmptyState} in 4 tools (PR-8/11)

### DIFF
--- a/docs/interactive/tools/_common/components/Loading.jsx
+++ b/docs/interactive/tools/_common/components/Loading.jsx
@@ -16,6 +16,10 @@ purpose: |
              to localized "載入中… / Loading…" via window.__t.
     size     'sm' | 'md' | 'lg' (optional, default 'md'), spinner
              diameter; size tokens align with --da-space scale.
+    testid   string (optional), override default
+             data-testid="loading-spinner" for tool-scoped assertions
+             (e.g. 'simulate-preview-state-loading'). Mirrors
+             EmptyState's testid prop. Added PR-portal-8.
 
   Behaviour notes:
     Pure CSS spinner (animated border), no SVG/lucide-react dep so
@@ -24,7 +28,7 @@ purpose: |
     (idempotent: tracked by window.__loadingSpinnerStyleInjected).
     Centers in parent (block-level wrapper); caller controls outer
     sizing via wrapping div.
-    data-testid="loading-spinner" for spec assertions.
+    Default data-testid="loading-spinner" (overridable via testid prop).
 
   Closure deps: none. Pure functional component using React global.
 ---
@@ -64,7 +68,7 @@ function buildSpinnerStyle(dim) {
   };
 }
 
-function Loading({ message, size }) {
+function Loading({ message, size, testid }) {
   useEffect(() => { injectSpinnerStyle(); }, []);
 
   const t = window.__t || ((zh, en) => en);
@@ -73,7 +77,7 @@ function Loading({ message, size }) {
   const spinnerStyle = buildSpinnerStyle(dim);
 
   return (
-    <div data-testid="loading-spinner" style={WRAPPER_STYLE}>
+    <div data-testid={testid || 'loading-spinner'} style={WRAPPER_STYLE}>
       <div style={spinnerStyle} aria-hidden="true" />
       <div style={TEXT_STYLE} role="status" aria-live="polite">
         {text}

--- a/docs/interactive/tools/glossary.jsx
+++ b/docs/interactive/tools/glossary.jsx
@@ -5,11 +5,16 @@ audience: ["platform-engineer", "domain-expert", tenant]
 version: v2.7.0
 lang: en
 related: [schema-explorer, wizard, onboarding-checklist]
+dependencies: [
+  "_common/components/EmptyState.jsx"
+]
 ---
 
 import React, { useState } from 'react';
 
 const t = window.__t || ((zh, en) => en);
+// PR-portal-8: shared empty-state replaces inline "No terms" div.
+const EmptyState = window.__EmptyState;
 
 const GLOSSARY = [
   { term: 'Rule Pack', category: 'Core', def: 'A pre-built bundle of Prometheus recording rules and alert rules for a specific technology (e.g., MariaDB, Redis). You pick the ones you need — no PromQL required.', related: ['Recording Rule', 'Alert Rule', 'Projected Volume'], tryLink: '../assets/jsx-loader.html?component=../rule-pack-selector.jsx' },
@@ -131,7 +136,10 @@ export default function GlossaryPage() {
         </div>
 
         {filtered.length === 0 && (
-          <div className="text-center text-slate-400 py-12">{t('沒有符合的術語', 'No terms match your search.')}</div>
+          <EmptyState
+            icon="📖"
+            title={t('沒有符合的術語', 'No terms match your search.')}
+          />
         )}
       </div>
     </div>

--- a/docs/interactive/tools/simulate-preview.jsx
+++ b/docs/interactive/tools/simulate-preview.jsx
@@ -6,7 +6,8 @@ version: v2.7.0
 lang: en
 related: [tenant-manager, alert-builder, routing-trace, master-onboarding]
 dependencies: [
-  "_common/hooks/useDebouncedValue.js"
+  "_common/hooks/useDebouncedValue.js",
+  "_common/components/Loading.jsx"
 ]
 ---
 
@@ -24,6 +25,7 @@ const t = window.__t || ((zh, en) => en);
  * the canonical hook, the inline copy is removed.
  * ──────────────────────────────────────────────────────────────────── */
 const useDebouncedValue = window.__useDebouncedValue;
+const Loading = window.__Loading;
 
 /* ── URL param helpers (S#94 deep-link pattern reuse) ────────────────
  *
@@ -348,12 +350,11 @@ function SimulatePreview() {
           )}
 
           {status === STATUS.LOADING && (
-            <div
-              data-testid="simulate-preview-state-loading"
-              className="text-sm text-[color:var(--da-color-muted)] py-8 text-center"
-            >
-              {t('Simulate 中…', 'Simulating…')}
-            </div>
+            <Loading
+              testid="simulate-preview-state-loading"
+              size="sm"
+              message={t('Simulate 中…', 'Simulating…')}
+            />
           )}
 
           {status === STATUS.ERROR && errorInfo && (

--- a/docs/interactive/tools/template-gallery.jsx
+++ b/docs/interactive/tools/template-gallery.jsx
@@ -5,11 +5,16 @@ audience: [tenant, "platform-engineer"]
 version: v2.7.0
 lang: en
 related: [playground, rule-pack-selector, threshold-calculator]
+dependencies: [
+  "_common/components/Loading.jsx"
+]
 ---
 
 import React, { useState, useMemo, useEffect } from 'react';
 
 const t = window.__t || ((zh, en) => en);
+// PR-portal-8: shared spinner replaces the inline 8x8 border-spin div.
+const Loading = window.__Loading;
 
 /* ── Fallback pack list (used if JSON fetch fails) ── */
 const FALLBACK_PACKS = [
@@ -128,14 +133,11 @@ export default function TemplateGallery() {
     return set;
   }, [TEMPLATES]);
 
-  /* ── Loading state ── */
+  /* ── Loading state ── PR-portal-8: shared <Loading> swap. */
   if (!templateData && !loadError) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-8 flex items-center justify-center">
-        <div className="text-center">
-          <div className="inline-block w-8 h-8 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin mb-4" />
-          <p className="text-slate-500 text-sm">{t('載入模板資料...', 'Loading template data...')}</p>
-        </div>
+        <Loading message={t('載入模板資料...', 'Loading template data...')} />
       </div>
     );
   }

--- a/docs/interactive/tools/tenant-manager.jsx
+++ b/docs/interactive/tools/tenant-manager.jsx
@@ -19,7 +19,9 @@ dependencies: [
   "_common/hooks/useURLState.js",
   "_common/hooks/useVirtualGrid.js",
   "tenant-manager/hooks/useSavedViews.js",
-  "tenant-manager/components/SavedViewsPanel.jsx"
+  "tenant-manager/components/SavedViewsPanel.jsx",
+  "_common/components/Loading.jsx",
+  "_common/components/EmptyState.jsx"
 ]
 ---
 
@@ -55,6 +57,9 @@ const useVirtualGrid = window.__useVirtualGrid;
 // frontend gap.
 const useSavedViews = window.__useSavedViews;
 const SavedViewsPanel = window.__SavedViewsPanel;
+// PR-portal-8: shared loading + empty-state UI from _common/components/.
+const Loading = window.__Loading;
+const EmptyState = window.__EmptyState;
 // PR-2b: tracked URL params. Module-level const so identity stays
 // stable across renders — passing `['q']` inline as a literal would
 // create a new array each render and trigger useURLState's internal
@@ -430,12 +435,12 @@ export default function TenantManager() {
   const enableVirtualization = filtered.length > VIRTUAL_GRID_THRESHOLD;
 
   if (loading) {
+    // PR-portal-8: replaced inline 48px hourglass + muted text with
+    // shared <Loading> from _common/components/. Wrapper preserves
+    // the full-screen centred layout the original gave.
     return (
       <div style={{ ...styles.container, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <div style={{ textAlign: 'center' }}>
-          <div style={{ fontSize: '48px', marginBottom: 'var(--da-space-4)' }} aria-hidden="true">&#8987;</div>
-          <div style={{ color: 'var(--da-color-muted)' }}>{t('載入租戶數據中...', 'Loading tenant data...')}</div>
-        </div>
+        <Loading size="lg" message={t('載入租戶數據中...', 'Loading tenant data...')} />
       </div>
     );
   }
@@ -820,20 +825,25 @@ export default function TenantManager() {
         )}
 
         {filtered.length === 0 && (
-          <div style={{ textAlign: 'center', padding: 'var(--da-space-12)', backgroundColor: 'white', borderRadius: 'var(--da-radius-lg)' }}>
-            <div style={{ fontSize: '48px', marginBottom: 'var(--da-space-4)' }}>🔍</div>
-            <div style={{ color: 'var(--da-color-muted)', fontWeight: 'var(--da-font-weight-medium)' }}>
-              {t('未找到符合條件的租戶', 'No tenants match your filters')}
-            </div>
-            {!activeFilters.length && !searchText && (
-              <button
-                onClick={() => setActiveGroupId(null)}
-                style={{ ...styles.button, marginTop: 'var(--da-space-4)' }}
-              >
-                {t('建立群組', 'Create Group')}
-              </button>
-            )}
-          </div>
+          // PR-portal-8: replaced inline 🔍 + muted text + conditional
+          // CTA with shared <EmptyState>. The CTA only appears when
+          // there are no active filters AND no search — i.e. the user
+          // genuinely has no tenants in this view, not because they
+          // over-filtered.
+          <EmptyState
+            icon="🔍"
+            title={t('未找到符合條件的租戶', 'No tenants match your filters')}
+            actionLabel={
+              !activeFilters.length && !searchText
+                ? t('建立群組', 'Create Group')
+                : undefined
+            }
+            onAction={
+              !activeFilters.length && !searchText
+                ? () => setActiveGroupId(null)
+                : undefined
+            }
+          />
         )}
 
         {activeGroupId && groups[activeGroupId] && (


### PR DESCRIPTION
## Summary

PR-8 of the 11-PR refactor sweep. **Realizes the PR-2 ([#204](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/204)) investment** by adopting the `Loading` and `EmptyState` components in real tools. Without this PR, the components shipped by PR-2 were dead code — no consumer used them.

Sweep: 5 inline-pattern sites across 4 tools.

## Changes

### `Loading.jsx` enhancement (1 line)
Added `testid` prop (mirrors `EmptyState` which already accepts one). Required so `simulate-preview`'s Playwright testid `simulate-preview-state-loading` survives the swap.

### Loading swaps (3 sites, 3 tools)

| Tool | Before | After |
|------|--------|-------|
| `simulate-preview.jsx` | inline `<div data-testid="simulate-preview-state-loading">Simulating…</div>` | `<Loading testid="simulate-preview-state-loading" size="sm" message=...>` |
| `tenant-manager.jsx` | full-screen 48px hourglass + muted text | `<Loading size="lg" message=...>` wrapped in centred container |
| `template-gallery.jsx` | centred `w-8 h-8 border-spinner` div + text | `<Loading message=...>` |

### EmptyState swaps (2 sites, 2 tools)

| Tool | Before | After |
|------|--------|-------|
| `tenant-manager.jsx` | 🔍 + "No tenants match" text + conditional `<button>Create Group</button>` | `<EmptyState icon="🔍" title=... actionLabel={cond ? '...' : undefined} onAction={cond ? fn : undefined}>` |
| `glossary.jsx` | `<div className="text-center text-slate-400 py-12">No terms match...</div>` | `<EmptyState icon="📖" title=...>` |

Each consumer adds the relevant dep to its front-matter `dependencies:` block + picks up via `const X = window.__X;` at the top of the file.

## Test plan

- [x] All 38 pre-commit hooks green
- [x] All 19 dep paths in modified files resolve on disk
- [x] `lint_jsx_babel --ci --strict-linecount` exit 0; **static warnings dropped 357 → 350 (-7)** since the swaps removed 7 inline `style={{}}` blocks
- [x] Existing testids preserved (`simulate-preview-state-loading`)
- [x] `tool-consistency-check` clean
- [x] `make pr-preflight` — READY (38/38, 0 behind main, no scope drift)
- [ ] CI green (Playwright will visually verify simulate-preview + tenant-manager loading/empty paths render correctly)

## Roadmap

| PR | Scope | Status |
|----|-------|--------|
| #203-#207 | PR-1..5 | ✅ all merged |
| [#208](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/208) | PR-6 — Lint friction unblockers | ✅ merged |
| [#209](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/209) | PR-7 — Hub dynamic counts + Internal phase + reclassify | ✅ merged |
| **PR-8** (this) | `_common/{Loading,EmptyState}` adoption sweep | ⬅ here |
| PR-9 | `portal-shared.jsx` shim conversion (uses PR-6 allowlist) | next |
| PR-10 | 3 sibling setup wizard decomposition (uses PR-6 allowlist) | next |
| PR-11 | Subtree ErrorBoundaries | depends on PR-2/8/10 |

## Risk

**Low.** Behaviour-preserving swap — same loading messages, same testids (simulate-preview), same conditional CTA logic (tenant-manager). Visual rendering uses the shared component's design tokens (`--da-color-accent` for spinner, `--da-radius-sm` for button) which match the original tools' look.

For tenant-manager specifically, the EmptyState swap re-orders the conditional logic from "JSX-conditional render of `<button>`" inside a div to "pass `actionLabel`/`onAction` conditionally to `<EmptyState>`". Same external contract; cleaner React idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
