### PR TITLE
refactor(audit): cli_argv fixture (R5) wave 5 — final cleanup, 36 sites

### DIFF
--- a/tests/dx/test_run_chaos_soak.py
+++ b/tests/dx/test_run_chaos_soak.py
@@ -226,39 +226,35 @@ class TestRunConfig:
 # main — caller-error surfaces (avoids the long soak loop)
 # ---------------------------------------------------------------------------
 class TestMainCallerErrors:
-    def test_missing_config_dir_returns_one(self, monkeypatch, tmp_path, capsys):
+    def test_missing_config_dir_returns_one(self, monkeypatch, tmp_path, capsys, cli_argv):
         out_dir = tmp_path / "out"
         ghost = tmp_path / "ghost-config"
-        monkeypatch.setattr(sys, "argv", [
-            "run_chaos_soak.py",
+        cli_argv("run_chaos_soak.py",
             "--target-url", "http://localhost:8080",
             "--config-dir", str(ghost),
             "--output-dir", str(out_dir),
-            "--duration-min", "1",
-        ])
+            "--duration-min", "1")
         # main() returns 1 on missing config dir before the soak loop.
         assert rcs.main() == 1
         err = capsys.readouterr().err
         assert "config-dir not found" in err
 
-    def test_unreachable_target_returns_one(self, monkeypatch, tmp_path, capsys):
+    def test_unreachable_target_returns_one(self, monkeypatch, tmp_path, capsys, cli_argv):
         config_dir = tmp_path / "conf"
         config_dir.mkdir()
         out_dir = tmp_path / "out"
         # fetch_metrics returns None → "cannot reach" → exit 1.
         monkeypatch.setattr(rcs, "fetch_metrics", lambda *a, **kw: None)
-        monkeypatch.setattr(sys, "argv", [
-            "run_chaos_soak.py",
+        cli_argv("run_chaos_soak.py",
             "--target-url", "http://localhost:8080",
             "--config-dir", str(config_dir),
             "--output-dir", str(out_dir),
-            "--duration-min", "1",
-        ])
+            "--duration-min", "1")
         assert rcs.main() == 1
         err = capsys.readouterr().err
         assert "cannot reach" in err
 
-    def test_zero_duration_completes_with_empty_metrics(self, monkeypatch, tmp_path):
+    def test_zero_duration_completes_with_empty_metrics(self, monkeypatch, tmp_path, cli_argv):
         # Empty initial metrics is a WARN, not a hard error. Pair it with
         # `--duration-min 0` so the soak loop exits immediately on the first
         # `time.time() < end_at` check — verifies the harness completes
@@ -267,13 +263,11 @@ class TestMainCallerErrors:
         config_dir.mkdir()
         out_dir = tmp_path / "out"
         monkeypatch.setattr(rcs, "fetch_metrics", lambda *a, **kw: {})
-        monkeypatch.setattr(sys, "argv", [
-            "run_chaos_soak.py",
+        cli_argv("run_chaos_soak.py",
             "--target-url", "http://localhost:8080",
             "--config-dir", str(config_dir),
             "--output-dir", str(out_dir),
-            "--duration-min", "0",
-        ])
+            "--duration-min", "0")
         # `--duration-min 0` → loop never executes → returns 0 cleanly.
         assert rcs.main() == 0
         # Output files were created in the finally block.

--- a/tests/lint/test_check_bilingual_content.py
+++ b/tests/lint/test_check_bilingual_content.py
@@ -233,22 +233,18 @@ class TestOutputFormatting:
 class TestCLI:
     """CLI main() 測試。"""
 
-    def test_main_no_findings(self, tmp_path, monkeypatch, capsys):
+    def test_main_no_findings(self, tmp_path, monkeypatch, capsys, cli_argv):
         """無 findings 時正常退出。"""
-        monkeypatch.setattr(sys, "argv", [
-            "check_bilingual_content",
-        ])
+        cli_argv("check_bilingual_content")
         monkeypatch.setattr(cbc, "DOCS_DIR", tmp_path)
         monkeypatch.setattr(cbc, "PROJECT_ROOT", tmp_path)
         cbc.main()
         out = capsys.readouterr().out
         assert "passed" in out
 
-    def test_main_json_flag(self, tmp_path, monkeypatch, capsys):
+    def test_main_json_flag(self, tmp_path, monkeypatch, capsys, cli_argv):
         """--json 輸出 JSON。"""
-        monkeypatch.setattr(sys, "argv", [
-            "check_bilingual_content", "--json",
-        ])
+        cli_argv("check_bilingual_content", "--json")
         monkeypatch.setattr(cbc, "DOCS_DIR", tmp_path)
         monkeypatch.setattr(cbc, "PROJECT_ROOT", tmp_path)
         cbc.main()
@@ -256,25 +252,21 @@ class TestCLI:
         data = json.loads(out)
         assert "status" in data
 
-    def test_main_ci_exits_on_warnings(self, tmp_path, monkeypatch, capsys):
+    def test_main_ci_exits_on_warnings(self, tmp_path, monkeypatch, capsys, cli_argv):
         """--ci 有 warnings 時 exit 1。"""
         en_doc = tmp_path / "bad.en.md"
         en_doc.write_text("# 完全中文\n\n全部中文內容。" * 10,
                           encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "check_bilingual_content", "--ci",
-        ])
+        cli_argv("check_bilingual_content", "--ci")
         monkeypatch.setattr(cbc, "DOCS_DIR", tmp_path)
         monkeypatch.setattr(cbc, "PROJECT_ROOT", tmp_path)
         with pytest.raises(SystemExit) as exc_info:
             cbc.main()
         assert exc_info.value.code == 1
 
-    def test_main_threshold_flag(self, tmp_path, monkeypatch, capsys):
+    def test_main_threshold_flag(self, tmp_path, monkeypatch, capsys, cli_argv):
         """--threshold 參數生效。"""
-        monkeypatch.setattr(sys, "argv", [
-            "check_bilingual_content", "--threshold", "0.99",
-        ])
+        cli_argv("check_bilingual_content", "--threshold", "0.99")
         monkeypatch.setattr(cbc, "DOCS_DIR", tmp_path)
         monkeypatch.setattr(cbc, "PROJECT_ROOT", tmp_path)
         cbc.main()

--- a/tests/lint/test_check_bilingual_extended.py
+++ b/tests/lint/test_check_bilingual_extended.py
@@ -250,16 +250,14 @@ class TestCheckAlert:
 class TestMain:
     """main() CLI tests."""
 
-    def test_main_check_mode(self, tmp_path, monkeypatch, capsys):
+    def test_main_check_mode(self, tmp_path, monkeypatch, capsys, cli_argv):
         rp_dir = tmp_path / "rule-packs"
         rp_dir.mkdir()
         _write_pack(rp_dir, "rule-pack-test.yaml", [
             {"name": "test", "rules": [_make_bilingual_alert("Alert1")]}
         ])
         monkeypatch.setattr(cba, "Path", lambda x: rp_dir if "rule-packs" in str(x) else Path(x))
-        monkeypatch.setattr(sys, "argv", [
-            "check_bilingual_annotations", "--check"
-        ])
+        cli_argv("check_bilingual_annotations", "--check")
         # We need to monkeypatch the default rule_pack_dir
         # The main function constructs the path internally
         # Let's use a different approach

--- a/tests/lint/test_check_cli_coverage.py
+++ b/tests/lint/test_check_cli_coverage.py
@@ -398,30 +398,29 @@ class TestOutputFormatting:
 # ---------------------------------------------------------------------------
 
 class TestCLI:
-    def test_main_no_ci_always_zero(self, monkeypatch, capsys):
+    def test_main_no_ci_always_zero(self, monkeypatch, capsys, cli_argv):
         """Without --ci, main() exits 0 even with errors (display-only mode)."""
         monkeypatch.setattr(cc, "ENTRYPOINT_PATH",
                             cc.Path("/nonexistent"))
-        monkeypatch.setattr(sys, "argv", ["check_cli_coverage.py"])
+        cli_argv("check_cli_coverage.py")
         with pytest.raises(SystemExit) as exc_info:
             cc.main()
         assert exc_info.value.code == 0
 
-    def test_main_ci_with_errors(self, monkeypatch, capsys):
+    def test_main_ci_with_errors(self, monkeypatch, capsys, cli_argv):
         """With --ci and errors, main() exits 1."""
         monkeypatch.setattr(cc, "ENTRYPOINT_PATH",
                             cc.Path("/nonexistent"))
-        monkeypatch.setattr(sys, "argv", ["check_cli_coverage.py", "--ci"])
+        cli_argv("check_cli_coverage.py", "--ci")
         with pytest.raises(SystemExit) as exc_info:
             cc.main()
         assert exc_info.value.code == 1
 
-    def test_main_json_flag(self, monkeypatch, capsys):
+    def test_main_json_flag(self, monkeypatch, capsys, cli_argv):
         """Test main() with --json flag."""
         monkeypatch.setattr(cc, "ENTRYPOINT_PATH",
                             cc.Path("/nonexistent"))
-        monkeypatch.setattr(sys, "argv",
-                            ["check_cli_coverage.py", "--json"])
+        cli_argv("check_cli_coverage.py", "--json")
         with pytest.raises(SystemExit):
             cc.main()
         captured = capsys.readouterr()

--- a/tests/lint/test_check_head_blob_hygiene.py
+++ b/tests/lint/test_check_head_blob_hygiene.py
@@ -272,11 +272,11 @@ class TestMainProgressMilestones:
     """
 
     @pytest.mark.timeout(30)
-    def test_default_mode_emits_milestones(self, git_repo, capsys, monkeypatch):
+    def test_default_mode_emits_milestones(self, git_repo, capsys, monkeypatch, cli_argv):
         """Default mode must show: 'Reading N...' + 'batch read complete' + final summary."""
         repo = git_repo(20, content_size_bytes=200)
         # main() reads sys.argv via argparse; simulate `--ci` invocation.
-        monkeypatch.setattr(sys, "argv", ["check_head_blob_hygiene.py", "--ci"])
+        cli_argv("check_head_blob_hygiene.py", "--ci")
         rc = chbh.main()
         out = capsys.readouterr().out
         assert rc == 0
@@ -289,11 +289,11 @@ class TestMainProgressMilestones:
 
     @pytest.mark.timeout(30)
     def test_default_mode_emits_per_100_progress_for_large_batch(
-        self, git_repo, capsys, monkeypatch
+        self, git_repo, capsys, monkeypatch, cli_argv
     ):
         """At 200+ files, default mode must show ...scanned 100/N and 200/N progress."""
         repo = git_repo(250, content_size_bytes=200)
-        monkeypatch.setattr(sys, "argv", ["check_head_blob_hygiene.py", "--ci"])
+        cli_argv("check_head_blob_hygiene.py", "--ci")
         rc = chbh.main()
         out = capsys.readouterr().out
         assert rc == 0
@@ -303,15 +303,11 @@ class TestMainProgressMilestones:
 
     @pytest.mark.timeout(30)
     def test_verbose_mode_shows_per_file_progress(
-        self, git_repo, capsys, monkeypatch
+        self, git_repo, capsys, monkeypatch, cli_argv
     ):
         """--verbose: per-file scan line for each blob (not per-100)."""
         repo = git_repo(5, content_size_bytes=100)
-        monkeypatch.setattr(
-            sys,
-            "argv",
-            ["check_head_blob_hygiene.py", "--ci", "--verbose"],
-        )
+        cli_argv("check_head_blob_hygiene.py", "--ci", "--verbose")
         rc = chbh.main()
         out = capsys.readouterr().out
         assert rc == 0

--- a/tests/lint/test_check_subprocess_timeout.py
+++ b/tests/lint/test_check_subprocess_timeout.py
@@ -428,32 +428,28 @@ class TestMain:
     """
 
     @pytest.mark.timeout(30)
-    def test_main_clean_codebase_exits_0(self, tmp_path, capsys, monkeypatch):
+    def test_main_clean_codebase_exits_0(self, tmp_path, capsys, monkeypatch, cli_argv):
         """No violations + --ci → exit 0 + clean message."""
         clean = tmp_path / "clean.py"
         clean.write_text(
             "import subprocess\n"
             "subprocess.run(['ls'], timeout=30)\n"
         )
-        monkeypatch.setattr(
-            sys, "argv", ["check_subprocess_timeout.py", "--ci", str(clean)]
-        )
+        cli_argv("check_subprocess_timeout.py", "--ci", str(clean))
         rc = cst.main()
         out = capsys.readouterr().out
         assert rc == 0
         assert "no subprocess calls without timeout=" in out
 
     @pytest.mark.timeout(30)
-    def test_main_violations_under_ci_only_warns(self, tmp_path, capsys, monkeypatch):
+    def test_main_violations_under_ci_only_warns(self, tmp_path, capsys, monkeypatch, cli_argv):
         """Violations + --ci (no --strict-...) → exit 0, but reports."""
         dirty = tmp_path / "dirty.py"
         dirty.write_text(
             "import subprocess\n"
             "subprocess.run(['ls'])\n"
         )
-        monkeypatch.setattr(
-            sys, "argv", ["check_subprocess_timeout.py", "--ci", str(dirty)]
-        )
+        cli_argv("check_subprocess_timeout.py", "--ci", str(dirty))
         rc = cst.main()
         out = capsys.readouterr().out
         assert rc == 0  # warn-only
@@ -461,38 +457,31 @@ class TestMain:
         assert "subprocess.run-no-timeout" in out
 
     @pytest.mark.timeout(30)
-    def test_main_violations_under_strict_exits_1(self, tmp_path, capsys, monkeypatch):
+    def test_main_violations_under_strict_exits_1(self, tmp_path, capsys, monkeypatch, cli_argv):
         """Violations + --ci + --strict-subprocess-timeout → exit 1."""
         dirty = tmp_path / "dirty.py"
         dirty.write_text(
             "import subprocess\n"
             "subprocess.run(['ls'])\n"
         )
-        monkeypatch.setattr(
-            sys, "argv",
-            [
-                "check_subprocess_timeout.py",
+        cli_argv("check_subprocess_timeout.py",
                 "--ci",
                 "--strict-subprocess-timeout",
-                str(dirty),
-            ],
-        )
+                str(dirty))
         rc = cst.main()
         out = capsys.readouterr().out
         assert rc == 1
         assert "ERROR" in out
 
     @pytest.mark.timeout(30)
-    def test_main_no_ci_always_exits_0(self, tmp_path, capsys, monkeypatch):
+    def test_main_no_ci_always_exits_0(self, tmp_path, capsys, monkeypatch, cli_argv):
         """Violations + no --ci → exit 0 (audit mode never fails)."""
         dirty = tmp_path / "dirty.py"
         dirty.write_text(
             "import subprocess\n"
             "subprocess.run(['ls'])\n"
         )
-        monkeypatch.setattr(
-            sys, "argv", ["check_subprocess_timeout.py", str(dirty)]
-        )
+        cli_argv("check_subprocess_timeout.py", str(dirty))
         rc = cst.main()
         assert rc == 0  # audit mode never fails
 

--- a/tests/ops/test_blind_spot_discovery.py
+++ b/tests/ops/test_blind_spot_discovery.py
@@ -350,7 +350,7 @@ class TestRenderReportAdvanced:
 class TestMainIntegration:
     """main() CLI 整合測試。"""
 
-    def test_text_output(self, monkeypatch, capsys, tmp_path):
+    def test_text_output(self, monkeypatch, capsys, tmp_path, cli_argv):
         """main() 預設文字輸出。"""
         conf_dir = tmp_path / "conf.d"
         conf_dir.mkdir()
@@ -358,11 +358,9 @@ class TestMainIntegration:
             "mariadb:\n  connection_count:\n    warning: 100\n",
             encoding="utf-8",
         )
-        monkeypatch.setattr(sys, "argv", [
-            "blind_spot_discovery",
+        cli_argv("blind_spot_discovery",
             "--config-dir", str(conf_dir),
-            "--prometheus", "http://prom:9090",
-        ])
+            "--prometheus", "http://prom:9090")
         monkeypatch.setattr(bsd, "query_prometheus_targets", lambda url: [
             {"job": "mysqld_exporter", "instance": "10.0.0.1:9104",
              "namespace": "db-a", "labels": {}},
@@ -371,7 +369,7 @@ class TestMainIntegration:
         out = capsys.readouterr().out
         assert "Summary" in out
 
-    def test_json_output(self, monkeypatch, capsys, tmp_path):
+    def test_json_output(self, monkeypatch, capsys, tmp_path, cli_argv):
         """--json-output 輸出 JSON。"""
         conf_dir = tmp_path / "conf.d"
         conf_dir.mkdir()
@@ -379,19 +377,17 @@ class TestMainIntegration:
             "mariadb:\n  connection_count:\n    warning: 100\n",
             encoding="utf-8",
         )
-        monkeypatch.setattr(sys, "argv", [
-            "blind_spot_discovery",
+        cli_argv("blind_spot_discovery",
             "--config-dir", str(conf_dir),
             "--prometheus", "http://prom:9090",
-            "--json-output",
-        ])
+            "--json-output")
         monkeypatch.setattr(bsd, "query_prometheus_targets", lambda url: [])
         bsd.main()
         out = capsys.readouterr().out
         data = json.loads(out)
         assert isinstance(data, list)
 
-    def test_exclude_jobs(self, monkeypatch, capsys, tmp_path):
+    def test_exclude_jobs(self, monkeypatch, capsys, tmp_path, cli_argv):
         """--exclude-jobs 正確排除 job。"""
         conf_dir = tmp_path / "conf.d"
         conf_dir.mkdir()
@@ -399,12 +395,10 @@ class TestMainIntegration:
             "mariadb:\n  connection_count:\n    warning: 100\n",
             encoding="utf-8",
         )
-        monkeypatch.setattr(sys, "argv", [
-            "blind_spot_discovery",
+        cli_argv("blind_spot_discovery",
             "--config-dir", str(conf_dir),
             "--prometheus", "http://prom:9090",
-            "--exclude-jobs", "prometheus,node-exporter",
-        ])
+            "--exclude-jobs", "prometheus,node-exporter")
         monkeypatch.setattr(bsd, "query_prometheus_targets", lambda url: [
             {"job": "prometheus", "instance": "localhost:9090",
              "namespace": "monitoring", "labels": {}},
@@ -413,16 +407,14 @@ class TestMainIntegration:
         out = capsys.readouterr().out
         assert "Summary" in out
 
-    def test_prom_env_fallback(self, monkeypatch, capsys, tmp_path):
+    def test_prom_env_fallback(self, monkeypatch, capsys, tmp_path, cli_argv):
         """PROMETHEUS_URL env var 作為 fallback。"""
         conf_dir = tmp_path / "conf.d"
         conf_dir.mkdir()
         (conf_dir / "t1.yaml").write_text("redis:\n  x: {}\n",
                                           encoding="utf-8")
         monkeypatch.setenv("PROMETHEUS_URL", "http://env-prom:9090")
-        monkeypatch.setattr(sys, "argv", [
-            "blind_spot_discovery", "--config-dir", str(conf_dir),
-        ])
+        cli_argv("blind_spot_discovery", "--config-dir", str(conf_dir))
         captured_url = []
         def mock_targets(url):
             captured_url.append(url)

--- a/tests/ops/test_inject_metadata_join.py
+++ b/tests/ops/test_inject_metadata_join.py
@@ -135,17 +135,17 @@ class TestProcessFile:
 # main — directory walk + filtering
 # ---------------------------------------------------------------------------
 class TestMain:
-    def test_missing_rule_packs_dir_exits_one(self, tmp_path, monkeypatch, capsys):
+    def test_missing_rule_packs_dir_exits_one(self, tmp_path, monkeypatch, capsys, cli_argv):
         ghost = tmp_path / "no-such-dir"
         monkeypatch.setattr(imj, "RULE_PACKS_DIR", str(ghost))
-        monkeypatch.setattr(sys, "argv", ["inject_metadata_join.py"])
+        cli_argv("inject_metadata_join.py")
         with pytest.raises(SystemExit) as exc:
             imj.main()
         assert exc.value.code == 1
         err = capsys.readouterr().err
         assert "Rule packs directory not found" in err
 
-    def test_skips_operational_pack_and_non_yaml(self, tmp_path, monkeypatch, capsys):
+    def test_skips_operational_pack_and_non_yaml(self, tmp_path, monkeypatch, capsys, cli_argv):
         # 3 files: operational (skipped), README.md (not yaml), real pack.
         # Real pack has no alerts needing inject → process_file returns False
         # → count stays 0 in the summary.
@@ -160,7 +160,7 @@ class TestMain:
             encoding="utf-8",
         )
         monkeypatch.setattr(imj, "RULE_PACKS_DIR", str(rp_dir))
-        monkeypatch.setattr(sys, "argv", ["inject_metadata_join.py"])
+        cli_argv("inject_metadata_join.py")
         imj.main()
         out = capsys.readouterr().out
         assert "Modified 0 Rule Pack files" in out

--- a/tests/ops/test_operator_check.py
+++ b/tests/ops/test_operator_check.py
@@ -415,17 +415,17 @@ class TestExitCode:
 # main — CLI entry
 # ---------------------------------------------------------------------------
 class TestMain:
-    def test_default_run_exits_zero(self, monkeypatch):
+    def test_default_run_exits_zero(self, monkeypatch, cli_argv):
         # Stub everything so main() doesn't actually contact a cluster.
         monkeypatch.setattr(oc.OperatorChecker, "run_all_checks", lambda self: None)
         monkeypatch.setattr(oc.OperatorChecker, "print_human_report", lambda self: None)
         monkeypatch.setattr(oc.OperatorChecker, "exit_code", lambda self: 0)
-        monkeypatch.setattr(sys, "argv", ["operator_check.py"])
+        cli_argv("operator_check.py")
         with pytest.raises(SystemExit) as exc:
             oc.main()
         assert exc.value.code == 0
 
-    def test_json_flag_picks_json_reporter(self, monkeypatch):
+    def test_json_flag_picks_json_reporter(self, monkeypatch, cli_argv):
         called = {"json": False, "human": False}
         monkeypatch.setattr(oc.OperatorChecker, "run_all_checks", lambda self: None)
         monkeypatch.setattr(
@@ -437,18 +437,18 @@ class TestMain:
             lambda self: called.__setitem__("human", True),
         )
         monkeypatch.setattr(oc.OperatorChecker, "exit_code", lambda self: 0)
-        monkeypatch.setattr(sys, "argv", ["operator_check.py", "--json"])
+        cli_argv("operator_check.py", "--json")
         with pytest.raises(SystemExit):
             oc.main()
         assert called["json"] is True
         assert called["human"] is False
 
-    def test_ci_flag_propagates_to_exit_code(self, monkeypatch):
+    def test_ci_flag_propagates_to_exit_code(self, monkeypatch, cli_argv):
         # When --ci is set and exit_code returns 1, main() exits 1.
         monkeypatch.setattr(oc.OperatorChecker, "run_all_checks", lambda self: None)
         monkeypatch.setattr(oc.OperatorChecker, "print_human_report", lambda self: None)
         monkeypatch.setattr(oc.OperatorChecker, "exit_code", lambda self: 1)
-        monkeypatch.setattr(sys, "argv", ["operator_check.py", "--ci"])
+        cli_argv("operator_check.py", "--ci")
         with pytest.raises(SystemExit) as exc:
             oc.main()
         assert exc.value.code == 1

--- a/tests/ops/test_scaffold_db.py
+++ b/tests/ops/test_scaffold_db.py
@@ -626,15 +626,13 @@ class TestGenerateProfile:
         assert "profiles" in result
         assert result["profiles"]["empty"] == {}
 
-    def test_generate_profile_cli(self, monkeypatch):
+    def test_generate_profile_cli(self, monkeypatch, cli_argv):
         """--generate-profile via CLI writes _profiles.yaml."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            monkeypatch.setattr(sys, "argv", [
-                "scaffold_tenant.py",
+            cli_argv("scaffold_tenant.py",
                 "--generate-profile", "test-profile",
                 "--db", "mariadb",
-                "-o", tmpdir,
-            ])
+                "-o", tmpdir)
             with pytest.raises(SystemExit) as exc_info:
                 scaffold_tenant.main()
             assert exc_info.value.code == 0

--- a/tests/ops/test_validate_config_extended.py
+++ b/tests/ops/test_validate_config_extended.py
@@ -208,21 +208,17 @@ class TestMainCLI:
             }}}, f)
         return str(d)
 
-    def test_main_basic(self, tmp_path, monkeypatch, capsys):
+    def test_main_basic(self, tmp_path, monkeypatch, capsys, cli_argv):
         config_dir = self._make_config_dir(tmp_path)
-        monkeypatch.setattr(sys, "argv", [
-            "validate_config", "--config-dir", config_dir
-        ])
+        cli_argv("validate_config", "--config-dir", config_dir)
         with pytest.raises(SystemExit) as exc:
             vc.main()
         out = capsys.readouterr().out
         assert "validate-config" in out or "Validation" in out
 
-    def test_main_json(self, tmp_path, monkeypatch, capsys):
+    def test_main_json(self, tmp_path, monkeypatch, capsys, cli_argv):
         config_dir = self._make_config_dir(tmp_path)
-        monkeypatch.setattr(sys, "argv", [
-            "validate_config", "--config-dir", config_dir, "--json"
-        ])
+        cli_argv("validate_config", "--config-dir", config_dir, "--json")
         with pytest.raises(SystemExit) as exc:
             vc.main()
         out = capsys.readouterr().out
@@ -230,23 +226,19 @@ class TestMainCLI:
         assert isinstance(parsed, list)
         assert any(r["check"] == "yaml_syntax" for r in parsed)
 
-    def test_main_nonexistent_dir(self, monkeypatch, capsys):
-        monkeypatch.setattr(sys, "argv", [
-            "validate_config", "--config-dir", "/nonexistent/path"
-        ])
+    def test_main_nonexistent_dir(self, monkeypatch, capsys, cli_argv):
+        cli_argv("validate_config", "--config-dir", "/nonexistent/path")
         with pytest.raises(SystemExit) as exc:
             vc.main()
         assert exc.value.code == 1
 
-    def test_main_with_policy(self, tmp_path, monkeypatch, capsys):
+    def test_main_with_policy(self, tmp_path, monkeypatch, capsys, cli_argv):
         config_dir = self._make_config_dir(tmp_path)
         policy = tmp_path / "policy.yaml"
         policy.write_text(yaml.dump({"allowed_domains": ["hooks.example.com"]}),
                           encoding="utf-8")
-        monkeypatch.setattr(sys, "argv", [
-            "validate_config", "--config-dir", config_dir,
-            "--policy", str(policy)
-        ])
+        cli_argv("validate_config", "--config-dir", config_dir,
+            "--policy", str(policy))
         with pytest.raises(SystemExit) as exc:
             vc.main()
         out = capsys.readouterr().out

--- a/tests/shared/test_entrypoint.py
+++ b/tests/shared/test_entrypoint.py
@@ -176,30 +176,30 @@ class TestPrintUsage:
 class TestMainRouting:
     """main() subcommand dispatch 測試。"""
 
-    def test_unknown_command_exits(self, monkeypatch):
+    def test_unknown_command_exits(self, monkeypatch, cli_argv):
         """未知 command 應 sys.exit(1)。"""
-        monkeypatch.setattr(sys, "argv", ["da-tools", "nonexistent-xyz"])
+        cli_argv("da-tools", "nonexistent-xyz")
         with pytest.raises(SystemExit) as exc_info:
             entrypoint.main()
         assert exc_info.value.code == 1
 
-    def test_help_exits_zero(self, monkeypatch):
+    def test_help_exits_zero(self, monkeypatch, cli_argv):
         """--help 應 sys.exit(0)。"""
-        monkeypatch.setattr(sys, "argv", ["da-tools", "--help"])
+        cli_argv("da-tools", "--help")
         with pytest.raises(SystemExit) as exc_info:
             entrypoint.main()
         assert exc_info.value.code == 0
 
-    def test_no_args_exits_zero(self, monkeypatch):
+    def test_no_args_exits_zero(self, monkeypatch, cli_argv):
         """無參數時顯示 usage 並 sys.exit(0)。"""
-        monkeypatch.setattr(sys, "argv", ["da-tools"])
+        cli_argv("da-tools")
         with pytest.raises(SystemExit) as exc_info:
             entrypoint.main()
         assert exc_info.value.code == 0
 
-    def test_version_flag_exits_zero(self, monkeypatch):
+    def test_version_flag_exits_zero(self, monkeypatch, cli_argv):
         """--version 應 sys.exit(0)。"""
-        monkeypatch.setattr(sys, "argv", ["da-tools", "--version"])
+        cli_argv("da-tools", "--version")
         with pytest.raises(SystemExit) as exc_info:
             entrypoint.main()
         assert exc_info.value.code == 0


### PR DESCRIPTION
## Summary

**Final wave for R5.** Migrated all remaining low-density files (1-4 sites each).

- 36 sites migrated across 12 test files
- Cumulative R5 across all 5 waves: **~204 sites** migrated total (audit's earlier 195 estimate undershot slightly)
- Net line change: **-50** (81 insertions, 131 deletions)

### Files (36 sites)

| File | Sites |
|---|---|
| tests/lint/test_check_subprocess_timeout.py | 4 |
| tests/lint/test_check_bilingual_content.py | 4 |
| tests/shared/test_entrypoint.py | 4 |
| tests/ops/test_blind_spot_discovery.py | 4 |
| tests/ops/test_validate_config_extended.py | 4 |
| tests/lint/test_check_head_blob_hygiene.py | 3 |
| tests/lint/test_check_cli_coverage.py | 3 |
| tests/dx/test_run_chaos_soak.py | 3 |
| tests/ops/test_operator_check.py | 3 |
| tests/ops/test_inject_metadata_join.py | 2 |
| tests/ops/test_scaffold_db.py | 1 |
| tests/lint/test_check_bilingual_extended.py | 1 |

### Migrator edge case caught + reverted

\`test_baseline_discovery.py::_run_observation\` is a helper method that **CANNOT** take fixtures (its docstring documents this explicitly). The AST migrator processed it because it doesn't filter out non-test functions. **Two bugs surfaced** in that one site:

1. \`cli_argv\` insertion into signature corrupted \`samples=4\` → \`samples, cli_argv=4\` (the \`end_col_offset\` of an \`arg\` AST node points to end of name only, before the default expression).
2. The body call should not have been migrated since helper methods can't access fixtures.

Reverted that helper to its pre-migration state. The file is no longer in this PR's diff (1 site reverted = net zero change).

### Remaining \`setattr(sys, \"argv\", ...)\` sites — intentional non-migrations

- \`tests/ops/test_baseline_discovery.py::_run_observation\` — helper method (documented)
- \`tests/ops/test_scaffold_db.py::run_scaffold\` — helper that builds \`argv\` as a variable (regex doesn't match by design)
- \`tests/conftest.py\` — the \`cli_argv\` fixture itself implements via setattr

### Verification

\`pytest\` on the 12 wave-5 files + reverted file: **501 passed, 1 skipped, 4 failed**.

The 4 failures are pre-existing Windows-host CSV failures (file permissions / line-ending duplication), confirmed identical with main via \`git stash\` round-trip. Not introduced by this migration.

## Cumulative R5 totals (all 5 waves)

| Wave | PR | Sites | Net lines |
|---|---|---|---|
| 1 | #304 | 60 | -113 |
| 2 | #305 | 43 | -57 |
| 3 | #306 | 37 | -47 |
| 4 | #307 | 28 | -41 |
| 5 | #308 (this) | 36 | -50 |
| **Total** | | **~204** | **-308** |

R5 is effectively complete after this PR — all remaining \`setattr(sys, \"argv\", ...)\` occurrences are documented intentional non-migrations.

## Test plan

- [x] pytest on 13 files (501 passed, 1 skipped; 4 failures pre-existing on main)
- [x] Migrator edge case (helper method + defaulted last arg) caught and manually reverted
- [x] Remaining non-migrated sites documented with rationale
- [x] pre-push hooks (protect-main, require-preflight, registry-drift) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)