### PR TITLE
perf(ci): add t.Parallel to pure-function Go tests (sweep start)

### DIFF
--- a/components/tenant-api/internal/handler/sanitize_test.go
+++ b/components/tenant-api/internal/handler/sanitize_test.go
@@ -3,6 +3,7 @@ package handler
 import "testing"
 
 func TestValidateTenantID(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		id      string
 		wantErr bool
@@ -35,6 +36,7 @@ func TestValidateTenantID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.id, func(t *testing.T) {
+			t.Parallel()
 			err := ValidateTenantID(tt.id)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateTenantID(%q) error = %v, wantErr %v", tt.id, err, tt.wantErr)

--- a/components/tenant-api/internal/rbac/rbac_test.go
+++ b/components/tenant-api/internal/rbac/rbac_test.go
@@ -3,6 +3,7 @@ package rbac
 import "testing"
 
 func TestTenantMatches(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		patterns []string
@@ -20,6 +21,7 @@ func TestTenantMatches(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := tenantMatches(tt.patterns, tt.tenantID); got != tt.want {
 				t.Errorf("tenantMatches(%v, %q) = %v, want %v", tt.patterns, tt.tenantID, got, tt.want)
 			}
@@ -28,6 +30,7 @@ func TestTenantMatches(t *testing.T) {
 }
 
 func TestPermCovers(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		grant Permission
@@ -47,6 +50,7 @@ func TestPermCovers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := permCovers(tt.grant, tt.want); got != tt.ok {
 				t.Errorf("permCovers(%s, %s) = %v, want %v", tt.grant, tt.want, got, tt.ok)
 			}
@@ -55,6 +59,7 @@ func TestPermCovers(t *testing.T) {
 }
 
 func TestHasPermission(t *testing.T) {
+	t.Parallel()
 	m := NewForTest(&RBACConfig{
 		Groups: []GroupRule{
 			{Name: "platform-admins", Tenants: []string{"*"}, Permissions: []Permission{PermAdmin}},
@@ -82,6 +87,7 @@ func TestHasPermission(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := m.HasPermission(tt.groups, tt.tenant, tt.want); got != tt.expected {
 				t.Errorf("HasPermission(%v, %q, %s) = %v, want %v",
 					tt.groups, tt.tenant, tt.want, got, tt.expected)
@@ -91,6 +97,7 @@ func TestHasPermission(t *testing.T) {
 }
 
 func TestOpenModeReadOnly(t *testing.T) {
+	t.Parallel()
 	// Empty config (open mode) allows read, denies write
 	m := NewForTest(&RBACConfig{})
 

--- a/components/threshold-exporter/app/internal/batchpr/render_test.go
+++ b/components/threshold-exporter/app/internal/batchpr/render_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestPlanMarkdown_NilPlanSafe(t *testing.T) {
+	t.Parallel()
 	var p *Plan
 	got := p.Markdown()
 	if got == "" {
@@ -14,6 +15,7 @@ func TestPlanMarkdown_NilPlanSafe(t *testing.T) {
 }
 
 func TestPlanMarkdown_ContainsAllItems(t *testing.T) {
+	t.Parallel()
 	plan, err := BuildPlan(PlanInput{
 		Proposals: []ProposalRef{
 			{MemberTenantIDs: []string{"alpha", "beta"}, Dialect: "prom",
@@ -51,6 +53,7 @@ func TestPlanMarkdown_ContainsAllItems(t *testing.T) {
 }
 
 func TestPlanMarkdown_WarningsRenderedWhenPresent(t *testing.T) {
+	t.Parallel()
 	plan, err := BuildPlan(PlanInput{
 		Proposals: []ProposalRef{
 			{MemberTenantIDs: []string{"known", "missing-dir"}, Dialect: "prom"},
@@ -72,6 +75,7 @@ func TestPlanMarkdown_WarningsRenderedWhenPresent(t *testing.T) {
 }
 
 func TestPlanMarkdown_NoWarningsSectionWhenClean(t *testing.T) {
+	t.Parallel()
 	plan, err := BuildPlan(PlanInput{
 		Proposals: []ProposalRef{
 			{MemberTenantIDs: []string{"t1"}, Dialect: "prom"},

--- a/components/threshold-exporter/app/internal/profile/normalize_test.go
+++ b/components/threshold-exporter/app/internal/profile/normalize_test.go
@@ -3,6 +3,7 @@ package profile
 import "testing"
 
 func TestNormaliseExpr_StripsNumericLiterals(t *testing.T) {
+	t.Parallel()
 	// Whitespace is fully stripped at the end of normalisation, so
 	// expected values collapse spaces between tokens.
 	cases := []struct{ in, want string }{
@@ -17,6 +18,7 @@ func TestNormaliseExpr_StripsNumericLiterals(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
 			if got := normaliseExpr(tc.in); got != tc.want {
 				t.Errorf("normaliseExpr(%q) = %q, want %q", tc.in, got, tc.want)
 			}
@@ -25,6 +27,7 @@ func TestNormaliseExpr_StripsNumericLiterals(t *testing.T) {
 }
 
 func TestNormaliseExpr_StripsLabelStringValues(t *testing.T) {
+	t.Parallel()
 	cases := []struct{ in, want string }{
 		{`x{tenant="tenant-a"}`, `x{tenant="<STR>"}`},
 		{`x{tenant="tenant-b"}`, `x{tenant="<STR>"}`},
@@ -34,6 +37,7 @@ func TestNormaliseExpr_StripsLabelStringValues(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
 			if got := normaliseExpr(tc.in); got != tc.want {
 				t.Errorf("normaliseExpr(%q) = %q, want %q", tc.in, got, tc.want)
 			}
@@ -42,6 +46,7 @@ func TestNormaliseExpr_StripsLabelStringValues(t *testing.T) {
 }
 
 func TestNormaliseExpr_PerTenantVariantsCollapse(t *testing.T) {
+	t.Parallel()
 	// The motivating use case: same alert per tenant, only label
 	// value + threshold differ. Both must normalise to the same
 	// signature so they cluster.
@@ -53,6 +58,7 @@ func TestNormaliseExpr_PerTenantVariantsCollapse(t *testing.T) {
 }
 
 func TestNormaliseExpr_DifferentFunctionsStayDistinct(t *testing.T) {
+	t.Parallel()
 	// rate() and irate() are different signals — they must NOT
 	// collapse, even with identical surroundings.
 	r := `rate(foo[5m]) > 1`
@@ -63,6 +69,7 @@ func TestNormaliseExpr_DifferentFunctionsStayDistinct(t *testing.T) {
 }
 
 func TestNormaliseExpr_CollapsesWhitespace(t *testing.T) {
+	t.Parallel()
 	// Two formattings of the same expression normalise identically.
 	tight := `rate(foo[5m])>1`
 	loose := `rate(foo[5m])  >   1`
@@ -73,12 +80,14 @@ func TestNormaliseExpr_CollapsesWhitespace(t *testing.T) {
 }
 
 func TestNormaliseExpr_EmptyReturnsEmpty(t *testing.T) {
+	t.Parallel()
 	if got := normaliseExpr(""); got != "" {
 		t.Errorf("normaliseExpr(\"\") = %q, want empty", got)
 	}
 }
 
 func TestNormaliseExpr_DigitsInIdentifiersPreserved(t *testing.T) {
+	t.Parallel()
 	// `node_cpu_seconds_total` contains no digits but other metric
 	// names like `http_requests_total_5xx` do. The normaliser must
 	// not strip digits that are part of an identifier.


### PR DESCRIPTION
## Summary

Audit flagged that `components/` has **zero `t.Parallel()` calls** across all 82 Go test files. This PR starts the sweep with the 4 safest candidates: pure-function unit tests with no shared state, no env mutation, no filesystem I/O, no `time.Sleep`.

Files touched (across both `tenant-api` and `threshold-exporter`):

| File | t.Parallel additions |
|---|---|
| `tenant-api/internal/handler/sanitize_test.go` | 1 outer + 1 inner |
| `tenant-api/internal/rbac/rbac_test.go` | 4 outer + 3 inner |
| `threshold-exporter/.../batchpr/render_test.go` | 4 outer |
| `threshold-exporter/.../profile/normalize_test.go` | 7 outer + 2 inner |

22 additions across 16 outer test funcs and 6 table-test subtest closures.

## Verification (local)

- `go vet` clean across all 4 packages
- `go test -v` shows `PAUSE`/`CONT` markers — parallel is honoured
- All tests pass

## Expected impact

Wall-clock impact will be small in absolute terms (these tests are already fast — the bigger wins live in `watchloop_test.go` and `config_debounce_test.go` with sleeps that genuinely block parallel until `t.Setenv` migrations land). The value of this PR is establishing the **project-wide pattern**, which follow-ups can replicate.

## Why scoped this small

`os.Setenv` and shared filesystem state in larger test files prevent `t.Parallel()` until those are migrated to `t.Setenv` and per-test isolation. Starting with the obviously-safe set lets the pattern land + soak before tackling the harder cases.

## Follow-ups (separate PRs)

- `t.Setenv` migration for `config_test.go`, `gitops/writer_extra_test.go` (gates further parallelism in those files)
- `t.Parallel()` for the next batch of pure files (parser tests, client tests)
- `watchloop_test.go` debounce / hierarchy tests — last (highest risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)