### PR TITLE
refactor(audit): cli_argv fixture (R5) wave 4 — 28 more sites (168/195 total)

### DIFF
--- a/tests/dx/test_bump_docs.py
+++ b/tests/dx/test_bump_docs.py
@@ -274,18 +274,16 @@ import sys
 class TestMainCLI:
     """main() CLI 路徑覆蓋。"""
 
-    def test_show_current(self, monkeypatch, capsys):
+    def test_show_current(self, monkeypatch, capsys, cli_argv):
         """--show-current 顯示版號。"""
-        monkeypatch.setattr(sys, "argv", ["bump_docs", "--show-current"])
+        cli_argv("bump_docs", "--show-current")
         bump_docs.main()
         out = capsys.readouterr().out
         assert "Current versions" in out
 
-    def test_check_only(self, monkeypatch, capsys):
+    def test_check_only(self, monkeypatch, capsys, cli_argv):
         """--check 模式不修改檔案。"""
-        monkeypatch.setattr(sys, "argv", [
-            "bump_docs", "--platform", "99.99.99", "--check",
-        ])
+        cli_argv("bump_docs", "--platform", "99.99.99", "--check")
         # Should not raise (just reports mismatches)
         try:
             bump_docs.main()
@@ -294,32 +292,26 @@ class TestMainCLI:
         out = capsys.readouterr().out
         assert "platform" in out.lower() or "PLATFORM" in out or len(out) > 0
 
-    def test_dry_run(self, monkeypatch, capsys):
+    def test_dry_run(self, monkeypatch, capsys, cli_argv):
         """--dry-run 顯示差異但不修改。"""
-        monkeypatch.setattr(sys, "argv", [
-            "bump_docs", "--platform", "99.99.99", "--dry-run",
-        ])
+        cli_argv("bump_docs", "--platform", "99.99.99", "--dry-run")
         bump_docs.main()
         out = capsys.readouterr().out
         # Should show diffs or "no changes"
         assert len(out) > 0
 
-    def test_init_changelog(self, tmp_path, monkeypatch, capsys):
+    def test_init_changelog(self, tmp_path, monkeypatch, capsys, cli_argv):
         """--init-changelog 插入 stub。"""
         cl = tmp_path / "CHANGELOG.md"
         cl.write_text("# CL\n\n## [v1.0.0]\n", encoding="utf-8")
         monkeypatch.setattr(bump_docs, "REPO_ROOT", tmp_path)
-        monkeypatch.setattr(sys, "argv", [
-            "bump_docs", "--init-changelog", "3.0.0",
-        ])
+        cli_argv("bump_docs", "--init-changelog", "3.0.0")
         bump_docs.main()
         assert "v3.0.0" in cl.read_text(encoding="utf-8")
 
-    def test_what_if(self, monkeypatch, capsys):
+    def test_what_if(self, monkeypatch, capsys, cli_argv):
         """--what-if 顯示規則審計。"""
-        monkeypatch.setattr(sys, "argv", [
-            "bump_docs", "--what-if",
-        ])
+        cli_argv("bump_docs", "--what-if")
         try:
             bump_docs.main()
         except SystemExit:
@@ -328,12 +320,10 @@ class TestMainCLI:
         # Should show some rule audit output
         assert len(out) > 0
 
-    def test_scope_flag(self, monkeypatch, capsys):
+    def test_scope_flag(self, monkeypatch, capsys, cli_argv):
         """--scope 限制範圍。"""
-        monkeypatch.setattr(sys, "argv", [
-            "bump_docs", "--platform", "99.99.99",
-            "--check", "--scope", "docs",
-        ])
+        cli_argv("bump_docs", "--platform", "99.99.99",
+            "--check", "--scope", "docs")
         try:
             bump_docs.main()
         except SystemExit:

--- a/tests/dx/test_pr_preflight_orchestrator.py
+++ b/tests/dx/test_pr_preflight_orchestrator.py
@@ -328,7 +328,7 @@ class TestMainOrchestrator:
         monkeypatch.setattr(pp, "clear_markers", lambda repo_root: 0)
         monkeypatch.setattr(os, "chdir", lambda p: None)
 
-    def test_check_commit_msg_path_short_circuits(self, monkeypatch, tmp_path, capsys):
+    def test_check_commit_msg_path_short_circuits(self, monkeypatch, tmp_path, capsys, cli_argv):
         # Provide a valid commit-msg file → check_commit_msg_file returns 0.
         f = tmp_path / "msg"
         f.write_text("feat: ok\n", encoding="utf-8")
@@ -337,39 +337,37 @@ class TestMainOrchestrator:
         # through the full validation (we just want orchestrator dispatch).
         monkeypatch.setattr(pp, "check_commit_msg_file",
                             lambda path, repo_root: 0)
-        monkeypatch.setattr(sys, "argv",
-                            ["pr_preflight.py", "--check-commit-msg", str(f)])
+        cli_argv("pr_preflight.py", "--check-commit-msg", str(f))
         assert pp.main() == 0
 
-    def test_check_pr_title_path_short_circuits(self, monkeypatch, tmp_path):
+    def test_check_pr_title_path_short_circuits(self, monkeypatch, tmp_path, cli_argv):
         self._stub_repo_root_and_marker(monkeypatch, tmp_path)
         monkeypatch.setattr(pp, "check_pr_title",
                             lambda title, repo_root, max_length=70: 0)
-        monkeypatch.setattr(sys, "argv",
-                            ["pr_preflight.py", "--check-pr-title", "feat: x"])
+        cli_argv("pr_preflight.py", "--check-pr-title", "feat: x")
         assert pp.main() == 0
 
-    def test_all_pass_returns_zero(self, monkeypatch, tmp_path):
+    def test_all_pass_returns_zero(self, monkeypatch, tmp_path, cli_argv):
         self._stub_repo_root_and_marker(monkeypatch, tmp_path)
         self._stub_all_checks(monkeypatch)
-        monkeypatch.setattr(sys, "argv", ["pr_preflight.py", "--ci"])
+        cli_argv("pr_preflight.py", "--ci")
         assert pp.main() == 0
 
-    def test_failure_with_ci_flag_returns_one(self, monkeypatch, tmp_path):
+    def test_failure_with_ci_flag_returns_one(self, monkeypatch, tmp_path, cli_argv):
         self._stub_repo_root_and_marker(monkeypatch, tmp_path)
         self._stub_all_checks(monkeypatch, fail_check="Conflict")
-        monkeypatch.setattr(sys, "argv", ["pr_preflight.py", "--ci"])
+        cli_argv("pr_preflight.py", "--ci")
         assert pp.main() == 1
 
-    def test_failure_without_ci_flag_returns_zero(self, monkeypatch, tmp_path):
+    def test_failure_without_ci_flag_returns_zero(self, monkeypatch, tmp_path, cli_argv):
         # Without --ci, even a FAIL exits 0 (interactive mode shows summary
         # but doesn't gate).
         self._stub_repo_root_and_marker(monkeypatch, tmp_path)
         self._stub_all_checks(monkeypatch, fail_check="Conflict")
-        monkeypatch.setattr(sys, "argv", ["pr_preflight.py"])
+        cli_argv("pr_preflight.py")
         assert pp.main() == 0
 
-    def test_skip_hooks_records_skip_status(self, monkeypatch, tmp_path, capsys):
+    def test_skip_hooks_records_skip_status(self, monkeypatch, tmp_path, capsys, cli_argv):
         self._stub_repo_root_and_marker(monkeypatch, tmp_path)
         self._stub_all_checks(monkeypatch)
 
@@ -378,7 +376,7 @@ class TestMainOrchestrator:
             raise AssertionError("check_local_hooks should be skipped")
         monkeypatch.setattr(pp, "check_local_hooks", fail_if_called)
 
-        monkeypatch.setattr(sys, "argv", ["pr_preflight.py", "--skip-hooks", "--ci"])
+        cli_argv("pr_preflight.py", "--skip-hooks", "--ci")
         assert pp.main() == 0
         out = capsys.readouterr().out
         assert "Local hooks" in out

--- a/tests/dx/test_tenant_verify.py
+++ b/tests/dx/test_tenant_verify.py
@@ -168,53 +168,41 @@ def test_inheritance_chain_reflected_in_output(verify_module, conf_d):
     assert len(mkt["defaults_chain"]) == 1, f"marketing tenant: {mkt['defaults_chain']}"
 
 
-def test_main_no_args_returns_usage_error(verify_module, conf_d, monkeypatch, capsys):
+def test_main_no_args_returns_usage_error(verify_module, conf_d, monkeypatch, capsys, cli_argv):
     """No tenant_id and no --all → exit 1 with error to stderr."""
     monkeypatch.chdir(conf_d.parent)  # cwd has conf.d/
-    monkeypatch.setattr(sys, "argv", ["tenant-verify"])
+    cli_argv("tenant-verify")
     code = verify_module.main()
     assert code == 1
     captured = capsys.readouterr()
     assert "tenant_id is required" in captured.err
 
 
-def test_main_all_with_expect_merged_hash_is_error(verify_module, conf_d, monkeypatch, capsys):
+def test_main_all_with_expect_merged_hash_is_error(verify_module, conf_d, monkeypatch, capsys, cli_argv):
     """--all + --expect-merged-hash makes no sense (one hash, many tenants)."""
     monkeypatch.chdir(conf_d.parent)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["tenant-verify", "--all", "--expect-merged-hash", "deadbeef", "--conf-d", str(conf_d)],
-    )
+    cli_argv("tenant-verify", "--all", "--expect-merged-hash", "deadbeef", "--conf-d", str(conf_d))
     code = verify_module.main()
     assert code == 1
     captured = capsys.readouterr()
     assert "incompatible with --all" in captured.err
 
 
-def test_main_conf_d_not_found_returns_error(verify_module, monkeypatch, capsys, tmp_path):
+def test_main_conf_d_not_found_returns_error(verify_module, monkeypatch, capsys, tmp_path, cli_argv):
     """Bogus --conf-d path → exit 1."""
     bogus = tmp_path / "nonexistent"
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["tenant-verify", "db-fin-a", "--conf-d", str(bogus)],
-    )
+    cli_argv("tenant-verify", "db-fin-a", "--conf-d", str(bogus))
     code = verify_module.main()
     assert code == 1
     captured = capsys.readouterr()
     assert "conf.d not found" in captured.err
 
 
-def test_main_json_output_is_parseable(verify_module, conf_d, monkeypatch, capsys):
+def test_main_json_output_is_parseable(verify_module, conf_d, monkeypatch, capsys, cli_argv):
     """--json must emit valid JSON (operator pipes to jq for diff)."""
     import json as _json
 
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["tenant-verify", "db-fin-a", "--conf-d", str(conf_d), "--json"],
-    )
+    cli_argv("tenant-verify", "db-fin-a", "--conf-d", str(conf_d), "--json")
     code = verify_module.main()
     assert code == 0
     captured = capsys.readouterr()
@@ -224,20 +212,14 @@ def test_main_json_output_is_parseable(verify_module, conf_d, monkeypatch, capsy
     assert parsed["merged_hash"]
 
 
-def test_main_expect_mismatch_exit_code_2(verify_module, conf_d, monkeypatch):
+def test_main_expect_mismatch_exit_code_2(verify_module, conf_d, monkeypatch, cli_argv):
     """Round-trip the exit-code-2 contract that B-4 checklist depends on."""
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "tenant-verify",
+    cli_argv("tenant-verify",
             "db-fin-a",
             "--conf-d",
             str(conf_d),
             "--expect-merged-hash",
             "0000000000000000",
-            "--json",
-        ],
-    )
+            "--json")
     code = verify_module.main()
     assert code == 2

--- a/tests/ops/test_alert_correlate.py
+++ b/tests/ops/test_alert_correlate.py
@@ -391,7 +391,7 @@ class TestCLI:
         assert args.window == "5m"
         assert args.min_score == 0.3
 
-    def test_main_with_input_file(self, monkeypatch, capsys, tmp_path):
+    def test_main_with_input_file(self, monkeypatch, capsys, tmp_path, cli_argv):
         data = [
             {"labels": {"alertname": "A", "tenant": "db-a", "severity": "warning",
                          "namespace": "db-a"},
@@ -404,33 +404,27 @@ class TestCLI:
         ]
         p = tmp_path / "alerts.json"
         p.write_text(json.dumps(data), encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "alert_correlate", "--input", str(p), "--json",
-        ])
+        cli_argv("alert_correlate", "--input", str(p), "--json")
         ac.main()
         out = capsys.readouterr().out
         report = json.loads(out)
         assert report["total_alerts"] == 2
 
-    def test_main_no_alerts(self, monkeypatch, capsys):
-        monkeypatch.setattr(sys, "argv", [
-            "alert_correlate", "--prometheus", "http://fake:9090",
-        ])
+    def test_main_no_alerts(self, monkeypatch, capsys, cli_argv):
+        cli_argv("alert_correlate", "--prometheus", "http://fake:9090")
         monkeypatch.setattr(ac, "load_alerts_from_alertmanager",
                             lambda *a, **k: [])
         ac.main()
         out = capsys.readouterr().out
         assert "No correlated" in out
 
-    def test_main_invalid_window(self, monkeypatch):
-        monkeypatch.setattr(sys, "argv", [
-            "alert_correlate", "--window", "invalid",
-        ])
+    def test_main_invalid_window(self, monkeypatch, cli_argv):
+        cli_argv("alert_correlate", "--window", "invalid")
         with pytest.raises(SystemExit) as exc_info:
             ac.main()
         assert exc_info.value.code == 1
 
-    def test_main_ci_mode_critical(self, monkeypatch, tmp_path):
+    def test_main_ci_mode_critical(self, monkeypatch, tmp_path, cli_argv):
         """CI mode exits 1 when critical root cause found."""
         data = [
             {"labels": {"alertname": "A", "tenant": "db-a",
@@ -444,14 +438,12 @@ class TestCLI:
         ]
         p = tmp_path / "alerts.json"
         p.write_text(json.dumps(data), encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "alert_correlate", "--input", str(p), "--ci",
-        ])
+        cli_argv("alert_correlate", "--input", str(p), "--ci")
         with pytest.raises(SystemExit) as exc_info:
             ac.main()
         assert exc_info.value.code == 1
 
-    def test_main_markdown(self, monkeypatch, capsys, tmp_path):
+    def test_main_markdown(self, monkeypatch, capsys, tmp_path, cli_argv):
         data = [
             {"labels": {"alertname": "A", "tenant": "db-a"},
              "startsAt": "2026-03-15T10:00:00Z", "endsAt": ""},
@@ -460,9 +452,7 @@ class TestCLI:
         ]
         p = tmp_path / "alerts.json"
         p.write_text(json.dumps(data), encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "alert_correlate", "--input", str(p), "--markdown",
-        ])
+        cli_argv("alert_correlate", "--input", str(p), "--markdown")
         ac.main()
         out = capsys.readouterr().out
         assert "# Alert Correlation Report" in out

--- a/tests/ops/test_generate_rule_pack_split.py
+++ b/tests/ops/test_generate_rule_pack_split.py
@@ -432,7 +432,7 @@ class TestProcessRulePacks:
 # main — CLI
 # ---------------------------------------------------------------------------
 class TestMain:
-    def test_success_exits_zero(self, tmp_path, monkeypatch, capsys):
+    def test_success_exits_zero(self, tmp_path, monkeypatch, capsys, cli_argv):
         # Stub process_rule_packs to return clean report.
         monkeypatch.setattr(grps, "process_rule_packs", lambda **kw: {
             "status": "success",
@@ -444,12 +444,12 @@ class TestMain:
                 "metric_mismatches": [],
             },
         })
-        monkeypatch.setattr(sys, "argv", ["generate_rule_pack_split.py"])
+        cli_argv("generate_rule_pack_split.py")
         with pytest.raises(SystemExit) as exc:
             grps.main()
         assert exc.value.code == 0
 
-    def test_metric_mismatch_exits_one(self, monkeypatch):
+    def test_metric_mismatch_exits_one(self, monkeypatch, cli_argv):
         monkeypatch.setattr(grps, "process_rule_packs", lambda **kw: {
             "status": "success",
             "errors": [],
@@ -460,12 +460,12 @@ class TestMain:
                 "metric_mismatches": [{"file": "x.yaml", "missing_in_edge": ["m"]}],
             },
         })
-        monkeypatch.setattr(sys, "argv", ["generate_rule_pack_split.py"])
+        cli_argv("generate_rule_pack_split.py")
         with pytest.raises(SystemExit) as exc:
             grps.main()
         assert exc.value.code == 1
 
-    def test_error_status_exits_two(self, monkeypatch):
+    def test_error_status_exits_two(self, monkeypatch, cli_argv):
         monkeypatch.setattr(grps, "process_rule_packs", lambda **kw: {
             "status": "error",
             "errors": ["YAML parse failed"],
@@ -476,12 +476,12 @@ class TestMain:
                 "metric_mismatches": [],
             },
         })
-        monkeypatch.setattr(sys, "argv", ["generate_rule_pack_split.py"])
+        cli_argv("generate_rule_pack_split.py")
         with pytest.raises(SystemExit) as exc:
             grps.main()
         assert exc.value.code == 2
 
-    def test_json_flag_emits_json(self, monkeypatch, capsys):
+    def test_json_flag_emits_json(self, monkeypatch, capsys, cli_argv):
         monkeypatch.setattr(grps, "process_rule_packs", lambda **kw: {
             "status": "success",
             "errors": [],
@@ -492,8 +492,7 @@ class TestMain:
                 "metric_mismatches": [],
             },
         })
-        monkeypatch.setattr(sys, "argv",
-                            ["generate_rule_pack_split.py", "--json"])
+        cli_argv("generate_rule_pack_split.py", "--json")
         with pytest.raises(SystemExit):
             grps.main()
         out = capsys.readouterr().out
@@ -501,7 +500,7 @@ class TestMain:
         payload = json.loads(out)
         assert payload["status"] == "success"
 
-    def test_text_output_shows_warnings_and_mismatches(self, monkeypatch, capsys):
+    def test_text_output_shows_warnings_and_mismatches(self, monkeypatch, capsys, cli_argv):
         monkeypatch.setattr(grps, "process_rule_packs", lambda **kw: {
             "status": "success",
             "errors": [],
@@ -514,7 +513,7 @@ class TestMain:
                 ],
             },
         })
-        monkeypatch.setattr(sys, "argv", ["generate_rule_pack_split.py"])
+        cli_argv("generate_rule_pack_split.py")
         with pytest.raises(SystemExit):
             grps.main()
         out = capsys.readouterr().out
@@ -522,7 +521,7 @@ class TestMain:
         assert "y.yaml" in out
         assert "foo" in out
 
-    def test_text_output_error_branch(self, monkeypatch, capsys):
+    def test_text_output_error_branch(self, monkeypatch, capsys, cli_argv):
         monkeypatch.setattr(grps, "process_rule_packs", lambda **kw: {
             "status": "error",
             "errors": ["parse failed"],
@@ -533,7 +532,7 @@ class TestMain:
                 "metric_mismatches": [],
             },
         })
-        monkeypatch.setattr(sys, "argv", ["generate_rule_pack_split.py"])
+        cli_argv("generate_rule_pack_split.py")
         with pytest.raises(SystemExit):
             grps.main()
         out = capsys.readouterr().out


### PR DESCRIPTION
## Summary

Continuation of #304/#305/#306. Same AST-based migration script applied to the next top-5 files by `monkeypatch.setattr(sys, \"argv\", ...)` density.

- 28 sites migrated across 5 test files
- Cumulative R5 progress: 60 + 43 + 37 + 28 = **168 / 195** sites (~86%)
- Net line change: **-41** (58 insertions, 99 deletions)

### Files (28 sites)

| File | Sites |
|---|---|
| tests/dx/test_bump_docs.py | 6 |
| tests/dx/test_pr_preflight_orchestrator.py | 6 |
| tests/ops/test_generate_rule_pack_split.py | 6 |
| tests/ops/test_alert_correlate.py | 5 |
| tests/dx/test_tenant_verify.py | 5 |

### Verification

\`pytest\` on the 5 files: **173 passed, 0 failures**.

### Migration script hardening

Regex tightened to handle the trailing-comma-after-array case caught manually in wave 3:
\`\]\s*\)\` → \`\]\s*,?\s*\)\`

### Notes

\`monkeypatch\` parameter retained where present (matching wave 1-3 pattern); per-test unused-fixture cleanup deferred to a later sweep.

**Remaining**: ~27 sites across 14 lower-density files (1-4 sites each); a final wave-5 cleanup will close out R5 (195/195).

## Test plan

- [x] pytest on the 5 migrated files (173/173 pass, 0 failures)
- [x] AST migration script validated again
- [x] Regex hardening verified (no edge-case manual fix needed this wave)
- [x] pre-push hooks (protect-main, require-preflight, registry-drift) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)