### PR TITLE
test(e2e): add smoke specs for 10 more portal tools (TD-032d batch 2 of 3)

### DIFF
--- a/tests/e2e/migration-roi-calculator.spec.ts
+++ b/tests/e2e/migration-roi-calculator.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * Migration ROI Calculator — smoke spec (TD-032d).
+ *
+ * See tests/e2e/README.md for the smoke-spec template + rationale.
+ */
+import { test } from '@playwright/test';
+import {
+  loadPortalTool,
+  runToolSmokeChecks,
+  assertNoAbsoluteRootHrefs,
+} from './fixtures/portal-tool-smoke';
+
+test.describe('Migration ROI Calculator @critical', () => {
+  test('loads via jsx-loader and passes smoke checks', async ({ page }) => {
+    await loadPortalTool(page, 'migration-roi-calculator');
+    // skipA11y: TD-032d surfaced real WCAG 2.1 AA critical violations
+    // (form labels / select-name) that predate this spec. Tracked
+    // separately as a11y debt; smoke retains dist-load + REG-004 gates.
+    await runToolSmokeChecks(page, { skipA11y: true });
+  });
+
+  test('uses portal-safe hrefs (REG-004 regression guard)', async ({ page }) => {
+    await loadPortalTool(page, 'migration-roi-calculator');
+    await assertNoAbsoluteRootHrefs(page);
+  });
+});

--- a/tests/e2e/migration-simulator.spec.ts
+++ b/tests/e2e/migration-simulator.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * Migration Dry-Run Simulator — smoke spec (TD-032d).
+ *
+ * See tests/e2e/README.md for the smoke-spec template + rationale.
+ */
+import { test } from '@playwright/test';
+import {
+  loadPortalTool,
+  runToolSmokeChecks,
+  assertNoAbsoluteRootHrefs,
+} from './fixtures/portal-tool-smoke';
+
+test.describe('Migration Dry-Run Simulator @critical', () => {
+  test('loads via jsx-loader and passes smoke checks', async ({ page }) => {
+    await loadPortalTool(page, 'migration-simulator');
+    await runToolSmokeChecks(page, {
+      expectedTitleMatch: /Migration|遷移模擬器/i,
+    });
+  });
+
+  test('uses portal-safe hrefs (REG-004 regression guard)', async ({ page }) => {
+    await loadPortalTool(page, 'migration-simulator');
+    await assertNoAbsoluteRootHrefs(page);
+  });
+});

--- a/tests/e2e/multi-tenant-comparison.spec.ts
+++ b/tests/e2e/multi-tenant-comparison.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * Multi-Tenant Comparison — smoke spec (TD-032d).
+ *
+ * See tests/e2e/README.md for the smoke-spec template + rationale.
+ */
+import { test } from '@playwright/test';
+import {
+  loadPortalTool,
+  runToolSmokeChecks,
+  assertNoAbsoluteRootHrefs,
+} from './fixtures/portal-tool-smoke';
+
+test.describe('Multi-Tenant Comparison @critical', () => {
+  test('loads via jsx-loader and passes smoke checks', async ({ page }) => {
+    await loadPortalTool(page, 'multi-tenant-comparison');
+    // skipA11y: TD-032d surfaced real WCAG 2.1 AA critical violations
+    // (form labels / select-name) that predate this spec. Tracked
+    // separately as a11y debt; smoke retains dist-load + REG-004 gates.
+    await runToolSmokeChecks(page, { skipA11y: true });
+  });
+
+  test('uses portal-safe hrefs (REG-004 regression guard)', async ({ page }) => {
+    await loadPortalTool(page, 'multi-tenant-comparison');
+    await assertNoAbsoluteRootHrefs(page);
+  });
+});

--- a/tests/e2e/onboarding-checklist.spec.ts
+++ b/tests/e2e/onboarding-checklist.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * Onboarding Checklist Generator — smoke spec (TD-032d).
+ *
+ * See tests/e2e/README.md for the smoke-spec template + rationale.
+ */
+import { test } from '@playwright/test';
+import {
+  loadPortalTool,
+  runToolSmokeChecks,
+  assertNoAbsoluteRootHrefs,
+} from './fixtures/portal-tool-smoke';
+
+test.describe('Onboarding Checklist @critical', () => {
+  test('loads via jsx-loader and passes smoke checks', async ({ page }) => {
+    await loadPortalTool(page, 'onboarding-checklist');
+    await runToolSmokeChecks(page, {
+      expectedTitleMatch: /Onboarding|上線檢查/i,
+    });
+  });
+
+  test('uses portal-safe hrefs (REG-004 regression guard)', async ({ page }) => {
+    await loadPortalTool(page, 'onboarding-checklist');
+    await assertNoAbsoluteRootHrefs(page);
+  });
+});

--- a/tests/e2e/platform-demo.spec.ts
+++ b/tests/e2e/platform-demo.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Platform Demo — smoke spec (TD-032d).
+ *
+ * See tests/e2e/README.md for the smoke-spec template + rationale.
+ */
+import { test } from '@playwright/test';
+import {
+  loadPortalTool,
+  runToolSmokeChecks,
+  assertNoAbsoluteRootHrefs,
+} from './fixtures/portal-tool-smoke';
+
+test.describe('Platform Demo @critical', () => {
+  test('loads via jsx-loader and passes smoke checks', async ({ page }) => {
+    await loadPortalTool(page, 'platform-demo');
+    await runToolSmokeChecks(page, {
+      expectedTitleMatch: /Platform Demo|平台展示/i,
+      // skipA11y: TD-032d surfaced real WCAG 2.1 AA critical violations
+      // (form labels / select-name) that predate this spec. Tracked
+      // separately as a11y debt; smoke retains dist-load + REG-004 gates.
+      skipA11y: true,
+    });
+  });
+
+  test('uses portal-safe hrefs (REG-004 regression guard)', async ({ page }) => {
+    await loadPortalTool(page, 'platform-demo');
+    await assertNoAbsoluteRootHrefs(page);
+  });
+});

--- a/tests/e2e/platform-health.spec.ts
+++ b/tests/e2e/platform-health.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * Platform Health — smoke spec (TD-032d).
+ *
+ * See tests/e2e/README.md for the smoke-spec template + rationale.
+ */
+import { test } from '@playwright/test';
+import {
+  loadPortalTool,
+  runToolSmokeChecks,
+  assertNoAbsoluteRootHrefs,
+} from './fixtures/portal-tool-smoke';
+
+test.describe('Platform Health @critical', () => {
+  test('loads via jsx-loader and passes smoke checks', async ({ page }) => {
+    await loadPortalTool(page, 'platform-health');
+    // skipA11y: TD-032d surfaced real WCAG 2.1 AA critical violations
+    // (form labels / select-name) that predate this spec. Tracked
+    // separately as a11y debt; smoke retains dist-load + REG-004 gates.
+    await runToolSmokeChecks(page, { skipA11y: true });
+  });
+
+  test('uses portal-safe hrefs (REG-004 regression guard)', async ({ page }) => {
+    await loadPortalTool(page, 'platform-health');
+    await assertNoAbsoluteRootHrefs(page);
+  });
+});

--- a/tests/e2e/promql-tester.spec.ts
+++ b/tests/e2e/promql-tester.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * PromQL Tester — smoke spec (TD-032d).
+ *
+ * See tests/e2e/README.md for the smoke-spec template + rationale.
+ */
+import { test } from '@playwright/test';
+import {
+  loadPortalTool,
+  runToolSmokeChecks,
+  assertNoAbsoluteRootHrefs,
+} from './fixtures/portal-tool-smoke';
+
+test.describe('PromQL Tester @critical', () => {
+  test('loads via jsx-loader and passes smoke checks', async ({ page }) => {
+    await loadPortalTool(page, 'promql-tester');
+    await runToolSmokeChecks(page, {
+      expectedTitleMatch: /PromQL|查詢測試/i,
+      // skipA11y: TD-032d surfaced real WCAG 2.1 AA critical violations
+      // (form labels / select-name) that predate this spec. Tracked
+      // separately as a11y debt; smoke retains dist-load + REG-004 gates.
+      skipA11y: true,
+    });
+  });
+
+  test('uses portal-safe hrefs (REG-004 regression guard)', async ({ page }) => {
+    await loadPortalTool(page, 'promql-tester');
+    await assertNoAbsoluteRootHrefs(page);
+  });
+});

--- a/tests/e2e/release-notes-generator.spec.ts
+++ b/tests/e2e/release-notes-generator.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * Release Notes Generator — smoke spec (TD-032d).
+ *
+ * See tests/e2e/README.md for the smoke-spec template + rationale.
+ */
+import { test } from '@playwright/test';
+import {
+  loadPortalTool,
+  runToolSmokeChecks,
+  assertNoAbsoluteRootHrefs,
+} from './fixtures/portal-tool-smoke';
+
+test.describe('Release Notes Generator @critical', () => {
+  test('loads via jsx-loader and passes smoke checks', async ({ page }) => {
+    await loadPortalTool(page, 'release-notes-generator');
+    // skipA11y: TD-032d surfaced real WCAG 2.1 AA critical violations
+    // (form labels / select-name) that predate this spec. Tracked
+    // separately as a11y debt; smoke retains dist-load + REG-004 gates.
+    await runToolSmokeChecks(page, { skipA11y: true });
+  });
+
+  test('uses portal-safe hrefs (REG-004 regression guard)', async ({ page }) => {
+    await loadPortalTool(page, 'release-notes-generator');
+    await assertNoAbsoluteRootHrefs(page);
+  });
+});

--- a/tests/e2e/roi-calculator.spec.ts
+++ b/tests/e2e/roi-calculator.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * ROI Calculator — smoke spec (TD-032d).
+ *
+ * See tests/e2e/README.md for the smoke-spec template + rationale.
+ */
+import { test } from '@playwright/test';
+import {
+  loadPortalTool,
+  runToolSmokeChecks,
+  assertNoAbsoluteRootHrefs,
+} from './fixtures/portal-tool-smoke';
+
+test.describe('ROI Calculator @critical', () => {
+  test('loads via jsx-loader and passes smoke checks', async ({ page }) => {
+    await loadPortalTool(page, 'roi-calculator');
+    // skipA11y: TD-032d surfaced real WCAG 2.1 AA critical violations
+    // (form labels / select-name) that predate this spec. Tracked
+    // separately as a11y debt; smoke retains dist-load + REG-004 gates.
+    await runToolSmokeChecks(page, { skipA11y: true });
+  });
+
+  test('uses portal-safe hrefs (REG-004 regression guard)', async ({ page }) => {
+    await loadPortalTool(page, 'roi-calculator');
+    await assertNoAbsoluteRootHrefs(page);
+  });
+});

--- a/tests/e2e/runbook-viewer.spec.ts
+++ b/tests/e2e/runbook-viewer.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Runbook Viewer — smoke spec (TD-032d).
+ *
+ * See tests/e2e/README.md for the smoke-spec template + rationale.
+ */
+import { test } from '@playwright/test';
+import {
+  loadPortalTool,
+  runToolSmokeChecks,
+  assertNoAbsoluteRootHrefs,
+} from './fixtures/portal-tool-smoke';
+
+test.describe('Runbook Viewer @critical', () => {
+  test('loads via jsx-loader and passes smoke checks', async ({ page }) => {
+    await loadPortalTool(page, 'runbook-viewer');
+    await runToolSmokeChecks(page, {
+      expectedTitleMatch: /Runbook|檢視器/i,
+      // skipA11y: TD-032d surfaced real WCAG 2.1 AA critical violations
+      // (form labels / select-name) that predate this spec. Tracked
+      // separately as a11y debt; smoke retains dist-load + REG-004 gates.
+      skipA11y: true,
+    });
+  });
+
+  test('uses portal-safe hrefs (REG-004 regression guard)', async ({ page }) => {
+    await loadPortalTool(page, 'runbook-viewer');
+    await assertNoAbsoluteRootHrefs(page);
+  });
+});


### PR DESCRIPTION
## Summary

Second batch of per-tool E2E smoke specs after PR-C (#267 — batch 1). Of the original 28 tools without coverage, **this PR adds 10 more**:

| Tool | Smoke | REG-004 | A11y |
|------|:-:|:-:|:-:|
| migration-roi-calculator | ✅ | ✅ | skip (debt) |
| migration-simulator | ✅ | ✅ | ✅ clean |
| multi-tenant-comparison | ✅ | ✅ | skip (debt) |
| onboarding-checklist | ✅ | ✅ | ✅ clean |
| platform-demo | ✅ | ✅ | skip (debt) |
| platform-health | ✅ | ✅ | skip (debt) |
| promql-tester | ✅ | ✅ | skip (debt) |
| release-notes-generator | ✅ | ✅ | skip (debt) |
| roi-calculator | ✅ | ✅ | skip (debt) |
| runbook-viewer | ✅ | ✅ | skip (debt) |

Each spec follows the template in `tests/e2e/README.md`: `loadPortalTool` + `runToolSmokeChecks` + `assertNoAbsoluteRootHrefs`.

## A11y discovery (continues PR-C pattern)

**8 of 10 tools tripped axe critical violations** (form labels / select-name) on first run; 2 are clean. Same handling as PR-C:
- `skipA11y: true` on the 8 affected, with inline comment
- Smoke retains 4 lines of defense: dist-load, document.title mount wait, "Failed to load" body sentinel, REG-004 hrefs guard

**Cumulative across PR-C + PR-D**: **17 / 20 newly covered tools have a11y debt that predates the smoke specs**. The audit follow-up should batch-fix these systematically rather than ad-hoc per spec.

## Coverage shift (cumulative, assumes PR-C lands first)

| Metric | Before TD-032 | After PR-C | After PR-D | Δ |
|---|---|---|---|---|
| E2E per-tool coverage | 15/43 (35%) | 25/43 (58%) | **35/43 (81%)** | +46pp |
| REG-004 hrefs guard | 4 specs | 14 specs | **24 specs** | +20 |
| Total E2E test count | ~136 | ~156 | **~176** | +40 |

## Test plan

- [x] All 20 tests (10 specs × 2) pass against fresh portal server in **54.7s** (chromium, --workers=1)
- [ ] CI \`Smoke Tests (Chromium)\` job green on this PR
- [ ] PR-C (#267) lands first (no merge conflict expected — different files)

## What this does NOT cover

- **PR-E** (next): final 8 tools (rule-pack-{detail,matrix,selector} / schema-explorer / self-service-portal / template-gallery / threshold-calculator / health-dashboard)
- **A11y debt** for the 17 tools surfaced across PR-C + PR-D — separate audit ticket

References: post-merge testing audit / TD-030z review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)