### PR TITLE
fix(audit): two latent bugs surfaced during coverage sweep

### DIFF
--- a/scripts/tools/dx/axe_lite_static.py
+++ b/scripts/tools/dx/axe_lite_static.py
@@ -58,28 +58,57 @@ def scan_unicode_status(src: str) -> list[tuple[int, str]]:
     window) to have aria-hidden or aria-label.
 
     This is the most important WCAG 1.4.1 check for the colorblind hotfix.
-    We walk backward from each symbol occurrence to find the nearest `<tag`
-    open and check its attributes up to the matching `>`.
+    We walk backward from each symbol occurrence to find the nearest enclosing
+    `<tag` open and check its attributes up to the matching `>`.
+
+    Backward walk algorithm:
+      Walking from the symbol position back toward index 0, the FIRST `>`
+      we hit must be the close of an opening tag whose body contains the
+      symbol — UNLESS that `>` belongs to a closing tag (`</tag>`), which
+      means a sibling element that ended before our symbol. In the latter
+      case we step OVER the entire `<...>` block and keep walking back to
+      find the actual wrapping element.
+
+      Pre-fix bug (PR #290 audit follow-up): the prior implementation
+      gave up at the first `>`, which made the flag path unreachable for
+      typical JSX like `<div>✓</div>` (the `>` of `<div>` ended the walk
+      before any `<` was found). Verified with hand-crafted samples that
+      the function returned [] for every realistic JSX input.
     """
     out: list[tuple[int, str]] = []
     for i, ch in enumerate(src):
         if ch not in UNICODE_STATUS:
             continue
-        # Walk backwards to find the nearest `<tag` open
+        # Walk backwards to find the nearest enclosing `<tag` open.
         k = i
+        opener_lt = -1
         while k > 0:
             k -= 1
-            if src[k] == "<" and (
-                src[k + 1 : k + 2].isalpha()
-                or src[k + 1 : k + 2] in ("_",)
-            ):
+            if src[k] == "<":
+                # Opening tag if next char is alpha/underscore.
+                # Closing tag (</) handled by the `>` branch below.
+                if src[k + 1 : k + 2].isalpha() or src[k + 1 : k + 2] == "_":
+                    opener_lt = k
+                    break
+                # Otherwise (e.g. `<<` or `<5`) keep walking.
+            elif src[k] == ">":
+                # End of some `<...>` block. Find its matching `<`.
+                lt = src.rfind("<", 0, k)
+                if lt == -1:
+                    # Stray `>` with no opener — bail out.
+                    break
+                if src[lt + 1 : lt + 2] == "/":
+                    # Closing tag </tag>: a sibling that ended before our
+                    # symbol. Step over the whole block and keep walking.
+                    k = lt
+                    continue
+                # Opening tag <tag>: this `>` ends an opener whose body
+                # encloses our symbol. The opener starts at `lt`.
+                opener_lt = lt
                 break
-            if src[k] == ">":
-                # passed a close; give up on backward scan
-                k = -1
-                break
-        if k <= 0:
+        if opener_lt < 0:
             continue
+        k = opener_lt
         # Skip if this symbol is inside a comment/string — approximate by
         # checking the opening `<` is at col 0 of text content (not inside
         # attribute value). A cheap way: require the intervening `>` exists

--- a/scripts/tools/ops/operator_check.py
+++ b/scripts/tools/ops/operator_check.py
@@ -178,7 +178,10 @@ class OperatorChecker:
             exporter_targets = [t for t in targets if any(
                 kw in t.get("labels", {}).get("job", "").lower() for kw in ["threshold", "exporter"]
             )]
-        except (KeyError, TypeError):
+        except (KeyError, TypeError, AttributeError):
+            # AttributeError: data is None or a string (e.g. when
+            # http_get_json returns a non-dict body). Surfaced during
+            # the audit-list coverage sweep — see PR #291 description.
             exporter_targets = []
 
         if not exporter_targets:

--- a/tests/dx/test_axe_lite_static.py
+++ b/tests/dx/test_axe_lite_static.py
@@ -41,12 +41,9 @@ class TestStripFrontmatter:
 # ---------------------------------------------------------------------------
 # scan_unicode_status — WCAG 1.4.1
 # ---------------------------------------------------------------------------
-# NOTE: The scanner's backward-walk logic short-circuits at the first `>`
-# encountered between symbol and `<` — for typical JSX (`<div>✓</div>`)
-# this means the "bare symbol" path is unreachable in practice. The tests
-# below exercise the entry points that DO trigger (no-symbol shortcut,
-# attribute-value ignore path) plus negative space (no crash on empty /
-# non-JSX input).
+# NOTE: PR #290 surfaced that the original backward-walk gave up at the
+# first `>`, making the flag path unreachable for typical JSX. This bug
+# is now fixed (this PR); the tests below pin the corrected behaviour.
 class TestScanUnicodeStatus:
     def test_empty_input_no_findings(self):
         assert axe.scan_unicode_status("") == []
@@ -60,16 +57,45 @@ class TestScanUnicodeStatus:
         src = '<input title="✓ done" />'
         assert axe.scan_unicode_status(src) == []
 
-    def test_symbol_inside_long_attribute_value_with_aria_hidden_ignored(self):
-        # Even though aria-hidden is present, the early `close_gt > i`
-        # branch handles attribute-resident symbols first.
-        src = '<span aria-hidden="true" title="✓ ok">x</span>'
+    def test_aria_hidden_passes(self):
+        # aria-hidden on the wrapping element silences the warning.
+        src = '<span aria-hidden="true">✓</span>'
         assert axe.scan_unicode_status(src) == []
 
-    def test_normal_text_content_returns_empty(self):
-        # Backward-walk gives up at `>` of the opening tag, so visible-
-        # text symbols return empty. This pins current behaviour.
-        src = '<div>✓ done</div>'
+    def test_aria_label_passes(self):
+        src = '<span aria-label="success">✓</span>'
+        assert axe.scan_unicode_status(src) == []
+
+    def test_aria_labelledby_passes(self):
+        src = '<span aria-labelledby="status-msg">✓</span>'
+        assert axe.scan_unicode_status(src) == []
+
+    def test_bare_symbol_in_div_flagged(self):
+        # Post-fix: backward walk now finds the wrapping <div> and flags
+        # because no aria-* attribute is present.
+        src = '<div>⚠ warning</div>'
+        findings = axe.scan_unicode_status(src)
+        assert len(findings) == 1
+        line, msg = findings[0]
+        assert "status symbol" in msg
+        assert "aria-hidden" in msg or "aria-label" in msg
+
+    def test_multiple_bare_symbols_each_flagged(self):
+        src = '<div>✓</div>\n<section>❌</section>'
+        findings = axe.scan_unicode_status(src)
+        assert len(findings) == 2
+
+    def test_walks_past_closing_sibling_to_find_real_wrapper(self):
+        # The fix: walking backward from ✓, we encounter `</span>` first.
+        # Pre-fix this was treated as "give up at >". Post-fix we walk
+        # PAST the closing sibling to find <div>, the real wrapper.
+        src = '<div><span>x</span>✓</div>'
+        findings = axe.scan_unicode_status(src)
+        assert len(findings) == 1
+
+    def test_parent_aria_label_within_window_passes(self):
+        # Wrapper has no aria-* but parent within 500-char window does.
+        src = '<div aria-label="status"><span>✓</span></div>'
         assert axe.scan_unicode_status(src) == []
 
     def test_returns_list_type(self):

--- a/tests/ops/test_operator_check.py
+++ b/tests/ops/test_operator_check.py
@@ -327,6 +327,19 @@ class TestCheckTargetHealth:
         result = checker.check_target_health()
         assert result.status == "warn"
 
+    def test_malformed_response_does_not_crash(self, monkeypatch):
+        # PR #291 audit follow-up: when http_get_json returns a non-dict
+        # body (None / string / list), `data.get(...)` raises AttributeError.
+        # The except clause now catches AttributeError too, so the function
+        # degrades gracefully to the "no targets found" warn path.
+        for malformed in (None, "not a dict", ["list-not-dict"], 42):
+            monkeypatch.setattr(oc, "http_get_json",
+                                lambda *a, _body=malformed, **kw: (_body, None))
+            checker = oc.OperatorChecker(_make_args(prometheus="http://localhost:9090"))
+            result = checker.check_target_health()
+            assert result.status == "warn"
+            assert "no targets" in result.detail
+
 
 # ---------------------------------------------------------------------------
 # run_all_checks + reports + exit_code


### PR DESCRIPTION
## Summary

Two latent bugs caught while writing audit-list coverage tests in PRs #290 and #291. Both fix-and-pin: source fixes paired with regression tests.

## Bug 1: `axe_lite_static.scan_unicode_status` — flag path unreachable

The WCAG 1.4.1 Unicode-status check walks backward from each symbol looking for the nearest enclosing `<tag` open. **The pre-fix loop gave up at the first `>` encountered**, which made the flag path unreachable for typical JSX like `<div>✓</div>` — the closing `>` of `<div>` ended the walk before any `<` was found.

### Smoke test on 5 real JSX files (post-fix)

```
alert-builder.jsx: 5 findings (⚠ at L42, L510, L511, ...)
alert-timeline.jsx: 1 finding (⚠ at L151)
AlertPreviewTab.jsx: 1 finding (⚠ at L272)
TOTAL: 7 actual WCAG 1.4.1 violations
```

These were silently missed before. Fixing the resulting JSX is a **separate follow-up ticket** — fixing the scanner is in scope here.

### Algorithm change

When walking backward and hitting a `>`, find its matching `<`. If `</tag` (closing tag), step OVER the entire `<...>` block (it's a closed sibling) and keep walking. If `<tag` (opening), that's our wrapping element.

### Tests added (5 net new)

- `test_aria_hidden_passes` / `test_aria_label_passes` / `test_aria_labelledby_passes`
- `test_bare_symbol_in_div_flagged` ← regression pin for the bug
- `test_multiple_bare_symbols_each_flagged`
- `test_walks_past_closing_sibling_to_find_real_wrapper` ← validates the closing-tag step-over logic
- `test_parent_aria_label_within_window_passes`

Pre-fix tests that asserted `[]` for bare-symbol cases were updated to the correct flag behaviour.

### CI safety

✅ Verified: `axe_lite_static.py` is **not wired into any CI gate** (no hits in `.pre-commit-config.yaml` / `.github/workflows/` / `Makefile`). Newly-flagged findings don't break CI.

## Bug 2: `operator_check.check_target_health` — except clause too narrow

`data.get("data", {}).get("activeTargets", [])` raises `AttributeError` when `data` is `None` / a string / a list (i.e. when `http_get_json` returns a non-dict body). The `except (KeyError, TypeError)` clause caught neither, so the function would **crash** instead of degrading gracefully to the "no targets found" warn path.

### Fix

One-line: add `AttributeError` to the except tuple.

### Test added

- `test_malformed_response_does_not_crash` — iterates over `None` / string / list / int responses and asserts the function returns `status="warn"` with detail `"no targets"` instead of crashing.

## Verification

- 41/41 axe_lite_static tests pass (was 36, +5 net new)
- 42/42 operator_check tests pass (was 41, +1 net new)
- Smoke test on 5 real JSX files surfaces 7 actual WCAG violations (separate follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)