### PR TITLE
refactor(audit): R3 Go testutil wave 4 — WriteFile + WriteFileMode helpers; tenant-api 100%

### DIFF
--- a/components/tenant-api/internal/handler/tenant_effective_test.go
+++ b/components/tenant-api/internal/handler/tenant_effective_test.go
@@ -20,22 +20,18 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/vencil/tenant-api/internal/testutil"
 	cfg "github.com/vencil/threshold-exporter/pkg/config"
 )
 
-// writeFile is a small helper that mkdirs + writes with test-failure cleanup.
+// writeFile is a thin wrapper kept for call-site brevity; delegates to the
+// shared testutil.WriteFile (mkdir + write).
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
-	}
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
+	testutil.WriteFile(t, path, content)
 }
 
 func TestGetTenantEffective_Success_Flat(t *testing.T) {

--- a/components/tenant-api/internal/testutil/yaml.go
+++ b/components/tenant-api/internal/testutil/yaml.go
@@ -55,3 +55,18 @@ func MkTempYAML(t testing.TB, name, content string) (dir, path string) {
 	path = WriteYAML(t, dir, name, content)
 	return dir, path
 }
+
+// WriteFile writes content to an absolute path, creating parent directories
+// as needed. Returns the path. Use this when the caller already has a
+// pre-computed deep path (e.g. `dir/sub/tenant-x.yaml`) instead of
+// (dir, name) — common in hierarchy / nested-fixture tests.
+func WriteFile(t testing.TB, path, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("WriteFile mkdir %q: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+	return path
+}

--- a/components/threshold-exporter/app/config_dimensional_test.go
+++ b/components/threshold-exporter/app/config_dimensional_test.go
@@ -6,11 +6,11 @@ package main
 // config_test.go.
 
 import (
-	"os"
-	"path/filepath"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/vencil/threshold-exporter/internal/testutil"
 )
 
 // region DimensionalMetrics — label parsing and dimensional resolution
@@ -352,10 +352,7 @@ tenants:
     "oracle_tablespace{tablespace=~\"SYS.*\"}": "95"
 `
 	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
-		t.Fatal(err)
-	}
+	path := testutil.WriteFileMode(t, dir, "config.yaml", content, 0600)
 
 	mgr := NewConfigManager(path)
 	if err := mgr.Load(); err != nil {

--- a/components/threshold-exporter/app/config_hierarchy_test.go
+++ b/components/threshold-exporter/app/config_hierarchy_test.go
@@ -18,18 +18,14 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/vencil/threshold-exporter/internal/testutil"
 )
 
-// writeFile is a test helper that creates the parent dir and writes content.
-// Using a helper keeps the fixture-building code in tests readable.
+// writeFile is a thin wrapper kept for call-site brevity (23 callers in
+// this file); delegates to the shared testutil.WriteFile.
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
-	}
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
+	testutil.WriteFile(t, path, content)
 }
 
 // TestScanDirHierarchical_FlatMode covers the degenerate case of a conf.d/

--- a/components/threshold-exporter/app/config_loaddir_test.go
+++ b/components/threshold-exporter/app/config_loaddir_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/vencil/threshold-exporter/internal/testutil"
 )
 
 // region DirectoryLoading — LoadDir tests and file hashing
@@ -39,10 +40,7 @@ tenants:
     _state_container_crashloop: "disable"
 `
 	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
-		t.Fatal(err)
-	}
+	path := testutil.WriteFileMode(t, dir, "config.yaml", content, 0600)
 
 	mgr := NewConfigManager(path)
 	if err := mgr.Load(); err != nil {

--- a/components/threshold-exporter/app/config_three_state_test.go
+++ b/components/threshold-exporter/app/config_three_state_test.go
@@ -7,12 +7,11 @@ package main
 // config_test.go.
 
 import (
-	"os"
-	"path/filepath"
 	"sort"
 	"testing"
 	"time"
 
+	"github.com/vencil/threshold-exporter/internal/testutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -293,10 +292,7 @@ tenants:
     mysql_connections: "50"
 `
 	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
-		t.Fatal(err)
-	}
+	path := testutil.WriteFileMode(t, dir, "config.yaml", content, 0600)
 
 	mgr := NewConfigManager(path)
 	if err := mgr.Load(); err != nil {

--- a/components/threshold-exporter/app/internal/testutil/yaml.go
+++ b/components/threshold-exporter/app/internal/testutil/yaml.go
@@ -52,3 +52,30 @@ func WriteYAMLBytes(t testing.TB, dir, name string, content []byte) string {
 	}
 	return path
 }
+
+// WriteFileMode is the mode-explicit variant of WriteYAML, for tests that
+// need a specific permission bit (e.g. 0600 for security-sensitive
+// fixtures). Most tests should prefer WriteYAML's 0644 default.
+func WriteFileMode(t testing.TB, dir, name, content string, mode os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatalf("WriteFileMode(%q, %v): %v", name, mode, err)
+	}
+	return path
+}
+
+// WriteFile writes content to an absolute path, creating parent directories
+// as needed. Returns the path. Use this when the caller already has a
+// pre-computed deep path (e.g. `team-a/sub/tenant-x.yaml`) instead of
+// (dir, name) — common in hierarchy / nested-fixture tests.
+func WriteFile(t testing.TB, path, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("WriteFile mkdir %q: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary

Adds two new helper variants identified in PR #315 as wave 4+ scope. Both helpers go into BOTH testutil packages (tenant-api + threshold-exporter) so each module stays self-contained.

**Closes tenant-api at 100% (36/36 sites).** Brings combined R3 to ~71%.

## New helpers

| Helper | Use case |
|---|---|
| \`WriteFile(t, path, content)\` | Full-path version of \`WriteYAML\` that mkdirs the parent. Use when caller already has a deep path (e.g. \`team-a/sub/x.yaml\`). |
| \`WriteFileMode(t, dir, name, content, mode)\` | Mode-explicit variant for tests that need 0o600 (security-sensitive fixtures). Most callers should still prefer \`WriteYAML\`'s 0o644 default. |

## Migrated (5 files; ~30 indirect callers via local helpers)

| File | Migration |
|---|---|
| \`tenant-api/.../tenant_effective_test.go\` | local \`writeFile\` helper → \`testutil.WriteFile\` (5 callers) — **closes the LAST tenant-api site** |
| \`threshold-exporter/.../config_hierarchy_test.go\` | local \`writeFile\` helper → \`testutil.WriteFile\` (23 callers) |
| \`threshold-exporter/.../config_three_state_test.go\` | 1 inline 0o600 site → \`testutil.WriteFileMode\` |
| \`threshold-exporter/.../config_dimensional_test.go\` | 1 inline 0o600 site → \`testutil.WriteFileMode\` |
| \`threshold-exporter/.../config_loaddir_test.go\` | 1 inline 0o600 site → \`testutil.WriteFileMode\` |

## Verification

- \`go vet ./...\` (both modules) → clean
- \`go test ./internal/handler/...\` (tenant-api) → pass
- threshold-exporter test runs blocked by Windows AV \"Access denied\" on test.exe — pre-existing environmental issue, will validate in CI

## Cumulative R3 Go progress

| Module | Sites | % |
|---|---|---|
| **tenant-api** | **36 / ~36** | **100% — closed** ✓ |
| threshold-exporter | 8 / ~26 | ~31% |
| **Combined** | **44 / ~62** | **~71%** |

## Remaining R3 Go scope (threshold-exporter only)

~18 sites across files that need additional helper variants OR have already-fine local helpers:
- Bench files (\`config_bench_test.go\`, \`config_hierarchy_bench_test.go\`) ignore errors — different pattern
- \`config_test.go\` has local \`writeTestFile\` helper (0o600) — wave 5
- \`watchloop_test.go\` has local \`writeTestYAML\` helper (full path, 0o600) — wave 5
- \`cmd/da-{guard,batchpr}/main_test.go\` and \`pkg/config/scope_test.go\` use local helpers in nested-loop fixture setup — wave 5+

## Test plan

- [x] go vet on both modules
- [x] go test on tenant-api/handler (covers tenant_effective)
- [x] threshold-exporter compiles cleanly with new helpers
- [x] pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)