### PR TITLE
refactor(audit): cli_argv fixture (R5) wave 3 — 37 more sites (140/195 total)

### DIFF
--- a/tests/dx/test_add_frontmatter_extra.py
+++ b/tests/dx/test_add_frontmatter_extra.py
@@ -231,82 +231,71 @@ class TestFindMarkdownFiles:
 # main — CLI orchestrator
 # ---------------------------------------------------------------------------
 class TestMain:
-    def test_missing_base_dir_returns_one(self, monkeypatch, tmp_path, caplog):
+    def test_missing_base_dir_returns_one(self, monkeypatch, tmp_path, caplog, cli_argv):
         ghost = tmp_path / "ghost"
-        monkeypatch.setattr(sys, "argv",
-                            ["add_frontmatter.py", "--base-dir", str(ghost)])
+        cli_argv("add_frontmatter.py", "--base-dir", str(ghost))
         assert af.main() == 1
 
-    def test_no_md_files_returns_zero(self, monkeypatch, tmp_path):
+    def test_no_md_files_returns_zero(self, monkeypatch, tmp_path, cli_argv):
         # Empty base dir → 0 md files → return 0 (warning logged).
-        monkeypatch.setattr(sys, "argv",
-                            ["add_frontmatter.py", "--base-dir", str(tmp_path)])
+        cli_argv("add_frontmatter.py", "--base-dir", str(tmp_path))
         assert af.main() == 0
 
-    def test_dry_run_returns_zero_and_does_not_modify(self, monkeypatch, tmp_path):
+    def test_dry_run_returns_zero_and_does_not_modify(self, monkeypatch, tmp_path, cli_argv):
         docs = tmp_path / "docs"
         docs.mkdir()
         f = docs / "a.md"
         original = "# A\n\nbody\n"
         f.write_text(original, encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "add_frontmatter.py",
+        cli_argv("add_frontmatter.py",
             "--base-dir", str(tmp_path),
-            "--dry-run",
-        ])
+            "--dry-run")
         assert af.main() == 0
         # File unchanged.
         assert f.read_text(encoding="utf-8") == original
 
     def test_check_mode_with_missing_frontmatter_returns_one(
-        self, monkeypatch, tmp_path,
+        self, monkeypatch, tmp_path, cli_argv,
     ):
         docs = tmp_path / "docs"
         docs.mkdir()
         (docs / "missing.md").write_text("# No FM\n", encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "add_frontmatter.py",
+        cli_argv("add_frontmatter.py",
             "--base-dir", str(tmp_path),
-            "--check",
-        ])
+            "--check")
         assert af.main() == 1
 
     def test_check_mode_when_all_have_frontmatter_returns_zero(
-        self, monkeypatch, tmp_path,
+        self, monkeypatch, tmp_path, cli_argv,
     ):
         docs = tmp_path / "docs"
         docs.mkdir()
         (docs / "ok.md").write_text(
             "---\ntitle: x\n---\nbody\n", encoding="utf-8",
         )
-        monkeypatch.setattr(sys, "argv", [
-            "add_frontmatter.py",
+        cli_argv("add_frontmatter.py",
             "--base-dir", str(tmp_path),
-            "--check",
-        ])
+            "--check")
         assert af.main() == 0
 
-    def test_check_mode_does_not_modify_files(self, monkeypatch, tmp_path):
+    def test_check_mode_does_not_modify_files(self, monkeypatch, tmp_path, cli_argv):
         docs = tmp_path / "docs"
         docs.mkdir()
         f = docs / "missing.md"
         original = "# No FM\n"
         f.write_text(original, encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "add_frontmatter.py",
+        cli_argv("add_frontmatter.py",
             "--base-dir", str(tmp_path),
-            "--check",
-        ])
+            "--check")
         af.main()
         # --check is read-only.
         assert f.read_text(encoding="utf-8") == original
 
-    def test_real_run_writes_frontmatter(self, monkeypatch, tmp_path):
+    def test_real_run_writes_frontmatter(self, monkeypatch, tmp_path, cli_argv):
         docs = tmp_path / "docs"
         docs.mkdir()
         f = docs / "a.md"
         f.write_text("# Title\n\nbody\n", encoding="utf-8")
-        monkeypatch.setattr(sys, "argv",
-                            ["add_frontmatter.py", "--base-dir", str(tmp_path)])
+        cli_argv("add_frontmatter.py", "--base-dir", str(tmp_path))
         assert af.main() == 0
         assert f.read_text(encoding="utf-8").startswith("---\n")

--- a/tests/lint/test_fix_file_hygiene.py
+++ b/tests/lint/test_fix_file_hygiene.py
@@ -135,65 +135,62 @@ class TestFixFileNonRegular:
 # main — CLI surface
 # ---------------------------------------------------------------------------
 class TestMain:
-    def test_no_args_returns_zero(self, monkeypatch):
-        monkeypatch.setattr(sys, "argv", ["fix_file_hygiene.py"])
+    def test_no_args_returns_zero(self, monkeypatch, cli_argv):
+        cli_argv("fix_file_hygiene.py")
         assert ffh.main() == 0
 
-    def test_help_long_flag_returns_zero(self, monkeypatch, capsys):
-        monkeypatch.setattr(sys, "argv", ["fix_file_hygiene.py", "--help"])
+    def test_help_long_flag_returns_zero(self, monkeypatch, capsys, cli_argv):
+        cli_argv("fix_file_hygiene.py", "--help")
         assert ffh.main() == 0
         out = capsys.readouterr().out
         assert "Usage" in out
         assert "--check" in out
 
-    def test_help_short_flag_returns_zero(self, monkeypatch, capsys):
-        monkeypatch.setattr(sys, "argv", ["fix_file_hygiene.py", "-h"])
+    def test_help_short_flag_returns_zero(self, monkeypatch, capsys, cli_argv):
+        cli_argv("fix_file_hygiene.py", "-h")
         assert ffh.main() == 0
         assert "Usage" in capsys.readouterr().out
 
-    def test_unknown_flag_returns_two(self, monkeypatch, capsys):
-        monkeypatch.setattr(sys, "argv", ["fix_file_hygiene.py", "--bogus"])
+    def test_unknown_flag_returns_two(self, monkeypatch, capsys, cli_argv):
+        cli_argv("fix_file_hygiene.py", "--bogus")
         assert ffh.main() == 2
         err = capsys.readouterr().err
         assert "--bogus" in err
 
-    def test_clean_files_return_zero(self, monkeypatch, tmp_path, capsys):
+    def test_clean_files_return_zero(self, monkeypatch, tmp_path, capsys, cli_argv):
         f = tmp_path / "ok.txt"
         f.write_bytes(b"clean\n")
-        monkeypatch.setattr(sys, "argv", ["fix_file_hygiene.py", str(f)])
+        cli_argv("fix_file_hygiene.py", str(f))
         assert ffh.main() == 0
         # No "fixed N file(s)" line on clean run.
         assert "file-hygiene" not in capsys.readouterr().out
 
-    def test_dirty_file_fixed_returns_one(self, monkeypatch, tmp_path, capsys):
+    def test_dirty_file_fixed_returns_one(self, monkeypatch, tmp_path, capsys, cli_argv):
         f = tmp_path / "needs_fix.txt"
         f.write_bytes(b"no newline")
-        monkeypatch.setattr(sys, "argv", ["fix_file_hygiene.py", str(f)])
+        cli_argv("fix_file_hygiene.py", str(f))
         assert ffh.main() == 1
         # File mutated in-place.
         assert f.read_bytes() == b"no newline\n"
         out = capsys.readouterr().out
         assert "fixed 1 file" in out
 
-    def test_check_mode_reports_without_modifying(self, monkeypatch, tmp_path, capsys):
+    def test_check_mode_reports_without_modifying(self, monkeypatch, tmp_path, capsys, cli_argv):
         f = tmp_path / "dirty.txt"
         f.write_bytes(b"no newline")
-        monkeypatch.setattr(sys, "argv", ["fix_file_hygiene.py", "--check", str(f)])
+        cli_argv("fix_file_hygiene.py", "--check", str(f))
         assert ffh.main() == 1
         # File NOT mutated in check mode.
         assert f.read_bytes() == b"no newline"
         out = capsys.readouterr().out
         assert "would fix 1 file" in out
 
-    def test_mixed_clean_and_dirty(self, monkeypatch, tmp_path, capsys):
+    def test_mixed_clean_and_dirty(self, monkeypatch, tmp_path, capsys, cli_argv):
         clean = tmp_path / "clean.txt"
         clean.write_bytes(b"good\n")
         dirty = tmp_path / "dirty.txt"
         dirty.write_bytes(b"\x00bad")
-        monkeypatch.setattr(
-            sys, "argv",
-            ["fix_file_hygiene.py", str(clean), str(dirty)],
-        )
+        cli_argv("fix_file_hygiene.py", str(clean), str(dirty))
         assert ffh.main() == 1
         assert clean.read_bytes() == b"good\n"
         assert dirty.read_bytes() == b"bad\n"

--- a/tests/lint/test_validate_mermaid_extended.py
+++ b/tests/lint/test_validate_mermaid_extended.py
@@ -232,80 +232,66 @@ class TestCheckArrowSyntax:
 class TestMainCLI:
     """validate_mermaid main() CLI tests."""
 
-    def test_main_with_valid_file(self, tmp_path, monkeypatch, capsys):
+    def test_main_with_valid_file(self, tmp_path, monkeypatch, capsys, cli_argv):
         md = tmp_path / "test.md"
         md.write_text("```mermaid\ngraph TD\n    A-->B\n```\n",
                       encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "validate_mermaid", str(md)
-        ])
+        cli_argv("validate_mermaid", str(md))
         with pytest.raises(SystemExit) as exc:
             vm.main()
         assert exc.value.code == 0
         combined = capsys.readouterr()
         assert "Total diagrams found: 1" in combined.out
 
-    def test_main_with_directory(self, tmp_path, monkeypatch, capsys):
+    def test_main_with_directory(self, tmp_path, monkeypatch, capsys, cli_argv):
         md = tmp_path / "test.md"
         md.write_text("```mermaid\ngraph TD\n    A-->B\n```\n",
                       encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "validate_mermaid", str(tmp_path)
-        ])
+        cli_argv("validate_mermaid", str(tmp_path))
         with pytest.raises(SystemExit) as exc:
             vm.main()
         assert exc.value.code == 0
         combined = capsys.readouterr()
         assert "Total diagrams found:" in combined.out
 
-    def test_main_nonexistent_path(self, monkeypatch, capsys):
-        monkeypatch.setattr(sys, "argv", [
-            "validate_mermaid", "/nonexistent/path"
-        ])
+    def test_main_nonexistent_path(self, monkeypatch, capsys, cli_argv):
+        cli_argv("validate_mermaid", "/nonexistent/path")
         with pytest.raises(SystemExit) as exc:
             vm.main()
         assert exc.value.code == 1
 
-    def test_main_no_md_files(self, tmp_path, monkeypatch, capsys):
+    def test_main_no_md_files(self, tmp_path, monkeypatch, capsys, cli_argv):
         """Directory with no .md files."""
         (tmp_path / "readme.txt").write_text("not markdown", encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "validate_mermaid", str(tmp_path)
-        ])
+        cli_argv("validate_mermaid", str(tmp_path))
         with pytest.raises(SystemExit) as exc:
             vm.main()
         assert exc.value.code == 0
 
-    def test_main_ci_with_errors(self, tmp_path, monkeypatch, capsys):
+    def test_main_ci_with_errors(self, tmp_path, monkeypatch, capsys, cli_argv):
         md = tmp_path / "bad.md"
         md.write_text(
             "```mermaid\ngraph TD\n    subgraph X\n    A-->B\n```\n",
             encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "validate_mermaid", "--ci", str(md)
-        ])
+        cli_argv("validate_mermaid", "--ci", str(md))
         with pytest.raises(SystemExit) as exc:
             vm.main()
         assert exc.value.code == 1
 
-    def test_main_verbose(self, tmp_path, monkeypatch, capsys):
+    def test_main_verbose(self, tmp_path, monkeypatch, capsys, cli_argv):
         md = tmp_path / "test.md"
         md.write_text("```mermaid\ngraph TD\n    A-->B\n```\n",
                       encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "validate_mermaid", "--verbose", str(md)
-        ])
+        cli_argv("validate_mermaid", "--verbose", str(md))
         with pytest.raises(SystemExit) as exc:
             vm.main()
         assert exc.value.code == 0
 
-    def test_main_single_non_md_file(self, tmp_path, monkeypatch, capsys):
+    def test_main_single_non_md_file(self, tmp_path, monkeypatch, capsys, cli_argv):
         """Single file that's not .md."""
         f = tmp_path / "test.txt"
         f.write_text("not markdown", encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "validate_mermaid", str(f)
-        ])
+        cli_argv("validate_mermaid", str(f))
         with pytest.raises(SystemExit) as exc:
             vm.main()
         assert exc.value.code == 0

--- a/tests/ops/test_batch_diagnose.py
+++ b/tests/ops/test_batch_diagnose.py
@@ -298,45 +298,37 @@ class TestDiscoverTenantsEdge:
 class TestMainCLI:
     """main() CLI 整合測試。"""
 
-    def test_tenants_flag(self, monkeypatch, capsys):
+    def test_tenants_flag(self, monkeypatch, capsys, cli_argv):
         """--tenants 直接指定 tenant 清單。"""
-        monkeypatch.setattr(sys, "argv", [
-            "batch_diagnose", "--tenants", "db-a,db-b",
-            "--prometheus", "http://prom:9090", "--dry-run",
-        ])
+        cli_argv("batch_diagnose", "--tenants", "db-a,db-b",
+            "--prometheus", "http://prom:9090", "--dry-run")
         bd.main()
         out = capsys.readouterr().out
         assert "db-a" in out
         assert "db-b" in out
         assert "2 tenants" in out
 
-    def test_dry_run_single(self, monkeypatch, capsys):
+    def test_dry_run_single(self, monkeypatch, capsys, cli_argv):
         """--dry-run 列出 tenant 但不執行檢查。"""
-        monkeypatch.setattr(sys, "argv", [
-            "batch_diagnose", "--tenants", "db-a", "--dry-run",
-        ])
+        cli_argv("batch_diagnose", "--tenants", "db-a", "--dry-run")
         bd.main()
         out = capsys.readouterr().out
         assert "db-a" in out
         assert "dry-run" in out.lower() or "without --dry-run" in out
 
-    def test_no_tenants_exits(self, monkeypatch):
+    def test_no_tenants_exits(self, monkeypatch, cli_argv):
         """沒有 tenant 時 exit 1。"""
-        monkeypatch.setattr(sys, "argv", [
-            "batch_diagnose", "--tenants", "",
-        ])
+        cli_argv("batch_diagnose", "--tenants", "")
         # Empty tenants string → discover from ConfigMap → mock empty
         with patch.object(bd, "discover_tenants", return_value=[]):
             with pytest.raises(SystemExit) as exc_info:
                 bd.main()
             assert exc_info.value.code == 1
 
-    def test_json_output(self, monkeypatch, capsys):
+    def test_json_output(self, monkeypatch, capsys, cli_argv):
         """--json 輸出 JSON 格式。"""
-        monkeypatch.setattr(sys, "argv", [
-            "batch_diagnose", "--tenants", "db-a",
-            "--prometheus", "http://prom:9090", "--json",
-        ])
+        cli_argv("batch_diagnose", "--tenants", "db-a",
+            "--prometheus", "http://prom:9090", "--json")
 
         def mock_run_for_tenant(tenant, prom_url, timeout=30):
             return {"tenant": tenant, "status": "healthy",
@@ -350,12 +342,10 @@ class TestMainCLI:
         assert data["health_score"] == 1.0
         assert data["total_tenants"] == 1
 
-    def test_text_output(self, monkeypatch, capsys):
+    def test_text_output(self, monkeypatch, capsys, cli_argv):
         """預設文字輸出。"""
-        monkeypatch.setattr(sys, "argv", [
-            "batch_diagnose", "--tenants", "db-a",
-            "--prometheus", "http://prom:9090",
-        ])
+        cli_argv("batch_diagnose", "--tenants", "db-a",
+            "--prometheus", "http://prom:9090")
 
         def mock_run_for_tenant(tenant, prom_url, timeout=30):
             return {"tenant": tenant, "status": "healthy",
@@ -368,14 +358,12 @@ class TestMainCLI:
         assert "Health Score" in out
         assert "db-a" in out
 
-    def test_output_file(self, monkeypatch, tmp_path, capsys):
+    def test_output_file(self, monkeypatch, tmp_path, capsys, cli_argv):
         """--output 寫入 JSON 檔案。"""
         out_file = tmp_path / "report.json"
-        monkeypatch.setattr(sys, "argv", [
-            "batch_diagnose", "--tenants", "db-a",
+        cli_argv("batch_diagnose", "--tenants", "db-a",
             "--prometheus", "http://prom:9090",
-            "--output", str(out_file),
-        ])
+            "--output", str(out_file))
 
         def mock_run_for_tenant(tenant, prom_url, timeout=30):
             return {"tenant": tenant, "status": "healthy",
@@ -388,12 +376,10 @@ class TestMainCLI:
         data = json.loads(out_file.read_text(encoding="utf-8"))
         assert data["total_tenants"] == 1
 
-    def test_executor_exception(self, monkeypatch, capsys):
+    def test_executor_exception(self, monkeypatch, capsys, cli_argv):
         """ThreadPoolExecutor 例外被捕獲。"""
-        monkeypatch.setattr(sys, "argv", [
-            "batch_diagnose", "--tenants", "db-a",
-            "--prometheus", "http://prom:9090", "--json",
-        ])
+        cli_argv("batch_diagnose", "--tenants", "db-a",
+            "--prometheus", "http://prom:9090", "--json")
 
         def mock_run_for_tenant(tenant, prom_url, timeout=30):
             raise RuntimeError("boom")
@@ -405,12 +391,10 @@ class TestMainCLI:
         data = json.loads(out)
         assert data["issue_count"] == 1
 
-    def test_auto_discover(self, monkeypatch, capsys):
+    def test_auto_discover(self, monkeypatch, capsys, cli_argv):
         """不指定 --tenants 時自動探索。"""
-        monkeypatch.setattr(sys, "argv", [
-            "batch_diagnose", "--prometheus", "http://prom:9090",
-            "--dry-run",
-        ])
+        cli_argv("batch_diagnose", "--prometheus", "http://prom:9090",
+            "--dry-run")
         monkeypatch.setattr(bd, "discover_tenants",
                             lambda **kw: ["db-a", "db-b"])
         bd.main()

--- a/tests/ops/test_grafana_import.py
+++ b/tests/ops/test_grafana_import.py
@@ -213,33 +213,33 @@ class TestVerifyDashboards:
 # main — CLI
 # ---------------------------------------------------------------------------
 class TestMain:
-    def test_no_args_errors_and_exits(self, monkeypatch):
-        monkeypatch.setattr(sys, "argv", ["grafana_import.py"])
+    def test_no_args_errors_and_exits(self, monkeypatch, cli_argv):
+        cli_argv("grafana_import.py")
         with pytest.raises(SystemExit) as exc:
             gi.main()
         # parser.error() exits 2.
         assert exc.value.code == 2
 
-    def test_verify_pass_exits_zero(self, monkeypatch, capsys):
+    def test_verify_pass_exits_zero(self, monkeypatch, capsys, cli_argv):
         monkeypatch.setattr(gi, "verify_dashboards",
                             lambda ns: [{"check": "x", "status": "pass", "detail": "ok"}])
-        monkeypatch.setattr(sys, "argv", ["grafana_import.py", "--verify", "--namespace", "monitoring"])
+        cli_argv("grafana_import.py", "--verify", "--namespace", "monitoring")
         with pytest.raises(SystemExit) as exc:
             gi.main()
         assert exc.value.code == 0
 
-    def test_verify_fail_exits_one(self, monkeypatch):
+    def test_verify_fail_exits_one(self, monkeypatch, cli_argv):
         monkeypatch.setattr(gi, "verify_dashboards",
                             lambda ns: [{"check": "x", "status": "fail", "detail": "broken"}])
-        monkeypatch.setattr(sys, "argv", ["grafana_import.py", "--verify"])
+        cli_argv("grafana_import.py", "--verify")
         with pytest.raises(SystemExit) as exc:
             gi.main()
         assert exc.value.code == 1
 
-    def test_verify_json_output(self, monkeypatch, capsys):
+    def test_verify_json_output(self, monkeypatch, capsys, cli_argv):
         monkeypatch.setattr(gi, "verify_dashboards",
                             lambda ns: [{"check": "c", "status": "pass", "detail": "d"}])
-        monkeypatch.setattr(sys, "argv", ["grafana_import.py", "--verify", "--json"])
+        cli_argv("grafana_import.py", "--verify", "--json")
         with pytest.raises(SystemExit):
             gi.main()
         out = capsys.readouterr().out
@@ -248,33 +248,30 @@ class TestMain:
         assert payload["mode"] == "verify"
         assert payload["status"] == "pass"
 
-    def test_dashboard_dir_not_found_exits_one(self, monkeypatch, tmp_path, capsys):
+    def test_dashboard_dir_not_found_exits_one(self, monkeypatch, tmp_path, capsys, cli_argv):
         ghost = tmp_path / "no-such-dir"
-        monkeypatch.setattr(sys, "argv",
-                            ["grafana_import.py", "--dashboard-dir", str(ghost)])
+        cli_argv("grafana_import.py", "--dashboard-dir", str(ghost))
         with pytest.raises(SystemExit) as exc:
             gi.main()
         assert exc.value.code == 1
         err = capsys.readouterr().err
         assert "not found" in err.lower()
 
-    def test_dashboard_dir_no_jsons_exits_one(self, monkeypatch, tmp_path, capsys):
+    def test_dashboard_dir_no_jsons_exits_one(self, monkeypatch, tmp_path, capsys, cli_argv):
         d = tmp_path / "empty-dir"
         d.mkdir()
         (d / "readme.txt").write_text("x", encoding="utf-8")  # not .json
-        monkeypatch.setattr(sys, "argv",
-                            ["grafana_import.py", "--dashboard-dir", str(d)])
+        cli_argv("grafana_import.py", "--dashboard-dir", str(d))
         with pytest.raises(SystemExit) as exc:
             gi.main()
         assert exc.value.code == 1
         err = capsys.readouterr().err
         assert "No dashboard files" in err
 
-    def test_single_dashboard_dry_run_exits_zero(self, monkeypatch, tmp_path, capsys):
+    def test_single_dashboard_dry_run_exits_zero(self, monkeypatch, tmp_path, capsys, cli_argv):
         f = tmp_path / "dash.json"
         f.write_text(json.dumps({"title": "T"}), encoding="utf-8")
-        monkeypatch.setattr(sys, "argv",
-                            ["grafana_import.py", "--dashboard", str(f), "--dry-run"])
+        cli_argv("grafana_import.py", "--dashboard", str(f), "--dry-run")
         with pytest.raises(SystemExit) as exc:
             gi.main()
         assert exc.value.code == 0


### PR DESCRIPTION
## Summary

Continuation of #304 (wave 1) + #305 (wave 2). Same AST-based migration script applied to the next top-5 files by `monkeypatch.setattr(sys, \"argv\", ...)` density.

- 37 sites migrated across 5 test files (36 via script + 1 manual edge case)
- Cumulative R5 progress: 60 + 43 + 37 = **140 / 195** sites (~72%)
- Net line change: **-47** (84 insertions, 131 deletions)

### Files (37 sites)

| File | Sites |
|---|---|
| tests/lint/test_fix_file_hygiene.py | 8 |
| tests/ops/test_batch_diagnose.py | 8 |
| tests/dx/test_add_frontmatter_extra.py | 7 |
| tests/lint/test_validate_mermaid_extended.py | 7 |
| tests/ops/test_grafana_import.py | 7 |

### Edge case found

1 site in test_fix_file_hygiene.py used a multi-line `monkeypatch.setattr(\n  sys, \"argv\",\n  [...],\n)` form with a trailing comma after the closing \`]\`. The current regex's \`\]\s*\)\` tail doesn't match that comma; migrated manually. Future waves: extend the regex to allow \`\],?\s*\)\` if needed.

### Verification

\`pytest\` on the 5 files: **134 passed, 2 skipped** (pre-existing skips). No failures, no regressions.

### Notes

\`monkeypatch\` parameter retained where present (matching wave 1+2 pattern); per-test unused-fixture cleanup deferred to a later sweep.

## Test plan

- [x] pytest on the 5 migrated files (134/134 pass)
- [x] AST migration script validated again
- [x] Manual edge case caught and verified individually
- [x] pre-push hooks (protect-main, require-preflight, registry-drift) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)