### PR TITLE
test(audit): property + mutation pilot batch 2 — 4 more functions, 20/21 caught (~95%)

### DIFF
--- a/tests/shared/_mutation_pilot.py
+++ b/tests/shared/_mutation_pilot.py
@@ -174,6 +174,74 @@ MUTATIONS: list[Mutation] = [
         old="        if m not in builtin_funcs and not m[0].isupper():",
         new="        if m not in builtin_funcs:",
     ),
+    # ── parse_duration_seconds (_lib_validation) ──────────────────
+    Mutation(
+        target_file="scripts/tools/_lib_validation.py",
+        test_file="tests/shared/test_property_tools.py tests/shared/test_lib_python.py",
+        label="duration: drop float from numeric pass-through (only int)",
+        fn_name="parse_duration_seconds",
+        old="    if isinstance(value, (int, float)):\n        return int(value)",
+        new="    if isinstance(value, int):\n        return int(value)",
+    ),
+    Mutation(
+        target_file="scripts/tools/_lib_validation.py",
+        test_file="tests/shared/test_property_tools.py tests/shared/test_lib_python.py",
+        label="duration: drop type-check (let m.match raise on non-string)",
+        fn_name="parse_duration_seconds",
+        old="    if not value or not isinstance(value, str):\n        return None",
+        new="    if not value:\n        return None",
+    ),
+    # ── format_duration (_lib_validation) ─────────────────────────
+    Mutation(
+        target_file="scripts/tools/_lib_validation.py",
+        test_file="tests/shared/test_property_tools.py tests/shared/test_lib_python.py",
+        label="format: drop modulo check (3600s+1 wrongly emits 'h' rounded)",
+        fn_name="format_duration",
+        old="    if seconds >= 3600 and seconds % 3600 == 0:",
+        new="    if seconds >= 3600:",
+    ),
+    Mutation(
+        target_file="scripts/tools/_lib_validation.py",
+        test_file="tests/shared/test_property_tools.py tests/shared/test_lib_python.py",
+        label="format: drop minute-modulo check (61s wrongly emits 'm')",
+        fn_name="format_duration",
+        old="    if seconds >= 60 and seconds % 60 == 0:",
+        new="    if seconds >= 60:",
+    ),
+    # ── is_disabled (_lib_validation) ─────────────────────────────
+    Mutation(
+        target_file="scripts/tools/_lib_validation.py",
+        test_file="tests/shared/test_property_tools.py tests/shared/test_lib_python.py",
+        label="is_disabled: drop case-folding (.lower() removed)",
+        fn_name="is_disabled",
+        old="    return value.strip().lower() in _DISABLED_VALUES",
+        new="    return value.strip() in _DISABLED_VALUES",
+    ),
+    Mutation(
+        target_file="scripts/tools/_lib_validation.py",
+        test_file="tests/shared/test_property_tools.py tests/shared/test_lib_python.py",
+        label="is_disabled: drop whitespace strip",
+        fn_name="is_disabled",
+        old="    return value.strip().lower() in _DISABLED_VALUES",
+        new="    return value.lower() in _DISABLED_VALUES",
+    ),
+    # ── validate_and_clamp (_lib_validation) ──────────────────────
+    Mutation(
+        target_file="scripts/tools/_lib_validation.py",
+        test_file="tests/shared/test_property_tools.py tests/shared/test_lib_python.py",
+        label="clamp: invert lower-bound check (< → <=)",
+        fn_name="validate_and_clamp",
+        old="    if seconds < min_sec:",
+        new="    if seconds <= min_sec:",
+    ),
+    Mutation(
+        target_file="scripts/tools/_lib_validation.py",
+        test_file="tests/shared/test_property_tools.py tests/shared/test_lib_python.py",
+        label="clamp: invert upper-bound check (> → >=)",
+        fn_name="validate_and_clamp",
+        old="    if seconds > max_sec:",
+        new="    if seconds >= max_sec:",
+    ),
 ]
 
 

--- a/tests/shared/test_lib_python.py
+++ b/tests/shared/test_lib_python.py
@@ -617,6 +617,7 @@ class TestOnboardHintsRoundTrip:
         assert os.path.isfile(path)
         assert path.endswith("onboard-hints.json")
 
+    @_skipif_unix_modes
     def test_write_file_permissions(self, config_dir):
         """寫入檔案權限為 0o600（SAST 規範）。"""
         path = lib.write_onboard_hints(str(config_dir), {"x": 1})

--- a/tests/shared/test_property_tools.py
+++ b/tests/shared/test_property_tools.py
@@ -47,6 +47,7 @@ from hypothesis import strategies as st
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
     os.path.abspath(__file__))))
 for _path in (
+    os.path.join(_REPO_ROOT, "scripts", "tools"),
     os.path.join(_REPO_ROOT, "scripts", "tools", "ops"),
     os.path.join(_REPO_ROOT, "scripts", "tools", "dx"),
 ):
@@ -57,6 +58,7 @@ for _path in (
 import generate_rule_pack_split as grps  # noqa: E402
 import generate_doc_map as gdm  # noqa: E402
 import generate_changelog as gc  # noqa: E402
+import _lib_validation as lv  # noqa: E402
 
 
 # Hypothesis settings: keep the example budget tight so this file runs
@@ -304,3 +306,213 @@ class TestParseCommitProperties:
         result = gc.parse_commit(subject)
         if result is not None:
             assert result["breaking"] is True
+
+
+# ---------------------------------------------------------------------------
+# parse_duration_seconds — Prometheus-style duration parser
+# ---------------------------------------------------------------------------
+# Pilot extension batch 2 (paired with mutation pilot extension): four pure
+# functions in _lib_validation.py that drive timing guardrails throughout
+# the platform. Each function gets property tests here AND mutation entries
+# in tests/shared/_mutation_pilot.py. Together they pin parse↔format
+# round-trip, monotonicity, idempotency, and clamp invariants.
+class TestParseDurationSecondsProperties:
+
+    @given(st.integers(min_value=0, max_value=10**6))
+    @PILOT_SETTINGS
+    def test_int_input_returned_as_int(self, n):
+        # Property: int input passes through as int.
+        result = lv.parse_duration_seconds(n)
+        assert result == n
+        assert isinstance(result, int)
+
+    @given(st.floats(min_value=0, max_value=1e6, allow_nan=False, allow_infinity=False))
+    @PILOT_SETTINGS
+    def test_float_input_truncated_to_int(self, x):
+        # Property: float input is converted via int() (truncation).
+        result = lv.parse_duration_seconds(x)
+        assert result == int(x)
+        assert isinstance(result, int)
+
+    @given(st.one_of(
+        st.none(),
+        st.text(alphabet=string.ascii_letters + " ", min_size=0, max_size=20),
+        st.lists(st.integers(), max_size=3),
+        st.dictionaries(st.text(), st.text(), max_size=2),
+    ))
+    @PILOT_SETTINGS
+    def test_invalid_input_returns_none(self, junk):
+        # Property: anything that isn't a duration string or numeric → None.
+        # The text strategy is constrained to alphabet only (no digits) so
+        # it can't accidentally produce a valid duration.
+        result = lv.parse_duration_seconds(junk)
+        assert result is None
+
+    @given(st.sampled_from([
+        ("5s", 5), ("30s", 30), ("60s", 60),
+        ("1m", 60), ("5m", 300),
+        ("1h", 3600), ("4h", 14400),
+        ("1d", 86400),
+    ]))
+    @PILOT_SETTINGS
+    def test_known_durations(self, kv):
+        # Property: well-known examples from the docstring.
+        s, expected = kv
+        assert lv.parse_duration_seconds(s) == expected
+
+    @given(st.integers(min_value=1, max_value=1000))
+    @PILOT_SETTINGS
+    def test_seconds_unit_monotonic(self, n):
+        # Property: more seconds (same unit) → larger output.
+        a = lv.parse_duration_seconds(f"{n}s")
+        b = lv.parse_duration_seconds(f"{n + 1}s")
+        assert a is not None and b is not None
+        assert b > a
+
+
+# ---------------------------------------------------------------------------
+# format_duration — seconds → "Ns" / "Nm" / "Nh"
+# ---------------------------------------------------------------------------
+class TestFormatDurationProperties:
+
+    @given(st.integers(min_value=0, max_value=10**6))
+    @PILOT_SETTINGS
+    def test_output_ends_in_smh(self, n):
+        # Property: output suffix is always s, m, or h (never d).
+        out = lv.format_duration(n)
+        assert out[-1] in ("s", "m", "h")
+        assert "d" not in out, f"format_duration({n}) emitted day unit: {out!r}"
+
+    @given(st.integers(min_value=0, max_value=10**6))
+    @PILOT_SETTINGS
+    def test_round_trip_via_parse(self, n):
+        # Property: format → parse round-trips.
+        formatted = lv.format_duration(n)
+        parsed = lv.parse_duration_seconds(formatted)
+        assert parsed == n, (
+            f"round-trip failed: {n} → {formatted!r} → {parsed}"
+        )
+
+    @given(st.integers(min_value=1, max_value=3599))
+    @PILOT_SETTINGS
+    def test_sub_hour_uses_minute_or_second(self, n):
+        # Property: values < 3600 never use 'h' (no whole hours present).
+        out = lv.format_duration(n)
+        assert not out.endswith("h"), (
+            f"format_duration({n}) chose hour unit despite n<3600: {out!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# is_disabled — three-state disabled detection
+# ---------------------------------------------------------------------------
+class TestIsDisabledProperties:
+
+    @given(st.sampled_from(["disable", "disabled", "off", "false"]))
+    @PILOT_SETTINGS
+    def test_canonical_values_disabled(self, val):
+        assert lv.is_disabled(val) is True
+
+    @given(st.sampled_from(["disable", "disabled", "off", "false"]))
+    @PILOT_SETTINGS
+    def test_case_insensitive(self, val):
+        # Property: case doesn't matter.
+        assert lv.is_disabled(val.upper()) is True
+        assert lv.is_disabled(val.title()) is True
+
+    @given(
+        st.sampled_from(["disable", "disabled", "off", "false"]),
+        st.text(alphabet=" \t", min_size=0, max_size=5),
+        st.text(alphabet=" \t", min_size=0, max_size=5),
+    )
+    @PILOT_SETTINGS
+    def test_whitespace_stripped(self, val, lpad, rpad):
+        # Property: leading/trailing whitespace is stripped.
+        assert lv.is_disabled(lpad + val + rpad) is True
+
+    @given(st.one_of(
+        st.none(),
+        st.integers(),
+        st.lists(st.text()),
+        st.dictionaries(st.text(), st.text()),
+    ))
+    @PILOT_SETTINGS
+    def test_non_string_returns_false(self, junk):
+        # Property: non-string input always returns False.
+        assert lv.is_disabled(junk) is False
+
+    @given(st.text(alphabet=string.ascii_letters,
+                   min_size=1, max_size=15).filter(
+                       lambda s: s.strip().lower()
+                                  not in {"disable", "disabled", "off", "false"}))
+    @PILOT_SETTINGS
+    def test_arbitrary_strings_not_disabled(self, s):
+        # Property: any string that ISN'T one of the canonical disable
+        # values returns False.
+        assert lv.is_disabled(s) is False
+
+
+# ---------------------------------------------------------------------------
+# validate_and_clamp — guardrail enforcement on timing parameters
+# ---------------------------------------------------------------------------
+class TestValidateAndClampProperties:
+
+    @given(
+        st.text(alphabet=string.ascii_letters + "_",
+                min_size=1, max_size=20).filter(
+                    lambda s: s not in
+                              {"group_wait", "group_interval", "repeat_interval"}),
+        st.integers(min_value=0, max_value=10**5),
+    )
+    @PILOT_SETTINGS
+    def test_unknown_param_passes_through_unchanged(self, param, value):
+        # Property: any param not in GUARDRAILS returns input unchanged
+        # with empty warnings.
+        clamped, warnings = lv.validate_and_clamp(param, value, "test-tenant")
+        assert clamped == value
+        assert warnings == []
+
+    @given(st.sampled_from([
+        ("group_wait", "30s"),
+        ("group_interval", "5m"),
+        ("repeat_interval", "4h"),
+    ]))
+    @PILOT_SETTINGS
+    def test_in_bounds_value_unchanged(self, kv):
+        # Property: a value within [min, max] passes through unchanged.
+        param, value = kv
+        clamped, warnings = lv.validate_and_clamp(param, value, "test-tenant")
+        assert clamped == value
+        assert warnings == []
+
+    @given(st.sampled_from([
+        ("group_wait", "1s"),       # below 5s min
+        ("group_interval", "1s"),   # below 5s min
+        ("repeat_interval", "10s"), # below 60s min
+    ]))
+    @PILOT_SETTINGS
+    def test_below_min_clamped_to_min(self, kv):
+        # Property: values below min get clamped to the min, with a warning.
+        from _lib_constants import GUARDRAILS
+        param, value = kv
+        clamped, warnings = lv.validate_and_clamp(param, value, "test-tenant")
+        min_sec = GUARDRAILS[param][0]
+        assert lv.parse_duration_seconds(clamped) == min_sec
+        assert len(warnings) == 1
+        assert "below minimum" in warnings[0]
+
+    @given(st.sampled_from([
+        ("group_wait", "10m"),       # above 300s max
+        ("group_interval", "10m"),   # above 300s max
+        ("repeat_interval", "100h"), # above 259200s max (72h)
+    ]))
+    @PILOT_SETTINGS
+    def test_above_max_clamped_to_max(self, kv):
+        # Property: values above max get clamped to the max, with a warning.
+        from _lib_constants import GUARDRAILS
+        param, value = kv
+        clamped, warnings = lv.validate_and_clamp(param, value, "test-tenant")
+        max_sec = GUARDRAILS[param][1]
+        assert lv.parse_duration_seconds(clamped) == max_sec
+        assert len(warnings) == 1
+        assert "above maximum" in warnings[0]


### PR DESCRIPTION
## Summary

Continuation of #302 (property pilot, 4 fns) + #312 (mutation pilot, 4 fns). Extends both methodologies to cover 4 more pure functions in \`scripts/tools/_lib_validation.py\`:

- \`parse_duration_seconds\`
- \`format_duration\`
- \`is_disabled\`
- \`validate_and_clamp\`

These four are the timing-guardrail / disabled-state core used throughout the platform's threshold/routing logic — high-leverage mutation targets.

## Property tests added (17 new in \`TestProperty*\` classes)

| Class | Tests | What it pins |
|---|---|---|
| \`TestParseDurationSecondsProperties\` | 5 | int/float pass-through, invalid→None, known examples, monotonicity |
| \`TestFormatDurationProperties\` | 3 | output unit always s/m/h (never d), parse∘format=id, sub-hour never uses 'h' |
| \`TestIsDisabledProperties\` | 5 | canonical values, case-insensitive, whitespace strip, non-string→False, arbitrary→False |
| \`TestValidateAndClampProperties\` | 4 | unknown param pass-through, in-bounds unchanged, below-min clamped, above-max clamped |

## Mutation entries added (8 new)

| Function | Mutation | Catches |
|---|---|---|
| \`parse_duration_seconds\` | drop float numeric pass-through | int-vs-float distinction |
| \`parse_duration_seconds\` | drop type-check (let regex raise) | non-string handling |
| \`format_duration\` | drop hour-modulo (\`>= 3600\` only) | round-trip via parse |
| \`format_duration\` | drop minute-modulo (\`>= 60\` only) | round-trip via parse |
| \`is_disabled\` | drop case-folding | case-insensitivity |
| \`is_disabled\` | drop whitespace strip | strip semantics |
| \`validate_and_clamp\` | invert lower-bound (\`<\` → \`<=\`) | boundary handling |
| \`validate_and_clamp\` | invert upper-bound (\`>\` → \`>=\`) | boundary handling |

## Mutation results

Cumulative pilot now: **21 mutations across 8 functions**.

- **20/21 CAUGHT (~95% mutation score)**
- 1 SURVIVED — equivalent mutation in \`_parse_front_matter\`, documented in #312; redundant early-out (regex below catches it)

All 8 NEW mutations on \`_lib_validation.py\` are caught by the combination of existing \`tests/shared/test_lib_python.py\` + new property tests in \`TestProperty*\` classes. **No new test gaps surfaced** — the existing unit suite + new property tests are jointly mutation-resistant.

## Side fix — Windows-host file-mode skip

\`TestOnboardHintsRoundTrip::test_write_file_permissions\` also asserts exact 0o600 mode bits. Same Windows-NTFS pitfall as #320; missed it in that PR's sweep. Adding \`_skipif_unix_modes\` here closes the gap.

## Verification

\`\`\`
python tests/shared/_mutation_pilot.py
  → 20/21 caught, 1 SURVIVED (documented equivalent), 0 setup-fails

pytest tests/shared/test_property_tools.py tests/shared/test_lib_python.py
  → 143 passed, 4 skipped (3 platform-mode skips + 1 pre-existing)
\`\`\`

## What this advances

Audit ④ \"Better Methods\" dimension: ~50% → ~60%.

| | Before | After |
|---|---|---|
| Property-based functions | 4 | **8** |
| Mutation pilot functions | 4 | **8** |
| Mutations crafted | 13 | **21** |
| Mutation score | 92% | **95%** |

Both methodologies now demonstrated on critical-path validation code (timing guardrails), not just doc/changelog parsers.

## Test plan

- [x] All 17 new property tests pass
- [x] Mutation pilot reports 20/21 caught
- [x] Surviving mutation is the previously-documented equivalent (not a real gap)
- [x] Side fix for Windows-host test_write_file_permissions
- [x] pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)