### PR TITLE
refactor(audit): R3 Go testutil wave 5 — WriteFilePathMode + 8 more sites; 52/62 (~84%)

### DIFF
--- a/components/threshold-exporter/app/cmd/da-batchpr/main_test.go
+++ b/components/threshold-exporter/app/cmd/da-batchpr/main_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/vencil/threshold-exporter/internal/testutil"
 )
 
 // --- Dispatcher --------------------------------------------------
@@ -258,12 +260,7 @@ func TestWriteReport_ToFileAndStdout(t *testing.T) {
 
 func mustWriteFile(t *testing.T, path string, body []byte) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(path, body, 0o644); err != nil {
-		t.Fatalf("write %q: %v", path, err)
-	}
+	testutil.WriteFile(t, path, string(body))
 }
 
 func keysOfBytesMap(m map[string][]byte) []string {

--- a/components/threshold-exporter/app/cmd/da-guard/main_test.go
+++ b/components/threshold-exporter/app/cmd/da-guard/main_test.go
@@ -17,6 +17,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/vencil/threshold-exporter/internal/testutil"
 )
 
 // runOnce is the test harness — wraps run() with captured stdout
@@ -28,9 +30,9 @@ func runOnce(t *testing.T, args ...string) (int, string, string) {
 	return code, stdout.String(), stderr.String()
 }
 
-// writeTree replicates the helper from pkg/config/scope_test.go
-// because the cmd package can't import test-only helpers from
-// pkg/config (Go's test isolation rule).
+// writeTree renders a literal directory layout for a single test.
+// (Previously replicated from pkg/config/scope_test.go; both now share
+// testutil.WriteFile for the body-write step.)
 func writeTree(t *testing.T, tmp string, files map[string]string) {
 	t.Helper()
 	for rel, body := range files {
@@ -41,12 +43,7 @@ func writeTree(t *testing.T, tmp string, files map[string]string) {
 			}
 			continue
 		}
-		if err := os.MkdirAll(filepath.Dir(clean), 0o755); err != nil {
-			t.Fatalf("mkdir parent of %q: %v", clean, err)
-		}
-		if err := os.WriteFile(clean, []byte(body), 0o644); err != nil {
-			t.Fatalf("write %q: %v", clean, err)
-		}
+		testutil.WriteFile(t, clean, body)
 	}
 }
 

--- a/components/threshold-exporter/app/config_slow_write_stress_test.go
+++ b/components/threshold-exporter/app/config_slow_write_stress_test.go
@@ -46,6 +46,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/vencil/threshold-exporter/internal/testutil"
 )
 
 // waitForQuiescence polls counterFn until its observed value is
@@ -153,9 +154,7 @@ func TestSlowWriteTornStateStress_FinalConvergence(t *testing.T) {
 		tid := fmt.Sprintf("tenant-%04d", i)
 		path := filepath.Join(dir, "team-a", tid+".yaml")
 		content := fmt.Sprintf("tenants:\n  %s:\n    mysql_connections: \"%d\"\n", tid, 100+i)
-		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-			t.Fatalf("write tenant %s: %v", tid, err)
-		}
+		testutil.WriteFilePathMode(t, path, content, 0o600)
 		// Synthetic fsnotify-equivalent: drive the trigger explicitly so
 		// the test stays deterministic across OS fsnotify implementations.
 		m.triggerDebouncedReload(ReloadReasonSource)

--- a/components/threshold-exporter/app/config_test.go
+++ b/components/threshold-exporter/app/config_test.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/vencil/threshold-exporter/internal/testutil"
 )
 
 // SV is a test helper to create a scalar ScheduledValue.
@@ -57,10 +59,7 @@ tenants:
     mysql_cpu: "40"
 `
 	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
-		t.Fatal(err)
-	}
+	path := testutil.WriteFileMode(t, dir, "config.yaml", content, 0600)
 
 	mgr := NewConfigManager(path)
 	if err := mgr.Load(); err != nil {
@@ -450,12 +449,12 @@ tenants:
 // Helpers
 // ============================================================
 
-// writeTestFile is a helper to create YAML files in test directories.
+// writeTestFile is a thin wrapper kept for call-site brevity (callers in
+// config_silent_mode_test.go and other sibling _test.go files); delegates
+// to the shared testutil.WriteFileMode with the package's 0600 convention.
 func writeTestFile(t *testing.T, dir, name, content string) {
 	t.Helper()
-	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0600); err != nil {
-		t.Fatal(err)
-	}
+	testutil.WriteFileMode(t, dir, name, content, 0600)
 }
 
 // endregion

--- a/components/threshold-exporter/app/internal/testutil/yaml.go
+++ b/components/threshold-exporter/app/internal/testutil/yaml.go
@@ -79,3 +79,17 @@ func WriteFile(t testing.TB, path, content string) string {
 	}
 	return path
 }
+
+// WriteFilePathMode is the mode-explicit + full-path variant. Mkdirs the
+// parent. Combines WriteFile (full path + mkdir) with WriteFileMode (custom
+// permission). Common in security-sensitive fixtures with nested layout.
+func WriteFilePathMode(t testing.TB, path, content string, mode os.FileMode) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("WriteFilePathMode mkdir %q: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatalf("WriteFilePathMode(%q, %v): %v", path, mode, err)
+	}
+	return path
+}

--- a/components/threshold-exporter/app/pkg/config/scope_test.go
+++ b/components/threshold-exporter/app/pkg/config/scope_test.go
@@ -15,6 +15,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/vencil/threshold-exporter/internal/testutil"
 )
 
 // writeTree renders a literal directory layout for a single test.
@@ -30,12 +32,8 @@ func writeTree(t *testing.T, tmp string, files map[string]string) {
 			}
 			continue
 		}
-		if err := os.MkdirAll(filepath.Dir(clean), 0o755); err != nil {
-			t.Fatalf("mkdir parent of %q: %v", clean, err)
-		}
-		if err := os.WriteFile(clean, []byte(body), 0o644); err != nil {
-			t.Fatalf("write %q: %v", clean, err)
-		}
+		// testutil.WriteFile handles the mkdir + write pair below.
+		testutil.WriteFile(t, clean, body)
 	}
 }
 

--- a/components/threshold-exporter/app/watchloop_test.go
+++ b/components/threshold-exporter/app/watchloop_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/vencil/threshold-exporter/internal/testutil"
 )
 
 // ============================================================
@@ -448,9 +450,9 @@ func TestConfigManager_IsLoaded(t *testing.T) {
 // Helper
 // ============================================================
 
+// writeTestYAML wraps testutil.WriteFilePathMode with the package's
+// 0600 mode convention, keeping call sites 2-arg.
 func writeTestYAML(t *testing.T, path, content string) {
 	t.Helper()
-	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
-		t.Fatalf("failed to write %s: %v", path, err)
-	}
+	testutil.WriteFilePathMode(t, path, content, 0600)
 }


### PR DESCRIPTION
## Summary

Adds the third helper variant identified in PR #316 as wave 5 scope, then migrates the remaining non-bench threshold-exporter sites that benefit from it.

Combined R3: **52/62 sites (~84%)**. Remaining 8 sites are all in bench files where the testutil contract doesn't apply (documented below).

## New helper

| Helper | Use case |
|---|---|
| \`WriteFilePathMode(t, path, content, mode)\` | Combines \`WriteFile\` (full path + mkdir) with \`WriteFileMode\` (custom permission). For security-sensitive nested fixtures (e.g. watchloop_test's \`writeTestYAML\`, slow-write-stress's tenant layout under \`team-a/\`). |

## Migrated (7 files; ~8 sites + helper consolidations)

| File | Migration |
|---|---|
| \`watchloop_test.go\` | local \`writeTestYAML\` → \`testutil.WriteFilePathMode\` (full path + 0o600) |
| \`config_slow_write_stress_test.go\` | 1 inline 0o600 site (full path) → \`WriteFilePathMode\` |
| \`config_test.go\` | 1 inline + local \`writeTestFile\` → \`testutil.WriteFileMode\` |
| \`pkg/config/scope_test.go\` | local \`writeTree\` body branch → \`testutil.WriteFile\` |
| \`cmd/da-guard/main_test.go\` | local \`writeTree\` (was duplicating scope_test's helper) → \`testutil.WriteFile\` |
| \`cmd/da-batchpr/main_test.go\` | local \`mustWriteFile\` → \`testutil.WriteFile\` |

## Verification

- \`go vet ./...\` (threshold-exporter/app) → clean
- \`go vet ./...\` (tenant-api) → clean (apart from pre-existing swag issue in \`docs/docs.go\`, unrelated)

## Cumulative R3 Go progress

| Module | Sites | % |
|---|---|---|
| **tenant-api** | **36 / ~36** | **100%** ✓ (closed in #316) |
| threshold-exporter | 16 / ~26 | ~62% |
| **Combined** | **52 / ~62** | **~84%** |

## Remaining R3 scope — bench files only (8 sites)

Documenting wave 5 stopping criterion: **bench helpers that don't fit the t.Fatal contract.**

- \`config_bench_test.go\` (4 sites): errors silently ignored — benchmark fixtures intentionally skip error checks for perf reasons. Not a fit for testutil's t.Fatal-on-error contract.
- \`config_hierarchy_bench_test.go\` (4 sites): inline writes inside setup functions that propagate \`error\` up the call chain — testutil's t.Fatal would short-circuit the propagation. Local \`writeYAMLFile\` helper is fine as-is.

These are intentional non-migrations.

## Test plan

- [x] go vet on both modules
- [x] All migrated files compile cleanly
- [x] Helpers chained correctly (4 layers: \`WriteYAML\` / \`WriteFile\` / \`WriteFileMode\` / \`WriteFilePathMode\`)
- [x] pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)