### PR TITLE
refactor(audit): R3 Go testutil wave 3 — close tenant-api + bootstrap threshold-exporter

### DIFF
--- a/components/tenant-api/internal/handler/group_test.go
+++ b/components/tenant-api/internal/handler/group_test.go
@@ -12,14 +12,13 @@ import (
 
 	"github.com/vencil/tenant-api/internal/groups"
 	"github.com/vencil/tenant-api/internal/rbac"
+	"github.com/vencil/tenant-api/internal/testutil"
 )
 
 func setupGroupsFile(t *testing.T, configDir, content string) {
 	t.Helper()
 	if content != "" {
-		if err := os.WriteFile(filepath.Join(configDir, "_groups.yaml"), []byte(content), 0644); err != nil {
-			t.Fatalf("write _groups.yaml: %v", err)
-		}
+		testutil.WriteYAML(t, configDir, "_groups.yaml", content)
 	}
 }
 

--- a/components/tenant-api/internal/handler/view_test.go
+++ b/components/tenant-api/internal/handler/view_test.go
@@ -10,15 +10,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/vencil/tenant-api/internal/testutil"
 	"github.com/vencil/tenant-api/internal/views"
 )
 
 func setupViewsFile(t *testing.T, configDir, content string) {
 	t.Helper()
 	if content != "" {
-		if err := os.WriteFile(filepath.Join(configDir, "_views.yaml"), []byte(content), 0644); err != nil {
-			t.Fatalf("write _views.yaml: %v", err)
-		}
+		testutil.WriteYAML(t, configDir, "_views.yaml", content)
 	}
 }
 

--- a/components/threshold-exporter/app/config_simulate_test.go
+++ b/components/threshold-exporter/app/config_simulate_test.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vencil/threshold-exporter/internal/testutil"
 	"github.com/vencil/threshold-exporter/pkg/config"
 )
 
@@ -302,19 +303,13 @@ func TestSimulate_VsResolve_ParityHash(t *testing.T) {
 	l1Bytes := []byte("defaults:\n  mysql_connections: 90\n  custom_label: \"team-a\"\n")
 	tenantBytes := []byte("tenants:\n  tenant-a:\n    cpu_threshold: 70\n    receivers:\n      - pagerduty\n    _metadata:\n      contact: \"alice\"\n")
 
-	if err := os.WriteFile(filepath.Join(dir, "_defaults.yaml"), l0Bytes, 0o644); err != nil {
-		t.Fatalf("write L0: %v", err)
-	}
+	testutil.WriteYAMLBytes(t, dir, "_defaults.yaml", l0Bytes)
 	teamDir := filepath.Join(dir, "team-a")
 	if err := os.MkdirAll(teamDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(teamDir, "_defaults.yaml"), l1Bytes, 0o644); err != nil {
-		t.Fatalf("write L1: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(teamDir, "tenant-a.yaml"), tenantBytes, 0o644); err != nil {
-		t.Fatalf("write tenant: %v", err)
-	}
+	testutil.WriteYAMLBytes(t, teamDir, "_defaults.yaml", l1Bytes)
+	testutil.WriteYAMLBytes(t, teamDir, "tenant-a.yaml", tenantBytes)
 
 	// Disk path
 	m := NewConfigManager(dir)

--- a/components/threshold-exporter/app/internal/testutil/yaml.go
+++ b/components/threshold-exporter/app/internal/testutil/yaml.go
@@ -1,0 +1,54 @@
+// Package testutil provides shared test helpers for the threshold-exporter
+// Go module.
+//
+// Mirrors the tenant-api/internal/testutil package introduced in PR #313.
+// Same shape, separate module — Go's internal/ visibility doesn't cross
+// module boundaries, so each module needs its own copy.
+//
+// See tenant-api/internal/testutil/yaml.go for the full rationale (R3 in
+// the audit). Quick summary: replaces the 4-line "WriteFile + Join +
+// err-check" idiom with one line, calls t.Helper() so failure line
+// numbers point to the caller.
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// WriteYAML writes content to dir/name with mode 0644. Calls t.Fatalf on
+// error. Returns the full path so the caller can chain into Read/Stat
+// without re-joining.
+//
+//	path := testutil.WriteYAML(t, dir, "_defaults.yaml", body)
+func WriteYAML(t testing.TB, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteYAML(%q): %v", name, err)
+	}
+	return path
+}
+
+// MkTempYAML creates a t.TempDir(), writes name=content into it, and
+// returns (dir, fullPath). t.TempDir() is auto-cleaned by the testing
+// framework — no need for t.Cleanup.
+func MkTempYAML(t testing.TB, name, content string) (dir, path string) {
+	t.Helper()
+	dir = t.TempDir()
+	path = WriteYAML(t, dir, name, content)
+	return dir, path
+}
+
+// WriteYAMLBytes is a []byte variant of WriteYAML, for callers that have
+// the content already as bytes (e.g. pre-computed `l0Bytes := []byte(...)`).
+// Avoids round-trip through string for those paths.
+func WriteYAMLBytes(t testing.TB, dir, name string, content []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("WriteYAMLBytes(%q): %v", name, err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary

Two-module wave 3:

1. **Closes the last 2 tenant-api migration sites** (the 3rd was in a helper that does \`mkdir + write\` — different semantics from \`WriteYAML\`, intentional skip).
2. **Creates the threshold-exporter parallel testutil package** (separate Go module → can't share tenant-api's), and migrates the first threshold-exporter test file.

## (1) tenant-api close-out — 2 sites

| File | Site |
|---|---|
| \`internal/handler/group_test.go::setupGroupsFile\` | → \`testutil.WriteYAML\` |
| \`internal/handler/view_test.go::setupViewsFile\` | → \`testutil.WriteYAML\` |

Cumulative tenant-api: **35 / ~36 sites (~97%)**.

The last 1 site is in \`tenant_effective_test.go::writeFile\` which adds \`os.MkdirAll\` before write — a different pattern from the rest. Skipped to keep the helper API tight; can be migrated in a future wave by adding a \`WriteFile(t, path, content)\` variant that does mkdir+write.

## (2) threshold-exporter testutil bootstrap

New package: \`components/threshold-exporter/app/internal/testutil/yaml.go\`

Same \`WriteYAML\` + \`MkTempYAML\` shape as tenant-api/internal/testutil (mirrors PR #313). Adds a \`WriteYAMLBytes\` variant for callers that already have content as \`[]byte\` (common in the exporter — many tests build \`l0Bytes := []byte(...)\` for hierarchy fixtures).

Migrated 1 file:

| File | Sites |
|---|---|
| \`config_simulate_test.go\` | 3 (all \`WriteYAMLBytes\`) |

Note: most other threshold-exporter test files use mode \`0o600\` (more restrictive, security-relevant) OR have a local \`writeFile\` helper that adds \`os.MkdirAll\`. The current testutil API uses \`0o644\` + no mkdir; expanding to cover those patterns is wave 4+ scope.

## Verification

- \`go vet\` (threshold-exporter/app/...) → clean
- \`go test ./internal/handler/...\` (tenant-api) → pass (~12s)
- \`go test threshold-exporter -run TestSimulate\` → 1 pre-existing failure (\`TestSimulate_VsResolve_ParityHash\`; verified identical on main via \`git stash\`, unrelated to migration)

## Cumulative R3 Go progress (across both modules)

| Module | Sites | % |
|---|---|---|
| tenant-api | 35 / ~36 | ~97% |
| threshold-exporter | 3 / ~26 | ~12% |
| **Combined** | **38 / ~62** | **~61%** |

## Test plan

- [x] go vet on threshold-exporter/app/...
- [x] go test on affected tenant-api packages
- [x] Pre-existing failure verified via stash round-trip
- [x] pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)