### PR TITLE
refactor(audit): patch_repo_root fixture (R4) + migrate 24 sites

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,44 @@ def routing_dir():
         yield tmpdir
 
 
+@pytest.fixture
+def patch_repo_root(monkeypatch, tmp_path):
+    """Replace a tool module's repo-root constant with `tmp_path`.
+
+    Returns a callable: `patch_repo_root(module, attr="REPO_ROOT") -> Path`.
+    The returned Path is the same `tmp_path` so the caller can populate
+    fixture data on it.
+
+    Why this exists: 60+ tests across 13 files were repeating
+    `monkeypatch.setattr(my_module, "REPO_ROOT", tmp_path)` (or `PROJECT_ROOT`,
+    `CLAUDE_MD`, etc.) verbatim. The audit's TD-042 sweep showed how easily
+    one renamed constant breaks every test that hard-codes the attribute
+    name; this fixture funnels them through one indirection.
+
+    Usage:
+        def test_foo(patch_repo_root):
+            root = patch_repo_root(my_module)              # default REPO_ROOT
+            (root / "docs").mkdir()
+            ...
+
+        def test_bar(patch_repo_root):
+            root = patch_repo_root(my_module, "PROJECT_ROOT")   # explicit attr
+            ...
+
+        def test_file_path(patch_repo_root):
+            root = patch_repo_root(my_module)
+            claude_md = root / "CLAUDE.md"
+            claude_md.write_text("...")
+            patch_repo_root(my_module, "CLAUDE_MD", value=claude_md)
+            ...
+    """
+    def _patch(module, attr: str = "REPO_ROOT", value=None):
+        target = tmp_path if value is None else value
+        monkeypatch.setattr(module, attr, target)
+        return tmp_path
+    return _patch
+
+
 # ── pytest configuration ──────────────────────────────────────────────
 
 def pytest_addoption(parser):

--- a/tests/dx/test_generate_doc_map.py
+++ b/tests/dx/test_generate_doc_map.py
@@ -20,14 +20,14 @@ import generate_doc_map as gdm  # noqa: E402
 
 
 @pytest.fixture
-def fake_repo(tmp_path, monkeypatch):
+def fake_repo(patch_repo_root, monkeypatch):
     """Mount a tmp_path tree as REPO_ROOT.
 
     Yields the tmp_path so tests can populate docs/ etc. The
     DOC_MAP_ZH / DOC_MAP_EN module-level paths are also redirected so
     the writer / checker hit the temp tree.
     """
-    monkeypatch.setattr(gdm, "REPO_ROOT", tmp_path)
+    tmp_path = patch_repo_root(gdm)
     monkeypatch.setattr(
         gdm, "DOC_MAP_ZH", tmp_path / "docs" / "internal" / "doc-map.md",
     )

--- a/tests/lint/test_lint_tool_consistency.py
+++ b/tests/lint/test_lint_tool_consistency.py
@@ -146,8 +146,8 @@ class TestCheckToolMeta:
 # check_jsx_frontmatter
 # ---------------------------------------------------------------------------
 class TestCheckJsxFrontmatter:
-    def test_valid_related(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, 'PROJECT_ROOT', tmp_path)
+    def test_valid_related(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         jsx_dir = tmp_path / "tools" / "portal" / "src" / "interactive" / "tools"
         jsx_dir.mkdir(parents=True)
         (jsx_dir / "a.jsx").write_text(
@@ -164,8 +164,8 @@ class TestCheckJsxFrontmatter:
         ltc.check_jsx_frontmatter(tools, errors, warnings)
         assert len(errors) == 0
 
-    def test_invalid_related_key(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, 'PROJECT_ROOT', tmp_path)
+    def test_invalid_related_key(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         jsx_dir = tmp_path / "tools" / "portal" / "src" / "interactive" / "tools"
         jsx_dir.mkdir(parents=True)
         (jsx_dir / "a.jsx").write_text(
@@ -177,8 +177,8 @@ class TestCheckJsxFrontmatter:
         assert len(errors) == 1
         assert "nonexistent" in errors[0]
 
-    def test_missing_jsx_file(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, 'PROJECT_ROOT', tmp_path)
+    def test_missing_jsx_file(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         tools = [{"key": "ghost", "file": "interactive/tools/ghost.jsx"}]
         errors, warnings = [], []
         ltc.check_jsx_frontmatter(tools, errors, warnings)
@@ -190,8 +190,8 @@ class TestCheckJsxFrontmatter:
 # check_appears_in
 # ---------------------------------------------------------------------------
 class TestCheckAppearsIn:
-    def test_link_found(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, 'PROJECT_ROOT', tmp_path)
+    def test_link_found(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         md_dir = tmp_path / "docs"
         md_dir.mkdir()
         (md_dir / "guide.md").write_text(
@@ -203,8 +203,8 @@ class TestCheckAppearsIn:
         ltc.check_appears_in(tools, errors, warnings)
         assert len(errors) == 0
 
-    def test_link_missing(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, 'PROJECT_ROOT', tmp_path)
+    def test_link_missing(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         md_dir = tmp_path / "docs"
         md_dir.mkdir()
         (md_dir / "guide.md").write_text("No links here.", encoding="utf-8")
@@ -226,8 +226,8 @@ class TestCheckAppearsIn:
 # check_flow_components
 # ---------------------------------------------------------------------------
 class TestCheckFlowComponents:
-    def test_valid_flow(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, 'PROJECT_ROOT', tmp_path)
+    def test_valid_flow(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         # TD-042: flow component paths now resolve against tools/portal/src/
         # (after stripping leading "./" / "../"); flows.json itself stays
         # under docs/assets/.
@@ -248,8 +248,8 @@ class TestCheckFlowComponents:
         ltc.check_flow_components(tools, errors, warnings)
         assert len(errors) == 0
 
-    def test_unknown_tool_in_flow(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, 'PROJECT_ROOT', tmp_path)
+    def test_unknown_tool_in_flow(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         assets = tmp_path / "docs" / "assets"
         assets.mkdir(parents=True)
         import json
@@ -263,8 +263,8 @@ class TestCheckFlowComponents:
         ltc.check_flow_components(tools, errors, warnings)
         assert any("nonexistent" in e for e in errors)
 
-    def test_missing_flows_json(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, 'PROJECT_ROOT', tmp_path)
+    def test_missing_flows_json(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         tools = [{"key": "wizard"}]
         errors, warnings = [], []
         ltc.check_flow_components(tools, errors, warnings)

--- a/tests/lint/test_lint_tool_consistency_extended.py
+++ b/tests/lint/test_lint_tool_consistency_extended.py
@@ -95,8 +95,8 @@ class TestCheckToolMeta:
 class TestCheckJsxFrontmatter:
     """check_jsx_frontmatter() tests."""
 
-    def test_valid_frontmatter(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_valid_frontmatter(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         jsx_dir = tmp_path / "tools" / "portal" / "src" / "interactive" / "tools"
         jsx_dir.mkdir(parents=True)
         jsx = jsx_dir / "tool-a.jsx"
@@ -116,8 +116,8 @@ class TestCheckJsxFrontmatter:
         ltc.check_jsx_frontmatter(tools, errors, warnings)
         assert errors == []
 
-    def test_missing_jsx_file(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_missing_jsx_file(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         (tmp_path / "docs").mkdir()
         tools = [{"key": "ghost", "file": "interactive/tools/ghost.jsx"}]
         errors = []
@@ -126,8 +126,8 @@ class TestCheckJsxFrontmatter:
         assert len(errors) == 1
         assert "not found" in errors[0]
 
-    def test_no_frontmatter(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_no_frontmatter(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         jsx_dir = tmp_path / "tools" / "portal" / "src" / "interactive" / "tools"
         jsx_dir.mkdir(parents=True)
         jsx = jsx_dir / "tool-a.jsx"
@@ -139,8 +139,8 @@ class TestCheckJsxFrontmatter:
         assert len(warnings) == 1
         assert "frontmatter" in warnings[0]
 
-    def test_no_related_in_frontmatter(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_no_related_in_frontmatter(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         jsx_dir = tmp_path / "tools" / "portal" / "src" / "interactive" / "tools"
         jsx_dir.mkdir(parents=True)
         jsx = jsx_dir / "tool-a.jsx"
@@ -152,8 +152,8 @@ class TestCheckJsxFrontmatter:
         assert len(warnings) == 1
         assert "related" in warnings[0]
 
-    def test_unknown_related_key(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_unknown_related_key(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         jsx_dir = tmp_path / "tools" / "portal" / "src" / "interactive" / "tools"
         jsx_dir.mkdir(parents=True)
         jsx = jsx_dir / "tool-a.jsx"
@@ -174,8 +174,8 @@ class TestCheckJsxFrontmatter:
 class TestCheckAppearsIn:
     """check_appears_in() tests."""
 
-    def test_link_found(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_link_found(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         md = tmp_path / "docs" / "guide.md"
         md.parent.mkdir(parents=True)
         md.write_text("See [tool](interactive/tools/tool-a.jsx)",
@@ -188,8 +188,8 @@ class TestCheckAppearsIn:
         ltc.check_appears_in(tools, errors, warnings)
         assert errors == []
 
-    def test_link_not_found(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_link_not_found(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         md = tmp_path / "docs" / "guide.md"
         md.parent.mkdir(parents=True)
         md.write_text("No links here", encoding="utf-8")
@@ -202,8 +202,8 @@ class TestCheckAppearsIn:
         assert len(errors) == 1
         assert "no link found" in errors[0]
 
-    def test_nonexistent_md(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_nonexistent_md(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         tools = [{"key": "tool-a",
                   "file": "interactive/tools/tool-a.jsx",
                   "appears_in": ["docs/nonexistent.md"]}]
@@ -227,8 +227,8 @@ class TestCheckAppearsIn:
 class TestCheckFlowComponents:
     """check_flow_components() tests."""
 
-    def test_no_flows_file(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_no_flows_file(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         (tmp_path / "docs" / "assets").mkdir(parents=True)
         tools = []
         errors = []
@@ -237,8 +237,8 @@ class TestCheckFlowComponents:
         assert len(warnings) == 1
         assert "not found" in warnings[0]
 
-    def test_empty_flows(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_empty_flows(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         assets = tmp_path / "docs" / "assets"
         assets.mkdir(parents=True)
         (assets / "flows.json").write_text('{"flows": {}}',
@@ -250,8 +250,8 @@ class TestCheckFlowComponents:
         assert len(warnings) == 1
         assert "no flows" in warnings[0]
 
-    def test_valid_flow(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_valid_flow(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         # TD-042: flow component paths now resolve against tools/portal/src/
         # (after stripping leading "./" / "../"); flows.json itself stays
         # under docs/assets/.
@@ -272,8 +272,8 @@ class TestCheckFlowComponents:
         ltc.check_flow_components(tools, errors, warnings)
         assert errors == []
 
-    def test_flow_unknown_tool(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_flow_unknown_tool(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         assets = tmp_path / "docs" / "assets"
         assets.mkdir(parents=True)
         flows = {"flows": {"onboard": {"steps": [
@@ -288,8 +288,8 @@ class TestCheckFlowComponents:
         assert len(errors) == 1
         assert "nonexistent" in errors[0]
 
-    def test_flow_missing_title(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_flow_missing_title(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         assets = tmp_path / "docs" / "assets"
         assets.mkdir(parents=True)
         flows = {"flows": {"onboard": {"steps": [
@@ -303,8 +303,8 @@ class TestCheckFlowComponents:
         ltc.check_flow_components(tools, errors, warnings)
         assert any("title" in w for w in warnings)
 
-    def test_flow_empty_steps(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_flow_empty_steps(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         assets = tmp_path / "docs" / "assets"
         assets.mkdir(parents=True)
         flows = {"flows": {"empty-flow": {"steps": []}}}
@@ -316,8 +316,8 @@ class TestCheckFlowComponents:
         ltc.check_flow_components(tools, errors, warnings)
         assert any("no steps" in w for w in warnings)
 
-    def test_flow_bad_json(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(ltc, "PROJECT_ROOT", tmp_path)
+    def test_flow_bad_json(self, patch_repo_root):
+        tmp_path = patch_repo_root(ltc, "PROJECT_ROOT")
         assets = tmp_path / "docs" / "assets"
         assets.mkdir(parents=True)
         (assets / "flows.json").write_text("{bad json", encoding="utf-8")


### PR DESCRIPTION
## Summary

**Audit's R4 refactor recommendation**: collapse 88 repeated `monkeypatch.setattr(<module>, "<ROOT_CONST>", tmp_path)` calls across 13 files into one fixture.

The original audit framed this as **"防 TD-042 級災難"** — when a constant gets renamed (e.g. REPO_ROOT scope change during the monorepo restructure), every test that hard-coded the attribute name breaks at once. This fixture funnels them through one indirection point.

## Fixture API (`tests/conftest.py`)

```python
def test_x(patch_repo_root):
    root = patch_repo_root(my_module)              # default REPO_ROOT
    (root / "docs").mkdir()

def test_y(patch_repo_root):
    root = patch_repo_root(my_module, "PROJECT_ROOT")   # custom attr

def test_z(patch_repo_root):
    root = patch_repo_root(my_module)
    claude = root / "CLAUDE.md"
    claude.write_text("...")
    patch_repo_root(my_module, "CLAUDE_MD", value=claude)   # custom value
```

## Migrated in this PR

| File | Sites |
|---|---|
| `tests/lint/test_lint_tool_consistency.py` | 8 |
| `tests/lint/test_lint_tool_consistency_extended.py` | 15 |
| `tests/dx/test_generate_doc_map.py` | 1 (fixture composition) |
| **Total** | **24 / 88** (~27%) |

## Deferred to follow-up PRs (per-test handling required)

- **`test_bump_docs.py` (16 sites)** — nests inside `tempfile.TemporaryDirectory()` rather than `tmp_path`; structural conversion needed
- **`test_check_frontmatter_versions.py` (16)** — compound patches (REPO_ROOT + DOCS_DIR + CLAUDE_MD set together per test)
- **`test_check_includes_sync_extended.py` (9)** — also patches `sys.argv`, so `monkeypatch` arg must stay; less migration win
- 6 smaller files with 1-7 sites each, scattered patterns

These are documented in the commit message; their migration is incremental and benefits remain even if only the simple cases adopt the fixture.

## Verification

- 96/96 affected tests pass locally
- Mechanical multi-line replace via `Edit replace_all=true` for the simple pattern
- 3 unrelated test failures on local Windows host are pre-existing subprocess encoding flakes (pass on Linux CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)