### PR TITLE
perf(ci): cache go-build + pip in Go Tests job (~12-15s/run saving)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,10 +187,16 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - name: Cache Go modules
+      - name: Cache Go modules + build cache
+        # path expanded to include ~/.cache/go-build so `go install swag@latest`
+        # below benefits from a warm build cache on cache-hit runs (saves ~5-8s
+        # on the swag CLI install step). Module cache (~/go/pkg/mod) is the
+        # primary key; build cache rides along.
         uses: actions/cache@v5
         with:
-          path: ~/go/pkg/mod
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
           key: ${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ matrix.go }}-
@@ -227,6 +233,18 @@ jobs:
       # Builds tenant-api, starts on a random port, fuzzes GET endpoints
       # with response_schema_conformance check. CONTRACT_MAX_EXAMPLES=5 keeps
       # CI runtime ~10-20s. The runner already has timeout=600 + auth header.
+      - name: Cache pip packages (schemathesis)
+        # Saves ~5-7s on the schemathesis install step on cache-hit runs.
+        # The Lint and Python Tests jobs already have pip cache; this brings
+        # parity to the Go Tests job which transitively pip-installs.
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-go-tests-schemathesis-v1
+          restore-keys: |
+            ${{ runner.os }}-pip-go-tests-
+            ${{ runner.os }}-pip-
+
       - name: Install schemathesis
         run: pip install schemathesis
 


### PR DESCRIPTION
## Summary

Two cache additions in the Go Tests CI job, expected to save **~12-15s per run** on cache-hit:

### 1. Expanded Go cache to include `~/.cache/go-build`

The existing module cache (`~/go/pkg/mod`) is now joined by Go's content-addressable build cache. This warms the `go install github.com/swaggo/swag/cmd/swag@latest` step that runs after tests (right before OpenAPI drift check).

- Previous baseline (PR #289 era): swag install ~12s
- Build-cache-hit estimate: ~3-5s
- **Saving: ~7-9s/run**

### 2. New pip cache for schemathesis

The Lint and Python Tests jobs already have pip caches; the Go Tests job didn't have one despite transitively `pip install schemathesis`. This PR adds parity.

- Previous baseline: schemathesis install ~7s
- Cache-hit estimate: ~1-2s
- **Saving: ~5-6s/run**

## Why now

Tier 1.2 from yesterday's gap analysis. Pure additive change — `go install` and `pip install` are both idempotent on cache-hit, so no behavioural risk.

## Verification

- First run after merge: caches populated, no change visible (or slightly slower if the cache key invalidates).
- Second run onward: speedup visible. Compare via `gh run view` before/after.
- No source code touched; only `.github/workflows/ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)