### PR TITLE
perf(e2e): convert post-load waitForTimeout to waitForLoadState (tenant-manager)

### DIFF
--- a/tests/e2e/tenant-manager.spec.ts
+++ b/tests/e2e/tenant-manager.spec.ts
@@ -62,7 +62,7 @@ test.describe('Tenant Manager @critical', () => {
     expect(iframeCount + contentDivCount).toBeGreaterThanOrEqual(0);
 
     // Wait a moment for data to load or show graceful message
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
 
     const bodyText = await page.locator('body').textContent();
     expect(bodyText).toBeTruthy();
@@ -72,7 +72,7 @@ test.describe('Tenant Manager @critical', () => {
     await loadTenantManager(page);
 
     // Wait for any tenant list or filter inputs to load
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
 
     // Look for filter/search input
     const filterInputs = page.locator('input[type="text"], input[placeholder*="search" i], input[aria-label*="filter" i]');
@@ -99,7 +99,7 @@ test.describe('Tenant Manager @critical', () => {
   test('should support metadata filtering', async ({ page }) => {
     await loadTenantManager(page);
 
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
 
     // Look for filter controls - common patterns: buttons, selects, checkboxes
     const filterControls = page.locator(
@@ -118,7 +118,7 @@ test.describe('Tenant Manager @critical', () => {
   test('should display result count or list', async ({ page }) => {
     await loadTenantManager(page);
 
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
 
     // Look for result indicators: list items, table rows, badges with counts
     const listItems = page.locator('[data-testid="result-item"], li, tr');
@@ -137,7 +137,7 @@ test.describe('Tenant Manager @critical', () => {
   test('should handle filter state persistence', async ({ page }) => {
     await loadTenantManager(page);
 
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
 
     // Find a filter input
     const filterInputs = page.locator('input[type="text"], input[placeholder*="search" i]');
@@ -159,7 +159,7 @@ test.describe('Tenant Manager @critical', () => {
   test('should show graceful degradation on data load errors', async ({ page }) => {
     await loadTenantManager(page);
 
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
 
     // Check for error message or empty state
     const errorMessages = page.locator(
@@ -218,7 +218,7 @@ test.describe('Tenant Manager @critical', () => {
     });
 
     await loadTenantManagerDirect(page);
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
 
     // Layered assertions:
     //   (a) Wire-level — JSX must call our endpoint with page_size=500.
@@ -270,7 +270,7 @@ test.describe('Tenant Manager @critical', () => {
     });
 
     await loadTenantManagerDirect(page);
-    await page.waitForTimeout(3000);
+    await page.waitForLoadState('networkidle', { timeout: 3000 }).catch(() => {});
 
     // The overflow banner contains "500" and "2000" plus a hint to
     // refine filters. We use a regex so the test survives small
@@ -346,7 +346,7 @@ test.describe('Tenant Manager @critical', () => {
     });
 
     await loadTenantManagerDirect(page);
-    await page.waitForTimeout(2000); // initial fetch (q='')
+    await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {}); // initial fetch (q='')
 
     // Type into the search input. `q` is debounced 300ms; pre-fix
     // would have fired one fetch per keystroke.
@@ -387,7 +387,7 @@ test.describe('Tenant Manager @critical', () => {
     // Navigate WITH ?q=preset already in the URL.
     await page.goto('../assets/jsx-loader.html?component=../interactive/tools/tenant-manager.jsx&q=preset');
     await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
 
     // The very first API call should already include q=preset
     // (initial state seeded from URL, not from empty string).
@@ -423,7 +423,7 @@ test.describe('Tenant Manager @critical', () => {
     });
 
     await loadTenantManagerDirect(page);
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
 
     // The virtualized container has data-testid="tenant-grid-virtual"
     // and is only rendered when `filtered.length > 50`. Its presence
@@ -462,7 +462,7 @@ test.describe('Tenant Manager @critical', () => {
     });
 
     await loadTenantManagerDirect(page);
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
 
     // Below threshold → no virtual container. All 10 cards in DOM.
     await expect(page.locator('[data-testid="tenant-grid-virtual"]')).toHaveCount(0);


### PR DESCRIPTION
## Summary

Converts 12 of 16 `waitForTimeout` calls in `tests/e2e/tenant-manager.spec.ts` from hard sleeps into network-bound waits. All 12 are "wait for data to load" patterns sitting right after `loadTenantManager*` helpers which already do their own networkidle wait — the 2-3s blind sleeps were redundant.

```ts
// Before
await page.waitForTimeout(2000);

// After
await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
```

Same upper bound, faster typical case. Network is usually idle within 100-500ms after a mocked `/api/v1/*` response.

## Why scoped to one file

CI Playwright is the longest job (113s). 47 `waitForTimeout` calls live across 8 specs. Doing them all at once is high-risk — historical TD-031/TD-032 flake at workers>1 means E2E sensitivity is real. This PR ships ONE file as a vetted pattern; follow-ups can replicate after this lands clean.

## Untouched (semantic justification in comments)

- line 88: 1000ms after fill — wait for filter response
- line 151: 500ms after fill — filter persistence
- line 316: 5000ms — intentional retry-after wait
- line 355: 800ms — > 300ms debounce + fetch + render

## Expected savings

10-20s per Playwright run when network is fast (typical CI case). Worst case identical to current behaviour (catch-fallback).

## Test plan

- [ ] Playwright Smoke job passes on CI with same or fewer flakes
- [ ] tenant-manager.spec.ts wall-clock time visibly lower (compare via `gh run view`)
- [ ] Follow-up PRs: batch-operations.spec.ts (18), group-management.spec.ts (4), etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)