### PR TITLE
perf(ci): t.Parallel sweep batch 3 (5 files, 31 additions, github/gitlab/refresh)

### DIFF
--- a/components/tenant-api/internal/github/client_test.go
+++ b/components/tenant-api/internal/github/client_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		repo    string
@@ -23,6 +24,7 @@ func TestNewClient(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := NewClient("token", tt.repo, "main")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewClient() error = %v, wantErr %v", err, tt.wantErr)
@@ -32,6 +34,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestNewClientDefaultBranch(t *testing.T) {
+	t.Parallel()
 	c, err := NewClient("tok", "o/r", "")
 	if err != nil {
 		t.Fatal(err)
@@ -42,6 +45,7 @@ func TestNewClientDefaultBranch(t *testing.T) {
 }
 
 func TestProviderName(t *testing.T) {
+	t.Parallel()
 	c, _ := NewClient("tok", "o/r", "main")
 	if c.ProviderName() != "GitHub" {
 		t.Errorf("expected 'GitHub', got %q", c.ProviderName())
@@ -49,6 +53,7 @@ func TestProviderName(t *testing.T) {
 }
 
 func TestValidateToken(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer good-token" {
 			w.WriteHeader(http.StatusUnauthorized)
@@ -73,6 +78,7 @@ func TestValidateToken(t *testing.T) {
 }
 
 func TestCreatePR(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/pulls") && r.Method == "POST" {
 			resp := map[string]interface{}{
@@ -116,6 +122,7 @@ func TestCreatePR(t *testing.T) {
 }
 
 func TestListOpenPRs(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		prs := []map[string]interface{}{
 			{
@@ -170,6 +177,7 @@ func TestListOpenPRs(t *testing.T) {
 }
 
 func TestListOpenPRs_APIError(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(w, `{"message":"internal error"}`)

--- a/components/tenant-api/internal/github/tracker_test.go
+++ b/components/tenant-api/internal/github/tracker_test.go
@@ -37,6 +37,7 @@ func newTestTracker(t *testing.T, prs []platform.PRInfo) (*Tracker, *httptest.Se
 }
 
 func TestTrackerSync(t *testing.T) {
+	t.Parallel()
 	tracker, srv := newTestTracker(t, []platform.PRInfo{
 		{Number: 1, WebURL: "https://gh/1", State: "open", Title: "PR1", HeadRef: "tenant-api/db-a/20260406", CreatedAt: "2026-04-06T10:00:00Z"},
 		{Number: 2, WebURL: "https://gh/2", State: "open", Title: "PR2", HeadRef: "tenant-api/db-b/20260406", CreatedAt: "2026-04-06T11:00:00Z"},
@@ -62,6 +63,7 @@ func TestTrackerSync(t *testing.T) {
 }
 
 func TestTrackerPendingPRForTenant(t *testing.T) {
+	t.Parallel()
 	tracker, srv := newTestTracker(t, []platform.PRInfo{
 		{Number: 5, WebURL: "https://gh/5", State: "open", Title: "PR5", HeadRef: "tenant-api/db-a/20260406", CreatedAt: "2026-04-06T10:00:00Z"},
 	})
@@ -84,6 +86,7 @@ func TestTrackerPendingPRForTenant(t *testing.T) {
 }
 
 func TestTrackerRegisterPR(t *testing.T) {
+	t.Parallel()
 	tracker, srv := newTestTracker(t, []platform.PRInfo{})
 	defer srv.Close()
 
@@ -111,6 +114,7 @@ func TestTrackerRegisterPR(t *testing.T) {
 }
 
 func TestTrackerLastSyncTime(t *testing.T) {
+	t.Parallel()
 	tracker, srv := newTestTracker(t, []platform.PRInfo{})
 	defer srv.Close()
 
@@ -126,6 +130,7 @@ func TestTrackerLastSyncTime(t *testing.T) {
 }
 
 func TestTrackerMostRecentPRPerTenant(t *testing.T) {
+	t.Parallel()
 	// When same tenant has multiple PRs, tracker keeps the highest number (newest)
 	tracker, srv := newTestTracker(t, []platform.PRInfo{
 		{Number: 1, WebURL: "https://gh/1", State: "open", Title: "Old", HeadRef: "tenant-api/db-a/20260401", CreatedAt: "2026-04-01T10:00:00Z"},
@@ -145,6 +150,7 @@ func TestTrackerMostRecentPRPerTenant(t *testing.T) {
 }
 
 func TestMinSyncInterval(t *testing.T) {
+	t.Parallel()
 	c, _ := NewClient("token", "owner/repo", "main")
 	tracker := NewTracker(c, 1*time.Second) // below minimum
 	if got := tracker.SyncInterval(); got < 10*time.Second {

--- a/components/tenant-api/internal/gitlab/tracker_test.go
+++ b/components/tenant-api/internal/gitlab/tracker_test.go
@@ -37,6 +37,7 @@ func newTestTracker(t *testing.T, mrs []platform.PRInfo) (*Tracker, *httptest.Se
 }
 
 func TestTrackerSync(t *testing.T) {
+	t.Parallel()
 	tracker, srv := newTestTracker(t, []platform.PRInfo{
 		{Number: 1, WebURL: "https://gl/1", State: "opened", Title: "MR1", HeadRef: "tenant-api/db-a/20260406", CreatedAt: "2026-04-06T10:00:00Z"},
 		{Number: 2, WebURL: "https://gl/2", State: "opened", Title: "MR2", HeadRef: "tenant-api/db-b/20260406", CreatedAt: "2026-04-06T11:00:00Z"},
@@ -62,6 +63,7 @@ func TestTrackerSync(t *testing.T) {
 }
 
 func TestTrackerPendingPRForTenant(t *testing.T) {
+	t.Parallel()
 	tracker, srv := newTestTracker(t, []platform.PRInfo{
 		{Number: 5, WebURL: "https://gl/5", State: "opened", Title: "MR5", HeadRef: "tenant-api/db-a/20260406", CreatedAt: "2026-04-06T10:00:00Z"},
 	})
@@ -84,6 +86,7 @@ func TestTrackerPendingPRForTenant(t *testing.T) {
 }
 
 func TestTrackerRegisterPR(t *testing.T) {
+	t.Parallel()
 	tracker, srv := newTestTracker(t, []platform.PRInfo{})
 	defer srv.Close()
 
@@ -111,6 +114,7 @@ func TestTrackerRegisterPR(t *testing.T) {
 }
 
 func TestTrackerRegisterPR_ReplaceSameTenant(t *testing.T) {
+	t.Parallel()
 	tracker, srv := newTestTracker(t, []platform.PRInfo{})
 	defer srv.Close()
 
@@ -131,6 +135,7 @@ func TestTrackerRegisterPR_ReplaceSameTenant(t *testing.T) {
 }
 
 func TestTrackerLastSyncTime(t *testing.T) {
+	t.Parallel()
 	tracker, srv := newTestTracker(t, []platform.PRInfo{})
 	defer srv.Close()
 
@@ -146,6 +151,7 @@ func TestTrackerLastSyncTime(t *testing.T) {
 }
 
 func TestTrackerMostRecentMRPerTenant(t *testing.T) {
+	t.Parallel()
 	tracker, srv := newTestTracker(t, []platform.PRInfo{
 		{Number: 1, WebURL: "https://gl/1", State: "opened", Title: "Old", HeadRef: "tenant-api/db-a/20260401", CreatedAt: "2026-04-01T10:00:00Z"},
 		{Number: 5, WebURL: "https://gl/5", State: "opened", Title: "New", HeadRef: "tenant-api/db-a/20260406", CreatedAt: "2026-04-06T10:00:00Z"},
@@ -164,6 +170,7 @@ func TestTrackerMostRecentMRPerTenant(t *testing.T) {
 }
 
 func TestMinSyncInterval(t *testing.T) {
+	t.Parallel()
 	c, _ := NewClient("token", "group/project", "main")
 	tracker := NewTracker(c, 1*time.Second) // below minimum
 	if got := tracker.SyncInterval(); got < 10*time.Second {

--- a/components/threshold-exporter/app/cmd/da-batchpr/refresh_test.go
+++ b/components/threshold-exporter/app/cmd/da-batchpr/refresh_test.go
@@ -27,6 +27,7 @@ func fixtureRefreshInputJSON() []byte {
 }
 
 func TestRefresh_HelpExitsOK(t *testing.T) {
+	t.Parallel()
 	stderr := &bytes.Buffer{}
 	stdout := &bytes.Buffer{}
 	code := cmdRefresh([]string{"--help"}, stdout, stderr)
@@ -36,6 +37,7 @@ func TestRefresh_HelpExitsOK(t *testing.T) {
 }
 
 func TestRefresh_MalformedInputJSON(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	bad := filepath.Join(tmp, "bad.json")
 	mustWriteFile(t, bad, []byte(`{not json`))
@@ -56,6 +58,7 @@ func TestRefresh_MalformedInputJSON(t *testing.T) {
 // --- runRefresh happy path -------------------------------------
 
 func TestRunRefresh_HappyPath_StubClients(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 	report := filepath.Join(tmp, "report.md")
 	resultJSON := filepath.Join(tmp, "result.json")
@@ -100,6 +103,7 @@ func TestRunRefresh_HappyPath_StubClients(t *testing.T) {
 // --- runRefresh with library validation error ------------------
 
 func TestRunRefresh_LibraryValidationError(t *testing.T) {
+	t.Parallel()
 	flags := &refreshFlags{reportPath: "-", resultJSONPath: "-"}
 	// Empty BaseMergedSHA → batchpr.Refresh returns hard error.
 	in := batchpr.RefreshInput{
@@ -119,6 +123,7 @@ func TestRunRefresh_LibraryValidationError(t *testing.T) {
 // --- exitCodeForRefresh mapping --------------------------------
 
 func TestExitCodeForRefresh(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		s    batchpr.RefreshSummary

--- a/components/threshold-exporter/app/config_metadata_test.go
+++ b/components/threshold-exporter/app/config_metadata_test.go
@@ -14,6 +14,7 @@ import (
 // ============================================================
 
 func TestResolveMetadata_WithMetadata(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Tenants: map[string]map[string]ScheduledValue{
 			"db-a": {
@@ -38,6 +39,7 @@ func TestResolveMetadata_WithMetadata(t *testing.T) {
 }
 
 func TestResolveMetadata_WithoutMetadata(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Tenants: map[string]map[string]ScheduledValue{
 			"db-a": {"mysql_connections": SV("70")},
@@ -58,6 +60,7 @@ func TestResolveMetadata_WithoutMetadata(t *testing.T) {
 }
 
 func TestResolveMetadata_PartialMetadata(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Tenants: map[string]map[string]ScheduledValue{
 			"db-a": {
@@ -81,6 +84,7 @@ func TestResolveMetadata_PartialMetadata(t *testing.T) {
 }
 
 func TestResolveMetadata_Sorted(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Tenants: map[string]map[string]ScheduledValue{
 			"db-c": {"mysql_connections": SV("70")},
@@ -98,6 +102,7 @@ func TestResolveMetadata_Sorted(t *testing.T) {
 }
 
 func TestResolveMetadata_UnconditionalOutput(t *testing.T) {
+	t.Parallel()
 	// All tenants must appear regardless of _metadata presence
 	cfg := &ThresholdConfig{
 		Tenants: map[string]map[string]ScheduledValue{


### PR DESCRIPTION
## Summary

Continues `t.Parallel()` rollout from PRs #284 + #286. **5 more pure-function test files** in one bundle per the CI/git cost-optimisation request.

## Files

| File | t.Parallel additions |
|---|---|
| `tenant-api/internal/github/client_test.go` | 7 outer + 1 inner |
| `tenant-api/internal/github/tracker_test.go` | 6 outer |
| `tenant-api/internal/gitlab/tracker_test.go` | 7 outer |
| `threshold-exporter/.../cmd/da-batchpr/refresh_test.go` | 5 outer (1 `t.Skip`-ed test left untouched) |
| `threshold-exporter/.../config_metadata_test.go` | 5 outer |
| **Total** | **31 additions** |

All files share the same safety profile: each test builds its own `httptest.Server` / `bytes.Buffer` / `ThresholdConfig` — no shared state.

## Verification (local)

- `gofmt` clean
- `go vet` clean across all 5 packages
- `go test -count=1` passes for all 5 packages

## Cumulative progress

| Phase | t.Parallel coverage |
|---|---|
| Pre-audit | 0 calls / 82 files (0%) |
| After PR #284 | 22 calls / 4 files (5%) |
| After PR #286 | 49 calls / 8 files (10%) |
| **After this PR** | **80 calls / 13 files (16%)** |

## Follow-ups (separate PRs)

- `t.Setenv` migration for `config_test.go` / `gitops/writer_extra_test.go` (unblocks medium-risk batch)
- `watchloop` / `debounce` tests — last (highest risk, fs watchers + timing-sensitive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)