### PR TITLE
fix(ci): playwright workflow trigger paths + browser cache

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,7 +6,12 @@ on:
       - main
       - develop
     paths:
-      - 'docs/interactive/**'
+      # TD-042: portal source moved to tools/portal/src/. Watch the
+      # whole portal package (source + build config + manifest) so any
+      # change that affects bundle output triggers smoke. Also watch
+      # docs/interactive/index.html which is the runtime entry loader.
+      - 'tools/portal/**'
+      - 'docs/interactive/index.html'
       - 'tests/e2e/**'
       - 'package.json'
       - '.github/workflows/playwright.yml'
@@ -14,7 +19,8 @@ on:
     branches:
       - main
     paths:
-      - 'docs/interactive/**'
+      - 'tools/portal/**'
+      - 'docs/interactive/index.html'
       - 'tests/e2e/**'
       - 'package.json'
       - '.github/workflows/playwright.yml'
@@ -59,6 +65,18 @@ jobs:
       - name: Install E2E dependencies
         working-directory: tests/e2e
         run: npm ci
+
+      # Cache Playwright browser binaries (~150 MB chromium download).
+      # `npx playwright install` is idempotent: re-running with cache hit
+      # is a fast no-op. Key includes the playwright version derived from
+      # tests/e2e/package-lock.json so cache invalidates on bump.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('tests/e2e/package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
       - name: Install Playwright browsers
         working-directory: tests/e2e


### PR DESCRIPTION
## Summary

Two TD-042 follow-up fixes to `.github/workflows/playwright.yml`:

- **Trigger paths**: TD-042 moved portal source from `docs/interactive/` to `tools/portal/src/`, but `playwright.yml` still filtered on the old path. PRs that only edit `tools/portal/src/**` would skip E2E entirely. Replaced with `tools/portal/**` (covers source + build config + manifest) plus `docs/interactive/index.html` (the runtime entry loader).
- **Browser cache**: `npx playwright install chromium` runs ~11s every CI run downloading ~150 MB. Added `actions/cache@v5` on `~/.cache/ms-playwright` keyed by `tests/e2e/package-lock.json`. `npx playwright install` is idempotent, so a cache hit is a fast no-op.

## Why now

Surfaced during a calibration audit of test-infra. Verified:
- `ci.yml` correctly migrated to `tools/portal/` (lines 259-276)
- Only `playwright.yml` was missed in the TD-042 sweep

## Test plan

- [ ] CI runs to verify path filter still triggers on relevant changes (this PR touches `.github/workflows/playwright.yml` so it self-triggers)
- [ ] Second run after merge to confirm cache hit + `npx playwright install` is fast
- [ ] No-op verification: a doc-only PR should NOT trigger Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)