### PR TITLE
refactor(audit): cli_argv fixture (R5) wave 2 — 43 more sites (103/195 total)

### DIFF
--- a/tests/dx/test_generate_changelog_extra.py
+++ b/tests/dx/test_generate_changelog_extra.py
@@ -241,79 +241,79 @@ class TestLintChangelog:
 # main — CLI orchestrator
 # ---------------------------------------------------------------------------
 class TestMain:
-    def test_lint_mode_clean_returns_zero(self, monkeypatch, tmp_path, capsys):
+    def test_lint_mode_clean_returns_zero(self, monkeypatch, tmp_path, capsys, cli_argv):
         cl = tmp_path / "CHANGELOG.md"
         cl.write_text(
             "## [v2.8.0] — T (2026-05-07)\n\n### X\n- a\n",
             encoding="utf-8",
         )
         monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr(sys, "argv", ["generate_changelog.py", "--lint"])
+        cli_argv('generate_changelog.py', '--lint')
         assert gc.main() == 0
         out = capsys.readouterr().out
         assert "clean" in out.lower()
 
-    def test_lint_mode_with_issues_returns_one(self, monkeypatch, tmp_path, capsys):
+    def test_lint_mode_with_issues_returns_one(self, monkeypatch, tmp_path, capsys, cli_argv):
         cl = tmp_path / "CHANGELOG.md"
         # No subsection → lint will flag.
         cl.write_text("## [v2.8.0] — T (2026-05-07)\n\nplain text\n",
                       encoding="utf-8")
         monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr(sys, "argv", ["generate_changelog.py", "--lint"])
+        cli_argv('generate_changelog.py', '--lint')
         assert gc.main() == 1
         out = capsys.readouterr().out
         assert "format issue" in out
 
-    def test_check_mode_all_conventional_returns_zero(self, monkeypatch, capsys):
+    def test_check_mode_all_conventional_returns_zero(self, monkeypatch, capsys, cli_argv):
         monkeypatch.setattr(gc, "get_latest_tag", lambda: None)
         monkeypatch.setattr(gc, "get_commits_since", lambda since: [
             ("abc1", "feat: a"),
             ("abc2", "fix(ci): b"),
         ])
-        monkeypatch.setattr(sys, "argv", ["generate_changelog.py", "--check"])
+        cli_argv('generate_changelog.py', '--check')
         assert gc.main() == 0
         err = capsys.readouterr().err
         assert "follow conventional" in err
 
-    def test_check_mode_with_non_conventional_returns_one(self, monkeypatch, capsys):
+    def test_check_mode_with_non_conventional_returns_one(self, monkeypatch, capsys, cli_argv):
         monkeypatch.setattr(gc, "get_latest_tag", lambda: "v2.7.0")
         monkeypatch.setattr(gc, "get_commits_since", lambda since: [
             ("abc1", "feat: ok"),
             ("ffff", "broken commit subject"),
         ])
         monkeypatch.setattr(gc, "load_ignored_commits", lambda: [])
-        monkeypatch.setattr(sys, "argv", ["generate_changelog.py", "--check"])
+        cli_argv('generate_changelog.py', '--check')
         assert gc.main() == 1
         err = capsys.readouterr().err
         assert "non-conventional" in err
         assert "broken commit subject" in err
 
-    def test_check_mode_ignored_commit_skipped(self, monkeypatch, capsys):
+    def test_check_mode_ignored_commit_skipped(self, monkeypatch, capsys, cli_argv):
         # Non-conventional commit but its SHA prefix is in ignore list.
         monkeypatch.setattr(gc, "get_latest_tag", lambda: None)
         monkeypatch.setattr(gc, "get_commits_since", lambda since: [
             ("abc123def456", "broken legacy subject"),
         ])
         monkeypatch.setattr(gc, "load_ignored_commits", lambda: ["abc123def456"])
-        monkeypatch.setattr(sys, "argv", ["generate_changelog.py", "--check"])
+        cli_argv('generate_changelog.py', '--check')
         assert gc.main() == 0
         err = capsys.readouterr().err
         assert "skipped via .changelog-lint-ignore" in err
 
-    def test_no_commits_returns_zero(self, monkeypatch, capsys):
+    def test_no_commits_returns_zero(self, monkeypatch, capsys, cli_argv):
         monkeypatch.setattr(gc, "get_latest_tag", lambda: "v2.7.0")
         monkeypatch.setattr(gc, "get_commits_since", lambda since: [])
-        monkeypatch.setattr(sys, "argv", ["generate_changelog.py"])
+        cli_argv('generate_changelog.py')
         assert gc.main() == 0
         err = capsys.readouterr().err
         assert "No commits" in err
 
-    def test_default_run_prints_to_stdout(self, monkeypatch, capsys):
+    def test_default_run_prints_to_stdout(self, monkeypatch, capsys, cli_argv):
         monkeypatch.setattr(gc, "get_latest_tag", lambda: "v2.7.0")
         monkeypatch.setattr(gc, "get_commits_since", lambda since: [
             ("abc1", "feat(api): add endpoint"),
         ])
-        monkeypatch.setattr(sys, "argv", ["generate_changelog.py"])
+        cli_argv('generate_changelog.py')
         assert gc.main() == 0
         out = capsys.readouterr().out
         assert "## [UNRELEASED]" in out
@@ -321,21 +321,19 @@ class TestMain:
         # Stats footer present.
         assert "<!-- Stats:" in out
 
-    def test_output_flag_writes_file(self, monkeypatch, tmp_path):
+    def test_output_flag_writes_file(self, monkeypatch, tmp_path, cli_argv):
         out_path = tmp_path / "draft.md"
         monkeypatch.setattr(gc, "get_latest_tag", lambda: None)
         monkeypatch.setattr(gc, "get_commits_since", lambda since: [
             ("abc1", "feat: x"),
         ])
-        monkeypatch.setattr(sys, "argv", [
-            "generate_changelog.py", "-o", str(out_path),
-        ])
+        cli_argv("generate_changelog.py", "-o", str(out_path))
         assert gc.main() == 0
         assert out_path.exists()
         content = out_path.read_text(encoding="utf-8")
         assert "## [UNRELEASED]" in content
 
-    def test_since_flag_overrides_latest_tag(self, monkeypatch, capsys):
+    def test_since_flag_overrides_latest_tag(self, monkeypatch, capsys, cli_argv):
         captured = {}
 
         def fake_get_commits(since_ref):
@@ -346,8 +344,6 @@ class TestMain:
         # get_latest_tag should NOT be called when --since is provided.
         monkeypatch.setattr(gc, "get_latest_tag",
                             lambda: pytest.fail("get_latest_tag should be skipped"))
-        monkeypatch.setattr(sys, "argv", [
-            "generate_changelog.py", "--since", "v2.5.0",
-        ])
+        cli_argv('generate_changelog.py', '--since', 'v2.5.0')
         assert gc.main() == 0
         assert captured["since"] == "v2.5.0"

--- a/tests/lint/test_check_includes_sync_extended.py
+++ b/tests/lint/test_check_includes_sync_extended.py
@@ -32,56 +32,56 @@ class TestMainCLI:
 
         return includes
 
-    def test_all_in_sync(self, tmp_path, monkeypatch, capsys):
+    def test_all_in_sync(self, tmp_path, monkeypatch, capsys, cli_argv):
         """All pairs in sync should return 0."""
         includes = self._setup_includes(tmp_path,
                                         "# Title\n\n- item 1\n",
                                         "# Title\n\n- item 1\n")
         monkeypatch.setattr(cis, "INCLUDES_DIR", includes)
-        monkeypatch.setattr(sys, "argv", ["check_includes_sync"])
+        cli_argv('check_includes_sync')
         result = cis.main()
         assert result == 0
         out = capsys.readouterr().out
         assert "in sync" in out
 
-    def test_missing_english_check_mode(self, tmp_path, monkeypatch, capsys):
+    def test_missing_english_check_mode(self, tmp_path, monkeypatch, capsys, cli_argv):
         """Missing English file in --check mode should return 1."""
         includes = self._setup_includes(tmp_path, create_en=False)
         monkeypatch.setattr(cis, "INCLUDES_DIR", includes)
-        monkeypatch.setattr(sys, "argv", ["check_includes_sync", "--check"])
+        cli_argv('check_includes_sync', '--check')
         result = cis.main()
         assert result == 1
 
-    def test_missing_english_no_check(self, tmp_path, monkeypatch, capsys):
+    def test_missing_english_no_check(self, tmp_path, monkeypatch, capsys, cli_argv):
         """Missing English file without --check returns 0."""
         includes = self._setup_includes(tmp_path, create_en=False)
         monkeypatch.setattr(cis, "INCLUDES_DIR", includes)
-        monkeypatch.setattr(sys, "argv", ["check_includes_sync"])
+        cli_argv('check_includes_sync')
         result = cis.main()
         # Without --check, returns 0 even with issues
         # Actually, the code returns 1 if total_issues > 0 or missing_en > 0
         # when --check is set, and 0 otherwise
         assert result == 0
 
-    def test_verbose_in_sync(self, tmp_path, monkeypatch, capsys):
+    def test_verbose_in_sync(self, tmp_path, monkeypatch, capsys, cli_argv):
         """--verbose shows OK for in-sync pairs."""
         includes = self._setup_includes(tmp_path,
                                         "# Title\n\n- item 1\n",
                                         "# Title\n\n- item 1\n")
         monkeypatch.setattr(cis, "INCLUDES_DIR", includes)
-        monkeypatch.setattr(sys, "argv", ["check_includes_sync", "--verbose"])
+        cli_argv('check_includes_sync', '--verbose')
         result = cis.main()
         assert result == 0
         out = capsys.readouterr().out
         assert "in sync" in out.lower()
 
-    def test_fix_creates_stubs(self, tmp_path, monkeypatch, capsys):
+    def test_fix_creates_stubs(self, tmp_path, monkeypatch, capsys, cli_argv):
         """--fix creates missing English stubs."""
         includes = self._setup_includes(tmp_path,
                                         "# 規則包\n",
                                         create_en=False)
         monkeypatch.setattr(cis, "INCLUDES_DIR", includes)
-        monkeypatch.setattr(sys, "argv", ["check_includes_sync", "--fix"])
+        cli_argv('check_includes_sync', '--fix')
         result = cis.main()
         assert result == 0
         en_file = includes / "snippet.en.md"
@@ -89,28 +89,28 @@ class TestMainCLI:
         content = en_file.read_text(encoding="utf-8")
         assert "Rule Pack" in content
 
-    def test_structural_mismatch(self, tmp_path, monkeypatch, capsys):
+    def test_structural_mismatch(self, tmp_path, monkeypatch, capsys, cli_argv):
         """Structural mismatch between zh and en."""
         includes = self._setup_includes(
             tmp_path,
             "```yaml\nkey: val\n```\n",
             "no code blocks\n")
         monkeypatch.setattr(cis, "INCLUDES_DIR", includes)
-        monkeypatch.setattr(sys, "argv", ["check_includes_sync", "--check"])
+        cli_argv('check_includes_sync', '--check')
         result = cis.main()
         assert result == 1
         out = capsys.readouterr().out
         assert "code blocks" in out
 
-    def test_no_includes_dir(self, tmp_path, monkeypatch, capsys):
+    def test_no_includes_dir(self, tmp_path, monkeypatch, capsys, cli_argv):
         """Nonexistent includes dir returns 1."""
         monkeypatch.setattr(cis, "INCLUDES_DIR",
                             tmp_path / "nonexistent")
-        monkeypatch.setattr(sys, "argv", ["check_includes_sync"])
+        cli_argv('check_includes_sync')
         result = cis.main()
         assert result == 1
 
-    def test_no_zh_files(self, tmp_path, monkeypatch, capsys):
+    def test_no_zh_files(self, tmp_path, monkeypatch, capsys, cli_argv):
         """No Chinese files returns 0."""
         includes = tmp_path / "docs" / "includes"
         includes.mkdir(parents=True)
@@ -118,17 +118,17 @@ class TestMainCLI:
         (includes / "snippet.en.md").write_text("English only",
                                                  encoding="utf-8")
         monkeypatch.setattr(cis, "INCLUDES_DIR", includes)
-        monkeypatch.setattr(sys, "argv", ["check_includes_sync"])
+        cli_argv('check_includes_sync')
         result = cis.main()
         assert result == 0
 
-    def test_abbreviations_md_ignored(self, tmp_path, monkeypatch, capsys):
+    def test_abbreviations_md_ignored(self, tmp_path, monkeypatch, capsys, cli_argv):
         """abbreviations.md should be ignored."""
         includes = tmp_path / "docs" / "includes"
         includes.mkdir(parents=True)
         (includes / "abbreviations.md").write_text("content",
                                                     encoding="utf-8")
         monkeypatch.setattr(cis, "INCLUDES_DIR", includes)
-        monkeypatch.setattr(sys, "argv", ["check_includes_sync"])
+        cli_argv('check_includes_sync')
         result = cis.main()
         assert result == 0

--- a/tests/ops/test_assemble_config_dir.py
+++ b/tests/ops/test_assemble_config_dir.py
@@ -323,47 +323,42 @@ class TestMainCLI:
         _write_file(src_b / "db-b.yaml", "tenants:\n  db-b:\n    y: '2'")
         return f"{src_a},{src_b}"
 
-    def test_check_mode_no_conflicts(self, config_dir, monkeypatch):
+    def test_check_mode_no_conflicts(self, config_dir, monkeypatch, cli_argv):
         """--check 模式無衝突回傳 0。"""
         sources = self._setup_sources(config_dir)
-        monkeypatch.setattr(sys, "argv",
-                            ["assemble", "--sources", sources, "--check"])
+        cli_argv("assemble", "--sources", sources, "--check")
         assert main() == 0
 
-    def test_check_mode_json(self, config_dir, monkeypatch, capsys):
+    def test_check_mode_json(self, config_dir, monkeypatch, capsys, cli_argv):
         """--check --json 輸出 JSON 格式。"""
         sources = self._setup_sources(config_dir)
-        monkeypatch.setattr(sys, "argv",
-                            ["assemble", "--sources", sources, "--check", "--json"])
+        cli_argv("assemble", "--sources", sources, "--check", "--json")
         assert main() == 0
         output = json.loads(capsys.readouterr().out)
         assert output["status"] == "ok"
         assert output["file_count"] == 2
 
-    def test_assemble_mode(self, config_dir, monkeypatch):
+    def test_assemble_mode(self, config_dir, monkeypatch, cli_argv):
         """組裝模式正確複製檔案。"""
         sources = self._setup_sources(config_dir)
         out = Path(config_dir) / "output"
-        monkeypatch.setattr(sys, "argv",
-                            ["assemble", "--sources", sources, "--output", str(out)])
+        cli_argv("assemble", "--sources", sources, "--output", str(out))
         assert main() == 0
         assert (out / "db-a.yaml").exists()
         assert (out / "db-b.yaml").exists()
 
-    def test_assemble_with_manifest(self, config_dir, monkeypatch):
+    def test_assemble_with_manifest(self, config_dir, monkeypatch, cli_argv):
         """組裝模式產生 manifest JSON。"""
         sources = self._setup_sources(config_dir)
         out = Path(config_dir) / "output"
         manifest_path = Path(config_dir) / "manifest.json"
-        monkeypatch.setattr(sys, "argv",
-                            ["assemble", "--sources", sources,
-                             "--output", str(out), "--manifest", str(manifest_path)])
+        cli_argv("assemble", "--sources", sources, "--output", str(out), "--manifest", str(manifest_path))
         assert main() == 0
         assert manifest_path.exists()
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         assert manifest["file_count"] == 2
 
-    def test_conflict_returns_1(self, config_dir, monkeypatch):
+    def test_conflict_returns_1(self, config_dir, monkeypatch, cli_argv):
         """檔案衝突回傳 exit code 1。"""
         src_a = Path(config_dir) / "team-a"
         src_b = Path(config_dir) / "team-b"
@@ -371,11 +366,10 @@ class TestMainCLI:
         src_b.mkdir()
         _write_file(src_a / "db-a.yaml", "a: 1")
         _write_file(src_b / "db-a.yaml", "a: 99")
-        monkeypatch.setattr(sys, "argv",
-                            ["assemble", "--sources", f"{src_a},{src_b}", "--check"])
+        cli_argv("assemble", "--sources", f"{src_a},{src_b}", "--check")
         assert main() == 1
 
-    def test_conflict_json_output(self, config_dir, monkeypatch, capsys):
+    def test_conflict_json_output(self, config_dir, monkeypatch, capsys, cli_argv):
         """衝突時 --json 輸出衝突詳情。"""
         src_a = Path(config_dir) / "team-a"
         src_b = Path(config_dir) / "team-b"
@@ -383,37 +377,30 @@ class TestMainCLI:
         src_b.mkdir()
         _write_file(src_a / "db-a.yaml", "a: 1")
         _write_file(src_b / "db-a.yaml", "a: 99")
-        monkeypatch.setattr(sys, "argv",
-                            ["assemble", "--sources", f"{src_a},{src_b}",
-                             "--check", "--json"])
+        cli_argv("assemble", "--sources", f"{src_a},{src_b}", "--check", "--json")
         assert main() == 1
         output = json.loads(capsys.readouterr().out)
         assert output["status"] == "conflict"
         assert "db-a.yaml" in output["conflicts"]
 
-    def test_missing_source_returns_2(self, config_dir, monkeypatch):
+    def test_missing_source_returns_2(self, config_dir, monkeypatch, cli_argv):
         """不存在的 source 目錄回傳 exit code 2。"""
-        monkeypatch.setattr(sys, "argv",
-                            ["assemble", "--sources", "/nonexistent/dir", "--check"])
+        cli_argv('assemble', '--sources', '/nonexistent/dir', '--check')
         assert main() == 2
 
-    def test_assemble_json_output(self, config_dir, monkeypatch, capsys):
+    def test_assemble_json_output(self, config_dir, monkeypatch, capsys, cli_argv):
         """組裝模式 --json 輸出結構化結果。"""
         sources = self._setup_sources(config_dir)
         out = Path(config_dir) / "output"
-        monkeypatch.setattr(sys, "argv",
-                            ["assemble", "--sources", sources,
-                             "--output", str(out), "--json"])
+        cli_argv("assemble", "--sources", sources, "--output", str(out), "--json")
         assert main() == 0
         output = json.loads(capsys.readouterr().out)
         assert output["status"] == "ok"
         assert output["file_count"] == 2
 
-    def test_assemble_with_validate(self, config_dir, monkeypatch):
+    def test_assemble_with_validate(self, config_dir, monkeypatch, cli_argv):
         """組裝模式含 --validate 檢查 YAML 有效性。"""
         sources = self._setup_sources(config_dir)
         out = Path(config_dir) / "output"
-        monkeypatch.setattr(sys, "argv",
-                            ["assemble", "--sources", sources,
-                             "--output", str(out), "--validate"])
+        cli_argv("assemble", "--sources", sources, "--output", str(out), "--validate")
         assert main() == 0

--- a/tests/ops/test_drift_detect.py
+++ b/tests/ops/test_drift_detect.py
@@ -481,57 +481,41 @@ class TestCLI:
         assert args.json is False
         assert args.ci is False
 
-    def test_main_text_output(self, two_dirs, monkeypatch, capsys):
+    def test_main_text_output(self, two_dirs, monkeypatch, capsys, cli_argv):
         """預設 text 輸出。"""
         dir_a, dir_b = two_dirs
-        monkeypatch.setattr(sys, "argv", [
-            "drift_detect",
-            "--dirs", f"{dir_a},{dir_b}",
-            "--labels", "A,B",
-        ])
+        cli_argv("drift_detect", "--dirs", f"{dir_a},{dir_b}", "--labels", "A,B")
         dd.main()
         out = capsys.readouterr().out
         assert "Cross-Cluster" in out
         assert "Unexpected" in out
 
-    def test_main_json_output(self, two_dirs, monkeypatch, capsys):
+    def test_main_json_output(self, two_dirs, monkeypatch, capsys, cli_argv):
         """--json 輸出 JSON。"""
         dir_a, dir_b = two_dirs
-        monkeypatch.setattr(sys, "argv", [
-            "drift_detect",
-            "--dirs", f"{dir_a},{dir_b}",
-            "--json",
-        ])
+        cli_argv("drift_detect", "--dirs", f"{dir_a},{dir_b}", "--json")
         dd.main()
         out = capsys.readouterr().out
         data = json.loads(out)
         assert "pair_count" in data
 
-    def test_main_markdown_output(self, two_dirs, monkeypatch, capsys):
+    def test_main_markdown_output(self, two_dirs, monkeypatch, capsys, cli_argv):
         """--markdown 輸出 Markdown。"""
         dir_a, dir_b = two_dirs
-        monkeypatch.setattr(sys, "argv", [
-            "drift_detect",
-            "--dirs", f"{dir_a},{dir_b}",
-            "--markdown",
-        ])
+        cli_argv("drift_detect", "--dirs", f"{dir_a},{dir_b}", "--markdown")
         dd.main()
         out = capsys.readouterr().out
         assert "# Cross-Cluster" in out
 
-    def test_main_ci_exits_on_drift(self, two_dirs, monkeypatch, capsys):
+    def test_main_ci_exits_on_drift(self, two_dirs, monkeypatch, capsys, cli_argv):
         """--ci 有 unexpected drift 時 exit 1。"""
         dir_a, dir_b = two_dirs
-        monkeypatch.setattr(sys, "argv", [
-            "drift_detect",
-            "--dirs", f"{dir_a},{dir_b}",
-            "--ci",
-        ])
+        cli_argv("drift_detect", "--dirs", f"{dir_a},{dir_b}", "--ci")
         with pytest.raises(SystemExit) as exc_info:
             dd.main()
         assert exc_info.value.code == 1
 
-    def test_main_ci_success(self, tmp_path, monkeypatch, capsys):
+    def test_main_ci_success(self, tmp_path, monkeypatch, capsys, cli_argv):
         """--ci 無 drift 時 exit 0。"""
         d1 = tmp_path / "d1"
         d2 = tmp_path / "d2"
@@ -539,45 +523,32 @@ class TestCLI:
         d2.mkdir()
         _write_yaml(d1, "db-a.yaml", "same: true")
         _write_yaml(d2, "db-a.yaml", "same: true")
-        monkeypatch.setattr(sys, "argv", [
-            "drift_detect",
-            "--dirs", f"{d1},{d2}",
-            "--ci",
-        ])
+        cli_argv("drift_detect", "--dirs", f"{d1},{d2}", "--ci")
         # Should not raise
         dd.main()
 
-    def test_main_insufficient_dirs(self, tmp_path, monkeypatch):
+    def test_main_insufficient_dirs(self, tmp_path, monkeypatch, cli_argv):
         """只給 1 個目錄 → exit 1。"""
         d = tmp_path / "only"
         d.mkdir()
-        monkeypatch.setattr(sys, "argv", [
-            "drift_detect", "--dirs", str(d),
-        ])
+        cli_argv("drift_detect", "--dirs", str(d))
         with pytest.raises(SystemExit) as exc_info:
             dd.main()
         assert exc_info.value.code == 1
 
-    def test_main_missing_dir(self, tmp_path, monkeypatch):
+    def test_main_missing_dir(self, tmp_path, monkeypatch, cli_argv):
         """不存在的目錄 → exit 1。"""
         d = tmp_path / "exists"
         d.mkdir()
-        monkeypatch.setattr(sys, "argv", [
-            "drift_detect",
-            "--dirs", f"{d},{tmp_path / 'nope'}",
-        ])
+        cli_argv("drift_detect", "--dirs", f"{d},{tmp_path / 'nope'}")
         with pytest.raises(SystemExit) as exc_info:
             dd.main()
         assert exc_info.value.code == 1
 
-    def test_main_label_mismatch(self, two_dirs, monkeypatch):
+    def test_main_label_mismatch(self, two_dirs, monkeypatch, cli_argv):
         """--labels 數量不符 → exit 1。"""
         dir_a, dir_b = two_dirs
-        monkeypatch.setattr(sys, "argv", [
-            "drift_detect",
-            "--dirs", f"{dir_a},{dir_b}",
-            "--labels", "A,B,C",
-        ])
+        cli_argv("drift_detect", "--dirs", f"{dir_a},{dir_b}", "--labels", "A,B,C")
         with pytest.raises(SystemExit) as exc_info:
             dd.main()
         assert exc_info.value.code == 1

--- a/tests/shared/test_validate_all.py
+++ b/tests/shared/test_validate_all.py
@@ -533,18 +533,18 @@ class TestRunOne:
 class TestMainCLI:
     """main() CLI 整合測試。"""
 
-    def test_list_mode(self, capsys, monkeypatch):
+    def test_list_mode(self, capsys, monkeypatch, cli_argv):
         """--list 模式列出所有檢查並正常結束。"""
-        monkeypatch.setattr(sys, "argv", ["validate_all", "--list"])
+        cli_argv('validate_all', '--list')
         va.main()
         out = capsys.readouterr().out
         # 應包含至少一個 TOOLS 名稱
         assert "links" in out
         assert "versions" in out
 
-    def test_list_mode_shows_all_tools(self, capsys, monkeypatch):
+    def test_list_mode_shows_all_tools(self, capsys, monkeypatch, cli_argv):
         """--list 模式列出全部 TOOLS。"""
-        monkeypatch.setattr(sys, "argv", ["validate_all", "--list"])
+        cli_argv('validate_all', '--list')
         va.main()
         out = capsys.readouterr().out
         for name, _, _, _ in TOOLS:
@@ -632,18 +632,16 @@ class TestMainCLI:
         """Mock _run_one that always fails."""
         return (short_name, "fail", 0.2, "error", "failure output")
 
-    def test_list_flag(self, monkeypatch, capsys):
+    def test_list_flag(self, monkeypatch, capsys, cli_argv):
         """--list 列出所有 checks。"""
-        monkeypatch.setattr(sys, "argv", ["validate_all", "--list"])
+        cli_argv('validate_all', '--list')
         va.main()
         out = capsys.readouterr().out
         assert "versions" in out or "links" in out
 
-    def test_sequential_json(self, monkeypatch, capsys):
+    def test_sequential_json(self, monkeypatch, capsys, cli_argv):
         """Sequential + --json 輸出。"""
-        monkeypatch.setattr(sys, "argv", [
-            "validate_all", "--json", "--only", "versions",
-        ])
+        cli_argv('validate_all', '--json', '--only', 'versions')
         monkeypatch.setattr(va, "_run_one", self._mock_run_one)
         with pytest.raises(SystemExit) as exc_info:
             va.main()
@@ -653,11 +651,9 @@ class TestMainCLI:
         assert data["passed"] >= 1
         assert data["mode"] == "sequential"
 
-    def test_sequential_text(self, monkeypatch, capsys):
+    def test_sequential_text(self, monkeypatch, capsys, cli_argv):
         """Sequential text 輸出。"""
-        monkeypatch.setattr(sys, "argv", [
-            "validate_all", "--only", "versions",
-        ])
+        cli_argv('validate_all', '--only', 'versions')
         monkeypatch.setattr(va, "_run_one", self._mock_run_one)
         with pytest.raises(SystemExit) as exc_info:
             va.main()
@@ -665,12 +661,9 @@ class TestMainCLI:
         out = capsys.readouterr().out
         assert "Validation Report" in out
 
-    def test_skip_flag(self, monkeypatch, capsys):
+    def test_skip_flag(self, monkeypatch, capsys, cli_argv):
         """--skip 跳過指定 check。"""
-        monkeypatch.setattr(sys, "argv", [
-            "validate_all", "--skip", "versions,links",
-            "--only", "freshness",
-        ])
+        cli_argv('validate_all', '--skip', 'versions,links', '--only', 'freshness')
         monkeypatch.setattr(va, "_run_one", self._mock_run_one)
         with pytest.raises(SystemExit) as exc_info:
             va.main()
@@ -678,21 +671,17 @@ class TestMainCLI:
         out = capsys.readouterr().out
         assert len(out) > 0
 
-    def test_ci_stops_on_failure(self, monkeypatch):
+    def test_ci_stops_on_failure(self, monkeypatch, cli_argv):
         """--ci 模式遇到失敗時 exit 1。"""
-        monkeypatch.setattr(sys, "argv", [
-            "validate_all", "--ci", "--only", "versions",
-        ])
+        cli_argv('validate_all', '--ci', '--only', 'versions')
         monkeypatch.setattr(va, "_run_one", self._mock_run_one_fail)
         with pytest.raises(SystemExit) as exc_info:
             va.main()
         assert exc_info.value.code == 1
 
-    def test_verbose_flag(self, monkeypatch, capsys):
+    def test_verbose_flag(self, monkeypatch, capsys, cli_argv):
         """--verbose 顯示完整輸出。"""
-        monkeypatch.setattr(sys, "argv", [
-            "validate_all", "--verbose", "--only", "versions",
-        ])
+        cli_argv('validate_all', '--verbose', '--only', 'versions')
         monkeypatch.setattr(va, "_run_one", self._mock_run_one)
         with pytest.raises(SystemExit) as exc_info:
             va.main()


### PR DESCRIPTION
## Summary

Continuation of #304 (R5 wave 1, 60 sites). Same AST-based migration script applied to the next top-5 files by `monkeypatch.setattr(sys, \"argv\", ...)` density.

- 43 sites migrated across 5 test files
- Cumulative R5 progress: 60 + 43 = **103 / 195** sites (~53%)
- Net line change: **-57** (86 insertions, 143 deletions)

### Files (43 sites)

| File | Sites |
|---|---|
| tests/ops/test_assemble_config_dir.py | 9 |
| tests/lint/test_check_includes_sync_extended.py | 9 |
| tests/dx/test_generate_changelog_extra.py | 9 |
| tests/shared/test_validate_all.py | 8 |
| tests/ops/test_drift_detect.py | 8 |

### Verification

`pytest` on the 5 files: **181 passed, 5 failed**.

The 5 failures are **all pre-existing Windows-host issues** (file-permission mode bits, path-separator backslash) confirmed identical with `git stash` on main vs feature branch. Not introduced by this migration.

### Notes

`monkeypatch` parameter retained where present (matching wave-1 pattern): some tests still use `monkeypatch` for other patches; removing it requires per-test inspection and is deferred to a later sweep.

## Test plan

- [x] pytest on the 5 migrated files (181/186 pass; 5 failures pre-existing on main)
- [x] AST migration script approach validated in #304
- [x] Net line reduction (-57) confirms fixture call-site is shorter than raw \`monkeypatch.setattr\`
- [x] pre-push hooks (protect-main, require-preflight, registry-drift) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)