### PR TITLE
fix(lint): pre-commit JSX hooks were dead — paths still pointed at docs/

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -329,7 +329,7 @@ repos:
         entry: python3 -X utf8 scripts/tools/lint/lint_jsx_babel.py --ci
         language: python
         pass_filenames: false
-        files: ^docs/(interactive/tools|getting-started)/.*\.jsx$
+        files: ^tools/portal/src/(interactive/tools|getting-started)/.*\.jsx$
         # Promoted from manual → auto (docs/harness-hardening):
         # catches NUL bytes, browser-mode Babel incompatibilities, and
         # broken JSX syntax before they reach HEAD. Skips silently if
@@ -340,7 +340,7 @@ repos:
         entry: python3 -X utf8 scripts/tools/lint/lint_jsx_babel.py --ci --strict-linecount
         language: python
         pass_filenames: false
-        files: ^docs/(interactive/tools|getting-started)/.*\.jsx$
+        files: ^tools/portal/src/(interactive/tools|getting-started)/.*\.jsx$
         # Auto-stage (NOT manual) — runs on every commit to catch
         # line-count regressions immediately. Locks in the progress
         # from PR-2d (#153 Phase 1+2+3 / S#69-S#72): codebase had 0
@@ -403,7 +403,7 @@ repos:
         entry: python3 -X utf8 scripts/tools/lint/check_i18n_coverage.py
         language: python
         pass_filenames: false
-        files: ^(docs/(interactive/tools|getting-started)/.*\.jsx|rule-packs/.*\.yaml|scripts/tools/.*\.py|components/da-tools/app/entrypoint\.py)$
+        files: ^(tools/portal/src/(interactive/tools|getting-started)/.*\.jsx|rule-packs/.*\.yaml|scripts/tools/.*\.py|components/da-tools/app/entrypoint\.py)$
         stages: [manual]
         additional_dependencies: ['pyyaml']
 
@@ -444,7 +444,7 @@ repos:
         entry: python3 -X utf8 scripts/tools/lint/check_portal_i18n.py --ci
         language: system
         pass_filenames: false
-        files: ^docs/(interactive/tools|getting-started)/.*\.jsx$
+        files: ^tools/portal/src/(interactive/tools|getting-started)/.*\.jsx$
         stages: [manual]
 
       - id: orphan-doc-check
@@ -561,7 +561,7 @@ repos:
         entry: python3 -X utf8 scripts/tools/lint/check_window_x_no_fallback.py --ci
         language: python
         pass_filenames: false
-        files: ^docs/(interactive|getting-started)/.*\.(jsx|js)$
+        files: ^tools/portal/src/(interactive|getting-started)/.*\.(jsx|js)$
         # Auto-stage, FATAL on findings. Codebase audit at scaffold time
         # showed 0 violations (TD-033/034 cleared all instances). Per-line
         # escape via `<!-- window-x-no-fallback: ignore -->` for legitimate

--- a/scripts/tools/lint/lint_jsx_babel.py
+++ b/scripts/tools/lint/lint_jsx_babel.py
@@ -56,8 +56,12 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 
 JSX_DIRS = [
-    PROJECT_ROOT / "docs" / "interactive" / "tools",
-    PROJECT_ROOT / "docs" / "getting-started",
+    # JSX source moved from docs/(interactive|getting-started)/ to
+    # tools/portal/src/* during the portal Vite/esbuild reorg
+    # (TD-030). The dist bundle ends up under docs/assets/dist/,
+    # but the scanner targets the readable source.
+    PROJECT_ROOT / "tools" / "portal" / "src" / "interactive" / "tools",
+    PROJECT_ROOT / "tools" / "portal" / "src" / "getting-started",
 ]
 
 NODE_SCRIPT = r"""


### PR DESCRIPTION
## Summary

5 pre-commit hooks declared \`files: ^docs/(interactive/tools|getting-started)/.*\.jsx\$\` but JSX source moved to \`tools/portal/src/\` during the TD-030 portal Vite/esbuild reorg. Result: those hooks **never fire on JSX changes** — they're dead gates that show \"Skipped (no files to check)\" in every commit.

## Hooks restored

| Hook | Stage | Purpose |
|---|---|---|
| \`jsx-babel-check\` | auto | Babel parse validation |
| \`jsx-babel-check-strict-linecount\` | auto | Line-count regression gate |
| \`window-x-no-fallback-check\` | auto, FATAL | TD-037 \`window.__X\` no-fallback rule |
| \`i18n-coverage-check\` | manual | i18n coverage report |
| \`check-portal-i18n\` | manual | Portal JSX i18n coverage |

\`scripts/tools/lint/lint_jsx_babel.py\` had its own \`JSX_DIRS\` pointing at the same stale paths; updated those too. The other 3 lint scripts (\`check_i18n_coverage\`, \`check_portal_i18n\`, \`check_window_x_no_fallback\`) already targeted \`tools/portal/src/\` internally — they were running against the right files but only when the pre-commit \`files:\` filter let them in, which it never did because of the stale path.

## Discovery

Spotted while looking up axe-lite-static's neighbor hooks during PR #318 review. Verified by running \`lint_jsx_babel.py --ci\` directly: the script reported **\"no JSX files found\"** on Windows (and crashed with UnicodeEncodeError on the success symbol — separate cp950 issue unrelated to this PR).

## Verification

| Hook | Run |
|---|---|
| \`jsx-babel-check\` | Passed |
| \`jsx-babel-check-strict-linecount\` | Passed |
| \`window-x-no-fallback-check\` | Passed |
| \`i18n-coverage-check\` (manual) | Passed |
| \`check-portal-i18n\` (manual) | Passed |
| \`dev-rules-enforcement-check\` | Passed (drift check between dev-rules.md ↔ pre-commit config still clean after path edits) |

All 5 hooks now find **56 JSX files** (was 0); current code is clean — no new violations surfaced. Hooks are now actually enforcing the gates they document.

## What this advances

Audit ⑥ \"Legacy\" → ~85% → ~88%. Closes 5 silent-gates: the linters were producing 0 output on every CI run because no input was reaching them. Future regressions in JSX a11y / Babel parse / line-count / i18n / window-X-fallback now trip the hooks at commit time as originally designed.

**Caveat**: \`lint_jsx_babel.py\` reports 350 static \`style={{ }}\` warnings (non-fatal under \`--strict-linecount\`); this matches the pre-PR-#160 backlog noted in the hook's inline comment. Cleaning that backlog and flipping \`--strict-static\` is a separate cleanup track.

## Test plan

- [x] All 5 hooks run cleanly on \`--all-files\`
- [x] Drift check between dev-rules.md ↔ pre-commit config stays clean
- [x] No new violations surfaced
- [x] pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)