### PR TITLE
test: close coverage on add_frontmatter + generate_changelog (30% -> 96%+)

### DIFF
--- a/tests/dx/test_add_frontmatter_extra.py
+++ b/tests/dx/test_add_frontmatter_extra.py
@@ -1,0 +1,312 @@
+"""Extension tests for add_frontmatter.py — closes the orchestrator gap.
+
+Audit flagged 33% coverage. The existing test_add_frontmatter.py covers
+the metadata-extraction helpers (detect_language / extract_version /
+extract_title / tag assignments). This file fills the remaining surface:
+  - has_frontmatter / read_file_content / write_file_content (file IO)
+  - generate_frontmatter (template rendering)
+  - process_file (end-to-end + dry-run + already-has-frontmatter shortcut)
+  - _is_excluded (path filter)
+  - find_markdown_files (directory walk + symlink + scope filtering)
+  - main() (--check / --dry-run / --base-dir orchestration)
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'scripts', 'tools', 'dx')
+sys.path.insert(0, _TOOLS_DIR)
+
+import add_frontmatter as af  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# has_frontmatter
+# ---------------------------------------------------------------------------
+class TestHasFrontmatter:
+    def test_file_with_frontmatter_returns_true(self, tmp_path):
+        f = tmp_path / "a.md"
+        f.write_text("---\ntitle: x\n---\nbody\n", encoding="utf-8")
+        assert af.has_frontmatter(str(f)) is True
+
+    def test_file_without_frontmatter_returns_false(self, tmp_path):
+        f = tmp_path / "a.md"
+        f.write_text("# Heading\n\nbody\n", encoding="utf-8")
+        assert af.has_frontmatter(str(f)) is False
+
+    def test_nonexistent_file_returns_false(self, tmp_path):
+        assert af.has_frontmatter(str(tmp_path / "ghost.md")) is False
+
+    def test_empty_file_returns_false(self, tmp_path):
+        f = tmp_path / "empty.md"
+        f.write_text("", encoding="utf-8")
+        assert af.has_frontmatter(str(f)) is False
+
+
+# ---------------------------------------------------------------------------
+# read/write_file_content
+# ---------------------------------------------------------------------------
+class TestReadWriteFileContent:
+    def test_round_trip(self, tmp_path):
+        f = tmp_path / "a.md"
+        original = "Hello\n中文\n"
+        af.write_file_content(str(f), original)
+        assert af.read_file_content(str(f)) == original
+
+    def test_overwrite_replaces_content(self, tmp_path):
+        f = tmp_path / "a.md"
+        f.write_text("old", encoding="utf-8")
+        af.write_file_content(str(f), "new")
+        assert f.read_text(encoding="utf-8") == "new"
+
+
+# ---------------------------------------------------------------------------
+# generate_frontmatter — template renderer
+# ---------------------------------------------------------------------------
+class TestGenerateFrontmatter:
+    def test_basic_block(self):
+        out = af.generate_frontmatter(
+            "Title", ["alpha", "beta"], ["devs"], "v2.8.0", "en",
+        )
+        assert out.startswith("---\n")
+        assert out.endswith("---\n")
+        assert 'title: "Title"' in out
+        assert "tags: [alpha, beta]" in out
+        assert "audience: [devs]" in out
+        assert "version: v2.8.0" in out
+        assert "lang: en" in out
+
+    def test_quotes_tags_with_spaces(self):
+        out = af.generate_frontmatter(
+            "T", ["multi word", "single"], ["adm in", "user"], "v1", "zh",
+        )
+        # Spaces → quoted; no-space → bare.
+        assert '"multi word"' in out
+        assert ", single" in out
+        assert '"adm in"' in out
+        assert ", user" in out
+
+
+# ---------------------------------------------------------------------------
+# process_file — end-to-end
+# ---------------------------------------------------------------------------
+class TestProcessFile:
+    def test_already_has_frontmatter_returns_unchanged(self, tmp_path):
+        f = tmp_path / "a.md"
+        original = "---\ntitle: x\n---\nbody"
+        f.write_text(original, encoding="utf-8")
+        was_modified, msg = af.process_file(str(f), str(tmp_path))
+        assert was_modified is False
+        assert "Already has front matter" in msg
+        assert f.read_text(encoding="utf-8") == original
+
+    def test_dry_run_does_not_modify_file(self, tmp_path):
+        f = tmp_path / "a.md"
+        original = "# Heading\n\nbody"
+        f.write_text(original, encoding="utf-8")
+        was_modified, msg = af.process_file(str(f), str(tmp_path), dry_run=True)
+        assert was_modified is True
+        assert "Would add" in msg
+        # File on disk unchanged.
+        assert f.read_text(encoding="utf-8") == original
+
+    def test_real_run_prepends_frontmatter(self, tmp_path):
+        # Use a docs/ subdirectory so detect_language / extract_title
+        # have realistic input.
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        f = docs / "guide.md"
+        f.write_text("# My Guide\n\nbody\n", encoding="utf-8")
+        was_modified, msg = af.process_file(str(f), str(tmp_path))
+        assert was_modified is True
+        assert "Added front matter" in msg
+        new = f.read_text(encoding="utf-8")
+        assert new.startswith("---\n")
+        assert "# My Guide\n\nbody\n" in new
+
+
+# ---------------------------------------------------------------------------
+# _is_excluded — path filter
+# ---------------------------------------------------------------------------
+class TestIsExcluded:
+    def test_normal_path_not_excluded(self):
+        assert af._is_excluded("docs/getting-started.md") is False
+
+    def test_known_exclude_relative_path(self, monkeypatch):
+        # Force a known entry into the EXCLUDE list to verify the lookup.
+        monkeypatch.setattr(af, "EXCLUDE_RELATIVE_PATHS", {"docs/skip-me.md"})
+        assert af._is_excluded("docs/skip-me.md") is True
+        assert af._is_excluded("docs/keep-me.md") is False
+
+    def test_prefix_excluded(self, monkeypatch):
+        monkeypatch.setattr(af, "EXCLUDE_PATH_PREFIXES", ("docs/internal/",))
+        assert af._is_excluded("docs/internal/secret.md") is True
+        assert af._is_excluded("docs/public/ok.md") is False
+
+    def test_glob_pattern_excluded(self, monkeypatch):
+        monkeypatch.setattr(af, "EXCLUDE_PATH_GLOBS", ("**/draft.md",))
+        assert af._is_excluded("docs/draft.md") is True
+        assert af._is_excluded("docs/sub/draft.md") is True
+        assert af._is_excluded("docs/final.md") is False
+
+    def test_uses_posix_separator_normalisation(self, monkeypatch):
+        # Backslash paths are normalised to forward slash before matching.
+        monkeypatch.setattr(af, "EXCLUDE_PATH_PREFIXES", ("docs/skip/",))
+        # Simulate a Windows path component.
+        rel = "docs" + os.sep + "skip" + os.sep + "file.md"
+        assert af._is_excluded(rel) is True
+
+
+# ---------------------------------------------------------------------------
+# find_markdown_files — directory walk
+# ---------------------------------------------------------------------------
+class TestFindMarkdownFiles:
+    def test_finds_md_in_docs_subdir(self, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "a.md").write_text("x", encoding="utf-8")
+        files = af.find_markdown_files(str(tmp_path))
+        assert any(f.endswith("a.md") for f in files)
+
+    def test_finds_md_in_rule_packs_subdir(self, tmp_path):
+        rp = tmp_path / "rule-packs"
+        rp.mkdir()
+        (rp / "rule-pack-database.md").write_text("x", encoding="utf-8")
+        files = af.find_markdown_files(str(tmp_path))
+        assert any("rule-pack-database.md" in f for f in files)
+
+    def test_finds_root_readme_and_changelog(self, tmp_path):
+        (tmp_path / "README.md").write_text("x", encoding="utf-8")
+        (tmp_path / "CHANGELOG.md").write_text("x", encoding="utf-8")
+        files = af.find_markdown_files(str(tmp_path))
+        names = {os.path.basename(f) for f in files}
+        assert "README.md" in names
+        assert "CHANGELOG.md" in names
+
+    def test_root_random_md_not_in_scope(self, tmp_path):
+        # Random .md at root (not README/CHANGELOG/README.en.md) is excluded.
+        (tmp_path / "random.md").write_text("x", encoding="utf-8")
+        files = af.find_markdown_files(str(tmp_path))
+        assert all(not f.endswith("random.md") for f in files)
+
+    def test_skips_hidden_dirs_and_node_modules(self, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / ".hidden").mkdir()
+        (docs / ".hidden" / "skip.md").write_text("x", encoding="utf-8")
+        (docs / "node_modules").mkdir()
+        (docs / "node_modules" / "skip.md").write_text("x", encoding="utf-8")
+        (docs / "real.md").write_text("x", encoding="utf-8")
+        files = af.find_markdown_files(str(tmp_path))
+        names = [os.path.basename(f) for f in files]
+        assert names.count("real.md") == 1
+        assert "skip.md" not in names
+
+    def test_skips_non_md_files(self, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "a.txt").write_text("x", encoding="utf-8")
+        (docs / "b.md").write_text("x", encoding="utf-8")
+        files = af.find_markdown_files(str(tmp_path))
+        assert all(f.endswith(".md") for f in files)
+
+    def test_returns_dedup_sorted(self, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        for n in ["c.md", "a.md", "b.md"]:
+            (docs / n).write_text("x", encoding="utf-8")
+        files = af.find_markdown_files(str(tmp_path))
+        # Sorted asc.
+        names = [os.path.basename(f) for f in files]
+        assert names == sorted(names)
+        # No duplicates.
+        assert len(names) == len(set(names))
+
+
+# ---------------------------------------------------------------------------
+# main — CLI orchestrator
+# ---------------------------------------------------------------------------
+class TestMain:
+    def test_missing_base_dir_returns_one(self, monkeypatch, tmp_path, caplog):
+        ghost = tmp_path / "ghost"
+        monkeypatch.setattr(sys, "argv",
+                            ["add_frontmatter.py", "--base-dir", str(ghost)])
+        assert af.main() == 1
+
+    def test_no_md_files_returns_zero(self, monkeypatch, tmp_path):
+        # Empty base dir → 0 md files → return 0 (warning logged).
+        monkeypatch.setattr(sys, "argv",
+                            ["add_frontmatter.py", "--base-dir", str(tmp_path)])
+        assert af.main() == 0
+
+    def test_dry_run_returns_zero_and_does_not_modify(self, monkeypatch, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        f = docs / "a.md"
+        original = "# A\n\nbody\n"
+        f.write_text(original, encoding="utf-8")
+        monkeypatch.setattr(sys, "argv", [
+            "add_frontmatter.py",
+            "--base-dir", str(tmp_path),
+            "--dry-run",
+        ])
+        assert af.main() == 0
+        # File unchanged.
+        assert f.read_text(encoding="utf-8") == original
+
+    def test_check_mode_with_missing_frontmatter_returns_one(
+        self, monkeypatch, tmp_path,
+    ):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "missing.md").write_text("# No FM\n", encoding="utf-8")
+        monkeypatch.setattr(sys, "argv", [
+            "add_frontmatter.py",
+            "--base-dir", str(tmp_path),
+            "--check",
+        ])
+        assert af.main() == 1
+
+    def test_check_mode_when_all_have_frontmatter_returns_zero(
+        self, monkeypatch, tmp_path,
+    ):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "ok.md").write_text(
+            "---\ntitle: x\n---\nbody\n", encoding="utf-8",
+        )
+        monkeypatch.setattr(sys, "argv", [
+            "add_frontmatter.py",
+            "--base-dir", str(tmp_path),
+            "--check",
+        ])
+        assert af.main() == 0
+
+    def test_check_mode_does_not_modify_files(self, monkeypatch, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        f = docs / "missing.md"
+        original = "# No FM\n"
+        f.write_text(original, encoding="utf-8")
+        monkeypatch.setattr(sys, "argv", [
+            "add_frontmatter.py",
+            "--base-dir", str(tmp_path),
+            "--check",
+        ])
+        af.main()
+        # --check is read-only.
+        assert f.read_text(encoding="utf-8") == original
+
+    def test_real_run_writes_frontmatter(self, monkeypatch, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        f = docs / "a.md"
+        f.write_text("# Title\n\nbody\n", encoding="utf-8")
+        monkeypatch.setattr(sys, "argv",
+                            ["add_frontmatter.py", "--base-dir", str(tmp_path)])
+        assert af.main() == 0
+        assert f.read_text(encoding="utf-8").startswith("---\n")

--- a/tests/dx/test_generate_changelog_extra.py
+++ b/tests/dx/test_generate_changelog_extra.py
@@ -1,0 +1,353 @@
+"""Extension tests for generate_changelog.py — git/IO + lint + main coverage.
+
+Audit flagged 28.5% coverage. The existing test_generate_changelog.py
+covers parse_commit / format_changelog / regex / constants — the pure
+logic. This file fills the orchestrator gap:
+  - git_cmd (subprocess wrapper, success + error)
+  - get_latest_tag (git describe with optional fallback)
+  - get_commits_since (git log + parse)
+  - load_ignored_commits (file-based ignore list)
+  - lint_changelog (full markdown lint)
+  - main() (default / --check / --lint / --output / --since)
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_TOOLS_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'scripts', 'tools', 'dx')
+sys.path.insert(0, _TOOLS_DIR)
+
+import generate_changelog as gc  # noqa: E402
+
+
+def _cp(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+# ---------------------------------------------------------------------------
+# git_cmd
+# ---------------------------------------------------------------------------
+class TestGitCmd:
+    def test_success_returns_stripped_stdout(self, monkeypatch):
+        monkeypatch.setattr(gc.subprocess, "run",
+                            lambda *a, **kw: _cp(0, "  hello\n", ""))
+        assert gc.git_cmd(["log"]) == "hello"
+
+    def test_failure_exits_one(self, monkeypatch, capsys):
+        monkeypatch.setattr(gc.subprocess, "run",
+                            lambda *a, **kw: _cp(128, "", "fatal: not a repo"))
+        with pytest.raises(SystemExit) as exc:
+            gc.git_cmd(["log"])
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "git log failed" in err
+        assert "not a repo" in err
+
+
+# ---------------------------------------------------------------------------
+# get_latest_tag
+# ---------------------------------------------------------------------------
+class TestGetLatestTag:
+    def test_success_returns_tag(self, monkeypatch):
+        monkeypatch.setattr(gc.subprocess, "run",
+                            lambda *a, **kw: _cp(0, "v2.7.0\n", ""))
+        assert gc.get_latest_tag() == "v2.7.0"
+
+    def test_no_tags_returns_none(self, monkeypatch):
+        # git describe exits non-zero when no tags exist.
+        monkeypatch.setattr(gc.subprocess, "run",
+                            lambda *a, **kw: _cp(128, "", "no tags"))
+        assert gc.get_latest_tag() is None
+
+    def test_oserror_returns_none(self, monkeypatch):
+        def boom(*a, **kw):
+            raise OSError("git not found")
+        monkeypatch.setattr(gc.subprocess, "run", boom)
+        assert gc.get_latest_tag() is None
+
+    def test_subprocess_error_returns_none(self, monkeypatch):
+        def boom(*a, **kw):
+            raise subprocess.SubprocessError("oops")
+        monkeypatch.setattr(gc.subprocess, "run", boom)
+        assert gc.get_latest_tag() is None
+
+
+# ---------------------------------------------------------------------------
+# get_commits_since
+# ---------------------------------------------------------------------------
+class TestGetCommitsSince:
+    def test_with_since_ref(self, monkeypatch):
+        log = "abcdef123456|feat: add x\n0011223344ff|fix(ci): typo"
+        monkeypatch.setattr(gc, "git_cmd", lambda args: log)
+        commits = gc.get_commits_since("v2.0.0")
+        assert commits == [
+            ("abcdef123456", "feat: add x"),
+            ("0011223344ff", "fix(ci): typo"),
+        ]
+
+    def test_without_since_ref_uses_head(self, monkeypatch):
+        captured = {}
+
+        def fake_git_cmd(args):
+            captured["args"] = args
+            return ""
+        monkeypatch.setattr(gc, "git_cmd", fake_git_cmd)
+        gc.get_commits_since(None)
+        # No since → log_range "HEAD".
+        assert "HEAD" in captured["args"]
+        assert ".." not in " ".join(captured["args"])
+
+    def test_empty_log_returns_empty_list(self, monkeypatch):
+        monkeypatch.setattr(gc, "git_cmd", lambda args: "")
+        assert gc.get_commits_since("v1") == []
+
+    def test_truncates_hash_to_12_chars(self, monkeypatch):
+        long_hash = "0123456789abcdef0123456789abcdef01234567"
+        monkeypatch.setattr(gc, "git_cmd", lambda args: f"{long_hash}|feat: x")
+        commits = gc.get_commits_since(None)
+        assert commits == [("0123456789ab", "feat: x")]
+
+    def test_lines_without_pipe_silently_skipped(self, monkeypatch):
+        # Defensive parse: garbage lines without `|` separator are dropped.
+        log = "abc123|feat: ok\nno-separator-line\ndef456|fix: also-ok"
+        monkeypatch.setattr(gc, "git_cmd", lambda args: log)
+        commits = gc.get_commits_since(None)
+        assert len(commits) == 2
+        assert commits[0][1] == "feat: ok"
+
+
+# ---------------------------------------------------------------------------
+# load_ignored_commits
+# ---------------------------------------------------------------------------
+class TestLoadIgnoredCommits:
+    def _stub_repo_root(self, monkeypatch, root: str):
+        monkeypatch.setattr(gc.subprocess, "run",
+                            lambda *a, **kw: _cp(0, root + "\n", ""))
+
+    def test_no_ignore_file_returns_empty(self, monkeypatch, tmp_path):
+        self._stub_repo_root(monkeypatch, str(tmp_path))
+        assert gc.load_ignored_commits() == []
+
+    def test_repo_root_lookup_fails_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(gc.subprocess, "run",
+                            lambda *a, **kw: _cp(128, "", "not a repo"))
+        assert gc.load_ignored_commits() == []
+
+    def test_oserror_returns_empty(self, monkeypatch):
+        def boom(*a, **kw):
+            raise OSError("denied")
+        monkeypatch.setattr(gc.subprocess, "run", boom)
+        assert gc.load_ignored_commits() == []
+
+    def test_parses_prefixes_lowercased(self, monkeypatch, tmp_path):
+        ignore = tmp_path / ".changelog-lint-ignore"
+        ignore.write_text(
+            "# leading comment line\n"
+            "\n"  # blank line
+            "ABCDEF123456 trailing comment is ok\n"
+            "  # indented comment\n"
+            "FFFF0000\n",
+            encoding="utf-8",
+        )
+        self._stub_repo_root(monkeypatch, str(tmp_path))
+        prefixes = gc.load_ignored_commits()
+        assert prefixes == ["abcdef123456", "ffff0000"]
+
+    def test_io_error_during_read_returns_empty(self, monkeypatch, tmp_path):
+        # Create directory-as-file to trigger OSError on open.
+        ignore = tmp_path / ".changelog-lint-ignore"
+        ignore.mkdir()  # opens as file → IsADirectoryError (subclass of OSError)
+        self._stub_repo_root(monkeypatch, str(tmp_path))
+        assert gc.load_ignored_commits() == []
+
+
+# ---------------------------------------------------------------------------
+# lint_changelog
+# ---------------------------------------------------------------------------
+class TestLintChangelog:
+    def _make(self, tmp_path: Path, content: str) -> Path:
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(content, encoding="utf-8")
+        return f
+
+    def test_missing_file_reports_issue(self, tmp_path):
+        ghost = tmp_path / "GHOST.md"
+        issues = gc.lint_changelog(str(ghost))
+        assert len(issues) == 1
+        assert "not found" in issues[0]
+
+    def test_clean_changelog_returns_no_issues(self, tmp_path):
+        f = self._make(tmp_path, (
+            "## [v2.8.0] — Title (2026-05-07)\n"
+            "\n"
+            "### ✨ Features\n"
+            "- something\n"
+            "\n"
+            "## [v2.7.0] — Earlier (2026-04-01)\n"
+            "\n"
+            "### 🐛 Bug Fixes\n"
+            "- fixed it\n"
+        ))
+        assert gc.lint_changelog(str(f)) == []
+
+    def test_missing_date_flagged(self, tmp_path):
+        f = self._make(tmp_path, (
+            "## [v2.8.0] — Title\n"
+            "\n"
+            "### Features\n"
+            "- x\n"
+        ))
+        issues = gc.lint_changelog(str(f))
+        assert any("missing date" in i for i in issues)
+
+    def test_no_subsection_flagged(self, tmp_path):
+        f = self._make(tmp_path, (
+            "## [v2.8.0] — Title (2026-05-07)\n"
+            "\n"
+            "Just a paragraph, no ### section.\n"
+        ))
+        issues = gc.lint_changelog(str(f))
+        assert any("no ### subsections" in i for i in issues)
+
+    def test_duplicate_version_flagged(self, tmp_path):
+        f = self._make(tmp_path, (
+            "## [v2.8.0] — First (2026-05-07)\n\n### X\n- a\n\n"
+            "## [v2.8.0] — Dup (2026-05-08)\n\n### Y\n- b\n"
+        ))
+        issues = gc.lint_changelog(str(f))
+        assert any("duplicate version" in i for i in issues)
+
+    def test_last_version_no_subsection_caught(self, tmp_path):
+        # The "current_version + has_subsection check" runs once at the
+        # next version header AND once at EOF — make sure the EOF case
+        # catches the trailing version.
+        f = self._make(tmp_path, (
+            "## [v2.8.0] — Earlier (2026-05-01)\n\n### X\n- a\n\n"
+            "## [v2.9.0] — Last (2026-05-07)\n"  # no ### below
+        ))
+        issues = gc.lint_changelog(str(f))
+        assert any("[2.9.0]" in i and "no ### subsections" in i for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# main — CLI orchestrator
+# ---------------------------------------------------------------------------
+class TestMain:
+    def test_lint_mode_clean_returns_zero(self, monkeypatch, tmp_path, capsys):
+        cl = tmp_path / "CHANGELOG.md"
+        cl.write_text(
+            "## [v2.8.0] — T (2026-05-07)\n\n### X\n- a\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["generate_changelog.py", "--lint"])
+        assert gc.main() == 0
+        out = capsys.readouterr().out
+        assert "clean" in out.lower()
+
+    def test_lint_mode_with_issues_returns_one(self, monkeypatch, tmp_path, capsys):
+        cl = tmp_path / "CHANGELOG.md"
+        # No subsection → lint will flag.
+        cl.write_text("## [v2.8.0] — T (2026-05-07)\n\nplain text\n",
+                      encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["generate_changelog.py", "--lint"])
+        assert gc.main() == 1
+        out = capsys.readouterr().out
+        assert "format issue" in out
+
+    def test_check_mode_all_conventional_returns_zero(self, monkeypatch, capsys):
+        monkeypatch.setattr(gc, "get_latest_tag", lambda: None)
+        monkeypatch.setattr(gc, "get_commits_since", lambda since: [
+            ("abc1", "feat: a"),
+            ("abc2", "fix(ci): b"),
+        ])
+        monkeypatch.setattr(sys, "argv", ["generate_changelog.py", "--check"])
+        assert gc.main() == 0
+        err = capsys.readouterr().err
+        assert "follow conventional" in err
+
+    def test_check_mode_with_non_conventional_returns_one(self, monkeypatch, capsys):
+        monkeypatch.setattr(gc, "get_latest_tag", lambda: "v2.7.0")
+        monkeypatch.setattr(gc, "get_commits_since", lambda since: [
+            ("abc1", "feat: ok"),
+            ("ffff", "broken commit subject"),
+        ])
+        monkeypatch.setattr(gc, "load_ignored_commits", lambda: [])
+        monkeypatch.setattr(sys, "argv", ["generate_changelog.py", "--check"])
+        assert gc.main() == 1
+        err = capsys.readouterr().err
+        assert "non-conventional" in err
+        assert "broken commit subject" in err
+
+    def test_check_mode_ignored_commit_skipped(self, monkeypatch, capsys):
+        # Non-conventional commit but its SHA prefix is in ignore list.
+        monkeypatch.setattr(gc, "get_latest_tag", lambda: None)
+        monkeypatch.setattr(gc, "get_commits_since", lambda since: [
+            ("abc123def456", "broken legacy subject"),
+        ])
+        monkeypatch.setattr(gc, "load_ignored_commits", lambda: ["abc123def456"])
+        monkeypatch.setattr(sys, "argv", ["generate_changelog.py", "--check"])
+        assert gc.main() == 0
+        err = capsys.readouterr().err
+        assert "skipped via .changelog-lint-ignore" in err
+
+    def test_no_commits_returns_zero(self, monkeypatch, capsys):
+        monkeypatch.setattr(gc, "get_latest_tag", lambda: "v2.7.0")
+        monkeypatch.setattr(gc, "get_commits_since", lambda since: [])
+        monkeypatch.setattr(sys, "argv", ["generate_changelog.py"])
+        assert gc.main() == 0
+        err = capsys.readouterr().err
+        assert "No commits" in err
+
+    def test_default_run_prints_to_stdout(self, monkeypatch, capsys):
+        monkeypatch.setattr(gc, "get_latest_tag", lambda: "v2.7.0")
+        monkeypatch.setattr(gc, "get_commits_since", lambda since: [
+            ("abc1", "feat(api): add endpoint"),
+        ])
+        monkeypatch.setattr(sys, "argv", ["generate_changelog.py"])
+        assert gc.main() == 0
+        out = capsys.readouterr().out
+        assert "## [UNRELEASED]" in out
+        assert "add endpoint" in out
+        # Stats footer present.
+        assert "<!-- Stats:" in out
+
+    def test_output_flag_writes_file(self, monkeypatch, tmp_path):
+        out_path = tmp_path / "draft.md"
+        monkeypatch.setattr(gc, "get_latest_tag", lambda: None)
+        monkeypatch.setattr(gc, "get_commits_since", lambda since: [
+            ("abc1", "feat: x"),
+        ])
+        monkeypatch.setattr(sys, "argv", [
+            "generate_changelog.py", "-o", str(out_path),
+        ])
+        assert gc.main() == 0
+        assert out_path.exists()
+        content = out_path.read_text(encoding="utf-8")
+        assert "## [UNRELEASED]" in content
+
+    def test_since_flag_overrides_latest_tag(self, monkeypatch, capsys):
+        captured = {}
+
+        def fake_get_commits(since_ref):
+            captured["since"] = since_ref
+            return []
+
+        monkeypatch.setattr(gc, "get_commits_since", fake_get_commits)
+        # get_latest_tag should NOT be called when --since is provided.
+        monkeypatch.setattr(gc, "get_latest_tag",
+                            lambda: pytest.fail("get_latest_tag should be skipped"))
+        monkeypatch.setattr(sys, "argv", [
+            "generate_changelog.py", "--since", "v2.5.0",
+        ])
+        assert gc.main() == 0
+        assert captured["since"] == "v2.5.0"


### PR DESCRIPTION
## Summary

Bundles two audit-flagged low-coverage dx tools into one PR per the cost-optimisation request.

## Coverage delta

| Tool | Before | After | New tests |
|---|---|---|---|
| `add_frontmatter.py` | 33.3% | **95.8%** | +30 |
| `generate_changelog.py` | 28.5% | **97.1%** | +31 |
| **Total** | | | **61** |

## Approach

Existing `test_add_frontmatter.py` and `test_generate_changelog.py` already cover the pure-helper layer (detect_language / parse_commit / format_changelog / regex / constants). This PR adds **`*_extra.py` companion files** that fill the orchestrator + IO gap without touching the pinned existing tests — keeps diff minimal and review-friendly.

## test_add_frontmatter_extra.py

- `has_frontmatter` / `read_file_content` / `write_file_content` (file IO round-trip)
- `generate_frontmatter` (template + quoting rules for tags with spaces)
- `process_file` (already-has shortcut + dry-run + real write)
- `_is_excluded` (path filter incl. POSIX-separator normalisation)
- `find_markdown_files` (docs+rule-packs scan, hidden/node_modules skipping, root README/CHANGELOG inclusion, dedup+sort)
- `main()`: `--check` / `--dry-run` / `--base-dir` / read-only invariants

## test_generate_changelog_extra.py

- `git_cmd` (success + failure → exit 1)
- `get_latest_tag` (success + no-tags + OSError + SubprocessError)
- `get_commits_since` (with/without ref, hash truncation, defensive parse)
- `load_ignored_commits` (file parsing, comments, lowercasing, error paths)
- `lint_changelog` (clean / missing date / no subsection / duplicate / EOF-trailing version)
- `main()`: `--lint` / `--check` (clean/dirty/ignored) / `--since` / `--output` / default stdout

## Verification

61 tests pass locally in 0.61s. No real `git` invocations — all subprocess calls monkeypatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)