### PR TITLE
refactor(audit): R3 Go testutil wave 1 — yaml helper + 15 sites migrated

### DIFF
--- a/components/tenant-api/internal/groups/groups_test.go
+++ b/components/tenant-api/internal/groups/groups_test.go
@@ -1,9 +1,9 @@
 package groups
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
+
+	"github.com/vencil/tenant-api/internal/testutil"
 )
 
 const sampleGroupsYAML = `groups:
@@ -147,11 +147,7 @@ func TestNewManager_NoFile(t *testing.T) {
 }
 
 func TestNewManager_WithFile(t *testing.T) {
-	dir := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir, "_groups.yaml"), []byte(sampleGroupsYAML), 0644)
-	if err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	dir, _ := testutil.MkTempYAML(t, "_groups.yaml", sampleGroupsYAML)
 
 	mgr := NewManager(dir)
 
@@ -170,11 +166,7 @@ func TestNewManager_WithFile(t *testing.T) {
 }
 
 func TestManager_GetGroup(t *testing.T) {
-	dir := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir, "_groups.yaml"), []byte(sampleGroupsYAML), 0644)
-	if err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	dir, _ := testutil.MkTempYAML(t, "_groups.yaml", sampleGroupsYAML)
 
 	mgr := NewManager(dir)
 
@@ -193,11 +185,7 @@ func TestManager_GetGroup(t *testing.T) {
 }
 
 func TestManager_Reload(t *testing.T) {
-	dir := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir, "_groups.yaml"), []byte(sampleGroupsYAML), 0644)
-	if err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	dir, _ := testutil.MkTempYAML(t, "_groups.yaml", sampleGroupsYAML)
 
 	mgr := NewManager(dir)
 	if len(mgr.ListGroups()) != 2 {
@@ -211,10 +199,7 @@ func TestManager_Reload(t *testing.T) {
     members:
       - tenant-1
 `
-	err = os.WriteFile(filepath.Join(dir, "_groups.yaml"), []byte(updatedYAML), 0644)
-	if err != nil {
-		t.Fatalf("write updated: %v", err)
-	}
+	testutil.WriteYAML(t, dir, "_groups.yaml", updatedYAML)
 
 	if err := mgr.Reload(); err != nil {
 		t.Fatalf("Reload: %v", err)

--- a/components/tenant-api/internal/policy/policy_test.go
+++ b/components/tenant-api/internal/policy/policy_test.go
@@ -1,10 +1,10 @@
 package policy
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/vencil/tenant-api/internal/testutil"
 )
 
 const sampleDomainPolicyYAML = `domain_policies:
@@ -40,11 +40,7 @@ func TestNewManager_NoFile(t *testing.T) {
 
 func TestNewManager_ValidFile(t *testing.T) {
 	// When policy file exists with valid content, manager should load it
-	dir := t.TempDir()
-	path := filepath.Join(dir, "_domain_policy.yaml")
-	if err := os.WriteFile(path, []byte(sampleDomainPolicyYAML), 0644); err != nil {
-		t.Fatalf("failed to write policy file: %v", err)
-	}
+	dir, _ := testutil.MkTempYAML(t, "_domain_policy.yaml", sampleDomainPolicyYAML)
 
 	m := NewManager(dir)
 
@@ -418,11 +414,7 @@ func TestCheckWrite_EmptyConstraints(t *testing.T) {
 
 func TestNewManager_InvalidYAML(t *testing.T) {
 	// When policy file contains invalid YAML, NewManager should handle gracefully
-	dir := t.TempDir()
-	path := filepath.Join(dir, "_domain_policy.yaml")
-	if err := os.WriteFile(path, []byte("{{invalid yaml"), 0644); err != nil {
-		t.Fatalf("failed to write invalid file: %v", err)
-	}
+	dir, _ := testutil.MkTempYAML(t, "_domain_policy.yaml", "{{invalid yaml")
 
 	m := NewManager(dir)
 
@@ -435,13 +427,8 @@ func TestNewManager_InvalidYAML(t *testing.T) {
 
 func TestWatchLoop(t *testing.T) {
 	// Test that policy changes are picked up by watch loop
-	dir := t.TempDir()
-	path := filepath.Join(dir, "_domain_policy.yaml")
-
 	// Start with empty policy file
-	if err := os.WriteFile(path, []byte("domain_policies: {}"), 0644); err != nil {
-		t.Fatalf("failed to write initial file: %v", err)
-	}
+	dir, _ := testutil.MkTempYAML(t, "_domain_policy.yaml", "domain_policies: {}")
 
 	m := NewManager(dir)
 	stopCh := make(chan struct{})
@@ -460,9 +447,7 @@ func TestWatchLoop(t *testing.T) {
     description: Test policy
     tenants: [db-a]
     constraints: {}`
-	if err := os.WriteFile(path, []byte(newPolicy), 0644); err != nil {
-		t.Fatalf("failed to update file: %v", err)
-	}
+	testutil.WriteYAML(t, dir, "_domain_policy.yaml", newPolicy)
 
 	// TD-024: replace blind 200ms sleep with poll-until-loaded. The 100ms
 	// WatchLoop tick + 200ms sleep was tight on slow CI. Now we poll for

--- a/components/tenant-api/internal/testutil/yaml.go
+++ b/components/tenant-api/internal/testutil/yaml.go
@@ -1,0 +1,57 @@
+// Package testutil provides shared test helpers for the tenant-api Go module.
+//
+// This package collapses repeated test-setup boilerplate (R3 in the audit
+// — Refactor sweep). The most common patterns it replaces are:
+//
+//  1. The 4-line "write YAML or Fatal" idiom:
+//
+//     err := os.WriteFile(filepath.Join(dir, "_views.yaml"), []byte(yaml), 0644)
+//     if err != nil { t.Fatalf("write: %v", err) }
+//
+//     becomes one line via WriteYAML(t, dir, "_views.yaml", yaml).
+//
+//  2. The "MkTempDir + write one file" pattern that opens many tests:
+//
+//     dir := t.TempDir()
+//     err := os.WriteFile(filepath.Join(dir, "_views.yaml"), …)
+//     if err != nil { t.Fatalf(…) }
+//
+//     becomes dir, _ := MkTempYAML(t, "_views.yaml", yaml).
+//
+// All helpers take testing.TB so they work for both *testing.T and
+// *testing.B. They call t.Helper() so test-failure line numbers point to
+// the caller, not into this file.
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// WriteYAML writes content to dir/name with mode 0644. Calls t.Fatalf on
+// error. Returns the full path so the caller can chain into Read/Stat
+// without re-joining.
+//
+//	path := testutil.WriteYAML(t, dir, "_views.yaml", yamlBody)
+func WriteYAML(t testing.TB, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteYAML(%q): %v", name, err)
+	}
+	return path
+}
+
+// MkTempYAML creates a t.TempDir(), writes name=content into it, and
+// returns (dir, fullPath). t.TempDir() is auto-cleaned by the testing
+// framework — no need for t.Cleanup.
+//
+// Use this when a test needs exactly one YAML file in a fresh dir;
+// otherwise call t.TempDir() yourself and use WriteYAML for each file.
+func MkTempYAML(t testing.TB, name, content string) (dir, path string) {
+	t.Helper()
+	dir = t.TempDir()
+	path = WriteYAML(t, dir, name, content)
+	return dir, path
+}

--- a/components/tenant-api/internal/views/views_test.go
+++ b/components/tenant-api/internal/views/views_test.go
@@ -2,8 +2,9 @@ package views
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
+
+	"github.com/vencil/tenant-api/internal/testutil"
 )
 
 const sampleViewsYAML = `views:
@@ -182,11 +183,7 @@ func TestNewManager_NoFile(t *testing.T) {
 
 // TestNewManager_WithFile tests Manager creation with an existing _views.yaml file.
 func TestNewManager_WithFile(t *testing.T) {
-	dir := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir, "_views.yaml"), []byte(sampleViewsYAML), 0644)
-	if err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	dir, _ := testutil.MkTempYAML(t, "_views.yaml", sampleViewsYAML)
 
 	mgr := NewManager(dir)
 
@@ -206,11 +203,7 @@ func TestNewManager_WithFile(t *testing.T) {
 
 // TestManager_GetView tests retrieving a single view by ID.
 func TestManager_GetView(t *testing.T) {
-	dir := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir, "_views.yaml"), []byte(sampleViewsYAML), 0644)
-	if err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	dir, _ := testutil.MkTempYAML(t, "_views.yaml", sampleViewsYAML)
 
 	mgr := NewManager(dir)
 
@@ -254,10 +247,7 @@ func TestManager_ListViews(t *testing.T) {
     filters:
       env: staging
 `
-	err := os.WriteFile(filepath.Join(dir, "_views.yaml"), []byte(multiViewYAML), 0644)
-	if err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	testutil.WriteYAML(t, dir, "_views.yaml", multiViewYAML)
 
 	mgr := NewManager(dir)
 	list := mgr.ListViews()
@@ -286,11 +276,7 @@ func TestManager_Reload(t *testing.T) {
     filters:
       env: prod
 `
-	filePath := filepath.Join(dir, "_views.yaml")
-	err := os.WriteFile(filePath, []byte(initialYAML), 0644)
-	if err != nil {
-		t.Fatalf("write initial: %v", err)
-	}
+	testutil.WriteYAML(t, dir, "_views.yaml", initialYAML)
 
 	mgr := NewManager(dir)
 	initial := mgr.Get()
@@ -313,10 +299,7 @@ func TestManager_Reload(t *testing.T) {
     filters:
       env: dev
 `
-	err = os.WriteFile(filePath, []byte(updatedYAML), 0644)
-	if err != nil {
-		t.Fatalf("write updated: %v", err)
-	}
+	testutil.WriteYAML(t, dir, "_views.yaml", updatedYAML)
 
 	// Before reload, should still see old config
 	beforeReload := mgr.Get()
@@ -353,11 +336,7 @@ func TestManager_Reload_NoFile(t *testing.T) {
     filters:
       env: prod
 `
-	filePath := filepath.Join(dir, "_views.yaml")
-	err := os.WriteFile(filePath, []byte(initialYAML), 0644)
-	if err != nil {
-		t.Fatalf("write initial: %v", err)
-	}
+	filePath := testutil.WriteYAML(t, dir, "_views.yaml", initialYAML)
 
 	mgr := NewManager(dir)
 	initial := mgr.Get()
@@ -366,8 +345,7 @@ func TestManager_Reload_NoFile(t *testing.T) {
 	}
 
 	// Delete the file
-	err = os.Remove(filePath)
-	if err != nil {
+	if err := os.Remove(filePath); err != nil {
 		t.Fatalf("remove file: %v", err)
 	}
 
@@ -393,11 +371,7 @@ func TestManager_Reload_HashCaching(t *testing.T) {
     filters:
       env: prod
 `
-	filePath := filepath.Join(dir, "_views.yaml")
-	err := os.WriteFile(filePath, []byte(yaml), 0644)
-	if err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	testutil.WriteYAML(t, dir, "_views.yaml", yaml)
 
 	mgr := NewManager(dir)
 	first := mgr.Get()


### PR DESCRIPTION
## Summary

Audit's R3 refactor (Go-side analog of R5 cli_argv): collapse repeated \`os.WriteFile + filepath.Join + err-check\` boilerplate in tenant-api Go tests.

- **15 sites** migrated across 3 test files
- New \`internal/testutil\` package with 2 helpers
- Net line change in test code: **-56** (22 insertions, 78 deletions)

## New helper package

\`components/tenant-api/internal/testutil/yaml.go\` — 2 helpers:

| Helper | Replaces |
|---|---|
| \`WriteYAML(t, dir, name, content) → path\` | 4-line \`os.WriteFile\` + \`filepath.Join\` + err-check idiom |
| \`MkTempYAML(t, name, content) → (dir, path)\` | The typical \`t.TempDir()\` + write-one-file opener |

Both call \`t.Helper()\` so test-failure line numbers point to the caller. Both take \`testing.TB\` so they work for \`*testing.T\` and \`*testing.B\`.

## Migrated (15 sites / 3 files)

| File | Sites |
|---|---|
| \`internal/views/views_test.go\` | 7 |
| \`internal/groups/groups_test.go\` | 4 |
| \`internal/policy/policy_test.go\` | 4 |

## Verification

- \`go test ./internal/views/... ./internal/groups/... ./internal/policy/... ./internal/testutil/...\` → all 4 packages pass
- \`go vet\` on affected packages → clean

(Full module \`go vet ./...\` blocked by pre-existing missing-swag dependency in \`docs/docs.go\` — unrelated to this PR.)

## Remaining R3 Go scope

**tenant-api**: ~21 sites across 8+ files (rbac_extra 7, configwatcher 3, handler/* 9, gitops/writer_extra 2). Wave 2 candidates.

**threshold-exporter**: ~26 sites across 13 files. Separate Go module — needs its own \`internal/testutil/yaml.go\` (same shape, different import path). Wave 3+ scope.

## Test plan

- [x] go test on all 3 migrated packages + new testutil package
- [x] go vet on affected packages
- [x] Imports cleaned up (filepath / os removed where no longer needed)
- [x] pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)