### PR TITLE
chore(dx): make test-fast — full-suite local pytest with xdist (-n auto)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -700,6 +700,18 @@ bump-docs: ## 更新版號引用 (使用: make bump-docs PLATFORM=0.10.0 TOOLS=0
 test: ## 執行 Python 單元測試 (pytest)
 	@python3 -m pytest tests/ -v --tb=short $(ARGS)
 
+.PHONY: test-fast
+test-fast: ## 全套 pytest 平行加速（xdist -n auto，~2-3x；CI 同設定）
+	## Local full-suite run with pytest-xdist parallelism. Matches CI's
+	## .github/workflows/ci.yml step (-n auto). Typical wall-clock on a
+	## 4-core dev box: ~50-60s vs ~130s sequential. Skip for targeted
+	## runs (single-test / single-file) — xdist startup overhead (~2s)
+	## makes those slower, not faster.
+	##
+	## Sequential default (`make test`) stays as the friendly path for
+	## debugging (works with pdb, deterministic test order).
+	@python3 -m pytest tests/ -n auto --tb=short $(ARGS)
+
 .PHONY: coverage
 coverage: ## 測試覆蓋率報告 (使用: make coverage ARGS="--html" 產生 HTML)
 	@python3 -m pytest tests/ \


### PR DESCRIPTION
## Summary

Local pytest currently runs sequentially (~130s wall-clock for ~6300 tests on this dev box). CI already uses pytest-xdist via \`.github/workflows/ci.yml\` step (\`-n auto\`), so the test suite is empirically parallel-safe. This adds a Makefile target that gives local devs the same speedup without changing default behavior.

## Numbers (this Windows host, 4-core)

| Target | Wall-clock | Speedup |
|---|---|---|
| \`make test\` | **~130s** (sequential, current default) | 1× |
| \`make test-fast\` (this PR) | **~55s** (xdist -n auto) | **~2.4×** |
| CI Ubuntu (already on -n auto) | ~30s | 4× |

## Why a separate target, not pyproject.toml addopts

Adding \`-n auto\` to global addopts would penalize **targeted** runs (single-test, single-file) — xdist startup costs ~2s, so a 0.5s test becomes 2.5s. Most local pytest invocations are targeted (during debugging, TDD loops). Keeping default sequential preserves fast feedback for those, while \`make test-fast\` opts in for full-suite runs where the speedup matters.

## What stays the same

- \`make test\` — unchanged; sequential, friendly to pdb
- \`pytest <file>::<test_id>\` — unchanged; targeted runs unaffected

## What this advances

Audit ⑤ \"Speed\" advances: documents the local fast path that was implicit in CI but missing locally. CLAUDE.md's claim of \"xdist already (-n auto)\" was true for CI but the local invocation didn't pick it up. Now the discoverable path matches.

## Test plan

- [x] \`make test-fast\` runs full suite in ~55s (vs ~130s sequential)
- [x] Same pass/fail population as sequential (verified across 2 runs)
- [x] \`make test\` unchanged
- [x] No pyproject.toml change → targeted pytest invocations unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)