### PR TITLE
refactor(audit): R3 Go testutil wave 2 — 18 more sites; 33/36 tenant-api cumulative

### DIFF
--- a/components/tenant-api/internal/configwatcher/configwatcher_test.go
+++ b/components/tenant-api/internal/configwatcher/configwatcher_test.go
@@ -1,11 +1,12 @@
 package configwatcher
 
 import (
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/vencil/tenant-api/internal/testutil"
 )
 
 // testConfig is a tiny payload type for exercising the generic.
@@ -55,13 +56,11 @@ func emptyTestConfig() *testConfig {
 	return &testConfig{Items: map[string]string{}}
 }
 
+// writeYAML wraps testutil.WriteYAML with the package's "test.yaml"
+// convention so the existing call sites stay 1-arg.
 func writeYAML(t *testing.T, dir, body string) string {
 	t.Helper()
-	p := filepath.Join(dir, "test.yaml")
-	if err := os.WriteFile(p, []byte(body), 0644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	return p
+	return testutil.WriteYAML(t, dir, "test.yaml", body)
 }
 
 func TestNew_EmptyPath(t *testing.T) {
@@ -99,9 +98,7 @@ func TestReload_PicksUpFileChange(t *testing.T) {
 		t.Fatalf("initial foo = %q, want bar", got)
 	}
 
-	if err := os.WriteFile(path, []byte("foo: baz\nextra: hello\n"), 0644); err != nil {
-		t.Fatalf("rewrite: %v", err)
-	}
+	writeYAML(t, dir, "foo: baz\nextra: hello\n")
 	if err := w.Reload(); err != nil {
 		t.Fatalf("Reload: %v", err)
 	}
@@ -194,9 +191,7 @@ func TestWatchLoop_PicksUpChangeOnTick(t *testing.T) {
 	}()
 
 	// Rewrite + wait for at least one tick.
-	if err := os.WriteFile(path, []byte("foo: v2\n"), 0644); err != nil {
-		t.Fatalf("rewrite: %v", err)
-	}
+	writeYAML(t, dir, "foo: v2\n")
 
 	// Poll for up to 1s — flake guard for slow CI.
 	deadline := time.Now().Add(time.Second)

--- a/components/tenant-api/internal/gitops/writer_extra_test.go
+++ b/components/tenant-api/internal/gitops/writer_extra_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/vencil/tenant-api/internal/testutil"
 )
 
 // --- Validate extended tests ---
@@ -154,9 +156,7 @@ func TestDiff_NewFile(t *testing.T) {
 func TestDiff_IdenticalContent(t *testing.T) {
 	dir := t.TempDir()
 	content := "tenants:\n  db-a:\n    cpu: \"80\"\n"
-	if err := os.WriteFile(filepath.Join(dir, "db-a.yaml"), []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
+	testutil.WriteYAML(t, dir, "db-a.yaml", content)
 
 	w := NewWriter(dir, "")
 	diff, err := w.Diff("db-a", content)
@@ -171,9 +171,7 @@ func TestDiff_IdenticalContent(t *testing.T) {
 func TestDiff_ModifiedContent(t *testing.T) {
 	dir := t.TempDir()
 	original := "tenants:\n  db-a:\n    cpu: \"80\"\n"
-	if err := os.WriteFile(filepath.Join(dir, "db-a.yaml"), []byte(original), 0644); err != nil {
-		t.Fatal(err)
-	}
+	testutil.WriteYAML(t, dir, "db-a.yaml", original)
 
 	w := NewWriter(dir, "")
 	proposed := "tenants:\n  db-a:\n    cpu: \"90\"\n"

--- a/components/tenant-api/internal/handler/handler_test.go
+++ b/components/tenant-api/internal/handler/handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vencil/tenant-api/internal/gitops"
 	"github.com/vencil/tenant-api/internal/policy"
 	"github.com/vencil/tenant-api/internal/rbac"
+	"github.com/vencil/tenant-api/internal/testutil"
 )
 
 // newRequestWithChiParam creates an *http.Request with a chi URL parameter set.
@@ -34,9 +35,7 @@ func setupConfigDir(t *testing.T, files map[string]string) string {
 	t.Helper()
 	dir := t.TempDir()
 	for name, content := range files {
-		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
-			t.Fatalf("write %s: %v", name, err)
-		}
+		testutil.WriteYAML(t, dir, name, content)
 	}
 	return dir
 }
@@ -56,11 +55,7 @@ func newRBACManager(t *testing.T, yaml string) *rbac.Manager {
 		}
 		return mgr
 	}
-	dir := t.TempDir()
-	rbacFile := filepath.Join(dir, "_rbac.yaml")
-	if err := os.WriteFile(rbacFile, []byte(yaml), 0644); err != nil {
-		t.Fatalf("write rbac: %v", err)
-	}
+	_, rbacFile := testutil.MkTempYAML(t, "_rbac.yaml", yaml)
 	mgr, err := rbac.NewManager(rbacFile)
 	if err != nil {
 		t.Fatalf("rbac.NewManager: %v", err)

--- a/components/tenant-api/internal/handler/tenant_search_test.go
+++ b/components/tenant-api/internal/handler/tenant_search_test.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/vencil/tenant-api/internal/rbac"
+	"github.com/vencil/tenant-api/internal/testutil"
 )
 
 // ── fixture helpers ─────────────────────────────────────────────────
@@ -423,11 +422,8 @@ func TestSnapshotCache_ReuseDuringTTL(t *testing.T) {
 
 	// Mutate disk — add a second tenant. Within TTL the snapshot
 	// must NOT pick it up (proves cache reuse).
-	if err := os.WriteFile(filepath.Join(dir, "b.yaml"),
-		[]byte(fixtureTenantYAML("b", "prod", "tier1", "db", "mariadb", "alice")),
-		0644); err != nil {
-		t.Fatalf("write b: %v", err)
-	}
+	testutil.WriteYAML(t, dir, "b.yaml",
+		fixtureTenantYAML("b", "prod", "tier1", "db", "mariadb", "alice"))
 	second, err := cache.snapshot(dir)
 	if err != nil {
 		t.Fatalf("second snapshot: %v", err)
@@ -452,11 +448,8 @@ func TestSnapshotCache_RebuildsAfterTTL(t *testing.T) {
 
 	// Wait past TTL + add tenant; second snapshot MUST see it.
 	time.Sleep(5 * time.Millisecond)
-	if err := os.WriteFile(filepath.Join(dir, "b.yaml"),
-		[]byte(fixtureTenantYAML("b", "prod", "tier1", "db", "mariadb", "alice")),
-		0644); err != nil {
-		t.Fatalf("write b: %v", err)
-	}
+	testutil.WriteYAML(t, dir, "b.yaml",
+		fixtureTenantYAML("b", "prod", "tier1", "db", "mariadb", "alice"))
 	second, err := cache.snapshot(dir)
 	if err != nil {
 		t.Fatalf("second snapshot: %v", err)
@@ -474,11 +467,8 @@ func TestSnapshotCache_InvalidateForcesRebuild(t *testing.T) {
 	if _, err := cache.snapshot(dir); err != nil {
 		t.Fatalf("first snapshot: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "b.yaml"),
-		[]byte(fixtureTenantYAML("b", "prod", "tier1", "db", "mariadb", "alice")),
-		0644); err != nil {
-		t.Fatalf("write b: %v", err)
-	}
+	testutil.WriteYAML(t, dir, "b.yaml",
+		fixtureTenantYAML("b", "prod", "tier1", "db", "mariadb", "alice"))
 	cache.invalidate()
 	second, err := cache.snapshot(dir)
 	if err != nil {

--- a/components/tenant-api/internal/rbac/rbac_extra_test.go
+++ b/components/tenant-api/internal/rbac/rbac_extra_test.go
@@ -4,9 +4,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/vencil/tenant-api/internal/testutil"
 )
 
 // --- NewManager tests ---
@@ -35,8 +36,6 @@ func TestNewManager_FileNotFound(t *testing.T) {
 }
 
 func TestNewManager_ValidFile(t *testing.T) {
-	dir := t.TempDir()
-	rbacFile := filepath.Join(dir, "_rbac.yaml")
 	content := `groups:
   - name: admins
     tenants: ["*"]
@@ -45,9 +44,7 @@ func TestNewManager_ValidFile(t *testing.T) {
     tenants: ["db-a-*", "db-b-*"]
     permissions: [read, write]
 `
-	if err := os.WriteFile(rbacFile, []byte(content), 0644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	_, rbacFile := testutil.MkTempYAML(t, "_rbac.yaml", content)
 
 	m, err := NewManager(rbacFile)
 	if err != nil {
@@ -60,11 +57,7 @@ func TestNewManager_ValidFile(t *testing.T) {
 }
 
 func TestNewManager_InvalidYAML(t *testing.T) {
-	dir := t.TempDir()
-	rbacFile := filepath.Join(dir, "_rbac.yaml")
-	if err := os.WriteFile(rbacFile, []byte("{{not valid yaml"), 0644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	_, rbacFile := testutil.MkTempYAML(t, "_rbac.yaml", "{{not valid yaml")
 
 	_, err := NewManager(rbacFile)
 	if err == nil {
@@ -75,16 +68,12 @@ func TestNewManager_InvalidYAML(t *testing.T) {
 // --- Load / hot-reload tests ---
 
 func TestLoad_NoChangeSkipsUpdate(t *testing.T) {
-	dir := t.TempDir()
-	rbacFile := filepath.Join(dir, "_rbac.yaml")
 	content := `groups:
   - name: admins
     tenants: ["*"]
     permissions: [admin]
 `
-	if err := os.WriteFile(rbacFile, []byte(content), 0644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	_, rbacFile := testutil.MkTempYAML(t, "_rbac.yaml", content)
 
 	m, err := NewManager(rbacFile)
 	if err != nil {
@@ -102,16 +91,12 @@ func TestLoad_NoChangeSkipsUpdate(t *testing.T) {
 }
 
 func TestLoad_DetectsChange(t *testing.T) {
-	dir := t.TempDir()
-	rbacFile := filepath.Join(dir, "_rbac.yaml")
 	content1 := `groups:
   - name: admins
     tenants: ["*"]
     permissions: [admin]
 `
-	if err := os.WriteFile(rbacFile, []byte(content1), 0644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	dir, rbacFile := testutil.MkTempYAML(t, "_rbac.yaml", content1)
 
 	m, err := NewManager(rbacFile)
 	if err != nil {
@@ -131,9 +116,7 @@ func TestLoad_DetectsChange(t *testing.T) {
     tenants: ["*"]
     permissions: [read]
 `
-	if err := os.WriteFile(rbacFile, []byte(content2), 0644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	testutil.WriteYAML(t, dir, "_rbac.yaml", content2)
 
 	if err := m.Reload(); err != nil {
 		t.Fatalf("load after change: %v", err)
@@ -145,16 +128,12 @@ func TestLoad_DetectsChange(t *testing.T) {
 }
 
 func TestLoad_DeletedFile(t *testing.T) {
-	dir := t.TempDir()
-	rbacFile := filepath.Join(dir, "_rbac.yaml")
 	content := `groups:
   - name: admins
     tenants: ["*"]
     permissions: [admin]
 `
-	if err := os.WriteFile(rbacFile, []byte(content), 0644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	_, rbacFile := testutil.MkTempYAML(t, "_rbac.yaml", content)
 
 	m, err := NewManager(rbacFile)
 	if err != nil {
@@ -198,11 +177,7 @@ func TestWatchLoop_EmptyPath(t *testing.T) {
 }
 
 func TestWatchLoop_StopsOnClose(t *testing.T) {
-	dir := t.TempDir()
-	rbacFile := filepath.Join(dir, "_rbac.yaml")
-	if err := os.WriteFile(rbacFile, []byte("groups: []\n"), 0644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	_, rbacFile := testutil.MkTempYAML(t, "_rbac.yaml", "groups: []\n")
 
 	m, err := NewManager(rbacFile)
 	if err != nil {


### PR DESCRIPTION
## Summary

Continuation of #313 (R3 wave 1, 15 sites). Same \`testutil.WriteYAML\` / \`MkTempYAML\` helpers applied to remaining tenant-api test files.

- 18 sites migrated across 5 files
- Net line change: **-47** (30 insertions, 77 deletions)
- Cumulative tenant-api R3: **33 / ~36 sites (~92%)**

## Files (18 sites)

| File | Sites |
|---|---|
| \`internal/rbac/rbac_extra_test.go\` | 7 |
| \`internal/configwatcher/configwatcher_test.go\` | 3 (+ helper consolidation) |
| \`internal/handler/handler_test.go\` | 3 (in shared helpers) |
| \`internal/handler/tenant_search_test.go\` | 3 |
| \`internal/gitops/writer_extra_test.go\` | 2 |

## Helper consolidation in configwatcher

\`configwatcher_test.go\` had a local \`writeYAML(t, dir, body)\` helper that hardcoded the filename \"test.yaml\" — duplicated effort with \`testutil.WriteYAML\`. Kept the local wrapper (call sites stay 1-arg) but pointed it at the shared implementation. One less inline \`os.WriteFile\` path in the codebase.

## Verification

\`go test\` on all 4 affected packages:
- \`internal/rbac\` ✓
- \`internal/configwatcher\` ✓
- \`internal/handler\` ✓ (~32s on Windows host — gitops uses \`os/exec\` to git, slow on Windows; CI in dev container is faster)
- \`internal/gitops\` ✓

## Remaining R3 Go scope

| | Sites | Status |
|---|---|---|
| tenant-api trailing | 3 | wave 3 cleanup or rolled into next |
| threshold-exporter | ~26 | separate Go module — needs its own \`internal/testutil/yaml.go\` (same shape, different import path) |

## Test plan

- [x] go test on 4 affected packages
- [x] Imports cleaned (os, filepath, path/filepath removed where no longer used)
- [x] Helper consolidation in configwatcher preserves call-site brevity
- [x] pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)