### PR TITLE
fix(phase-b): replace ws/hub time.Sleep with poll + drain-on-cancel

### DIFF
--- a/components/tenant-api/internal/ws/hub.go
+++ b/components/tenant-api/internal/ws/hub.go
@@ -84,6 +84,15 @@ func (h *Hub) Unsubscribe(ch chan Event) {
 	h.mu.Unlock()
 }
 
+// ClientCount returns the number of currently-subscribed clients.
+// Useful for observability (metrics) and tests that need to wait for a
+// subscriber to be registered before broadcasting.
+func (h *Hub) ClientCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.clients)
+}
+
 // ServeHTTP implements http.Handler for the SSE endpoint.
 // GET /api/v1/events — clients connect and receive streaming JSON events.
 func (h *Hub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -112,16 +121,41 @@ func (h *Hub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "data: %s\n\n", string(data))
 	flusher.Flush()
 
-	// Stream events until client closes or context is done
+	// writeEvent marshals + flushes a single event. Factored so it can
+	// be reused by the drain loop on context cancel.
+	writeEvent := func(evt Event) {
+		data, _ := json.Marshal(evt)
+		fmt.Fprintf(w, "data: %s\n\n", string(data))
+		flusher.Flush()
+	}
+
+	// Stream events until client closes or context is done.
+	//
+	// On context cancel we drain any events that Broadcast has already
+	// pushed into ch but the main select hasn't picked up yet. Without
+	// this drain, races between Broadcast and cancel can drop in-flight
+	// events on the floor — which surfaces as flaky tests that "fix"
+	// themselves with a time.Sleep before cancel (the anti-pattern that
+	// TECH-DEBT-019 removes).
 	for {
 		select {
 		case <-r.Context().Done():
-			// Client disconnected
-			return
-		case evt := <-ch:
-			data, _ := json.Marshal(evt)
-			fmt.Fprintf(w, "data: %s\n\n", string(data))
-			flusher.Flush()
+			for {
+				select {
+				case evt, ok := <-ch:
+					if !ok {
+						return
+					}
+					writeEvent(evt)
+				default:
+					return
+				}
+			}
+		case evt, ok := <-ch:
+			if !ok {
+				return
+			}
+			writeEvent(evt)
 		}
 	}
 }

--- a/components/tenant-api/internal/ws/hub_test.go
+++ b/components/tenant-api/internal/ws/hub_test.go
@@ -10,6 +10,29 @@ import (
 	"time"
 )
 
+// waitForClientCount polls h.ClientCount() until it matches want or the
+// timeout expires. Mirrors the ticker-with-deadline pattern in
+// async/taskmanager_test.go to replace blind time.Sleep — see
+// TECH-DEBT-019.
+func waitForClientCount(t *testing.T, h *Hub, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	tick := time.NewTicker(time.Millisecond)
+	defer tick.Stop()
+
+	for {
+		if h.ClientCount() == want {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("waitForClientCount: want %d clients within %v, got %d", want, timeout, h.ClientCount())
+		case <-tick.C:
+		}
+	}
+}
+
 func TestSubscribeUnsubscribe(t *testing.T) {
 	h := NewHub()
 
@@ -184,8 +207,8 @@ func TestSSEEndpoint(t *testing.T) {
 		close(done)
 	}()
 
-	// Give the handler time to start
-	time.Sleep(100 * time.Millisecond)
+	// Wait until the handler has subscribed (no time.Sleep — see TECH-DEBT-019).
+	waitForClientCount(t, h, 1, time.Second)
 
 	// Broadcast an event
 	evt := Event{
@@ -196,11 +219,9 @@ func TestSSEEndpoint(t *testing.T) {
 	}
 	h.Broadcast(evt)
 
-	// Give the event time to be sent
-	time.Sleep(100 * time.Millisecond)
-
-	// Cancel the context to stop the handler, then wait for it to finish
-	// so we don't race on reading the ResponseRecorder body.
+	// Cancel the context to stop the handler. ServeHTTP drains any pending
+	// events from the channel before returning (see hub.go), so the body
+	// is guaranteed to contain the broadcast event by the time done fires.
 	cancel()
 
 	select {
@@ -280,8 +301,8 @@ func TestSSEStreamingFormat(t *testing.T) {
 		close(done)
 	}()
 
-	// Give handler time to initialize
-	time.Sleep(100 * time.Millisecond)
+	// Wait until the handler has subscribed (no time.Sleep — see TECH-DEBT-019).
+	waitForClientCount(t, h, 1, time.Second)
 
 	// Broadcast an event
 	evt := Event{
@@ -291,10 +312,8 @@ func TestSSEStreamingFormat(t *testing.T) {
 	}
 	h.Broadcast(evt)
 
-	// Give event time to be sent
-	time.Sleep(100 * time.Millisecond)
-
-	// Cancel the context to stop the handler
+	// Cancel the context to stop the handler. ServeHTTP drains pending
+	// events before returning, so the body is complete by the time done fires.
 	cancel()
 
 	// Wait for handler to finish


### PR DESCRIPTION
## Summary

Closes #224 (TECH-DEBT-019).

The 4 `time.Sleep` calls in `hub_test.go` (TestSSEEndpoint and TestSSEStreamingFormat) were synchronisation primitives — the same anti-pattern flagged by TECH-DEBT-017 in [watchloop_test.go:346](components/threshold-exporter/app/watchloop_test.go). They are flake-prone under `-race` on slow CI runners.

## Production change (`hub.go`)

- **Add `Hub.ClientCount()` accessor** — used by tests to wait for handler subscription. Also useful as a future metrics emit point.
- **`ServeHTTP` drains pending events on context cancel** — without this, a `Broadcast` immediately followed by `cancel` races the select branches and can drop in-flight events on the floor. This is exactly the fault the `time.Sleep` was papering over. Better behaviour for production too: SSE clients won't lose events on slow disconnects.

## Test change (`hub_test.go`)

- **New `waitForClientCount` helper** using `time.Ticker` + deadline (mirrors the pattern in [async/taskmanager_test.go](components/tenant-api/internal/async/taskmanager_test.go)). Replaces the two "wait for handler to subscribe" sleeps.
- **The two "wait for event to be sent" sleeps are removed entirely** — the drain-on-cancel guarantee in `ServeHTTP` makes them unnecessary.

## Test plan

- [x] `go test -race -count=10 ./internal/ws/` → all green, 10 iterations
- [x] `grep -n 'time\.Sleep' hub_test.go` → 0 actual call sites (only docstring/comment references remain)
- [x] `TestConcurrentBroadcasts` (uses 5 goroutines x 10 clients) still passes under race detector

## Coverage gap reference

Part of testing audit follow-up:

- [x] **#223** — TECH-DEBT-018 async path coverage (PR #227)
- [x] **#224 (this PR)** — TECH-DEBT-019 ws/hub sync
- [ ] #225 — TECH-DEBT-020 Playwright axe-core
- [ ] #226 — TECH-DEBT-021 swag init Makefile target

🤖 Generated with [Claude Code](https://claude.com/claude-code)