### PR TITLE
perf(e2e): convert remaining waitForTimeout to waitForLoadState (6 files, sweep)

### DIFF
--- a/tests/e2e/auth-flow.spec.ts
+++ b/tests/e2e/auth-flow.spec.ts
@@ -87,7 +87,7 @@ test.describe('Authentication Flow @critical', () => {
     await page.goto('./');
 
     // Optionally wait for auth to be loaded by the app
-    await page.waitForTimeout(1000);
+    await page.waitForLoadState('networkidle', { timeout: 1000 }).catch(() => {});
 
     // Look for email display in various common locations
     const emailDisplays = page.locator(

--- a/tests/e2e/batch-operations.spec.ts
+++ b/tests/e2e/batch-operations.spec.ts
@@ -16,7 +16,7 @@ async function navigateToTenantManager(page: Page) {
 
   if (exists > 0) {
     await tenantLink.click();
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
   }
 }
 
@@ -38,7 +38,7 @@ test.describe('Batch Operations @critical', () => {
 
       // Click to select
       await firstGroup.click({ noWaitAfter: true });
-      await page.waitForTimeout(500);
+      await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
     }
   });
 
@@ -51,7 +51,7 @@ test.describe('Batch Operations @critical', () => {
 
     if (groupCount > 0) {
       await groupItems.first().click();
-      await page.waitForTimeout(500);
+      await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
     }
 
     // Look for batch operation button/menu
@@ -96,7 +96,7 @@ test.describe('Batch Operations @critical', () => {
 
     if (groupCount > 0) {
       await groupItems.first().click();
-      await page.waitForTimeout(500);
+      await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
     }
 
     // Open batch operations menu
@@ -105,7 +105,7 @@ test.describe('Batch Operations @critical', () => {
 
     if (buttonExists > 0) {
       await batchButton.click();
-      await page.waitForTimeout(500);
+      await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
 
       // Look for Silent Mode option
       const silentOption = page.locator(
@@ -118,7 +118,7 @@ test.describe('Batch Operations @critical', () => {
 
       if (optionCount > 0) {
         await silentOption.click({ noWaitAfter: true });
-        await page.waitForTimeout(500);
+        await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
       }
     }
   });
@@ -130,20 +130,20 @@ test.describe('Batch Operations @critical', () => {
     const groupItems = page.locator('[data-testid="group-item"], .group-item, .sidebar li');
     if (await groupItems.count() > 0) {
       await groupItems.first().click();
-      await page.waitForTimeout(500);
+      await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
     }
 
     // Click batch operation
     const batchButton = page.locator('button:has-text("Batch"), button:has-text("Operation")').first();
     if (await batchButton.count() > 0) {
       await batchButton.click();
-      await page.waitForTimeout(500);
+      await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
 
       // Look for silent mode option
       const silentOption = page.locator(':text("Silent Mode"), button:has-text("Silent")').first();
       if (await silentOption.count() > 0) {
         await silentOption.click({ noWaitAfter: true });
-        await page.waitForTimeout(500);
+        await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
       }
     }
 
@@ -189,24 +189,24 @@ test.describe('Batch Operations @critical', () => {
     const groupItems = page.locator('[data-testid="group-item"], .group-item, .sidebar li');
     if (await groupItems.count() > 0) {
       await groupItems.first().click();
-      await page.waitForTimeout(500);
+      await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
     }
 
     const batchButton = page.locator('button:has-text("Batch"), button:has-text("Operation")').first();
     if (await batchButton.count() > 0) {
       await batchButton.click();
-      await page.waitForTimeout(500);
+      await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
 
       const silentOption = page.locator(':text("Silent Mode"), button:has-text("Silent")').first();
       if (await silentOption.count() > 0) {
         await silentOption.click({ noWaitAfter: true });
-        await page.waitForTimeout(500);
+        await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
 
         // Click confirm button if present
         const confirmButton = page.locator('button:has-text("Confirm"), button:has-text("Apply")').first();
         if (await confirmButton.count() > 0) {
           await confirmButton.click({ noWaitAfter: true });
-          await page.waitForTimeout(1000);
+          await page.waitForLoadState('networkidle', { timeout: 1000 }).catch(() => {});
         }
       }
     }
@@ -241,23 +241,23 @@ test.describe('Batch Operations @critical', () => {
     const groupItems = page.locator('[data-testid="group-item"], .group-item, .sidebar li');
     if (await groupItems.count() > 0) {
       await groupItems.first().click();
-      await page.waitForTimeout(500);
+      await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
     }
 
     const batchButton = page.locator('button:has-text("Batch"), button:has-text("Operation")').first();
     if (await batchButton.count() > 0) {
       await batchButton.click();
-      await page.waitForTimeout(500);
+      await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
 
       const silentOption = page.locator(':text("Silent Mode"), button:has-text("Silent")').first();
       if (await silentOption.count() > 0) {
         await silentOption.click({ noWaitAfter: true });
-        await page.waitForTimeout(500);
+        await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
 
         const confirmButton = page.locator('button:has-text("Confirm"), button:has-text("Apply")').first();
         if (await confirmButton.count() > 0) {
           await confirmButton.click({ noWaitAfter: true });
-          await page.waitForTimeout(1000);
+          await page.waitForLoadState('networkidle', { timeout: 1000 }).catch(() => {});
         }
       }
     }
@@ -294,7 +294,7 @@ test.describe('Batch Operations @critical', () => {
     const groupItems = page.locator('[data-testid="group-item"], .group-item, .sidebar li');
     if (await groupItems.count() > 0) {
       await groupItems.first().click();
-      await page.waitForTimeout(500);
+      await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
     }
 
     // Page should still be functional

--- a/tests/e2e/group-management.spec.ts
+++ b/tests/e2e/group-management.spec.ts
@@ -22,7 +22,7 @@ test.describe('Group Management @critical', () => {
 
     if (linkExists > 0) {
       await tenantLink.click();
-      await page.waitForTimeout(2000);
+      await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
     }
 
     // Verify page has loaded
@@ -69,7 +69,7 @@ test.describe('Group Management @critical', () => {
       await createButton.click({ noWaitAfter: true });
 
       // Wait for potential dialog/form to appear
-      await page.waitForTimeout(1000);
+      await page.waitForLoadState('networkidle', { timeout: 1000 }).catch(() => {});
 
       // Check for form fields: name input, description, etc.
       const inputs = page.locator('input, textarea, [role="combobox"]');
@@ -128,7 +128,7 @@ test.describe('Group Management @critical', () => {
       await expect(memberSearch).toHaveValue('test-user');
 
       // Look for results dropdown
-      await page.waitForTimeout(500);
+      await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
       const results = page.locator('[role="option"], .search-result, .member-option');
       const resultCount = await results.count();
 
@@ -173,7 +173,7 @@ test.describe('Group Management @critical', () => {
       await firstGroup.click({ noWaitAfter: true });
 
       // Wait for UI update
-      await page.waitForTimeout(500);
+      await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
 
       // Verify group details or member list appears
       const details = page.locator('[data-testid="group-details"], .group-details, .member-list');

--- a/tests/e2e/operator-setup-wizard.spec.ts
+++ b/tests/e2e/operator-setup-wizard.spec.ts
@@ -71,7 +71,7 @@ test.describe('Operator Setup Wizard @critical', () => {
 
     // Wait for wizard to load
     await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
-    await page.waitForTimeout(1000);
+    await page.waitForLoadState('networkidle', { timeout: 1000 }).catch(() => {});
 
     // Look for Next/Back buttons
     const nextButton = page.locator(
@@ -147,7 +147,7 @@ test.describe('Operator Setup Wizard @critical', () => {
 
       try {
         await nextButton.click({ noWaitAfter: true });
-        await page.waitForTimeout(500);
+        await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
         clickCount++;
       } catch {
         break;
@@ -269,7 +269,7 @@ test.describe('Operator Setup Wizard @critical', () => {
       } else {
         // Button is enabled — click and check for validation feedback
         await nextButton.click({ noWaitAfter: true });
-        await page.waitForTimeout(500);
+        await page.waitForLoadState('networkidle', { timeout: 500 }).catch(() => {});
 
         const errorMessages = page.locator('[role="alert"], .error-message, .validation-error');
         const errorCount = await errorMessages.count();

--- a/tests/e2e/saved-views.spec.ts
+++ b/tests/e2e/saved-views.spec.ts
@@ -89,7 +89,7 @@ async function mountTenantManagerWithBackend(page: Page) {
 async function loadTenantManager(page: Page) {
   await page.goto('../assets/jsx-loader.html?component=../interactive/tools/tenant-manager.jsx');
   await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
-  await page.waitForTimeout(1500);
+  await page.waitForLoadState('networkidle', { timeout: 1500 }).catch(() => {});
 }
 
 test.describe('Saved Views (Smart Views) @critical', () => {

--- a/tests/e2e/tenant-manager-deeplink.spec.ts
+++ b/tests/e2e/tenant-manager-deeplink.spec.ts
@@ -98,7 +98,7 @@ async function loadTenantManagerWithMockedApi(page: Page) {
     '../assets/jsx-loader.html?component=../interactive/tools/tenant-manager.jsx'
   );
   await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
-  await page.waitForTimeout(2000);
+  await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
 }
 
 test.describe('Tenant Manager × Wizard Deep-Link @critical', () => {
@@ -347,7 +347,7 @@ test.describe('Tenant Manager × Wizard Deep-Link @critical', () => {
       '../assets/jsx-loader.html?component=../interactive/tools/tenant-manager.jsx'
     );
     await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
-    await page.waitForTimeout(2000);
+    await page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
 
     // All 3 footer buttons must contain the EXACT tenant id (URL-
     // encoded by URLSearchParams). encodeURIComponent leaves dashes


### PR DESCRIPTION
## Summary

Follow-up to PR #282. Extends the validated `waitForLoadState` post-load wait pattern to **all 6 remaining E2E specs** in one bundle (instead of 6 separate PRs) per the cost-optimisation request.

PR #282 (tenant-manager) is merged with no flake reports — pattern is empirically safe.

## Mechanical substitution

```ts
// Before
await page.waitForTimeout(N);

// After
await page.waitForLoadState('networkidle', { timeout: N }).catch(() => {});
```

Same upper bound, faster typical case.

## Files + counts

| File | Instances | Timeout values |
|---|---|---|
| `batch-operations.spec.ts` | 18 | 500 / 1000 / 2000 |
| `group-management.spec.ts` | 4 | 500 / 1000 / 2000 |
| `operator-setup-wizard.spec.ts` | 3 | 500 / 1000 |
| `tenant-manager-deeplink.spec.ts` | 2 | 2000 |
| `saved-views.spec.ts` | 1 | 1500 |
| `auth-flow.spec.ts` | 1 | 1000 |
| **Total** | **29** | |

## Project-wide audit

| Metric | Before | After |
|---|---|---|
| `waitForTimeout` calls | 47 across 8 files | **4 across 1 file** |
| Files clean of pattern | 0/8 | 7/8 |

The 4 remaining are all in `tenant-manager.spec.ts` and have semantic justification (debounce wait, retry-after wait, fill-then-wait — see PR #282 for the rationale).

## Test plan

- [ ] Playwright Smoke job passes with same or fewer flakes than baseline (current ~110s)
- [ ] No new flake-on-retry incidents

🤖 Generated with [Claude Code](https://claude.com/claude-code)