### PR TITLE
fix(a11y): WCAG 3.3.2 input-label — close Category C (11 → 0)

### DIFF
--- a/scripts/tools/dx/axe_lite_static.py
+++ b/scripts/tools/dx/axe_lite_static.py
@@ -249,6 +249,25 @@ def scan_unlabeled_inputs(src: str) -> list[tuple[int, str]]:
                     src,
                 ):
                     continue
+            # Implicit label wrap: <label>…<input/textarea>…</label> creates a
+            # valid label-control association in HTML, no htmlFor needed. Detect
+            # the pattern by scanning for the nearest preceding `<label` open
+            # whose matching `</label>` close comes AFTER the input. This is a
+            # coarse check that ignores intermediate <label> closes; sufficient
+            # for typical JSX structures where labels wrap a single control.
+            prev_label_open = src.rfind("<label", 0, m.start())
+            if prev_label_open >= 0:
+                # If there's an intervening </label> between the open and the
+                # input, the input isn't actually inside that label scope.
+                intervening_close = src.find(
+                    "</label>", prev_label_open, m.start()
+                )
+                if intervening_close == -1:
+                    # And there must be a </label> after the input for it to
+                    # actually close the wrapping label.
+                    next_label_close = src.find("</label>", m.start())
+                    if next_label_close >= 0:
+                        continue
             line = src.count("\n", 0, m.start()) + 1
             out.append((line, f"<{tag}> has no accessible label"))
     return out

--- a/tests/dx/test_axe_lite_static.py
+++ b/tests/dx/test_axe_lite_static.py
@@ -183,6 +183,25 @@ class TestScanUnlabeledInputs:
         src = '<label htmlFor={`name${suffix}`}>L</label><input type="text" id="name" />'
         assert axe.scan_unlabeled_inputs(src) == []
 
+    def test_implicit_label_wrap_passes(self):
+        # <label>…<input/>…</label> creates a valid implicit association, no
+        # htmlFor needed (HTML/ARIA spec). Coarse heuristic: scanner looks for
+        # the nearest preceding `<label` open and a `</label>` close that
+        # surround the input.
+        src = '<label className="block"><span>Name</span><input type="text" /></label>'
+        assert axe.scan_unlabeled_inputs(src) == []
+
+    def test_textarea_inside_label_wrap_passes(self):
+        src = '<label><span>Comments</span><textarea /></label>'
+        assert axe.scan_unlabeled_inputs(src) == []
+
+    def test_input_after_closed_label_still_flagged(self):
+        # Sibling <label> without htmlFor doesn't label the input.
+        # </label> closes BEFORE the <input>, so the input isn't wrapped.
+        src = '<label>Name</label><input type="text" />'
+        findings = axe.scan_unlabeled_inputs(src)
+        assert len(findings) == 1
+
 
 # ---------------------------------------------------------------------------
 # scan_color_only_severity — WCAG 1.4.1 complementary

--- a/tools/portal/src/interactive/tools/AlertPreviewTab.jsx
+++ b/tools/portal/src/interactive/tools/AlertPreviewTab.jsx
@@ -123,6 +123,7 @@ function AlertPreviewTab() {
             value={yaml}
             onChange={(e) => setYaml(e.target.value)}
             className="w-full h-48 font-mono text-xs p-2 border rounded-lg bg-gray-50"
+            aria-label={t('Tenant 配置 YAML', 'Tenant Config YAML')}
           />
         </div>
 
@@ -156,6 +157,7 @@ function AlertPreviewTab() {
                           value={val.current}
                           onChange={(e) => updateMetric(key, e.target.value)}
                           className="flex-1"
+                          aria-label={key}
                         />
                         <span className="text-xs font-mono w-20 text-right">
                           {val.current}{val.unit === '%' ? '%' : ` ${val.unit}`}

--- a/tools/portal/src/interactive/tools/RoutingTraceTab.jsx
+++ b/tools/portal/src/interactive/tools/RoutingTraceTab.jsx
@@ -126,6 +126,7 @@ function RoutingTraceTab() {
         value={yaml}
         onChange={(e) => setYaml(e.target.value)}
         className="w-full h-40 font-mono text-xs p-2 border rounded-lg bg-gray-50"
+        aria-label={t('Routing Profile YAML', 'Routing Profile YAML')}
       />
 
       <button

--- a/tools/portal/src/interactive/tools/roi-calculator.jsx
+++ b/tools/portal/src/interactive/tools/roi-calculator.jsx
@@ -372,6 +372,7 @@ function Slider({ label, value, onChange, min, max, step = 1, unit = '' }) {
         type="range" min={min} max={max} step={step} value={value}
         onChange={e => onChange(Number(e.target.value))}
         style={{...styles.sliderInput}}
+        aria-label={label}
       />
       <div style={styles.sliderRange}>
         <span>{min}{unit}</span><span>{max}{unit}</span>


### PR DESCRIPTION
## Summary

Mixed fix: **7 scanner false-positives** (implicit-wrap labels are valid per HTML/ARIA spec) + **4 actual aria-label additions**. Total: 11 → 0.

## Scanner improvement (recovers 7 false positives)

\`scan_unlabeled_inputs\` previously only accepted explicit \`<label htmlFor=\"X\"><input id=\"X\">\` pairing. Per HTML spec, an \`<input>\`/\`<textarea>\` nested INSIDE a \`<label>\` element is also implicitly labeled — no \`htmlFor\` needed.

Added an \"implicit label wrap\" check: if there's an unclosed \`<label\` opening before the input AND a matching \`</label>\` after the input, treat as labeled. Also added 3 unit tests covering the new behavior.

This corrects false positives in 7 sites already using valid implicit wrapping:

| File | Lines |
|---|---|
| capacity-planner.jsx | L156, L163, L181 |
| multi-tenant-comparison.jsx | L348 |
| simulate-preview.jsx | L270, L286 |
| SavedViewsPanel.jsx | L292 |

## aria-label additions (4 actual violations)

Sites where the visible label text isn't programmatically associated:

| File | Line | Element | Fix |
|---|---|---|---|
| AlertPreviewTab.jsx | L122 | textarea | \`aria-label={t('Tenant 配置 YAML', 'Tenant Config YAML')}\` |
| AlertPreviewTab.jsx | L153 | input range | \`aria-label={key}\` (per-metric slider) |
| RoutingTraceTab.jsx | L125 | textarea | \`aria-label={t('Routing Profile YAML', ...)}\` |
| roi-calculator.jsx | L371 | input range | \`aria-label={label}\` (component prop) |

In all four cases the label was visually adjacent but not programmatically associated — screen readers couldn't read the input's name.

## Verification

\`axe_lite_static\` across all portal JSX:

| | Before | After |
|---|---|---|
| A unicode-status | 0 | 0 |
| B button-name | 0 | 0 |
| C input-label | **11** | **0** ✓ |
| D color-only-severity | 16 | 16 |
| **Total** | **27** | **16** |

All 44 axe_lite unit tests pass (41 existing + 3 new).

Cat D color-only-severity (16 sites) remains — separate PR; requires per-callsite design decision (which non-color signal to add).

## Test plan

- [x] axe_lite_static reports 0 Cat C violations across all portal JSX
- [x] 44/44 axe_lite unit tests pass (3 new for implicit-wrap behavior)
- [x] No new violations in any other category
- [x] pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)