### PR TITLE
docs(portal): document mutation testing investigation outcome (TD-041, Plan E)

### DIFF
--- a/tools/portal/README.md
+++ b/tools/portal/README.md
@@ -73,6 +73,25 @@ TD-030 sweep 期間 jsx-loader.html 與 dist bundle **同時存在**：
 
 最後 TD-030z PR 退役 jsx-loader.html。
 
+## Mutation testing — investigated, deferred (TD-041, 2026-05-07)
+
+> 簡短記錄一個試過但沒採用的方向，避免下次重複踩。
+
+**目的**：給 9 個 Vitest spec / 65 tests 加 Stryker mutation testing，驗證 assertions 不是空殼。
+
+**踩到的問題**：
+- Stryker 的 `mutate` glob rooted in 「config 所在目錄」（`tools/portal/`）
+- 我們的 source 在 `docs/interactive/tools/**`、test 在 `tests/portal/**` —— 三處分散
+- 即使用絕對路徑也失敗：`Glob did not result in any files`，因為 Stryker 把 project 拷貝到 `.stryker-tmp/` 時不會跨 project root 抓檔
+- vitest-runner 額外抱怨 `failed to find test files related to mutated files`
+
+**繞過選項（評估後不採用）**：
+1. 把 `stryker.config.json` 移到 repo root → 污染專案根目錄
+2. 用 `inPlace: true` 跳過拷貝 → mutation 直接改 working tree，CI 失敗時殘留壞檔
+3. 把 portal source 搬進 `tools/portal/src/` → 是 TD-030 結構大改，超出單一 testing PR 範圍
+
+**結論**：以目前 9 spec 規模，mutation testing 投入產出比不划算。建議再增加到 ~30 spec 或 portal monorepo restructure 之後再評估。npm devDep / config 都已 rollback，沒留下 dead artifacts。
+
 ## 相關
 - TD-030 sub-issues: [#247-253](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/247)
 - Project memory: `project_portal_vitest_choice.md`


### PR DESCRIPTION
## Summary

**Plan E** of B>C>A>D>E sequence. Investigated Stryker mutation testing for the 9 Vitest specs / 65 tests in tools/portal/. Did NOT ship any runtime config — Stryker's glob resolution doesn't fit the current 3-way split layout (config in tools/portal/, source in docs/interactive/, tests in tests/portal/) without significant restructure.

## What was tried

1. \`npm install --save-dev @stryker-mutator/{core,vitest-runner}\`
2. Created \`tools/portal/stryker.config.json\` with relative-path \`mutate\` glob
3. Smoke-test on 1 small target (\`useDebouncedValue.js\`)

## Failure modes encountered

- **Glob doesn't traverse upward**: \`../../docs/interactive/tools/...\` from tools/portal/ → "Glob did not result in any files". Stryker copies the project to .stryker-tmp/ and only sees files inside its project root.
- **Even absolute paths fail**: \`/workspaces/.../docs/...\` → same "no files" error. Stryker rejects paths outside the project boundary by design.
- **vitest-runner can't find related tests**: \`Vitest failed to find test files related to mutated files\`. Even though our tests directly \`import { X } from '../../docs/...'\`, vitest --related mode follows a different graph.

## Workarounds evaluated and rejected

| Option | Why rejected |
|---|---|
| Move stryker.config.json to repo root | Root pollution; large blast radius |
| \`inPlace: true\` to skip project copy | Mutations land on real working tree; CI fail = bad residue |
| Restructure portal source into tools/portal/src/ | TD-030 architecture change, way out of scope |

## Conclusion

With 9 specs, mutation testing ROI doesn't justify the restructure. Revisit at ~30 specs or after a portal monorepo restructure.

## Rolled-back state

- \`npm uninstall @stryker-mutator/{core,vitest-runner}\` ✓
- Removed \`stryker.config.json\` ✓
- Removed \`test:mutation\` npm script ✓
- Removed .gitignore entries for stryker artifacts ✓
- Documented investigation in \`tools/portal/README.md\` so future contributors don't repeat ✓

## Closes the B>C>A>D>E sequence

| Plan | PR | Status |
|---|---|---|
| B (lessons doc) | #273 | ✅ merged |
| C (window.__X lint) | #274 | ✅ merged |
| A (visual regression staged) | #275 | open |
| – (LL §2 + §5 hooks) | #276 | open |
| D (a11y budget tightening) | #277 | open |
| **E (this PR — investigation closed)** | **#TBD** | **doc-only** |

References: TD-035 (#272) post-merge audit; testing-playbook §LL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)