### PR TITLE
fix(ops): Windows-host test flakes wave 2 — SAST path + mode skips + subprocess encoding (9 fixed)

### DIFF
--- a/tests/shared/test_lib_python.py
+++ b/tests/shared/test_lib_python.py
@@ -17,11 +17,21 @@ import json
 import os
 import pathlib
 import stat
+import sys
 import tempfile
 from unittest.mock import patch, MagicMock
 
 import pytest
 import urllib.error
+
+# Some tests assert exact Unix mode bits (0o600). Windows NTFS doesn't
+# honor those — chmod() is a no-op and stat returns 0o666. The relevant
+# tests skip when sys.platform == "win32" so local Windows runs match
+# CI Linux on test-count, with this marker as the centralized opt-in.
+_skipif_unix_modes = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows NTFS doesn't honor Unix mode bits; chmod is a no-op",
+)
 
 import _lib_python as lib
 from factories import mock_http_response
@@ -640,6 +650,7 @@ class TestWriteTextSecure:
         lib.write_text_secure(path, "hello world")
         assert pathlib.Path(path).read_text(encoding="utf-8") == "hello world"
 
+    @_skipif_unix_modes
     def test_permissions_0o600(self, tmp_path):
         """寫入檔案權限為 0o600。"""
         path = str(tmp_path / "secure.txt")
@@ -662,6 +673,7 @@ class TestWriteTextSecure:
         lib.write_text_secure(path, "v2")
         assert pathlib.Path(path).read_text(encoding="utf-8") == "v2"
 
+    @_skipif_unix_modes
     def test_empty_string(self, tmp_path):
         """空字串寫入產生空檔案。"""
         path = str(tmp_path / "empty.txt")
@@ -684,6 +696,7 @@ class TestWriteJsonSecure:
         content = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
         assert content == {"key": "value", "count": 42}
 
+    @_skipif_unix_modes
     def test_permissions_0o600(self, tmp_path):
         """寫入檔案權限為 0o600。"""
         path = str(tmp_path / "secure.json")

--- a/tests/shared/test_pipeline_integration.py
+++ b/tests/shared/test_pipeline_integration.py
@@ -14,6 +14,18 @@ import pytest
 TOOLS_DIR = Path(__file__).parent.parent.parent / "scripts" / "tools"
 
 
+def _utf8_env():
+    """Force UTF-8 stderr/stdout in the child process.
+
+    Without this, Python on Windows defaults stderr to the console code
+    page (CP950 / CP932 / CP1252 depending on locale). When the child
+    emits Chinese strings (which scaffold/validate do for human-readable
+    diagnostics), the bytes can't be decoded as UTF-8 in the test, causing
+    UnicodeDecodeError. Setting PYTHONIOENCODING is the canonical fix.
+    """
+    return {**os.environ, "PYTHONIOENCODING": "utf-8"}
+
+
 @pytest.fixture
 def work_dir(tmp_path):
     """Create a temporary working directory."""
@@ -29,12 +41,13 @@ class TestPipelineIntegration:
             [sys.executable, str(TOOLS_DIR / "ops" / "scaffold_tenant.py"),
              "--tenant", "test-db", "--db", "mariadb",
              "--non-interactive", "--output-dir", str(work_dir)],
-            capture_output=True, timeout=30, cwd=str(work_dir)
+            capture_output=True, timeout=30, cwd=str(work_dir),
+            env=_utf8_env(), text=True, encoding="utf-8", errors="replace",
         )
         # scaffold may exit 0 or print to stdout
         assert result.returncode == 0, (
             f"scaffold failed with exit code {result.returncode}\n"
-            f"stderr: {result.stderr.decode()[:300]}"
+            f"stderr: {result.stderr[:300]}"
         )
         # Check that a YAML file was created
         yaml_files = list(work_dir.glob("**/*.yaml")) + list(work_dir.glob("**/*.yml"))
@@ -56,12 +69,13 @@ class TestPipelineIntegration:
         result = subprocess.run(
             [sys.executable, str(TOOLS_DIR / "ops" / "validate_config.py"),
              "--config-dir", str(conf_dir)],
-            capture_output=True, timeout=30
+            capture_output=True, timeout=30,
+            env=_utf8_env(), text=True, encoding="utf-8", errors="replace",
         )
         # validate-config should succeed on valid minimal config
         assert result.returncode == 0, (
             f"validate-config failed with exit code {result.returncode}\n"
-            f"stderr: {result.stderr.decode()[:300]}"
+            f"stderr: {result.stderr[:300]}"
         )
 
     def test_scaffold_then_validate_pipeline(self, work_dir):
@@ -71,10 +85,11 @@ class TestPipelineIntegration:
             [sys.executable, str(TOOLS_DIR / "ops" / "scaffold_tenant.py"),
              "--tenant", "pipeline-test-db", "--db", "mariadb",
              "--non-interactive", "--output-dir", str(work_dir)],
-            capture_output=True, timeout=30, cwd=str(work_dir)
+            capture_output=True, timeout=30, cwd=str(work_dir),
+            env=_utf8_env(), text=True, encoding="utf-8", errors="replace",
         )
         assert scaffold_result.returncode == 0, (
-            f"scaffold failed: {scaffold_result.stderr.decode()[:300]}"
+            f"scaffold failed: {scaffold_result.stderr[:300]}"
         )
 
         # Find the generated config directory
@@ -86,9 +101,10 @@ class TestPipelineIntegration:
         validate_result = subprocess.run(
             [sys.executable, str(TOOLS_DIR / "ops" / "validate_config.py"),
              "--config-dir", str(config_dir)],
-            capture_output=True, timeout=30
+            capture_output=True, timeout=30,
+            env=_utf8_env(), text=True, encoding="utf-8", errors="replace",
         )
         assert validate_result.returncode == 0, (
             f"validate-config failed on scaffolded config: "
-            f"{validate_result.stderr.decode()[:300]}"
+            f"{validate_result.stderr[:300]}"
         )

--- a/tests/shared/test_sast.py
+++ b/tests/shared/test_sast.py
@@ -40,8 +40,13 @@ def _read_source(path):
 
 
 def _short_path(path):
-    """回傳相對於 repo root 的短路徑。"""
-    return os.path.relpath(path, REPO_ROOT)
+    """回傳相對於 repo root 的短路徑（永遠用 forward-slash）。
+
+    Windows 上 os.path.relpath 會回傳 backslash 路徑，但 CHMOD_EXEMPT 的
+    key 一律是 forward-slash（POSIX 慣例）。為了讓 `short in CHMOD_EXEMPT`
+    在所有 OS 上一致，這裡顯式 normalize 到 forward-slash。
+    """
+    return os.path.relpath(path, REPO_ROOT).replace(os.sep, "/")
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

Continuation of #319. Closes the remaining 9 Windows-host test failures documented in that PR's \"still pre-existing\" list. After this PR, the known Windows-host flake count drops from 9 → 0 in \`tests/shared/\`.

## Three more classes of fix

### ⓵ Path separator in SAST exemption lookup (4 tests, **test fix**)

\`tests/shared/test_sast.py::_short_path\` used \`os.path.relpath\` which returns backslashes on Windows. \`CHMOD_EXEMPT\` keys are forward-slash (POSIX convention). Lookup \`short in CHMOD_EXEMPT\` always failed on Windows even for files that ARE in EXEMPT. Production code is fine; the test's path normalization had a Windows-specific bug.

**Fix**: \`os.path.relpath(...).replace(os.sep, \"/\")\` so lookups match regardless of OS.

### ⓶ Unix mode-bit assertions in lib_python (3 tests, targeted skips)

Same pattern as #319's mode-bit skips:

- \`TestWriteTextSecure::test_permissions_0o600\`
- \`TestWriteTextSecure::test_empty_string\` (also asserts mode)
- \`TestWriteJsonSecure::test_permissions_0o600\`

Centralized the marker as \`_skipif_unix_modes\` at file top so future mode-asserting tests in this file can opt in with one decorator.

### ⓷ Subprocess UnicodeDecodeError on Windows console codepage (2 tests)

\`tests/shared/test_pipeline_integration.py\` runs \`scaffold_tenant.py\` + \`validate_config.py\` as subprocesses and decodes stderr. The child processes emit Chinese diagnostic strings; on Windows the child defaults stderr to the console codepage (CP950 / CP932 / CP1252) so non-UTF-8 bytes hit \`result.stderr.decode()\` and crash with \`UnicodeDecodeError\`.

**Fix**: pass \`env={**os.environ, \"PYTHONIOENCODING\": \"utf-8\"}\` to force the child to emit UTF-8, plus \`text=True, encoding=\"utf-8\", errors=\"replace\"\` on the parent for defense-in-depth. Local helper \`_utf8_env()\` factored at file top.

## Verification

| Scope | Before | After |
|---|---|---|
| Targeted (4 affected files) | 1099 passed, 9 failed | **1105 passed, 3 skipped** |
| Wider sweep | (verified pre-existing failures unrelated via stash round-trip) | 0 new regressions |

The remaining Windows-host failures (~7 in \`test_preflight_marker.py\`) are bash-script-driven tests that don't apply to Windows environments without Git Bash semantics. **Out of scope for the audit.**

## Cumulative Windows-host fixes (this session)

| | PR | Tests fixed |
|---|---|---|
| Wave 1 | #319 | 9 (path / CSV / mode-skip) |
| Wave 2 | this | 9 (SAST path / mode-skip / subprocess encoding) |
| **Total** | | **18** |

## What this advances

Audit ⑥ \"Legacy\" dimension: ~75% → ~85%. Local Windows dev now matches CI Linux on 18 more tests across this session.

## Test plan

- [x] All 9 previously-failing tests now pass or skip cleanly on Windows
- [x] CI Linux still runs all tests (skip only triggers on \`sys.platform == 'win32'\`)
- [x] No new regressions in 1105-test targeted sweep
- [x] pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)