### PR TITLE
refactor(phase-b): tenant-api v2.8.0 refactor sweep wave 1 (PR-1..3 of 11)

### DIFF
--- a/components/tenant-api/README.md
+++ b/components/tenant-api/README.md
@@ -1,57 +1,167 @@
-# tenant-api (v2.7.0)
+# tenant-api (v2.8.0)
 
-> **Tenant Management REST API** — config-driven 的租戶管理服務，提供 CRUD + Batch 操作、RBAC 權限控制、GitOps commit-on-write 審計軌跡。搭配 oauth2-proxy sidecar 實現 IdP 整合認證。
->
-> **其他文件：** [README](../../README.md) (概覽) · [ADR-009](../../docs/adr/009-tenant-manager-crud-api.md) (架構決策) · [Architecture & Design](../../docs/architecture-and-design.md) (技術深度) · [API Reference](../../docs/api/README.md) (API 參考)
+> **Tenant Management REST API** — config-driven 多租戶 alerting 平台的後端寫入 + 讀取面，提供 RBAC 過濾後的 CRUD、批次操作、async task polling、SSE 事件流，以及 `direct` / GitHub PR / GitLab MR 三種寫回模式。認證由 oauth2-proxy sidecar 處理。
 
-## 架構
+## What this service does (and doesn't)
 
-- **chi Router**: 輕量 HTTP router，搭配 RequestID / RealIP / Logger / Recoverer / Timeout middleware
-- **RBAC**: `_rbac.yaml` 定義 group → tenant → permission 映射，`atomic.Value` hot-reload（預設 30s）
-- **GitOps Writer**: schema validation → YAML 寫入 → `git commit`（以操作者 email 為 author）
-- **Conflict Detection**: 寫入前檢查 git HEAD，若有其他變更返回 409 Conflict
-- **Path Traversal 防護**: `ValidateTenantID()` 拒絕 `..`、`/`、`\` 等路徑穿越
-- **Prometheus Metrics**: atomic counter 實現，零外部依賴（不需 prometheus/client_golang）
-- **Security**: `ReadHeaderTimeout` (Gosec G112)、1 MB body limit、non-root container
+**Does**
 
-## Endpoints
+- 暴露租戶 / 群組 / saved view 的 CRUD、批次操作、effective config 解析
+- 寫入時做 schema validation、domain policy 檢查、git commit-on-write 或 PR/MR 寫回
+- 套用 RBAC 對 tenant 列表 / group 成員 / pending PR / async task 做 per-caller filtering
+- per-caller rate limit、`X-Request-ID` echo、body-content range validation 等 v2.8.0 hardening surface
 
-| Method | Path | 說明 | 權限 |
+**Doesn't**
+
+- **不做認證**：身份來自 oauth2-proxy 注入的 `X-Forwarded-Email` / `X-Forwarded-Groups` header
+- **不做 schema 演化**：YAML schema 由 `pkg/config`（threshold-exporter）擁有
+- **不做持久化 task store**：async task 是 in-memory，pod restart 後資料消失（client polling 收到 404 時應視為 task lost）
+- **不做 PR / MR 合併**：建立 PR/MR 後等待人工 review，只追蹤狀態
+
+## Architecture
+
+- **chi Router** + 標準 middleware 鏈（RequestID / RealIP / Logger / Recoverer / Timeout）
+- **`X-Request-ID` echo**：chi 注入的 request id 寫回 response header，方便 client 對 log
+- **Per-caller rate limit**：sliding-window，預設 100 req/min/caller，`TA_RATE_LIMIT_PER_MIN=0` 關閉
+- **RBAC**：`_rbac.yaml` 定義 group → tenant → permission，`atomic.Value` hot-reload（預設 30s）；缺少 `_rbac.yaml` 進入 open-read mode
+- **Tenant-scoped authz**（v2.8.0 B-6 PR-2）：group / view / batch / PR list / task results 的成員都會被 per-tenant RBAC 再過一次
+- **GitOps Writer**：schema validation → YAML 寫入 → `git commit`（operator email 為 author，service account 為 committer）
+- **Conflict detection**：寫入後檢查 commit 的 parent；若 HEAD 在 read 跟 write 之間移動回 409
+- **Body-content validation**（issue #134）：fixed-shape 欄位走 go-playground/validator，`Patch` / `Filters` map 走 per-key registry，違反一次回完整 violations 陣列
+- **Domain policy**：寫入前檢查 `_domain_policy.yaml` 規則，違反回 403
+- **Async tasks**：4 worker goroutine 跑批次操作，`/api/v1/tasks/{id}` polling
+- **SSE event hub**：寫入成功後廣播 `config_change` 事件，UI 即時更新
+- **Path traversal 防護**：`ValidateTenantID()` 拒絕 `..`、`/`、`\`
+- **Prometheus metrics**：atomic counter 自實作，無 prometheus/client_golang 依賴
+- **Security**：`ReadHeaderTimeout` (Gosec G112)、1 MB body limit、non-root container
+
+## API reference
+
+### Health / Identity / Metrics（無需認證）
+
+| Method | Path | 說明 |
+|--------|------|------|
+| `GET` | `/health` | Liveness probe — always 200 |
+| `GET` | `/ready` | Readiness — 503 if `configDir` 無法 stat |
+| `GET` | `/metrics` | Prometheus text exposition |
+
+### Tenant
+
+| Method | Path | 權限 | 說明 |
 |--------|------|------|------|
-| `GET` | `/health` | Liveness probe | 無需認證 |
-| `GET` | `/ready` | Readiness probe（config-dir 可讀） | 無需認證 |
-| `GET` | `/metrics` | Prometheus metrics（text exposition） | 無需認證 |
-| `GET` | `/api/v1/tenants` | 列出所有租戶（含 silent/maintenance 狀態） | read |
-| `GET` | `/api/v1/tenants/{id}` | 取得租戶完整設定（raw YAML + resolved thresholds） | read |
-| `GET` | `/api/v1/tenants/{id}/effective` | **（v2.7.0 新增）** 返回套完繼承的 merged config + 來源鏈 (defaults chain) + dual hashes (`source_hash` + `merged_hash`，16 hex)。底層呼叫 `pkg/config/hierarchy.go` 的 stateless `ResolveEffective()`；404 回 `ErrTenantNotFound` sentinel，400 回 invalid/empty id。搭配 ADR-018 的 L0→L3 繼承語義（深合併 / array 替換 / null-as-delete） | read |
-| `PUT` | `/api/v1/tenants/{id}` | 更新租戶設定（validate → write → git commit） | write |
-| `POST` | `/api/v1/tenants/{id}/validate` | Dry-run 驗證（不寫入） | read |
-| `POST` | `/api/v1/tenants/{id}/diff` | 預覽變更 diff（current vs proposed） | read |
-| `POST` | `/api/v1/tenants/batch` | 批次操作（per-tenant 權限檢查） | read + per-tenant write |
+| `GET` | `/api/v1/me` | read | 回傳當前 caller 的 email + groups + RBAC 摘要 |
+| `GET` | `/api/v1/tenants` | read | 列出 RBAC 可見的租戶（含 silent / maintenance / `_metadata`） |
+| `GET` | `/api/v1/tenants/search` | read | **(v2.8.0 C-1)** 伺服端 search / filter / pagination；`q` / `environment` / `tier` / `domain` / `db_type` / `tag` / `page_size`（max 500）/ `offset` / `sort`。內含 30s snapshot cache，目標 1000 租戶下 p99 < 200ms。⚠️ numeric offset 仍是 v1 design — opaque cursor 未來換 |
+| `GET` | `/api/v1/tenants/{id}` | read | 取得 raw YAML + resolved thresholds |
+| `GET` | `/api/v1/tenants/{id}/effective` | read | **(v2.7.0 B-3)** merged config + 來源鏈 + dual hashes（`source_hash` + `merged_hash`，16 hex），底層走 `pkg/config/hierarchy.ResolveEffective()`，ADR-018 L0→L3 繼承語義 |
+| `PUT` | `/api/v1/tenants/{id}` | write | 寫入（validate → policy check → write → commit / PR） |
+| `POST` | `/api/v1/tenants/{id}/validate` | read | Dry-run 驗證 |
+| `POST` | `/api/v1/tenants/{id}/diff` | read | 預覽 unified diff |
+| `POST` | `/api/v1/tenants/batch` | read + per-tenant write | 批次（per-op RBAC + policy 檢查；`?async=true` 走 task pool） |
 
-## Metrics 輸出
+### Group / View
+
+| Method | Path | 權限 | 說明 |
+|--------|------|------|------|
+| `GET` | `/api/v1/groups` | read | 列出 group（過濾掉成員都不可讀的 group） |
+| `GET` | `/api/v1/groups/{id}` | read | 取得 group |
+| `PUT` | `/api/v1/groups/{id}` | write + per-member write | 寫入；caller 對所有 `members` 都需 PermWrite，否則 403 + forbidden 列表 |
+| `DELETE` | `/api/v1/groups/{id}` | write + per-member write | 刪除；同上權限模型 |
+| `POST` | `/api/v1/groups/{id}/batch` | read + per-member write | 對 group 全成員套 patch（同步 / async） |
+| `GET` | `/api/v1/views` | read | 列出 saved view |
+| `GET` `PUT` `DELETE` | `/api/v1/views/{id}` | read / write | Saved view CRUD |
+
+### Async / Eventing
+
+| Method | Path | 權限 | 說明 |
+|--------|------|------|------|
+| `GET` | `/api/v1/tasks/{id}` | read | Async task polling；`Results` 會被 caller-RBAC 過濾，全部不可讀回 403 |
+| `GET` | `/api/v1/prs` | read | Pending PR / MR 列表；caller 不可讀的 `tenant_id` 自動隱藏；`?tenant=<id>` 不可讀回空陣列（避免 existence oracle） |
+| `GET` | `/api/v1/events` | read | SSE 即時事件流（config_change） |
+
+## Operational concerns
+
+### Limits + caps
+
+| 項目 | 值 | 來源 |
+|------|----|------|
+| Per-caller rate limit | 100 req/min（預設） | `TA_RATE_LIMIT_PER_MIN` |
+| Request body | 1 MB（PUT / POST） | `io.LimitReader` |
+| Batch operations | 1–1000 ops | struct-tag validator |
+| Search page_size | 1–500（預設 50） | `tenant_search.go` |
+| Tenant snapshot cache TTL | 30s | `tenant_search.go::snapshotTTL` |
+| Patch key length | ≤ 256 chars | `body_validator.go::maxPatchKeyLen` |
+| Patch value length | ≤ 1024 chars | `body_validator.go::maxPatchValueLen` |
+| `_timeout_ms` value | ≤ 3,600,000（1 hr） | `body_validator.go` |
+
+### Rate-limit response shape
+
+```json
+{
+  "error":         "rate limit exceeded for user@example.com; try again in 12s",
+  "code":          "RATE_LIMITED",
+  "retry_after_s": 12
+}
+```
+
+`Retry-After` header 同步輸出。`/health` / `/ready` / `/metrics` 永遠跳過限流。
+
+### Conflict semantics
+
+寫入時記錄 git HEAD before / after；若 commit 的 parent 跟 before 不符（外部 commit 落地）回 `ErrConflict` → 409。Client 應 refresh 後重試。
+
+### Open-read mode
+
+未配置 `_rbac.yaml` 時：所有 read 端點放行，所有 write 端點放行（僅 `ValidateTenantID` 守 path traversal）。**不適合 production**，僅給單人 dev 環境使用。
+
+## Observability
+
+### Metrics（`/metrics`）
 
 ```prometheus
-# HELP tenant_api_up Whether the tenant-api is up.
-# TYPE tenant_api_up gauge
 tenant_api_up 1
-# HELP tenant_api_uptime_seconds Seconds since tenant-api started.
-# TYPE tenant_api_uptime_seconds gauge
 tenant_api_uptime_seconds 3600.0
-# HELP tenant_api_requests_total Total API requests.
-# TYPE tenant_api_requests_total counter
 tenant_api_requests_total 42
-# HELP tenant_api_errors_total Total API errors.
-# TYPE tenant_api_errors_total counter
 tenant_api_errors_total 2
-# HELP tenant_api_writes_total Total write operations (git commits).
-# TYPE tenant_api_writes_total counter
 tenant_api_writes_total 5
 ```
 
-## RBAC 設定
+### Request correlation
 
-透過 `_rbac.yaml` 定義群組權限：
+每筆 request 收到 `X-Request-ID` response header（chi 自動產或客戶傳入）。Server log 同步印出該 request id，客戶報問題時直接給 id 即可定位。
+
+### SSE events
+
+`GET /api/v1/events` 訂閱即時 config 變更：
+
+```
+event: config_change
+data: {"type":"config_change","tenant_id":"db-a-prod","timestamp":"2026-05-03T10:00:00Z","detail":"tenant config updated"}
+```
+
+## Configuration
+
+### Environment variables
+
+| 變數 | 預設值 | 說明 |
+|------|--------|------|
+| `TA_CONFIG_DIR` | `/conf.d` | 租戶 YAML 檔案目錄 |
+| `TA_GIT_DIR` | (同 config-dir) | Git repository root |
+| `TA_RBAC_PATH` | (空 = open-read) | `_rbac.yaml` 路徑 |
+| `TA_ADDR` | `:8080` | HTTP listen address |
+| `TA_RATE_LIMIT_PER_MIN` | `100` | Per-caller rate limit；`0` 關閉；malformed 值回退預設並印 WARN |
+| `TA_WRITE_MODE` | `direct` | `direct` / `pr` / `pr-github` / `pr-gitlab` |
+| `TA_GITHUB_TOKEN` | (空) | `pr-github` 必填 |
+| `TA_GITHUB_REPO` | (空) | `owner/repo` |
+| `TA_GITHUB_BASE_BRANCH` | `main` | PR target |
+| `TA_GITHUB_API_URL` | (空) | GitHub Enterprise API URL |
+| `TA_GITLAB_TOKEN` | (空) | `pr-gitlab` 必填 |
+| `TA_GITLAB_PROJECT` | (空) | `group/project` 或 numeric ID |
+| `TA_GITLAB_TARGET_BRANCH` | `main` | MR target |
+| `TA_GITLAB_API_URL` | (空) | 自託管 GitLab URL |
+| `GIT_COMMITTER_NAME` / `GIT_COMMITTER_EMAIL` | (空) | service account 身份；空時 fallback 到 author |
+
+### RBAC YAML
 
 ```yaml
 groups:
@@ -68,132 +178,87 @@ groups:
     permissions: [read]
 ```
 
-認證由 oauth2-proxy sidecar 處理，將 `X-Forwarded-Email` / `X-Forwarded-Groups` 注入後端請求 header。
+詳細 metadata-aware filtering（環境 / 域過濾）見 [rbac.go](internal/rbac/rbac.go) 註解。
 
-## K8s 部署
+## Write-back modes
 
-### Helm（推薦）
+| 模式 | 行為 | 適用場景 |
+|------|------|----------|
+| `direct` | 直接 `git commit` | dev、單人操作 |
+| `pr` / `pr-github` | 建 feature branch + GitHub PR | GitHub.com / Enterprise Server |
+| `pr-gitlab` | 建 feature branch + GitLab MR | GitLab.com / 自託管 |
+
+兩種 PR 模式啟動時會跑 `ValidateToken()` 驗證 token + 連線；失敗印 WARN 但不 fatal（後續 PR 創建會 503）。
 
 ```bash
-# 安裝
-helm install tenant-api \
-  oci://ghcr.io/vencil/charts/tenant-api --version 2.7.0 \
-  -n monitoring --create-namespace \
-  -f values-override.yaml
+# GitHub Enterprise
+export TA_WRITE_MODE=pr-github
+export TA_GITHUB_TOKEN=ghp_xxx          # contents:write + pull_requests:write
+export TA_GITHUB_REPO=org/config-repo
+export TA_GITHUB_API_URL=https://github.internal.example.com/api/v3
 
-# 升級
-helm upgrade tenant-api \
-  oci://ghcr.io/vencil/charts/tenant-api --version 2.7.0 \
-  -n monitoring -f values-override.yaml
+# GitLab self-hosted
+export TA_WRITE_MODE=pr-gitlab
+export TA_GITLAB_TOKEN=glpat-xxx        # api scope
+export TA_GITLAB_PROJECT=infra/alerting-config
+export TA_GITLAB_API_URL=https://gitlab.internal.example.com
 ```
 
-> **已 clone 專案？** 也可指向本地 chart 目錄：
-> ```bash
-> helm install tenant-api ./helm/tenant-api \
->   -n monitoring --create-namespace -f values-override.yaml
-> ```
+## Deployment
 
-Helm chart 會自動建立：Deployment + oauth2-proxy sidecar、Service (80 → oauth2-proxy, 8080 → tenant-api)、RBAC ConfigMap、NetworkPolicy、PDB。
+### Helm（建議）
+
+```bash
+helm install tenant-api \
+  oci://ghcr.io/vencil/charts/tenant-api --version 2.8.0 \
+  -n monitoring --create-namespace \
+  -f values-override.yaml
+```
+
+或指向本地 chart：`helm install tenant-api ./helm/tenant-api -n monitoring -f values-override.yaml`
+
+Chart 自動建立：Deployment + oauth2-proxy sidecar、Service（80 → oauth2-proxy、8080 → tenant-api）、RBAC ConfigMap、NetworkPolicy、PDB。
 
 ### Docker
 
 ```bash
-# 從 repo root 建構（因 go.mod replace directive 需要 threshold-exporter 模組）
-docker build -t ghcr.io/vencil/tenant-api:2.7.0 \
+# 從 repo root build（go.mod replace directive 需要 threshold-exporter 模組）
+docker build -t ghcr.io/vencil/tenant-api:2.8.0 \
   -f components/tenant-api/Dockerfile .
 
-# 執行
 docker run -p 8080:8080 -v $(pwd)/conf.d:/conf.d \
-  ghcr.io/vencil/tenant-api:2.7.0
+  ghcr.io/vencil/tenant-api:2.8.0
 ```
 
-### 驗證部署
+### Smoke test
 
 ```bash
-# Pod 狀態
 kubectl get pods -n monitoring -l app=tenant-api
-
-# Health check
 curl -s http://localhost:8080/health
-
-# 列出租戶
 curl -s http://localhost:8080/api/v1/tenants | python3 -m json.tool
-
-# Prometheus metrics
 curl -s http://localhost:8080/metrics
 ```
 
-## 環境變數
-
-| 變數 | 預設值 | 說明 |
-|------|--------|------|
-| `TA_CONFIG_DIR` | `/conf.d` | 租戶 YAML 檔案目錄 |
-| `TA_GIT_DIR` | (同 config-dir) | Git repository root |
-| `TA_RBAC_PATH` | (空 = open-read) | `_rbac.yaml` 路徑 |
-| `TA_ADDR` | `:8080` | HTTP listen address |
-| `TA_WRITE_MODE` | `direct` | 寫入模式：`direct`（直接 commit）/ `pr` 或 `pr-github`（GitHub PR）/ `pr-gitlab`（GitLab MR） |
-| `TA_GITHUB_TOKEN` | (空) | GitHub PAT（`write-mode=pr` 或 `pr-github` 時必填） |
-| `TA_GITHUB_REPO` | (空) | GitHub repo（`owner/repo` 格式） |
-| `TA_GITHUB_BASE_BRANCH` | `main` | GitHub PR 目標分支 |
-| `TA_GITHUB_API_URL` | (空) | GitHub Enterprise Server API URL |
-| `TA_GITLAB_TOKEN` | (空) | GitLab access token（`write-mode=pr-gitlab` 時必填） |
-| `TA_GITLAB_PROJECT` | (空) | GitLab 專案路徑（`group/project`）或數字 ID |
-| `TA_GITLAB_TARGET_BRANCH` | `main` | GitLab MR 目標分支 |
-| `TA_GITLAB_API_URL` | (空) | 自託管 GitLab 實例 URL |
-
-## Write-back 模式
-
-tenant-api 支援四種寫入模式，透過 `TA_WRITE_MODE` 環境變數切換：
-
-| 模式 | 說明 | 適用場景 |
-|------|------|----------|
-| `direct` | 直接 `git commit` 到本地 repo | 開發環境、單人操作 |
-| `pr` / `pr-github` | 建立 GitHub Pull Request | GitHub.com 或 GitHub Enterprise Server |
-| `pr-gitlab` | 建立 GitLab Merge Request | GitLab.com 或自託管 GitLab |
-
-### GitHub（含 Enterprise Server）
+## Development
 
 ```bash
-export TA_WRITE_MODE=pr-github
-export TA_GITHUB_TOKEN=ghp_xxxxxxxxxxxx   # Fine-grained PAT (contents:write + pull_requests:write)
-export TA_GITHUB_REPO=org/config-repo
-
-# 自託管 GitHub Enterprise Server（選填，預設 github.com）
-export TA_GITHUB_API_URL=https://github.internal.example.com/api/v3
-```
-
-### GitLab（含自託管實例）
-
-```bash
-export TA_WRITE_MODE=pr-gitlab
-export TA_GITLAB_TOKEN=glpat-xxxxxxxxxxxx  # Project/Group/Personal Access Token (api scope)
-export TA_GITLAB_PROJECT=infra/alerting-config  # 或數字 ID
-
-# 自託管 GitLab（選填，預設 gitlab.com）
-export TA_GITLAB_API_URL=https://gitlab.internal.example.com
-```
-
-兩種 PR 模式都支援自託管部署，只需額外設定對應的 `*_API_URL` 環境變數即可。啟動時會自動執行 `ValidateToken()` 驗證連線和權限，若配置有誤會在啟動階段立即報錯。
-
-## 開發
-
-```bash
-# 執行測試（99 個 Go 測試）
-cd components/tenant-api && go test ./...
+# 322 個 Go 測試（含 race detector）
+go test ./... -race
 
 # Lint
-cd components/tenant-api && golangci-lint run
+golangci-lint run
 
-# Build binary
-cd components/tenant-api && go build -o tenant-api ./cmd/server
+# Build
+go build -o tenant-api ./cmd/server
 ```
 
-## 版號策略
+Pre-commit hook (`.golangci.yml`) 與 repo 層 `make pr-preflight` 整合 — PR 合併前必跑。
 
-| Tag 格式 | 產出 | 說明 |
-|----------|------|------|
-| `tenant-api/v*` | `ghcr.io/vencil/tenant-api` Docker image + Helm chart | tenant-api 專屬版號線 |
-| `exporter/v*` | threshold-exporter + Helm chart | — |
-| `tools/v*` | da-tools CLI image | — |
-| `portal/v*` | da-portal image | — |
-| `v*` | Platform tag (GitHub Release) | 不觸發 build |
+## Versioning + references
+
+- Tag line: `tenant-api/v*` → `ghcr.io/vencil/tenant-api` Docker image + Helm chart
+- 版本歷程：[CHANGELOG.md](../../CHANGELOG.md)
+- 架構決策：[ADR-009 commit-on-write CRUD](../../docs/adr/009-tenant-manager-crud-api.md)、[ADR-011 PR-based write-back](../../docs/adr/011-pr-based-writeback.md)
+- 設計深度：[architecture-and-design.md](../../docs/architecture-and-design.md)
+- API 細節：[docs/api/README.md](../../docs/api/README.md)、[tenant-api-hardening.md](../../docs/api/tenant-api-hardening.md)（v2.8.0 B-6 hardening 詳解）
+- Repo overview：[../../README.md](../../README.md)

--- a/components/tenant-api/internal/github/client.go
+++ b/components/tenant-api/internal/github/client.go
@@ -20,10 +20,6 @@ import (
 	"github.com/vencil/tenant-api/internal/platform"
 )
 
-// PRInfo is an alias for platform.PRInfo for backward compatibility.
-// New code should use platform.PRInfo directly.
-type PRInfo = platform.PRInfo
-
 // Compile-time interface assertion: *Client implements platform.Client.
 var _ platform.Client = (*Client)(nil)
 

--- a/components/tenant-api/internal/github/tracker.go
+++ b/components/tenant-api/internal/github/tracker.go
@@ -1,141 +1,20 @@
 package github
 
 import (
-	"log"
-	"sync"
 	"time"
 
 	"github.com/vencil/tenant-api/internal/platform"
 )
 
-// Compile-time interface assertion: *Tracker implements platform.Tracker.
-var _ platform.Tracker = (*Tracker)(nil)
+// Tracker is the GitHub-flavored pending-PR cache. The implementation
+// is shared via platform.PollingTracker — github.Tracker exists only
+// as a typed alias so call sites can write `*github.Tracker` and stay
+// importing this package. See platform/tracker.go for the design.
+type Tracker = platform.PollingTracker
 
-// Tracker maintains an in-memory cache of pending PRs, periodically syncing
-// with the GitHub API. This allows the tenant-manager UI to display pending PR
-// status without hitting GitHub on every request.
-//
-// Design (ADR-011): eventual consistency — the cache may be up to syncInterval stale.
-// Implements platform.Tracker.
-type Tracker struct {
-	client       *Client
-	mu           sync.RWMutex
-	pendingPRs   []platform.PRInfo
-	byTenant     map[string]platform.PRInfo // tenantID → most recent pending PR
-	syncInterval time.Duration
-	lastSync     time.Time
-}
-
-// NewTracker creates a PR tracker with the given sync interval.
+// NewTracker creates a PR tracker that polls the given GitHub client.
+// `syncInterval` below 10s is clamped to 30s by the underlying
+// platform.PollingTracker (see its doc).
 func NewTracker(client *Client, syncInterval time.Duration) *Tracker {
-	if syncInterval < 10*time.Second {
-		syncInterval = 30 * time.Second
-	}
-	return &Tracker{
-		client:       client,
-		byTenant:     make(map[string]platform.PRInfo),
-		syncInterval: syncInterval,
-	}
-}
-
-// WatchLoop periodically syncs the pending PR list from GitHub.
-// Call this in a goroutine. Stops when stopCh is closed.
-func (t *Tracker) WatchLoop(stopCh <-chan struct{}) {
-	// Initial sync
-	t.sync()
-
-	ticker := time.NewTicker(t.syncInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			t.sync()
-		case <-stopCh:
-			return
-		}
-	}
-}
-
-// sync fetches the current open PRs from GitHub and updates the cache.
-func (t *Tracker) sync() {
-	prs, err := t.client.ListOpenPRs()
-	if err != nil {
-		log.Printf("WARN: github tracker: sync failed: %v", err)
-		return
-	}
-
-	byTenant := make(map[string]platform.PRInfo, len(prs))
-	for _, pr := range prs {
-		if pr.TenantID != "" {
-			// Keep the most recent PR per tenant (by PR number, higher = newer)
-			if existing, ok := byTenant[pr.TenantID]; !ok || pr.Number > existing.Number {
-				byTenant[pr.TenantID] = pr
-			}
-		}
-	}
-
-	t.mu.Lock()
-	t.pendingPRs = prs
-	t.byTenant = byTenant
-	t.lastSync = time.Now()
-	t.mu.Unlock()
-
-	log.Printf("github tracker: synced %d pending PRs", len(prs))
-}
-
-// PendingPRs returns all tracked pending PRs.
-func (t *Tracker) PendingPRs() []platform.PRInfo {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	result := make([]platform.PRInfo, len(t.pendingPRs))
-	copy(result, t.pendingPRs)
-	return result
-}
-
-// PendingPRForTenant returns the pending PR for a specific tenant, if any.
-func (t *Tracker) PendingPRForTenant(tenantID string) (platform.PRInfo, bool) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	pr, ok := t.byTenant[tenantID]
-	return pr, ok
-}
-
-// HasPendingPR checks if a tenant has an open PR pending review.
-func (t *Tracker) HasPendingPR(tenantID string) bool {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	_, ok := t.byTenant[tenantID]
-	return ok
-}
-
-// RegisterPR adds a newly created PR to the tracker immediately (before next sync).
-// If the tenant already has a pending PR, it replaces the existing entry.
-func (t *Tracker) RegisterPR(pr platform.PRInfo) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	// Replace existing entry for same tenant to avoid duplicates
-	if pr.TenantID != "" {
-		replaced := false
-		for i, existing := range t.pendingPRs {
-			if existing.TenantID == pr.TenantID {
-				t.pendingPRs[i] = pr
-				replaced = true
-				break
-			}
-		}
-		if !replaced {
-			t.pendingPRs = append(t.pendingPRs, pr)
-		}
-		t.byTenant[pr.TenantID] = pr
-	} else {
-		t.pendingPRs = append(t.pendingPRs, pr)
-	}
-}
-
-// LastSyncTime returns when the tracker last synced with GitHub.
-func (t *Tracker) LastSyncTime() time.Time {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return t.lastSync
+	return platform.NewPollingTracker(client.ListOpenPRs, "github", syncInterval)
 }

--- a/components/tenant-api/internal/github/tracker_test.go
+++ b/components/tenant-api/internal/github/tracker_test.go
@@ -43,7 +43,7 @@ func TestTrackerSync(t *testing.T) {
 	})
 	defer srv.Close()
 
-	tracker.sync()
+	tracker.Sync()
 
 	prs := tracker.PendingPRs()
 	if len(prs) != 2 {
@@ -67,7 +67,7 @@ func TestTrackerPendingPRForTenant(t *testing.T) {
 	})
 	defer srv.Close()
 
-	tracker.sync()
+	tracker.Sync()
 
 	pr, ok := tracker.PendingPRForTenant("db-a")
 	if !ok {
@@ -87,7 +87,7 @@ func TestTrackerRegisterPR(t *testing.T) {
 	tracker, srv := newTestTracker(t, []platform.PRInfo{})
 	defer srv.Close()
 
-	tracker.sync()
+	tracker.Sync()
 	if len(tracker.PendingPRs()) != 0 {
 		t.Fatal("expected empty tracker")
 	}
@@ -118,7 +118,7 @@ func TestTrackerLastSyncTime(t *testing.T) {
 		t.Error("expected zero time before first sync")
 	}
 
-	tracker.sync()
+	tracker.Sync()
 
 	if tracker.LastSyncTime().IsZero() {
 		t.Error("expected non-zero time after sync")
@@ -133,7 +133,7 @@ func TestTrackerMostRecentPRPerTenant(t *testing.T) {
 	})
 	defer srv.Close()
 
-	tracker.sync()
+	tracker.Sync()
 
 	pr, ok := tracker.PendingPRForTenant("db-a")
 	if !ok {
@@ -147,7 +147,7 @@ func TestTrackerMostRecentPRPerTenant(t *testing.T) {
 func TestMinSyncInterval(t *testing.T) {
 	c, _ := NewClient("token", "owner/repo", "main")
 	tracker := NewTracker(c, 1*time.Second) // below minimum
-	if tracker.syncInterval < 10*time.Second {
-		t.Errorf("expected sync interval >= 10s, got %v", tracker.syncInterval)
+	if got := tracker.SyncInterval(); got < 10*time.Second {
+		t.Errorf("expected sync interval >= 10s, got %v", got)
 	}
 }

--- a/components/tenant-api/internal/gitlab/tracker.go
+++ b/components/tenant-api/internal/gitlab/tracker.go
@@ -1,141 +1,20 @@
 package gitlab
 
 import (
-	"log"
-	"sync"
 	"time"
 
 	"github.com/vencil/tenant-api/internal/platform"
 )
 
-// Compile-time interface assertion: *Tracker implements platform.Tracker.
-var _ platform.Tracker = (*Tracker)(nil)
+// Tracker is the GitLab-flavored pending-MR cache. The implementation
+// is shared via platform.PollingTracker — gitlab.Tracker exists only
+// as a typed alias so call sites can write `*gitlab.Tracker` and stay
+// importing this package. See platform/tracker.go for the design.
+type Tracker = platform.PollingTracker
 
-// Tracker maintains an in-memory cache of pending MRs, periodically syncing
-// with the GitLab API. This allows the tenant-manager UI to display pending MR
-// status without hitting GitLab on every request.
-//
-// Design (ADR-011): eventual consistency — the cache may be up to syncInterval stale.
-// Implements platform.Tracker.
-type Tracker struct {
-	client       *Client
-	mu           sync.RWMutex
-	pendingMRs   []platform.PRInfo
-	byTenant     map[string]platform.PRInfo // tenantID → most recent pending MR
-	syncInterval time.Duration
-	lastSync     time.Time
-}
-
-// NewTracker creates an MR tracker with the given sync interval.
+// NewTracker creates an MR tracker that polls the given GitLab client.
+// `syncInterval` below 10s is clamped to 30s by the underlying
+// platform.PollingTracker (see its doc).
 func NewTracker(client *Client, syncInterval time.Duration) *Tracker {
-	if syncInterval < 10*time.Second {
-		syncInterval = 30 * time.Second
-	}
-	return &Tracker{
-		client:       client,
-		byTenant:     make(map[string]platform.PRInfo),
-		syncInterval: syncInterval,
-	}
-}
-
-// WatchLoop periodically syncs the pending MR list from GitLab.
-// Call this in a goroutine. Stops when stopCh is closed.
-func (t *Tracker) WatchLoop(stopCh <-chan struct{}) {
-	// Initial sync
-	t.sync()
-
-	ticker := time.NewTicker(t.syncInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			t.sync()
-		case <-stopCh:
-			return
-		}
-	}
-}
-
-// sync fetches the current open MRs from GitLab and updates the cache.
-func (t *Tracker) sync() {
-	mrs, err := t.client.ListOpenPRs()
-	if err != nil {
-		log.Printf("WARN: gitlab tracker: sync failed: %v", err)
-		return
-	}
-
-	byTenant := make(map[string]platform.PRInfo, len(mrs))
-	for _, mr := range mrs {
-		if mr.TenantID != "" {
-			// Keep the most recent MR per tenant (by IID number, higher = newer)
-			if existing, ok := byTenant[mr.TenantID]; !ok || mr.Number > existing.Number {
-				byTenant[mr.TenantID] = mr
-			}
-		}
-	}
-
-	t.mu.Lock()
-	t.pendingMRs = mrs
-	t.byTenant = byTenant
-	t.lastSync = time.Now()
-	t.mu.Unlock()
-
-	log.Printf("gitlab tracker: synced %d pending MRs", len(mrs))
-}
-
-// PendingPRs returns all tracked pending MRs.
-func (t *Tracker) PendingPRs() []platform.PRInfo {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	result := make([]platform.PRInfo, len(t.pendingMRs))
-	copy(result, t.pendingMRs)
-	return result
-}
-
-// PendingPRForTenant returns the pending MR for a specific tenant, if any.
-func (t *Tracker) PendingPRForTenant(tenantID string) (platform.PRInfo, bool) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	mr, ok := t.byTenant[tenantID]
-	return mr, ok
-}
-
-// HasPendingPR checks if a tenant has an open MR pending review.
-func (t *Tracker) HasPendingPR(tenantID string) bool {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	_, ok := t.byTenant[tenantID]
-	return ok
-}
-
-// RegisterPR adds a newly created MR to the tracker immediately (before next sync).
-// If the tenant already has a pending MR, it replaces the existing entry.
-func (t *Tracker) RegisterPR(pr platform.PRInfo) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	// Replace existing entry for same tenant to avoid duplicates
-	if pr.TenantID != "" {
-		replaced := false
-		for i, existing := range t.pendingMRs {
-			if existing.TenantID == pr.TenantID {
-				t.pendingMRs[i] = pr
-				replaced = true
-				break
-			}
-		}
-		if !replaced {
-			t.pendingMRs = append(t.pendingMRs, pr)
-		}
-		t.byTenant[pr.TenantID] = pr
-	} else {
-		t.pendingMRs = append(t.pendingMRs, pr)
-	}
-}
-
-// LastSyncTime returns when the tracker last synced with GitLab.
-func (t *Tracker) LastSyncTime() time.Time {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	return t.lastSync
+	return platform.NewPollingTracker(client.ListOpenPRs, "gitlab", syncInterval)
 }

--- a/components/tenant-api/internal/gitlab/tracker_test.go
+++ b/components/tenant-api/internal/gitlab/tracker_test.go
@@ -43,7 +43,7 @@ func TestTrackerSync(t *testing.T) {
 	})
 	defer srv.Close()
 
-	tracker.sync()
+	tracker.Sync()
 
 	prs := tracker.PendingPRs()
 	if len(prs) != 2 {
@@ -67,7 +67,7 @@ func TestTrackerPendingPRForTenant(t *testing.T) {
 	})
 	defer srv.Close()
 
-	tracker.sync()
+	tracker.Sync()
 
 	mr, ok := tracker.PendingPRForTenant("db-a")
 	if !ok {
@@ -87,7 +87,7 @@ func TestTrackerRegisterPR(t *testing.T) {
 	tracker, srv := newTestTracker(t, []platform.PRInfo{})
 	defer srv.Close()
 
-	tracker.sync()
+	tracker.Sync()
 	if len(tracker.PendingPRs()) != 0 {
 		t.Fatal("expected empty tracker")
 	}
@@ -138,7 +138,7 @@ func TestTrackerLastSyncTime(t *testing.T) {
 		t.Error("expected zero time before first sync")
 	}
 
-	tracker.sync()
+	tracker.Sync()
 
 	if tracker.LastSyncTime().IsZero() {
 		t.Error("expected non-zero time after sync")
@@ -152,7 +152,7 @@ func TestTrackerMostRecentMRPerTenant(t *testing.T) {
 	})
 	defer srv.Close()
 
-	tracker.sync()
+	tracker.Sync()
 
 	mr, ok := tracker.PendingPRForTenant("db-a")
 	if !ok {
@@ -166,7 +166,7 @@ func TestTrackerMostRecentMRPerTenant(t *testing.T) {
 func TestMinSyncInterval(t *testing.T) {
 	c, _ := NewClient("token", "group/project", "main")
 	tracker := NewTracker(c, 1*time.Second) // below minimum
-	if tracker.syncInterval < 10*time.Second {
-		t.Errorf("expected sync interval >= 10s, got %v", tracker.syncInterval)
+	if got := tracker.SyncInterval(); got < 10*time.Second {
+		t.Errorf("expected sync interval >= 10s, got %v", got)
 	}
 }

--- a/components/tenant-api/internal/gitops/writer.go
+++ b/components/tenant-api/internal/gitops/writer.go
@@ -67,16 +67,16 @@ func (w *Writer) SetOnWrite(fn OnWriteFunc) {
 
 // Write validates, persists, and commits a tenant's config YAML.
 //
-// Flow:
+// Flow (steps 2–6 are shared with writeSpecialFile via commitFileChange):
 //  1. Validate YAML schema (ParseConfig + ValidateTenantKeys)
 //  2. Lock mutex
 //  3. Record HEAD before write
 //  4. Write file to configDir/{tenantID}.yaml
 //  5. git add + git commit --author="<authorEmail>"
 //  6. Check HEAD again (conflict detection)
-//  7. Unlock mutex
+//  7. onWrite callback (e.g. SSE broadcast)
 func (w *Writer) Write(tenantID, authorEmail, yamlContent string) error {
-	// Step 1: validate schema before touching disk
+	// Step 1: validate schema before touching disk.
 	if errs := validate(tenantID, yamlContent); len(errs) > 0 {
 		return fmt.Errorf("validation failed: %s", strings.Join(errs, "; "))
 	}
@@ -84,46 +84,12 @@ func (w *Writer) Write(tenantID, authorEmail, yamlContent string) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	// Step 2: record HEAD before write
-	headBefore, err := w.currentHEAD()
-	if err != nil {
-		log.Printf("WARN: gitops: could not read HEAD before write (non-git mode?): %v", err)
-		// Proceed without conflict detection in non-git environments
-	}
-
-	// Step 3: write file
-	filePath := filepath.Join(w.configDir, tenantID+".yaml")
-	if err := os.WriteFile(filePath, []byte(yamlContent), 0644); err != nil {
-		return fmt.Errorf("write file: %w", err)
-	}
-
-	// Step 4: git commit
-	if err := w.gitCommit(filePath, tenantID, authorEmail); err != nil {
-		// Rollback: remove file if it didn't exist before (best-effort)
-		log.Printf("WARN: gitops: commit failed for tenant=%s: %v", tenantID, err)
-		return fmt.Errorf("git commit: %w", err)
-	}
-
-	// Step 5: conflict detection — verify our commit's parent is the HEAD we
-	// recorded before writing.  If HEAD~1 != headBefore, an external commit
-	// landed between our read and write (e.g. a concurrent git push).
-	if headBefore != "" {
-		parent, err := w.commitParent()
-		if err == nil && parent != headBefore {
-			log.Printf("WARN: gitops: external commit detected for tenant=%s (expected parent=%s, got=%s)",
-				tenantID, headBefore[:8], parent[:8])
-			return ErrConflict
-		}
-	}
-
-	log.Printf("gitops: tenant=%s committed by %s", tenantID, authorEmail)
-
-	// v2.6.0: Notify via callback (e.g. SSE hub broadcast)
-	if w.onWrite != nil {
-		w.onWrite(tenantID)
-	}
-
-	return nil
+	return w.commitFileChange(
+		filepath.Join(w.configDir, tenantID+".yaml"),
+		tenantID,
+		authorEmail,
+		[]byte(yamlContent),
+	)
 }
 
 // Diff returns the unified diff between the current file and proposed content.
@@ -178,9 +144,10 @@ func (w *Writer) WriteViewsFile(authorEmail, yamlContent string) error {
 }
 
 // writeSpecialFile is a shared implementation for writing _groups.yaml, _views.yaml, etc.
-// These files use the same mutex and conflict detection as tenant writes.
+// These files use the same mutex and conflict detection as tenant writes — only
+// the validation step differs (basic YAML well-formedness, not full schema).
 func (w *Writer) writeSpecialFile(filename, entityType, authorEmail, yamlContent string) error {
-	// Basic YAML validity check
+	// Basic YAML validity check (special files don't have a schema).
 	var raw map[string]interface{}
 	if err := yaml.Unmarshal([]byte(yamlContent), &raw); err != nil {
 		return fmt.Errorf("invalid YAML: %w", err)
@@ -189,35 +156,57 @@ func (w *Writer) writeSpecialFile(filename, entityType, authorEmail, yamlContent
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	return w.commitFileChange(
+		filepath.Join(w.configDir, filename),
+		entityType,
+		authorEmail,
+		[]byte(yamlContent),
+	)
+}
+
+// commitFileChange is the shared write+commit+conflict-detect+notify
+// flow used by both Write (tenant YAML) and writeSpecialFile
+// (_groups.yaml / _views.yaml). Caller MUST hold w.mu before calling.
+//
+// `commitTag` identifies what's being committed in log lines, the
+// commit message subject (via gitCommit), and the onWrite callback
+// argument. For tenant writes it's the tenant ID; for special files
+// it's the entity type ("groups" / "views").
+//
+// Returns ErrConflict if the recorded HEAD before the write differs
+// from our commit's parent (someone else pushed between our read and
+// our write). Non-git environments skip conflict detection but still
+// return commit errors verbatim.
+func (w *Writer) commitFileChange(filePath, commitTag, authorEmail string, content []byte) error {
 	headBefore, err := w.currentHEAD()
 	if err != nil {
-		log.Printf("WARN: gitops: could not read HEAD before %s write: %v", entityType, err)
+		// Proceed without conflict detection in non-git environments.
+		log.Printf("WARN: gitops: could not read HEAD before write (commit_tag=%s): %v", commitTag, err)
 	}
 
-	filePath := filepath.Join(w.configDir, filename)
-	if err := os.WriteFile(filePath, []byte(yamlContent), 0644); err != nil {
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 
-	if err := w.gitCommit(filePath, entityType, authorEmail); err != nil {
-		log.Printf("WARN: gitops: commit failed for %s: %v", entityType, err)
+	if err := w.gitCommit(filePath, commitTag, authorEmail); err != nil {
+		log.Printf("WARN: gitops: commit failed for commit_tag=%s: %v", commitTag, err)
 		return fmt.Errorf("git commit: %w", err)
 	}
 
 	if headBefore != "" {
 		parent, err := w.commitParent()
 		if err == nil && parent != headBefore {
-			log.Printf("WARN: gitops: external commit detected for %s (expected parent=%s, got=%s)",
-				entityType, headBefore[:8], parent[:8])
+			log.Printf("WARN: gitops: external commit detected for commit_tag=%s (expected parent=%s, got=%s)",
+				commitTag, headBefore[:8], parent[:8])
 			return ErrConflict
 		}
 	}
 
-	log.Printf("gitops: %s committed by %s", entityType, authorEmail)
+	log.Printf("gitops: commit_tag=%s committed by %s", commitTag, authorEmail)
 
-	// v2.6.0: Notify via callback (e.g. SSE hub broadcast)
+	// v2.6.0: Notify via callback (e.g. SSE hub broadcast).
 	if w.onWrite != nil {
-		w.onWrite(entityType)
+		w.onWrite(commitTag)
 	}
 
 	return nil

--- a/components/tenant-api/internal/handler/handler_test.go
+++ b/components/tenant-api/internal/handler/handler_test.go
@@ -116,6 +116,48 @@ func TestReady(t *testing.T) {
 	}
 }
 
+// TestReady_MissingDir asserts /ready returns 503 when the config
+// directory is not stat-able, so K8s readinessProbe drains traffic
+// away from a pod whose ConfigMap mount failed.
+func TestReady_MissingDir(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	handler := Ready(missing)
+
+	req := httptest.NewRequest("GET", "/ready", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("Ready() status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp["status"] != "not_ready" {
+		t.Errorf("Ready() status = %q, want %q", resp["status"], "not_ready")
+	}
+}
+
+// TestReady_NotADirectory asserts /ready returns 503 when the
+// configured config_dir is a file (operator misconfig).
+func TestReady_NotADirectory(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "imposter")
+	if err := os.WriteFile(filePath, []byte("not a dir"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	handler := Ready(filePath)
+
+	req := httptest.NewRequest("GET", "/ready", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("Ready() status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+}
+
 // --- GetTenant tests ---
 
 func TestGetTenant_Success(t *testing.T) {

--- a/components/tenant-api/internal/handler/health.go
+++ b/components/tenant-api/internal/handler/health.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
+	"os"
 )
 
 // Health handles GET /health — always returns 200 OK.
@@ -12,11 +13,34 @@ func Health(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
-// Ready handles GET /ready — returns 503 until the config dir is accessible.
+// Ready handles GET /ready — returns 503 when the config dir is not
+// stat-able (e.g. ConfigMap mount failed, PV detached). Returns 200
+// only when the directory is readable, so K8s drains traffic away
+// from a pod whose tenant data the app cannot serve.
 func Ready(configDir string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Simple readiness check: can we read the config directory?
 		w.Header().Set("Content-Type", "application/json")
+
+		info, err := os.Stat(configDir)
+		if err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"status":     "not_ready",
+				"config_dir": configDir,
+				"error":      err.Error(),
+			})
+			return
+		}
+		if !info.IsDir() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"status":     "not_ready",
+				"config_dir": configDir,
+				"error":      "config_dir is not a directory",
+			})
+			return
+		}
+
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"status":     "ready",

--- a/components/tenant-api/internal/handler/task.go
+++ b/components/tenant-api/internal/handler/task.go
@@ -80,15 +80,3 @@ func filterTaskResults(rbacMgr *rbac.Manager, idpGroups []string, results []asyn
 	}
 	return out
 }
-
-// ListTasks handles GET /api/v1/tasks
-// Returns all known tasks (limited to in-memory state).
-func ListTasks(taskMgr *async.Manager) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// Simple: return message about in-memory nature
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]string{
-			"message": "task list endpoint — use GET /api/v1/tasks/{id} to poll specific tasks",
-		})
-	}
-}

--- a/components/tenant-api/internal/handler/task_test.go
+++ b/components/tenant-api/internal/handler/task_test.go
@@ -271,47 +271,6 @@ func TestGetTask_OrphanedHint(t *testing.T) {
 	}
 }
 
-// TestListTasks verifies the ListTasks handler returns helpful message.
-func TestListTasks(t *testing.T) {
-	// Create task manager
-	taskMgr := async.NewManager(1)
-	defer taskMgr.Close()
-
-	// Create HTTP request
-	req := httptest.NewRequest("GET", "/api/v1/tasks", nil)
-	w := httptest.NewRecorder()
-
-	// Call handler
-	handler := ListTasks(taskMgr)
-	handler(w, req)
-
-	// Verify response
-	if w.Code != http.StatusOK {
-		t.Errorf("expected status 200, got %d", w.Code)
-	}
-
-	// Decode response
-	var resp map[string]string
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
-
-	// Verify response contains helpful message
-	if resp["message"] == "" {
-		t.Errorf("expected non-empty message")
-	}
-
-	if _, ok := resp["message"]; !ok {
-		t.Errorf("expected 'message' field in response")
-	}
-
-	// Verify Content-Type header
-	contentType := w.Header().Get("Content-Type")
-	if contentType != "application/json" {
-		t.Errorf("expected Content-Type application/json, got %s", contentType)
-	}
-}
-
 // TestGetTask_MultiplePolls verifies task status is consistent across polls.
 func TestGetTask_MultiplePolls(t *testing.T) {
 	// Create task manager

--- a/components/tenant-api/internal/handler/view.go
+++ b/components/tenant-api/internal/handler/view.go
@@ -84,12 +84,13 @@ func GetView(mgr *views.Manager) http.HandlerFunc {
 
 // PutViewRequest is the body for PUT /api/v1/views/{id}.
 //
-// `Filters` per-key length checks live in
-// `body_validator.go::validateFilterMap`.
+// `Filters` per-key value-length checks live in
+// `body_validator.go::validateFilterMap` (struct tags can't render
+// the offending key in the violation `field` path).
 type PutViewRequest struct {
 	Label       string            `json:"label" validate:"required,min=1,max=256"`
-	Description string            `json:"description" validate:"max=4096"`
-	Filters     map[string]string `json:"filters"`
+	Description string            `json:"description" validate:"max=1024"`
+	Filters     map[string]string `json:"filters" validate:"required,min=1,max=20"`
 }
 
 // PutView handles PUT /api/v1/views/{id}
@@ -129,32 +130,14 @@ func PutView(mgr *views.Manager, writer *gitops.Writer) http.HandlerFunc {
 		}
 
 		// v2.8.0 issue #134 — body-content range validation.
+		// Struct-tag rules (above) cover Label / Description /
+		// Filters element-count; per-pair Filters value length goes
+		// through validateFilterMap because validator's `dive` doesn't
+		// surface the offending key in the violation field path.
 		violations := validateStructTags(&req)
 		violations = append(violations, validateFilterMap(req.Filters, "filters")...)
 		if len(violations) > 0 {
 			writeValidationErrors(w, violations)
-			return
-		}
-
-		// Defensive: even though struct-tag covers max=256, keep the
-		// pre-existing 256-char hard fail in case validation is
-		// disabled in some bypass path. Length above 256 already
-		// caught by validateStructTags above, this is unreachable
-		// in normal flow but cheap.
-		if len(req.Label) > 256 {
-			writeJSONError(w, http.StatusBadRequest, "label exceeds 256 characters")
-			return
-		}
-		if len(req.Description) > 1024 {
-			writeJSONError(w, http.StatusBadRequest, "description exceeds 1024 characters")
-			return
-		}
-		if len(req.Filters) == 0 {
-			writeJSONError(w, http.StatusBadRequest, "filters must not be empty")
-			return
-		}
-		if len(req.Filters) > 20 {
-			writeJSONError(w, http.StatusBadRequest, "filters must not exceed 20 entries")
 			return
 		}
 

--- a/components/tenant-api/internal/platform/tracker.go
+++ b/components/tenant-api/internal/platform/tracker.go
@@ -1,0 +1,181 @@
+package platform
+
+import (
+	"log"
+	"sync"
+	"time"
+)
+
+// Lister fetches the current open PRs/MRs from a Git hosting platform.
+// Returned PRInfo entries should already be filtered to those owned by
+// tenant-api (provider-side branch-prefix filtering, etc.).
+type Lister func() ([]PRInfo, error)
+
+// Compile-time interface assertion: *PollingTracker implements Tracker.
+var _ Tracker = (*PollingTracker)(nil)
+
+// PollingTracker is the shared cache+poll engine for Git-platform
+// pending-PR/MR tracking. github/Tracker and gitlab/Tracker are now
+// thin aliases over this type — they only differ in (a) the Lister
+// they pass at construction and (b) the provider-name string used in
+// log lines.
+//
+// Design (ADR-011): eventual consistency — the cache may be up to
+// `syncInterval` stale. Concurrent reads use sync.RWMutex; sync()
+// acquires a write lock only at the moment of cache replacement.
+//
+// The polling cadence is floor-clamped at 10s to prevent operators
+// accidentally hammering the platform API with sub-second intervals
+// (which usually triggers rate limits and earns the deployment a
+// platform-side IP block).
+type PollingTracker struct {
+	lister       Lister
+	provider     string // "github" / "gitlab" — used in log lines only
+
+	mu           sync.RWMutex
+	pendingPRs   []PRInfo
+	byTenant     map[string]PRInfo // tenantID → most recent pending PR/MR
+	syncInterval time.Duration
+	lastSync     time.Time
+}
+
+// minSyncInterval is the floor for sync cadence. Constructors clamp
+// any below-minimum value up to a safe default.
+const minSyncInterval = 10 * time.Second
+
+// defaultSyncInterval is what gets substituted when the requested
+// interval is below the floor.
+const defaultSyncInterval = 30 * time.Second
+
+// NewPollingTracker constructs a tracker that calls `lister` on each
+// poll. `provider` is just a tag for log lines ("github" / "gitlab").
+// `syncInterval` below 10s is clamped to 30s — operators shouldn't
+// be polling that aggressively, see PollingTracker doc.
+func NewPollingTracker(lister Lister, provider string, syncInterval time.Duration) *PollingTracker {
+	if syncInterval < minSyncInterval {
+		syncInterval = defaultSyncInterval
+	}
+	return &PollingTracker{
+		lister:       lister,
+		provider:     provider,
+		byTenant:     make(map[string]PRInfo),
+		syncInterval: syncInterval,
+	}
+}
+
+// WatchLoop runs an initial sync, then re-syncs every syncInterval.
+// Runs until stopCh is closed. Caller is responsible for goroutine
+// lifecycle.
+func (t *PollingTracker) WatchLoop(stopCh <-chan struct{}) {
+	t.Sync()
+
+	ticker := time.NewTicker(t.syncInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			t.Sync()
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+// Sync fetches the current open PRs/MRs via the lister and replaces
+// the cache. Errors are logged but not propagated — the tracker keeps
+// serving stale data rather than going dark on transient API failures.
+//
+// Exported (vs. internal sync()) so tests can drive the poll
+// deterministically without waiting on the WatchLoop ticker.
+func (t *PollingTracker) Sync() {
+	prs, err := t.lister()
+	if err != nil {
+		log.Printf("WARN: %s tracker: sync failed: %v", t.provider, err)
+		return
+	}
+
+	byTenant := make(map[string]PRInfo, len(prs))
+	for _, pr := range prs {
+		if pr.TenantID == "" {
+			continue
+		}
+		// Keep the most recent PR per tenant (by Number — higher = newer
+		// because both GitHub PR numbers and GitLab IIDs are monotonic).
+		if existing, ok := byTenant[pr.TenantID]; !ok || pr.Number > existing.Number {
+			byTenant[pr.TenantID] = pr
+		}
+	}
+
+	t.mu.Lock()
+	t.pendingPRs = prs
+	t.byTenant = byTenant
+	t.lastSync = time.Now()
+	t.mu.Unlock()
+
+	log.Printf("%s tracker: synced %d pending PRs", t.provider, len(prs))
+}
+
+// PendingPRs returns a defensive copy of all tracked pending PRs/MRs.
+func (t *PollingTracker) PendingPRs() []PRInfo {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	out := make([]PRInfo, len(t.pendingPRs))
+	copy(out, t.pendingPRs)
+	return out
+}
+
+// PendingPRForTenant returns the most-recent pending PR/MR for the
+// given tenant, if any.
+func (t *PollingTracker) PendingPRForTenant(tenantID string) (PRInfo, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	pr, ok := t.byTenant[tenantID]
+	return pr, ok
+}
+
+// HasPendingPR reports whether a tenant has at least one open PR/MR.
+func (t *PollingTracker) HasPendingPR(tenantID string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	_, ok := t.byTenant[tenantID]
+	return ok
+}
+
+// RegisterPR adds a freshly-created PR/MR to the cache immediately,
+// before the next poll. If the same tenant already has an entry, the
+// existing entry is replaced (avoids transient duplicates between
+// "client just created" and "next sync confirms it").
+func (t *PollingTracker) RegisterPR(pr PRInfo) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if pr.TenantID == "" {
+		t.pendingPRs = append(t.pendingPRs, pr)
+		return
+	}
+
+	for i, existing := range t.pendingPRs {
+		if existing.TenantID == pr.TenantID {
+			t.pendingPRs[i] = pr
+			t.byTenant[pr.TenantID] = pr
+			return
+		}
+	}
+	t.pendingPRs = append(t.pendingPRs, pr)
+	t.byTenant[pr.TenantID] = pr
+}
+
+// LastSyncTime returns the timestamp of the most recent Sync call.
+// Zero value indicates Sync has never run.
+func (t *PollingTracker) LastSyncTime() time.Time {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.lastSync
+}
+
+// SyncInterval returns the (possibly floor-clamped) poll interval.
+// Exported for test inspection.
+func (t *PollingTracker) SyncInterval() time.Duration {
+	return t.syncInterval
+}


### PR DESCRIPTION
## Summary

Wave 1 of an **11-PR refactor sweep** readying tenant-api for v2.8.0 release. Three commits, all pure refactor + cleanup — no externally-visible behavior change apart from the `/ready` bug fix in PR-1.

Opened as a **draft** to observe CI; not asking for review/merge yet. Wave 2 (PR-4..6) and beyond will land on top before this branch goes ready.

## Commits

| # | Title | LoC delta | Risk |
|---|-------|-----------|------|
| **PR-1** | README v2.8.0 + /ready bug fix + dead-code purge | +274 / −217 | Low (one bug fix; mostly docs + dead-code) |
| **PR-2** | collapse `Writer.Write` + `writeSpecialFile` duplication | +44 / −55 | Low (pure refactor, behavior preserved) |
| **PR-3** | generic `platform.PollingTracker` for github + gitlab | +213 / −274 (~244 dup eliminated) | Low (pure refactor, all 11 tracker tests pass) |

### PR-1 — README + /ready + purge

- Rewrote `components/tenant-api/README.md` from v2.7.0 to v2.8.0; new sections (Capabilities matrix / Operational concerns / Observability / resource-grouped endpoints) surface v2.8.0 hardening (rate limit, X-Request-ID, tenant-scoped authz, body-content validation) the previous README missed.
- Fixed `Ready()` so it actually `os.Stat`s `configDir` — previously hard-coded 200 OK regardless of state, so a pod whose ConfigMap mount failed could not drain traffic. 2 regression tests added.
- Removed three call-site-less symbols: `handler.ListTasks` (never wired), `github.PRInfo` BC alias (no callers), `view.go` defensive validation block (tightened struct tags absorb the constraints).

### PR-2 — Writer dedup

- `gitops.Writer` had two near-identical methods (`Write` for tenant YAML, `writeSpecialFile` for `_groups.yaml` / `_views.yaml`) running the same six-step lock→HEAD→write→commit→conflict→callback flow.
- Extracted `commitFileChange(filePath, commitTag, authorEmail, content)` helper. Caller holds `w.mu`. Each entry-point method is now ~16 lines (was 60 / 45).
- Log format unified: every write now logs `commit_tag=<id-or-entity>` (was `tenant=%s` / bare `%s` mixture). No test or external consumer depends on log strings.
- writer.go: 454 → 443 LoC; ~30 LoC duplicate code removed.

### PR-3 — Generic platform.PollingTracker

- `github/tracker.go` and `gitlab/tracker.go` were 142 LoC each, ~95% identical (only field name `pendingPRs` vs `pendingMRs`, log strings, and the lister function differed).
- New `platform.PollingTracker` struct holds the cache + `RWMutex` + `Lister` + log-tag string. All `platform.Tracker` interface methods + `Sync()` (was internal `sync()`, exported for test drive) + `SyncInterval()` getter live there.
- `github.Tracker` and `gitlab.Tracker` are now type aliases to `*platform.PollingTracker` — call sites unchanged.
- Tests updated to call `Sync()` / `SyncInterval()` instead of probing private members. All 11 existing tracker tests pass against the generic implementation.
- Net: −63 LoC; ~244 LoC duplication eliminated.

## Test plan

- [ ] CI passes on this draft PR (Commitlint / CI / docs-ci / validate as triggered)
- [ ] After CI green, decide whether to merge wave 1 or stack wave 2 (PR-4..6) first
- [ ] Manual smoke before tag (covered by `make pr-preflight` later in the sweep)

Local verification (each PR):
- `go build ./...` clean
- `go vet ./...` clean
- `go test ./... -count=1` 323 tests pass (delta from 322 baseline: +2 Ready edge cases, −1 `TestListTasks`)
- 39 pre-commit hooks pass; 3 pre-push hooks pass

## Wave plan (PR-4..11, not in this PR)

PR-4 `HandlerDeps` struct → PR-5 main.go bootstrap split → PR-6 shared PR write-flow helper → PR-7 generic `filterByRBAC[T]` → PR-8 generic configwatcher → PR-9 unify error envelope → PR-10 slog migration → PR-11 rate limiter polish + http timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)