### PR TITLE
test: close 3 more 0%-coverage tools (check_alert + axe_lite + chaos_soak)

### DIFF
--- a/tests/dx/test_axe_lite_static.py
+++ b/tests/dx/test_axe_lite_static.py
@@ -1,0 +1,254 @@
+"""Tests for axe_lite_static.py — static WCAG heuristic scanner for JSX.
+
+Audit flagged 0% coverage. The 4 scan functions are pure (string in,
+findings out), so testing is straightforward — we hand-craft minimal
+JSX snippets that hit each branch.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'scripts', 'tools', 'dx')
+sys.path.insert(0, _TOOLS_DIR)
+
+import axe_lite_static as axe  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# strip_frontmatter — pure helper
+# ---------------------------------------------------------------------------
+class TestStripFrontmatter:
+    def test_no_frontmatter_returns_unchanged(self):
+        src = "function Foo() {}"
+        assert axe.strip_frontmatter(src) == src
+
+    def test_yaml_frontmatter_stripped(self):
+        src = "---\ntitle: x\n---\nfunction Foo() {}"
+        out = axe.strip_frontmatter(src)
+        assert "title" not in out
+        assert "function Foo()" in out
+
+    def test_unterminated_frontmatter_returned_unchanged(self):
+        # Opens with `---` but no closing line — defensive: no slice.
+        src = "---\ntitle: x\nstill in frontmatter"
+        assert axe.strip_frontmatter(src) == src
+
+
+# ---------------------------------------------------------------------------
+# scan_unicode_status — WCAG 1.4.1
+# ---------------------------------------------------------------------------
+# NOTE: The scanner's backward-walk logic short-circuits at the first `>`
+# encountered between symbol and `<` — for typical JSX (`<div>✓</div>`)
+# this means the "bare symbol" path is unreachable in practice. The tests
+# below exercise the entry points that DO trigger (no-symbol shortcut,
+# attribute-value ignore path) plus negative space (no crash on empty /
+# non-JSX input).
+class TestScanUnicodeStatus:
+    def test_empty_input_no_findings(self):
+        assert axe.scan_unicode_status("") == []
+
+    def test_no_status_chars_no_findings(self):
+        assert axe.scan_unicode_status("function f() { return 1; }") == []
+
+    def test_symbol_inside_attribute_value_ignored(self):
+        # Symbol is INSIDE the opening tag's attribute string — the
+        # `close_gt > i` branch returns early without flagging.
+        src = '<input title="✓ done" />'
+        assert axe.scan_unicode_status(src) == []
+
+    def test_symbol_inside_long_attribute_value_with_aria_hidden_ignored(self):
+        # Even though aria-hidden is present, the early `close_gt > i`
+        # branch handles attribute-resident symbols first.
+        src = '<span aria-hidden="true" title="✓ ok">x</span>'
+        assert axe.scan_unicode_status(src) == []
+
+    def test_normal_text_content_returns_empty(self):
+        # Backward-walk gives up at `>` of the opening tag, so visible-
+        # text symbols return empty. This pins current behaviour.
+        src = '<div>✓ done</div>'
+        assert axe.scan_unicode_status(src) == []
+
+    def test_returns_list_type(self):
+        # Smoke: function always returns list (callable contract).
+        result = axe.scan_unicode_status('<a>x</a>')
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# scan_buttons_without_name — WCAG 4.1.2
+# ---------------------------------------------------------------------------
+class TestScanButtonsWithoutName:
+    def test_button_with_text_passes(self):
+        src = '<button>Click me</button>'
+        assert axe.scan_buttons_without_name(src) == []
+
+    def test_button_with_aria_label_passes(self):
+        src = '<button aria-label="close" onClick={x}></button>'
+        assert axe.scan_buttons_without_name(src) == []
+
+    def test_button_with_title_passes(self):
+        src = '<button title="close"></button>'
+        assert axe.scan_buttons_without_name(src) == []
+
+    def test_empty_button_flagged(self):
+        src = '<button></button>'
+        findings = axe.scan_buttons_without_name(src)
+        assert len(findings) == 1
+        assert "no accessible name" in findings[0][1]
+
+    def test_jsx_expression_inside_treated_as_accessible(self):
+        # i18n pattern: button has {t('Submit')} — runtime string =
+        # accept (heuristic to reduce false positives).
+        src = '<button>{t("Submit", "送出")}</button>'
+        assert axe.scan_buttons_without_name(src) == []
+
+    def test_aria_hidden_only_child_does_not_count(self):
+        # icon button: only child is aria-hidden span → no accessible name.
+        src = '<button><span aria-hidden="true">✓</span></button>'
+        findings = axe.scan_buttons_without_name(src)
+        assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# scan_unlabeled_inputs — WCAG 3.3.2
+# ---------------------------------------------------------------------------
+class TestScanUnlabeledInputs:
+    def test_input_with_placeholder_passes(self):
+        src = '<input type="text" placeholder="search" />'
+        assert axe.scan_unlabeled_inputs(src) == []
+
+    def test_input_with_aria_label_passes(self):
+        src = '<input type="text" aria-label="name" />'
+        assert axe.scan_unlabeled_inputs(src) == []
+
+    def test_textarea_with_title_passes(self):
+        src = '<textarea title="comments" />'
+        assert axe.scan_unlabeled_inputs(src) == []
+
+    def test_unlabeled_input_flagged(self):
+        src = '<input type="text" />'
+        findings = axe.scan_unlabeled_inputs(src)
+        assert len(findings) == 1
+        assert "input" in findings[0][1]
+
+    def test_hidden_submit_button_radio_skipped(self):
+        # Non-text input types skip the label check.
+        src = (
+            '<input type="hidden" />\n'
+            '<input type="submit" />\n'
+            '<input type="checkbox" />\n'
+            '<input type="radio" />\n'
+        )
+        assert axe.scan_unlabeled_inputs(src) == []
+
+    def test_label_htmlfor_id_match_passes(self):
+        # Sibling <label htmlFor="name"> labels <input id="name">.
+        src = '<label htmlFor="name">Name</label><input type="text" id="name" />'
+        assert axe.scan_unlabeled_inputs(src) == []
+
+    def test_label_htmlfor_template_form_passes(self):
+        # Templated id: <label htmlFor={`name${suffix}`}>. The scanner's
+        # template-form regex looks for the input's id appearing inside
+        # the template literal — `name` matches.
+        src = '<label htmlFor={`name${suffix}`}>L</label><input type="text" id="name" />'
+        assert axe.scan_unlabeled_inputs(src) == []
+
+
+# ---------------------------------------------------------------------------
+# scan_color_only_severity — WCAG 1.4.1 complementary
+# ---------------------------------------------------------------------------
+class TestScanColorOnlySeverity:
+    def test_no_color_token_no_findings(self):
+        src = '<div className="text-blue">info</div>'
+        assert axe.scan_color_only_severity(src) == []
+
+    def test_color_with_border_passes(self):
+        src = '<div className="text-[color:var(--da-color-error)] border-2">err</div>'
+        assert axe.scan_color_only_severity(src) == []
+
+    def test_color_with_underline_passes(self):
+        src = '<span className="text-[color:var(--da-color-warning)] underline">w</span>'
+        assert axe.scan_color_only_severity(src) == []
+
+    def test_color_only_flagged(self):
+        src = '<div className="text-[color:var(--da-color-error)]">error msg</div>'
+        findings = axe.scan_color_only_severity(src)
+        assert len(findings) == 1
+        assert "non-color signal" in findings[0][1]
+
+    def test_color_with_unicode_symbol_in_window_passes(self):
+        src = (
+            '<div>'
+            '<span className="text-[color:var(--da-color-error)]">'
+            '✓ done</span></div>'
+        )
+        assert axe.scan_color_only_severity(src) == []
+
+    def test_color_with_role_alert_passes(self):
+        src = '<div role="alert" className="text-[color:var(--da-color-error)]">err</div>'
+        assert axe.scan_color_only_severity(src) == []
+
+
+# ---------------------------------------------------------------------------
+# check_file + main — file-bound + CLI
+# ---------------------------------------------------------------------------
+class TestCheckFile:
+    def test_clean_file_returns_zero(self, tmp_path, capsys):
+        f = tmp_path / "ok.jsx"
+        f.write_text(
+            'function X() { return <button>OK</button>; }',
+            encoding="utf-8",
+        )
+        total = axe.check_file(f)
+        assert total == 0
+        out = capsys.readouterr().out
+        assert "[ok.jsx]" in out
+
+    def test_file_with_violations_returns_count(self, tmp_path, capsys):
+        f = tmp_path / "bad.jsx"
+        f.write_text(
+            'function X() { return <><button></button><input type="text" /></>; }',
+            encoding="utf-8",
+        )
+        total = axe.check_file(f)
+        assert total >= 2  # at least button + input
+        out = capsys.readouterr().out
+        assert "L1" in out
+
+    def test_truncates_long_lists_with_summary(self, tmp_path, capsys):
+        # 12 unlabeled buttons → check_file prints first 10 + "and 2 more".
+        f = tmp_path / "many.jsx"
+        f.write_text("\n".join(["<button></button>"] * 12), encoding="utf-8")
+        axe.check_file(f)
+        out = capsys.readouterr().out
+        assert "and 2 more" in out
+
+
+class TestMain:
+    def test_no_args_returns_two_with_usage(self, capsys):
+        rc = axe.main(["axe_lite_static.py"])
+        assert rc == 2
+        out = capsys.readouterr().out
+        assert "usage:" in out
+
+    def test_help_flag_returns_zero(self, capsys):
+        rc = axe.main(["axe_lite_static.py", "--help"])
+        assert rc == 0
+        assert "usage" in capsys.readouterr().out
+
+    def test_short_help_flag_returns_zero(self, capsys):
+        assert axe.main(["axe_lite_static.py", "-h"]) == 0
+
+    def test_clean_file_returns_zero(self, tmp_path):
+        f = tmp_path / "ok.jsx"
+        f.write_text('<button>OK</button>', encoding="utf-8")
+        assert axe.main(["axe_lite_static.py", str(f)]) == 0
+
+    def test_violations_return_one(self, tmp_path):
+        f = tmp_path / "bad.jsx"
+        f.write_text('<button></button>', encoding="utf-8")
+        assert axe.main(["axe_lite_static.py", str(f)]) == 1

--- a/tests/dx/test_run_chaos_soak.py
+++ b/tests/dx/test_run_chaos_soak.py
@@ -1,0 +1,282 @@
+"""Tests for run_chaos_soak.py — v2.8.0 readiness chaos soak harness.
+
+Audit flagged 0% coverage. The pure functions (parse_metrics,
+trigger_reload) are easy to test directly. fetch_metrics needs
+urllib.request mocked. main() is the orchestrator (skipped here —
+its loop is time-bound and best exercised end-to-end).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_TOOLS_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'scripts', 'tools', 'dx')
+sys.path.insert(0, _TOOLS_DIR)
+
+import run_chaos_soak as rcs  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# parse_metrics — pure helper
+# ---------------------------------------------------------------------------
+class TestParseMetrics:
+    def test_empty_input_returns_empty_dict(self):
+        assert rcs.parse_metrics("") == {}
+
+    def test_extracts_tracked_metrics(self):
+        text = (
+            "# HELP go_goroutines Number of goroutines\n"
+            "# TYPE go_goroutines gauge\n"
+            "go_goroutines 42\n"
+            "go_memstats_alloc_bytes 1234567\n"
+        )
+        out = rcs.parse_metrics(text)
+        assert out["go_goroutines"] == 42.0
+        assert out["go_memstats_alloc_bytes"] == 1234567.0
+
+    def test_skips_comment_lines(self):
+        text = "# go_goroutines is a comment line\ngo_goroutines 5\n"
+        assert rcs.parse_metrics(text) == {"go_goroutines": 5.0}
+
+    def test_skips_labeled_samples(self):
+        # Labeled samples (with `{label=...}`) are skipped — we want
+        # process-level singletons.
+        text = (
+            'go_goroutines 10\n'
+            'go_goroutines{tenant="a"} 5\n'
+            'go_goroutines{tenant="b"} 5\n'
+        )
+        out = rcs.parse_metrics(text)
+        assert out["go_goroutines"] == 10.0  # only the unlabeled
+
+    def test_ignores_unknown_metric_names(self):
+        text = "irrelevant_metric 999\ngo_goroutines 5\n"
+        out = rcs.parse_metrics(text)
+        assert "irrelevant_metric" not in out
+        assert out["go_goroutines"] == 5.0
+
+    def test_skips_invalid_float_values(self):
+        text = "go_goroutines NotANumber\ngo_memstats_sys_bytes 1024\n"
+        out = rcs.parse_metrics(text)
+        assert "go_goroutines" not in out
+        assert out["go_memstats_sys_bytes"] == 1024.0
+
+    def test_skips_short_lines(self):
+        # Line with only metric name (no value) is skipped.
+        text = "go_goroutines\ngo_memstats_sys_bytes 100\n"
+        out = rcs.parse_metrics(text)
+        assert "go_goroutines" not in out
+        assert out["go_memstats_sys_bytes"] == 100.0
+
+    def test_skips_blank_lines(self):
+        text = "go_goroutines 5\n\n\ngo_memstats_sys_bytes 100\n"
+        out = rcs.parse_metrics(text)
+        assert len(out) == 2
+
+
+# ---------------------------------------------------------------------------
+# fetch_metrics — urllib wrapper
+# ---------------------------------------------------------------------------
+class TestFetchMetrics:
+    def test_success_returns_parsed_dict(self, monkeypatch):
+        body = b"go_goroutines 7\n"
+
+        class FakeResp:
+            def read(self):
+                return body
+            def __enter__(self):
+                return self
+            def __exit__(self, *a):
+                return False
+
+        monkeypatch.setattr(rcs.urllib.request, "urlopen",
+                            lambda url, timeout: FakeResp())
+        out = rcs.fetch_metrics("http://localhost:8080")
+        assert out == {"go_goroutines": 7.0}
+
+    def test_url_error_returns_none(self, monkeypatch, capsys):
+        def boom(*args, **kwargs):
+            raise urllib.error.URLError("connection refused")
+        monkeypatch.setattr(rcs.urllib.request, "urlopen", boom)
+        assert rcs.fetch_metrics("http://localhost:8080") is None
+        # Warning should land on stderr.
+        err = capsys.readouterr().err
+        assert "warn" in err.lower()
+
+    def test_timeout_returns_none(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise TimeoutError("timed out")
+        monkeypatch.setattr(rcs.urllib.request, "urlopen", boom)
+        assert rcs.fetch_metrics("http://localhost:8080", timeout_sec=1.0) is None
+
+    def test_oserror_returns_none(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise OSError("network down")
+        monkeypatch.setattr(rcs.urllib.request, "urlopen", boom)
+        assert rcs.fetch_metrics("http://localhost:8080") is None
+
+    def test_strips_trailing_slash_from_url(self, monkeypatch):
+        captured = {}
+
+        class FakeResp:
+            def read(self):
+                return b""
+            def __enter__(self):
+                return self
+            def __exit__(self, *a):
+                return False
+
+        def fake_urlopen(url, timeout):
+            captured["url"] = url
+            return FakeResp()
+
+        monkeypatch.setattr(rcs.urllib.request, "urlopen", fake_urlopen)
+        rcs.fetch_metrics("http://localhost:8080/")
+        assert captured["url"] == "http://localhost:8080/metrics"
+
+
+# ---------------------------------------------------------------------------
+# trigger_reload — filesystem mtime/content toggle
+# ---------------------------------------------------------------------------
+class TestTriggerReload:
+    def test_missing_dir_returns_false(self, tmp_path):
+        ghost = tmp_path / "no-such-dir"
+        assert rcs.trigger_reload(ghost) is False
+
+    def test_no_yaml_files_returns_false(self, tmp_path):
+        # Directory exists but contains no .yaml files.
+        (tmp_path / "readme.md").write_text("x", encoding="utf-8")
+        assert rcs.trigger_reload(tmp_path) is False
+
+    def test_only_underscore_files_returns_false(self, tmp_path):
+        # _defaults.yaml is intentionally skipped (platform invariant).
+        # If only underscore-prefixed files exist, no eligible target → False.
+        (tmp_path / "_defaults.yaml").write_text("x: 1\n", encoding="utf-8")
+        assert rcs.trigger_reload(tmp_path) is False
+
+    def test_appends_marker_on_first_call(self, tmp_path):
+        f = tmp_path / "tenant-a.yaml"
+        f.write_text("x: 1\n", encoding="utf-8")
+        assert rcs.trigger_reload(tmp_path) is True
+        new = f.read_text(encoding="utf-8")
+        assert "soak-toggle: A" in new
+
+    def test_toggles_a_to_b_on_second_call(self, tmp_path):
+        f = tmp_path / "tenant-a.yaml"
+        f.write_text("x: 1\n# soak-toggle: A\n", encoding="utf-8")
+        rcs.trigger_reload(tmp_path)
+        toggled = f.read_text(encoding="utf-8")
+        assert "soak-toggle: B" in toggled
+        assert "soak-toggle: A" not in toggled
+
+    def test_toggles_b_to_a(self, tmp_path):
+        f = tmp_path / "tenant-a.yaml"
+        f.write_text("x: 1\n# soak-toggle: B\n", encoding="utf-8")
+        rcs.trigger_reload(tmp_path)
+        toggled = f.read_text(encoding="utf-8")
+        assert "soak-toggle: A" in toggled
+        assert "soak-toggle: B" not in toggled
+
+    def test_skips_underscore_files_picks_other(self, tmp_path):
+        # _defaults.yaml is skipped; tenant-a.yaml is perturbed.
+        defaults = tmp_path / "_defaults.yaml"
+        defaults.write_text("baseline: 1\n", encoding="utf-8")
+        tenant = tmp_path / "tenant-a.yaml"
+        tenant.write_text("x: 1\n", encoding="utf-8")
+        assert rcs.trigger_reload(tmp_path) is True
+        # _defaults.yaml is unchanged; tenant-a.yaml has the marker.
+        assert defaults.read_text(encoding="utf-8") == "baseline: 1\n"
+        assert "soak-toggle" in tenant.read_text(encoding="utf-8")
+
+    def test_walks_subdirectories(self, tmp_path):
+        # rglob — nested files are eligible.
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        f = sub / "tenant-x.yaml"
+        f.write_text("x: 1\n", encoding="utf-8")
+        assert rcs.trigger_reload(tmp_path) is True
+        assert "soak-toggle" in f.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# RunConfig dataclass — smoke
+# ---------------------------------------------------------------------------
+class TestRunConfig:
+    def test_defaults_for_optional_fields(self):
+        cfg = rcs.RunConfig(
+            target_url="http://x",
+            config_dir="/tmp",
+            duration_min=1,
+            reload_interval_sec=10,
+            metrics_poll_sec=5,
+            output_dir="/out",
+        )
+        assert cfg.started_at_utc == ""
+        assert cfg.ended_at_utc == ""
+        assert cfg.reload_count == 0
+        assert cfg.poll_count == 0
+
+
+# ---------------------------------------------------------------------------
+# main — caller-error surfaces (avoids the long soak loop)
+# ---------------------------------------------------------------------------
+class TestMainCallerErrors:
+    def test_missing_config_dir_returns_one(self, monkeypatch, tmp_path, capsys):
+        out_dir = tmp_path / "out"
+        ghost = tmp_path / "ghost-config"
+        monkeypatch.setattr(sys, "argv", [
+            "run_chaos_soak.py",
+            "--target-url", "http://localhost:8080",
+            "--config-dir", str(ghost),
+            "--output-dir", str(out_dir),
+            "--duration-min", "1",
+        ])
+        # main() returns 1 on missing config dir before the soak loop.
+        assert rcs.main() == 1
+        err = capsys.readouterr().err
+        assert "config-dir not found" in err
+
+    def test_unreachable_target_returns_one(self, monkeypatch, tmp_path, capsys):
+        config_dir = tmp_path / "conf"
+        config_dir.mkdir()
+        out_dir = tmp_path / "out"
+        # fetch_metrics returns None → "cannot reach" → exit 1.
+        monkeypatch.setattr(rcs, "fetch_metrics", lambda *a, **kw: None)
+        monkeypatch.setattr(sys, "argv", [
+            "run_chaos_soak.py",
+            "--target-url", "http://localhost:8080",
+            "--config-dir", str(config_dir),
+            "--output-dir", str(out_dir),
+            "--duration-min", "1",
+        ])
+        assert rcs.main() == 1
+        err = capsys.readouterr().err
+        assert "cannot reach" in err
+
+    def test_zero_duration_completes_with_empty_metrics(self, monkeypatch, tmp_path):
+        # Empty initial metrics is a WARN, not a hard error. Pair it with
+        # `--duration-min 0` so the soak loop exits immediately on the first
+        # `time.time() < end_at` check — verifies the harness completes
+        # cleanly without fetching/looping.
+        config_dir = tmp_path / "conf"
+        config_dir.mkdir()
+        out_dir = tmp_path / "out"
+        monkeypatch.setattr(rcs, "fetch_metrics", lambda *a, **kw: {})
+        monkeypatch.setattr(sys, "argv", [
+            "run_chaos_soak.py",
+            "--target-url", "http://localhost:8080",
+            "--config-dir", str(config_dir),
+            "--output-dir", str(out_dir),
+            "--duration-min", "0",
+        ])
+        # `--duration-min 0` → loop never executes → returns 0 cleanly.
+        assert rcs.main() == 0
+        # Output files were created in the finally block.
+        assert (out_dir / "summary.txt").exists()
+        assert (out_dir / "metrics-timeseries.csv").exists()
+        assert (out_dir / "run-config.json").exists()

--- a/tests/ops/test_check_alert.py
+++ b/tests/ops/test_check_alert.py
@@ -1,0 +1,100 @@
+"""Tests for check_alert.py — Prometheus alert state query.
+
+Audit flagged this as a 0% covered tool. Tests stub http_get_json so
+no real Prometheus is contacted.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+_TOOLS_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'scripts', 'tools', 'ops')
+sys.path.insert(0, _TOOLS_DIR)
+
+import check_alert as ca  # noqa: E402
+
+
+def _stub_http(monkeypatch, payload, err=None):
+    """Replace _lib_python.http_get_json behind ca's import."""
+    import _lib_python as lib
+
+    def fake(*args, **kwargs):
+        return payload, err
+    monkeypatch.setattr(lib, "http_get_json", fake)
+    monkeypatch.setattr(ca, "http_get_json", fake)
+
+
+class TestCheckAlert:
+    def test_inactive_when_no_matching_alerts(self, monkeypatch, capsys):
+        _stub_http(monkeypatch, {"data": {"alerts": []}})
+        ca.check_alert("HighCPU", "db-a", "http://localhost:9090")
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["state"] == "inactive"
+        assert payload["alert"] == "HighCPU"
+        assert payload["tenant"] == "db-a"
+
+    def test_inactive_when_alertname_does_not_match(self, monkeypatch, capsys):
+        _stub_http(monkeypatch, {"data": {"alerts": [
+            {"labels": {"alertname": "OtherAlert", "tenant": "db-a"}, "state": "firing"},
+        ]}})
+        ca.check_alert("HighCPU", "db-a", "http://localhost:9090")
+        out = capsys.readouterr().out
+        assert json.loads(out)["state"] == "inactive"
+
+    def test_firing_when_tenant_label_matches(self, monkeypatch, capsys):
+        _stub_http(monkeypatch, {"data": {"alerts": [
+            {"labels": {"alertname": "HighCPU", "tenant": "db-a"},
+             "state": "firing", "activeAt": "2026-05-07T10:00:00Z"},
+        ]}})
+        ca.check_alert("HighCPU", "db-a", "http://localhost:9090")
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["state"] == "firing"
+        assert payload["details"][0]["state"] == "firing"
+
+    def test_firing_via_instance_label_fallback(self, monkeypatch, capsys):
+        # tenant label absent but instance matches.
+        _stub_http(monkeypatch, {"data": {"alerts": [
+            {"labels": {"alertname": "HighCPU", "instance": "db-a"},
+             "state": "firing", "activeAt": "2026-05-07T10:00:00Z"},
+        ]}})
+        ca.check_alert("HighCPU", "db-a", "http://localhost:9090")
+        assert json.loads(capsys.readouterr().out)["state"] == "firing"
+
+    def test_pending_when_only_pending_matches(self, monkeypatch, capsys):
+        _stub_http(monkeypatch, {"data": {"alerts": [
+            {"labels": {"alertname": "HighCPU", "tenant": "db-a"}, "state": "pending"},
+        ]}})
+        ca.check_alert("HighCPU", "db-a", "http://localhost:9090")
+        assert json.loads(capsys.readouterr().out)["state"] == "pending"
+
+    def test_firing_takes_priority_over_pending(self, monkeypatch, capsys):
+        # firing > pending — even if pending appears first.
+        _stub_http(monkeypatch, {"data": {"alerts": [
+            {"labels": {"alertname": "HighCPU", "tenant": "db-a"}, "state": "pending"},
+            {"labels": {"alertname": "HighCPU", "tenant": "db-a"}, "state": "firing"},
+        ]}})
+        ca.check_alert("HighCPU", "db-a", "http://localhost:9090")
+        assert json.loads(capsys.readouterr().out)["state"] == "firing"
+
+    def test_unknown_when_no_firing_or_pending(self, monkeypatch, capsys):
+        # Match exists but state is neither firing nor pending — falls
+        # through the elif/else ladder to "unknown".
+        _stub_http(monkeypatch, {"data": {"alerts": [
+            {"labels": {"alertname": "HighCPU", "tenant": "db-a"}, "state": "resolved"},
+        ]}})
+        ca.check_alert("HighCPU", "db-a", "http://localhost:9090")
+        assert json.loads(capsys.readouterr().out)["state"] == "unknown"
+
+    def test_http_error_exits_one(self, monkeypatch, capsys):
+        _stub_http(monkeypatch, None, err="connection refused")
+        with pytest.raises(SystemExit) as exc:
+            ca.check_alert("HighCPU", "db-a", "http://localhost:9090")
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert "error" in payload
+        assert "connection refused" in payload["error"]


### PR DESCRIPTION
## Summary

Continues the audit-driven coverage sweep. Bundles **3 more 0%-coverage tools** into one PR per the cost-optimisation request (1 review pass + 1 CI run for what would otherwise be 3 separate PRs).

## Coverage delta

| Tool | Before | After | Tests |
|---|---|---|---|
| `scripts/tools/ops/check_alert.py` | **0%** | **100%** | +8 |
| `scripts/tools/dx/axe_lite_static.py` | **0%** | **87.3%** | +36 |
| `scripts/tools/dx/run_chaos_soak.py` | **0%** | **84.7%** | +25 |
| **Total new tests** | | | **69** |

## Tools rationale

- **`check_alert.py`** — Prometheus alert state query. Tests stub `http_get_json` so no real Prometheus is contacted. Covers happy paths (firing / pending / inactive), state-priority logic (firing > pending > unknown), tenant-via-instance label fallback, and the connection-error → `exit(1)` path.

- **`axe_lite_static.py`** — WCAG static heuristic scanner. The 4 scan functions are pure (string in, findings out). Tests cover detected-violation branches plus early-return paths.

  > **Note**: while writing tests I discovered that `scan_unicode_status`'s flag path is **reachable only for unusual edge cases** — its backward-walk gives up at the first `>` encountered between the symbol and the nearest `<tag` open, which means typical JSX (`<div>✓</div>`) never triggers a finding. Tests pin current behaviour rather than claim the flag path triggers on common JSX. This is a latent bug in the scanner worth following up.

- **`run_chaos_soak.py`** — v2.8.0 readiness chaos soak harness. Pure functions (`parse_metrics`, `trigger_reload`) tested directly with `tmp_path`. `fetch_metrics` tested with `urllib.request.urlopen` monkeypatched. `main()` caller-error paths exercised with `--duration-min 0` to skip the actual soak loop (which would otherwise wait 60s+).

## Verification

All 69 tests pass locally in 0.59s. No real `kubectl` / `gh` / `git` / Prometheus invocations — every external dependency is monkeypatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)