### PR TITLE
docs(jsx): record PR-12 candidate in dx-tooling-backlog (PR-11 follow-up)

### DIFF
--- a/docs/internal/dx-tooling-backlog.md
+++ b/docs/internal/dx-tooling-backlog.md
@@ -123,6 +123,25 @@ v2.6.0 Phase .d-R2 建議：pack count slider 未連動 platform-data.json。改
 
 v2.6.0 Phase .d-R2 建議：template editing 時顯示即時 char counter，幫助使用者掌握各 receiver 的長度限制（Slack 3000 / Email 無限 / PagerDuty 1024）。
 
+### deployment-wizard + alert-builder Step component 抽取（PR-portal-11 follow-up）
+
+PR-portal-11 ([#213](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/213)) 在 4 個 multi-step / multi-tab 工具加上 subtree ErrorBoundary，唯獨 `deployment-wizard.jsx` (504 LOC) + `alert-builder.jsx` (616 LOC) 跳過：兩者 step content 都是 inline JSX (`{currentStep.id === 'tier' && (<div>...</div>)}` × 6 / `{step === N && (<div>...</div>)}` × 4)，不是抽出來的 Step component；直接包 boundary 會變多層 nesting + 條件交錯，醜且難 review。
+
+兩階段執行（建議放同一個 PR）：
+
+**Phase A — 抽 Step components**。每個 inline block 抽到 sibling `<wizard>/components/Step*.jsx`（deployment 6 個、alert-builder 4 個），符號用 `window.__DeployStepX` / `window.__AlertBuilderStepX` 前綴避免跨工具衝突（同 PR-portal-10 的 `__CICD_*` / `__DEPLOY_*` / `__RBAC_*` 命名慣例）。orchestrator 的 conditional render 變乾淨：`{currentStep.id === 'tier' && <StepTier {...stepProps} />}`。
+
+**Phase B — 套 boundary**。複製 PR-portal-11 的 cicd-setup-wizard pattern：`<ErrorBoundary key={currentStep.id} scope={'deployment-wizard/step/' + currentStep.id}>{...所有 conditionals...}</ErrorBoundary>`。1 個 wrap 配 `key={...id}` 每步換新 mount。
+
+**兩個必踩坑**：
+
+- **`auth` step 的雙條件** (`currentStep.id === 'auth' && config.tier === 'tier2'`) — `config.tier === 'tier2'` 邏輯**必須留在 orchestrator**（決定 step 是否出現），不要搬進 `StepAuth`；否則 step nav 顯示這個 step 但 component 內 early-return → 一片空白卡關。
+- **sed-damage threshold**：deployment-wizard 抽完 504 → ~150 LOC（70% shrink）+ alert-builder 616 → ~200 LOC（67% shrink）→ 兩個都觸發 `sed-damage-guard`。需把兩個路徑加進 `.sed-damage-allowlist`（PR-portal-9 #211 portal-shared.jsx 已有先例 + PR-portal-6 #208 機制本身）。
+
+**預估規模**：10 個新檔 + 2 個 orchestrator 改動 + 2 個 allowlist 條目 ≈ -770 LOC orchestrator 總減量；單一 PR ~800 LOC delta（reviewable，跟 PR-portal-10 同級）。
+
+**時程：post-v2.8.0**。當前兩個工具功能正常（loader-level boundary from PR-portal-2 仍能接全工具失敗），不是 bug 是 incremental quality。塞進 v2.8.0 release window 會讓 release notes 變雜（已 11 個 portal PR）。若 ship 後客戶遇到「某 step 壞掉拖死整個 wizard」事件再提前。
+
 ---
 
 ## 候選 — 測試品質


### PR DESCRIPTION
## Summary

Doc-only PR. Records the deferred-from-PR-portal-11 ([#213](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/213)) work for `deployment-wizard` + `alert-builder` under `dx-tooling-backlog.md` `候選 — 互動工具` section so it doesn't get lost.

## Why

Both `deployment-wizard.jsx` (504 LOC) and `alert-builder.jsx` (616 LOC) were skipped from PR-portal-11's subtree ErrorBoundary adoption because their step content is **inline JSX inside the orchestrator** (not extracted Step components like operator / cicd / rbac were). Wrapping inline blocks would create messy nesting; the right sequence is **extract-then-wrap** as a single follow-up PR.

## Backlog entry captures

- **Two-phase plan**: Phase A extract Step components, Phase B add boundary
- **Symbol-naming convention**: extends PR-portal-10's `__CICD_*` / `__DEPLOY_*` / `__RBAC_*` pattern with `__DeployStepX` / `__AlertBuilderStepX` to avoid window-global collisions
- **Two specific traps to watch**:
  1. `auth` step's tier-conditional (`config.tier === 'tier2'`) must **stay in orchestrator** (not move into `StepAuth`) to avoid blank-step UX
  2. Both wizards will trip `sed-damage-guard` 50% threshold (deployment 70% shrink, alert-builder 67%) and need `.sed-damage-allowlist` entries — precedent: PR-portal-9 ([#211](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/211)) `portal-shared.jsx`
- **Sizing**: ~10 new files + 2 orchestrator changes + 2 allowlist entries ≈ -770 LOC orchestrator delta; single PR ~800 LOC (matches PR-portal-10 reviewability)
- **Timing**: post-v2.8.0 — both tools work today (loader-level boundary still catches whole-tool failures); incremental quality, not a bug. If a customer reports "step N broken locks the whole wizard" → bump priority.

## Test plan

- [x] All 38 pre-commit hooks green
- [x] No code change; pure doc append in existing section
- [x] `make pr-preflight` — READY (38/38, 0 behind main, no scope drift)

## Roadmap context

| PR | Scope | Status |
|----|-------|--------|
| #203-#213 | PR-1..11 — v2.8.0 da-portal refactor sweep (11 PRs) | ✅ all merged |
| **This PR** | Doc-only backlog entry for the post-v2.8.0 follow-up | ⬅ here |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
