### PR TITLE
test(td-024): replace blind time.Sleep in 3 test sites with poll-until

### DIFF
--- a/components/tenant-api/internal/async/taskmanager_test.go
+++ b/components/tenant-api/internal/async/taskmanager_test.go
@@ -278,7 +278,26 @@ func TestClose(t *testing.T) {
 	}
 
 	m.Submit(taskID, fn)
-	time.Sleep(50 * time.Millisecond)
+
+	// TD-024: replace blind 50ms sleep with a poll for "task is actually
+	// being run by a worker" — the original sleep was a hack to give the
+	// worker time to pick up the work item. Polling for TaskRunning is
+	// deterministic and fast.
+	pollDeadline := time.NewTimer(time.Second)
+	defer pollDeadline.Stop()
+	pollTick := time.NewTicker(time.Millisecond)
+	defer pollTick.Stop()
+waitRunning:
+	for {
+		select {
+		case <-pollDeadline.C:
+			t.Fatalf("task %q did not enter TaskRunning within 1s", taskID)
+		case <-pollTick.C:
+			if cur, ok := m.Get(taskID); ok && cur.Status == TaskRunning {
+				break waitRunning
+			}
+		}
+	}
 
 	// Close should not panic and should wait for workers.
 	err := m.Close()

--- a/components/tenant-api/internal/handler/authz_test.go
+++ b/components/tenant-api/internal/handler/authz_test.go
@@ -260,13 +260,9 @@ func TestGetTask_FiltersResultsByTenantAccess(t *testing.T) {
 			{TenantID: "db-secret", Status: "ok"},
 		}, nil
 	})
-	// Wait for task completion.
-	for i := 0; i < 50; i++ {
-		if cur, ok := taskMgr.Get(task.ID); ok && cur.Status == async.TaskCompleted {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	// TD-024: use shared pollUntilTerminal (defined in async_test.go) instead
+	// of the blind for/sleep loop.
+	pollUntilTerminal(t, taskMgr, task.ID, time.Second)
 	taskID := task.ID
 
 	req := newRequestWithChiParam("GET", "/api/v1/tasks/"+taskID, "id", taskID, nil)
@@ -305,12 +301,8 @@ func TestGetTask_NoAccessibleResults_Returns403(t *testing.T) {
 	task := taskMgr.Submit("test-task", func(ctx context.Context) ([]async.TaskResult, error) {
 		return []async.TaskResult{{TenantID: "db-secret", Status: "ok"}}, nil
 	})
-	for i := 0; i < 50; i++ {
-		if cur, ok := taskMgr.Get(task.ID); ok && cur.Status == async.TaskCompleted {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	// TD-024: use shared pollUntilTerminal (see async_test.go).
+	pollUntilTerminal(t, taskMgr, task.ID, time.Second)
 	taskID := task.ID
 
 	req := newRequestWithChiParam("GET", "/api/v1/tasks/"+taskID, "id", taskID, nil)

--- a/components/tenant-api/internal/policy/policy_test.go
+++ b/components/tenant-api/internal/policy/policy_test.go
@@ -464,12 +464,30 @@ func TestWatchLoop(t *testing.T) {
 		t.Fatalf("failed to update file: %v", err)
 	}
 
-	// Give watch loop time to detect change (not deterministic, but reasonable)
-	// Note: In a real scenario with proper wait mechanisms, this would be more robust
-	time.Sleep(200 * time.Millisecond)
+	// TD-024: replace blind 200ms sleep with poll-until-loaded. The 100ms
+	// WatchLoop tick + 200ms sleep was tight on slow CI. Now we poll for
+	// up to 2s with 5ms granularity.
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(5 * time.Millisecond)
+	defer tick.Stop()
+waitLoaded:
+	for {
+		select {
+		case <-deadline.C:
+			t.Fatalf("WatchLoop did not pick up policy update within 2s")
+		case <-tick.C:
+			if cfg := m.Get(); len(cfg.DomainPolicies) == 1 {
+				if _, ok := cfg.DomainPolicies["test"]; ok {
+					break waitLoaded
+				}
+			}
+		}
+	}
 	close(stopCh)
 
-	// Verify the update was loaded
+	// Final verification — equivalent to old test, but redundant after
+	// the wait loop. Keep for explicit failure messaging.
 	cfg := m.Get()
 	if len(cfg.DomainPolicies) != 1 {
 		t.Errorf("after update, expected 1 policy, got %d", len(cfg.DomainPolicies))


### PR DESCRIPTION
## Summary

Closes #233. Continuation of TECH-DEBT-019 (ws/hub sleep cleanup).

Three real flake risks fixed:

1. **\`internal/async/taskmanager_test.go\` TestClose** — blind 50ms sleep replaced with poll for \`TaskRunning\` before closing. Original was a hack to give worker time to pick up work.
2. **\`internal/handler/authz_test.go\`** (×2) — manual 50-iteration poll loops replaced with the existing \`pollUntilTerminal\` helper (added by TD-018).
3. **\`internal/policy/policy_test.go\` TestWatchLoop_PicksUpFileUpdate** — blind 200ms sleep replaced with poll-until-loaded (2s deadline, 5ms granularity). Original code admitted \"not deterministic, but reasonable.\"

## Skipped on purpose (documented in commit message)
- Inner sleeps of already-correct poll loops (configwatcher_test.go:207)
- Simulate-work sleeps inside task bodies (taskmanager_test.go:381, task_test.go:284)
- Intentional pacing for status observation (task_test.go:325)
- Goroutine warmup (rbac_extra_test.go:220)
- TTL race tests (tenant_search_test.go:454)

## Test plan
- [x] \`go test -race -count=5 ./internal/async/... ./internal/handler/... ./internal/policy/...\` clean locally
- [ ] Nightly race CI (PR #237) will catch any regressions at -count=10

🤖 Generated with [Claude Code](https://claude.com/claude-code)