### PR TITLE
chore(lint): HA-10 observability — flaky-tests.yaml validator + expire_at gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -161,6 +161,19 @@ repos:
         # pass_filenames: true (default) — only re-scans the JSX files
         # touched by the commit, keeping the hook fast (<100ms typical).
 
+      # HA-10 observability layer (PR #325/#326 follow-up): validates
+      # flaky-tests.yaml schema + expire_at lifecycle. Fires when either
+      # the registry or CHANGELOG.md changes (CHANGELOG bumps shift the
+      # current-shipped version, which can flip an entry from valid to
+      # EXPIRED — catching that at commit time avoids a CI surprise).
+      - id: flaky-registry-check
+        name: Flaky-test registry schema + expire_at lifecycle (HA-10)
+        entry: python3 -X utf8 scripts/tools/lint/check_flaky_registry.py --ci
+        language: python
+        pass_filenames: false
+        files: ^(flaky-tests\.yaml|CHANGELOG\.md)$
+        additional_dependencies: ['pyyaml']
+
       - id: includes-sync
         name: Include snippet zh/en sync
         entry: python3 -X utf8 scripts/tools/lint/check_includes_sync.py --check

--- a/docs/internal/tool-map.en.md
+++ b/docs/internal/tool-map.en.md
@@ -131,10 +131,12 @@ lang: en
 | `check_design_token_usage.py` | JSX 設計 token 使用完整性 lint |
 | `check_dev_rules_enforcement.py` | detect doc-drift in dev-rules.md. |
 | `check_devrules_size.py` | Dev-rules 尺寸上限檢查。 |
+| `check_dist_source_consistency.py` | Catch portal dist commits without matching source change (testing-playbook §LL §2, TD-039). |
 | `check_doc_freshness.py` | 文件新鮮度檢查工具。 |
 | `check_doc_links.py` | 文件間交叉引用一致性檢查 |
 | `check_doc_reading_time.py` | 文件閱讀時間檢查工具。 |
 | `check_doc_template.py` | 文件模板合規性檢查工具。 |
+| `check_flaky_registry.py` | Validate `flaky-tests.yaml` schema + expire_at. |
 | `check_frontmatter_versions.py` | Frontmatter version global scan |
 | `check_glossary_coverage.py` | 術語表覆蓋率檢查 |
 | `check_hardcode_tenant.py` | Detect hardcoded tenant literals in PromQL label selectors (Rule #2). |
@@ -152,16 +154,19 @@ lang: en
 | `check_path_metadata_consistency.py` | Warn when conf.d/ hierarchical path disagrees with tenant `_metadata`. |
 | `check_playbook_freshness.py` | Playbook 知識退火檢查工具。 |
 | `check_playwright_rtl_drift.py` | Detect React Testing Library API names in Playwright specs (S#96, mechanical safety net for testing-playbook §LL §10). |
+| `check_portal_bundle_size.py` | Portal dist bundle size budget gate. |
 | `check_portal_i18n.py` | Portal JSX i18n hardcoded string detector |
 | `check_pr_scope_drift.py` | PR scope drift 偵測（pr-preflight 級）。 |
 | `check_repo_name.py` | Prevent wrong repository name in source files. |
 | `check_routing_profiles.py` | Lint routing profiles and domain policies (ADR-007). |
+| `check_skip_a11y_justification.py` | Require ticket-justification for `skipA11y: true` in E2E specs (testing-playbook §LL §5, TD-039). |
 | `check_structure.py` | Project structure enforcement. |
 | `check_subprocess_timeout.py` | flag subprocess calls without explicit timeout. |
 | `check_techdebt_drift.py` | TECH-DEBT / REG registry drift checker. |
 | `check_tool_registry_jsx_parity.py` | every tool-registry.yaml entry must have a backing .jsx file (and vice versa). |
 | `check_translation.py` | 自動化翻譯品質檢查 |
 | `check_undefined_tokens.py` | Detect JSX/CSS/HTML references to --da-* tokens not defined in design-tokens.css (with --report-orphans discovery mode). |
+| `check_window_x_no_fallback.py` | Forbid module-scope `const X = window.__X;` no-fallback reads (dev-rules.md §S6). |
 | `detect_sed_damage.py` | Detect sed -i damage on staged files. |
 | `fix_doc_links.py` | Auto-fix broken MkDocs cross-reference links. |
 | `fix_file_hygiene.py` | Fix file hygiene issues: strip null bytes and ensure EOF newline. |

--- a/docs/internal/tool-map.md
+++ b/docs/internal/tool-map.md
@@ -136,6 +136,7 @@ lang: zh
 | `check_doc_links.py` | 文件間交叉引用一致性檢查 |
 | `check_doc_reading_time.py` | 文件閱讀時間檢查工具。 |
 | `check_doc_template.py` | 文件模板合規性檢查工具。 |
+| `check_flaky_registry.py` | Validate `flaky-tests.yaml` schema + expire_at. |
 | `check_frontmatter_versions.py` | Frontmatter version global scan |
 | `check_glossary_coverage.py` | 術語表覆蓋率檢查 |
 | `check_hardcode_tenant.py` | Detect hardcoded tenant literals in PromQL label selectors (Rule #2). |

--- a/scripts/tools/lint/check_flaky_registry.py
+++ b/scripts/tools/lint/check_flaky_registry.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""check_flaky_registry.py — Validate `flaky-tests.yaml` schema + expire_at.
+
+HA-10 observability layer (PR #325/#326 follow-up). Closes the design
+loop on the flaky-test retry registry: every entry MUST have a tracked
+issue + a deadline version, and the deadline MUST advance the
+root-cause fix forward. Without this validator, entries can sit forever
+because no one notices when they should be removed.
+
+What this validates
+-------------------
+
+For each entry under `known_flakes:`:
+
+  Required fields (FATAL on missing/empty):
+    - test         : human-readable name shown in CI logs
+    - pattern      : Go test name regex (used by `go test -run`)
+    - max_retries  : integer 1..N (typical 1-3)
+    - owner        : GitHub team / handle
+    - tracked_by   : issue ref (HA-NN, issue #NNN, or free-text > 10 chars)
+    - expire_at    : version string (`v2.9.0`, `exporter/v2.9.0`, etc.)
+
+  Field-shape (FATAL on mis-shape):
+    - max_retries is a positive integer ≤ 5 (sanity cap)
+    - expire_at parses as a semver-ish version
+    - pattern is a valid regex
+
+  Lifecycle (FATAL on stale):
+    - expire_at version > current shipped version (read from CHANGELOG.md
+      latest `## [vX.Y.Z]` heading, or `--current-version` override).
+      An entry where current >= expire_at MUST be removed; this is the
+      forcing function for root-cause fixes.
+
+Behavior on empty registry
+--------------------------
+
+`known_flakes: []` (or missing key) is the **healthy** state — empty
+registry means no flakes are currently registered. The validator
+accepts it and exits 0.
+
+Usage
+-----
+
+    # Default: validate the repo's flaky-tests.yaml against CHANGELOG.md
+    python3 scripts/tools/lint/check_flaky_registry.py --ci
+
+    # Override current version (for tests + dev cycles)
+    python3 scripts/tools/lint/check_flaky_registry.py --current-version v2.9.0
+
+    # Custom registry path
+    python3 scripts/tools/lint/check_flaky_registry.py --registry path/to/file
+
+Exit codes
+----------
+
+  0  registry valid, no expired entries
+  1  schema errors OR expired entries (lists them on stderr)
+  2  configuration error (missing CHANGELOG, can't parse YAML, etc.)
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_REGISTRY = REPO_ROOT / "flaky-tests.yaml"
+DEFAULT_CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+
+
+# Required fields per entry (with min-length expectations for non-int fields).
+# tracked_by min length 5 keeps "HA-N" / "issue#NN" allowable but rejects
+# placeholders like "TBD" / "x".
+_REQUIRED_FIELDS: dict[str, int] = {
+    "test": 3,
+    "pattern": 1,
+    "owner": 2,
+    "tracked_by": 5,
+    "expire_at": 4,
+}
+_MAX_RETRIES_CAP = 5
+
+
+@dataclass(frozen=True)
+class Version:
+    """Represents a parsed version string for comparison.
+
+    Supports `vX.Y.Z` and `prefix/vX.Y.Z` (the project's release-line
+    convention). The prefix is preserved on the parsed Version so a
+    threshold-exporter expire_at like `exporter/v2.9.0` is only compared
+    against threshold-exporter's release line — not the platform `v*`
+    line. Cross-line comparison errors at parse time.
+    """
+
+    prefix: str  # "" for plain v*, otherwise "exporter", "tools", etc.
+    major: int
+    minor: int
+    patch: int
+
+    def __lt__(self, other: "Version") -> bool:
+        if self.prefix != other.prefix:
+            raise ValueError(
+                f"cannot compare versions across release lines: "
+                f"{self.prefix or '<root>'!r} vs {other.prefix or '<root>'!r}"
+            )
+        return (self.major, self.minor, self.patch) < (
+            other.major, other.minor, other.patch,
+        )
+
+    def __ge__(self, other: "Version") -> bool:
+        return not (self < other)
+
+    def __str__(self) -> str:
+        base = f"v{self.major}.{self.minor}.{self.patch}"
+        return f"{self.prefix}/{base}" if self.prefix else base
+
+
+_VERSION_RE = re.compile(
+    r"^(?:(?P<prefix>[a-z][a-z0-9-]*)/)?v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$"
+)
+
+
+def parse_version(s: str) -> Version:
+    """Parse a version string. Raises ValueError on bad shape."""
+    m = _VERSION_RE.match(s.strip())
+    if not m:
+        raise ValueError(
+            f"version {s!r} does not match expected shape "
+            f"`vX.Y.Z` or `prefix/vX.Y.Z`"
+        )
+    return Version(
+        prefix=m.group("prefix") or "",
+        major=int(m.group("major")),
+        minor=int(m.group("minor")),
+        patch=int(m.group("patch")),
+    )
+
+
+def latest_version_from_changelog(path: Path) -> Optional[Version]:
+    """Find the latest `## [vX.Y.Z]` heading in CHANGELOG.md.
+
+    The CHANGELOG is reverse-chronological (newest at top), so the FIRST
+    matching heading is the current shipped version. Returns None if no
+    matching heading is found.
+    """
+    if not path.is_file():
+        return None
+    pattern = re.compile(r"^##\s+\[(v\d+\.\d+\.\d+)\]")
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            m = pattern.match(line)
+            if m:
+                try:
+                    return parse_version(m.group(1))
+                except ValueError:
+                    continue
+    return None
+
+
+# ── Validation ──────────────────────────────────────────────────────
+
+
+@dataclass
+class Issue:
+    """One validation finding. severity ∈ {error}."""
+    entry_index: int    # zero-based index in known_flakes list
+    test_name: str      # may be empty if `test` field is missing
+    field: str          # the offending field (or '<entry>' for entry-level)
+    message: str
+
+    def format(self) -> str:
+        ref = f"#{self.entry_index} ({self.test_name or '<unnamed>'})"
+        return f"  {ref} [{self.field}]: {self.message}"
+
+
+def validate_entry(
+    idx: int, entry: dict, current: Optional[Version],
+) -> list[Issue]:
+    """Validate a single entry. Returns list of Issues (empty = healthy)."""
+    issues: list[Issue] = []
+    test_name = str(entry.get("test", ""))
+
+    # Schema — required fields
+    for field, min_len in _REQUIRED_FIELDS.items():
+        val = entry.get(field)
+        if val is None:
+            issues.append(Issue(
+                idx, test_name, field, f"missing required field"
+            ))
+            continue
+        if not isinstance(val, str) or len(val.strip()) < min_len:
+            issues.append(Issue(
+                idx, test_name, field,
+                f"must be a non-empty string (≥{min_len} chars), got {val!r}",
+            ))
+
+    # max_retries shape
+    mr = entry.get("max_retries")
+    if mr is None:
+        issues.append(Issue(idx, test_name, "max_retries", "missing required field"))
+    elif not isinstance(mr, int) or mr < 1 or mr > _MAX_RETRIES_CAP:
+        issues.append(Issue(
+            idx, test_name, "max_retries",
+            f"must be an integer in [1..{_MAX_RETRIES_CAP}], got {mr!r}",
+        ))
+
+    # pattern validity
+    pattern = entry.get("pattern")
+    if isinstance(pattern, str) and pattern:
+        try:
+            re.compile(pattern)
+        except re.error as e:
+            issues.append(Issue(
+                idx, test_name, "pattern",
+                f"not a valid regex: {e}",
+            ))
+
+    # expire_at parse + lifecycle
+    expire_raw = entry.get("expire_at")
+    if isinstance(expire_raw, str) and expire_raw:
+        try:
+            expire_v = parse_version(expire_raw)
+        except ValueError as e:
+            issues.append(Issue(idx, test_name, "expire_at", str(e)))
+        else:
+            if current is not None:
+                try:
+                    if current >= expire_v:
+                        issues.append(Issue(
+                            idx, test_name, "expire_at",
+                            f"EXPIRED — current shipped version {current} >= "
+                            f"expire_at {expire_v}. Remove this entry "
+                            f"(root-cause fix should have landed by now).",
+                        ))
+                except ValueError as e:
+                    # Cross-line comparison; surface as a soft schema error
+                    # rather than expiry — different release lines are
+                    # legitimate.
+                    issues.append(Issue(idx, test_name, "expire_at", str(e)))
+
+    return issues
+
+
+def validate_registry(
+    registry: dict, current: Optional[Version],
+) -> list[Issue]:
+    """Validate the parsed registry dict. Returns list of Issues."""
+    issues: list[Issue] = []
+
+    if not isinstance(registry, dict):
+        issues.append(Issue(
+            -1, "", "<root>",
+            f"top-level YAML must be a mapping, got {type(registry).__name__}",
+        ))
+        return issues
+
+    raw = registry.get("known_flakes")
+    if raw is None:
+        # Missing key is treated as empty — healthy.
+        return issues
+    if not isinstance(raw, list):
+        issues.append(Issue(
+            -1, "", "known_flakes",
+            f"must be a list, got {type(raw).__name__}",
+        ))
+        return issues
+
+    for idx, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            issues.append(Issue(
+                idx, "", "<entry>",
+                f"must be a mapping, got {type(entry).__name__}",
+            ))
+            continue
+        issues.extend(validate_entry(idx, entry, current))
+
+    return issues
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate flaky-tests.yaml schema + expire_at lifecycle.",
+    )
+    parser.add_argument(
+        "--registry", default=str(DEFAULT_REGISTRY),
+        help=f"Registry YAML path (default: {DEFAULT_REGISTRY.name})",
+    )
+    parser.add_argument(
+        "--changelog", default=str(DEFAULT_CHANGELOG),
+        help=f"CHANGELOG.md path (default: {DEFAULT_CHANGELOG.name})",
+    )
+    parser.add_argument(
+        "--current-version", default=None,
+        help="Override the current-shipped version (for testing). If "
+             "omitted, parsed from CHANGELOG.md latest `## [vX.Y.Z]` heading.",
+    )
+    parser.add_argument(
+        "--ci", action="store_true",
+        help="CI mode: terse output, exit 1 on any finding (default behavior).",
+    )
+    args = parser.parse_args(argv)
+
+    # Resolve current version
+    current: Optional[Version] = None
+    if args.current_version:
+        try:
+            current = parse_version(args.current_version)
+        except ValueError as e:
+            print(f"ERROR: --current-version: {e}", file=sys.stderr)
+            return 2
+    else:
+        current = latest_version_from_changelog(Path(args.changelog))
+        if current is None:
+            print(
+                f"WARN: could not parse current version from {args.changelog}; "
+                "expire_at lifecycle check will be skipped.",
+                file=sys.stderr,
+            )
+
+    # Load registry
+    registry_path = Path(args.registry)
+    if not registry_path.is_file():
+        # Missing registry is healthy: same semantics as empty.
+        return 0
+    try:
+        import yaml
+    except ImportError:
+        print("ERROR: pyyaml not installed", file=sys.stderr)
+        return 2
+    try:
+        with open(registry_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except yaml.YAMLError as e:
+        print(f"ERROR: cannot parse {registry_path}: {e}", file=sys.stderr)
+        return 2
+
+    issues = validate_registry(data, current)
+    if not issues:
+        # All clean — print a short success line for CI logs.
+        if not args.ci:
+            count = len(data.get("known_flakes") or [])
+            current_str = str(current) if current else "<unknown>"
+            print(
+                f"flaky-tests.yaml: {count} entries, all valid "
+                f"(current version: {current_str})"
+            )
+        return 0
+
+    # Surface findings
+    print(
+        f"flaky-tests.yaml validation FAILED: {len(issues)} issue(s)",
+        file=sys.stderr,
+    )
+    for issue in issues:
+        print(issue.format(), file=sys.stderr)
+    print(
+        "\nTo fix: edit flaky-tests.yaml. EXPIRED entries should be "
+        "removed once the root-cause fix has landed (registry shrinks "
+        "as bugs get fixed — that's the design).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/lint/test_check_flaky_registry.py
+++ b/tests/lint/test_check_flaky_registry.py
@@ -1,0 +1,359 @@
+"""Tests for scripts/tools/lint/check_flaky_registry.py.
+
+Covers:
+  - Version parsing (plain `v*` + `prefix/v*`)
+  - Cross-release-line comparison errors
+  - CHANGELOG version extraction
+  - Schema validation (required fields, max_retries shape, regex validity)
+  - expire_at lifecycle (current >= expire_at → EXPIRED)
+  - Empty / missing registry handling (healthy state)
+  - CLI exit codes
+  - --current-version override
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = REPO_ROOT / "scripts" / "tools" / "lint" / "check_flaky_registry.py"
+
+_spec = importlib.util.spec_from_file_location("check_flaky_registry", _SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["check_flaky_registry"] = mod
+_spec.loader.exec_module(mod)
+
+
+# ============================================================
+# parse_version
+# ============================================================
+
+class TestParseVersion:
+
+    def test_plain_version(self):
+        v = mod.parse_version("v2.7.0")
+        assert v.prefix == ""
+        assert (v.major, v.minor, v.patch) == (2, 7, 0)
+
+    def test_prefixed_version(self):
+        v = mod.parse_version("exporter/v2.9.1")
+        assert v.prefix == "exporter"
+        assert (v.major, v.minor, v.patch) == (2, 9, 1)
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="does not match"):
+            mod.parse_version("2.7.0")  # missing 'v'
+        with pytest.raises(ValueError, match="does not match"):
+            mod.parse_version("v2.7")  # missing patch
+        with pytest.raises(ValueError, match="does not match"):
+            mod.parse_version("v2.7.0-rc1")  # pre-release suffix unsupported
+
+    def test_str_round_trip(self):
+        for s in ("v2.7.0", "exporter/v0.1.5", "tools/v3.0.0"):
+            assert str(mod.parse_version(s)) == s
+
+
+class TestVersionComparison:
+
+    def test_lt_within_line(self):
+        assert mod.parse_version("v2.7.0") < mod.parse_version("v2.8.0")
+        assert mod.parse_version("v2.7.0") < mod.parse_version("v2.7.1")
+        assert mod.parse_version("v1.0.0") < mod.parse_version("v2.0.0")
+
+    def test_ge_within_line(self):
+        # not a < b == True → a >= b == False; a >= a should be True
+        v = mod.parse_version("v2.9.0")
+        assert v >= v
+        assert mod.parse_version("v2.9.0") >= mod.parse_version("v2.8.5")
+
+    def test_cross_line_raises(self):
+        a = mod.parse_version("v2.9.0")
+        b = mod.parse_version("exporter/v2.9.0")
+        with pytest.raises(ValueError, match="cannot compare"):
+            _ = a < b
+
+
+# ============================================================
+# latest_version_from_changelog
+# ============================================================
+
+class TestChangelogVersion:
+
+    def test_finds_top_heading(self, tmp_path):
+        c = tmp_path / "CHANGELOG.md"
+        c.write_text(
+            "# Changelog\n\n"
+            "## [v2.7.0] — title (date)\n"
+            "## [v2.6.0] — older\n",
+            encoding="utf-8",
+        )
+        v = mod.latest_version_from_changelog(c)
+        assert v is not None
+        assert str(v) == "v2.7.0"
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert mod.latest_version_from_changelog(tmp_path / "nope.md") is None
+
+    def test_no_heading_returns_none(self, tmp_path):
+        c = tmp_path / "CHANGELOG.md"
+        c.write_text("# Changelog\n\nNo version headings here.\n", encoding="utf-8")
+        assert mod.latest_version_from_changelog(c) is None
+
+
+# ============================================================
+# validate_entry — schema
+# ============================================================
+
+@pytest.fixture
+def valid_entry():
+    return {
+        "test": "TestFlaky",
+        "pattern": "^TestFlaky$",
+        "max_retries": 2,
+        "owner": "@team",
+        "tracked_by": "HA-N description",
+        "expire_at": "v2.9.0",
+    }
+
+
+@pytest.fixture
+def current_v270():
+    return mod.parse_version("v2.7.0")
+
+
+class TestValidateEntrySchema:
+
+    def test_valid_entry_no_issues(self, valid_entry, current_v270):
+        assert mod.validate_entry(0, valid_entry, current_v270) == []
+
+    def test_missing_required_field(self, valid_entry, current_v270):
+        del valid_entry["owner"]
+        issues = mod.validate_entry(0, valid_entry, current_v270)
+        assert any(i.field == "owner" and "missing" in i.message for i in issues)
+
+    def test_empty_string_field(self, valid_entry, current_v270):
+        valid_entry["owner"] = ""
+        issues = mod.validate_entry(0, valid_entry, current_v270)
+        assert any(i.field == "owner" for i in issues)
+
+    def test_too_short_tracked_by(self, valid_entry, current_v270):
+        valid_entry["tracked_by"] = "TBD"  # 3 chars, below 5 threshold
+        issues = mod.validate_entry(0, valid_entry, current_v270)
+        assert any(i.field == "tracked_by" for i in issues)
+
+    def test_max_retries_zero_rejected(self, valid_entry, current_v270):
+        valid_entry["max_retries"] = 0
+        issues = mod.validate_entry(0, valid_entry, current_v270)
+        assert any(i.field == "max_retries" for i in issues)
+
+    def test_max_retries_excessive_rejected(self, valid_entry, current_v270):
+        valid_entry["max_retries"] = 10  # over cap
+        issues = mod.validate_entry(0, valid_entry, current_v270)
+        assert any(i.field == "max_retries" for i in issues)
+
+    def test_max_retries_non_integer_rejected(self, valid_entry, current_v270):
+        valid_entry["max_retries"] = "two"
+        issues = mod.validate_entry(0, valid_entry, current_v270)
+        assert any(i.field == "max_retries" for i in issues)
+
+    def test_invalid_regex_pattern(self, valid_entry, current_v270):
+        valid_entry["pattern"] = "TestFoo("  # unbalanced paren
+        issues = mod.validate_entry(0, valid_entry, current_v270)
+        assert any(i.field == "pattern" and "regex" in i.message for i in issues)
+
+    def test_invalid_expire_at_format(self, valid_entry, current_v270):
+        valid_entry["expire_at"] = "2.9"  # missing v + patch
+        issues = mod.validate_entry(0, valid_entry, current_v270)
+        assert any(i.field == "expire_at" for i in issues)
+
+
+class TestValidateEntryLifecycle:
+
+    def test_not_expired(self, valid_entry):
+        # expire_at v2.9.0, current v2.7.0 → not expired
+        current = mod.parse_version("v2.7.0")
+        assert mod.validate_entry(0, valid_entry, current) == []
+
+    def test_expired_at_exact_match(self, valid_entry):
+        # current == expire_at → EXPIRED (must be removed before this version ships)
+        current = mod.parse_version("v2.9.0")
+        issues = mod.validate_entry(0, valid_entry, current)
+        assert any("EXPIRED" in i.message for i in issues)
+
+    def test_expired_past(self, valid_entry):
+        current = mod.parse_version("v3.0.0")
+        issues = mod.validate_entry(0, valid_entry, current)
+        assert any("EXPIRED" in i.message for i in issues)
+
+    def test_no_current_skips_lifecycle(self, valid_entry):
+        # If we can't determine current version, don't fail-CI; just skip.
+        assert mod.validate_entry(0, valid_entry, None) == []
+
+    def test_cross_line_expire_at_surfaces_error(self, valid_entry):
+        # current is platform v2.7.0; expire_at is exporter/v2.9.0.
+        # Cross-line comparison → schema error (caller chose the wrong line).
+        valid_entry["expire_at"] = "exporter/v2.9.0"
+        current = mod.parse_version("v2.7.0")
+        issues = mod.validate_entry(0, valid_entry, current)
+        assert any("cannot compare" in i.message for i in issues)
+
+
+# ============================================================
+# validate_registry — top-level shape
+# ============================================================
+
+class TestValidateRegistry:
+
+    def test_empty_known_flakes_healthy(self, current_v270):
+        assert mod.validate_registry({"known_flakes": []}, current_v270) == []
+
+    def test_missing_known_flakes_healthy(self, current_v270):
+        assert mod.validate_registry({}, current_v270) == []
+
+    def test_non_dict_top_level_error(self, current_v270):
+        issues = mod.validate_registry(["not", "a", "dict"], current_v270)
+        assert any(i.field == "<root>" for i in issues)
+
+    def test_non_list_known_flakes_error(self, current_v270):
+        issues = mod.validate_registry({"known_flakes": "string"}, current_v270)
+        assert any(i.field == "known_flakes" for i in issues)
+
+    def test_non_dict_entry_error(self, current_v270):
+        issues = mod.validate_registry(
+            {"known_flakes": ["string-not-dict"]}, current_v270,
+        )
+        assert any(i.field == "<entry>" for i in issues)
+
+
+# ============================================================
+# main — CLI / exit codes
+# ============================================================
+
+def _write_yaml(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+
+
+class TestMainCLI:
+
+    def test_missing_registry_exits_zero(self, tmp_path):
+        # Healthy "no flakes" state when file doesn't exist.
+        rc = mod.main([
+            "--registry", str(tmp_path / "nope.yaml"),
+            "--current-version", "v2.7.0",
+        ])
+        assert rc == 0
+
+    def test_empty_known_flakes_exits_zero(self, tmp_path, capsys):
+        f = tmp_path / "flakes.yaml"
+        _write_yaml(f, "known_flakes: []\n")
+        rc = mod.main([
+            "--registry", str(f), "--current-version", "v2.7.0",
+        ])
+        assert rc == 0
+
+    def test_valid_entry_exits_zero(self, tmp_path):
+        f = tmp_path / "flakes.yaml"
+        _write_yaml(f,
+            "known_flakes:\n"
+            "  - test: TestFlaky\n"
+            "    pattern: '^TestFlaky$'\n"
+            "    max_retries: 2\n"
+            "    owner: '@team'\n"
+            "    tracked_by: 'HA-N description'\n"
+            "    expire_at: v2.9.0\n"
+        )
+        rc = mod.main([
+            "--registry", str(f), "--current-version", "v2.7.0", "--ci",
+        ])
+        assert rc == 0
+
+    def test_expired_entry_exits_one(self, tmp_path, capsys):
+        f = tmp_path / "flakes.yaml"
+        _write_yaml(f,
+            "known_flakes:\n"
+            "  - test: TestStale\n"
+            "    pattern: '^TestStale$'\n"
+            "    max_retries: 1\n"
+            "    owner: '@team'\n"
+            "    tracked_by: 'HA-N description'\n"
+            "    expire_at: v2.5.0\n"  # past current v2.7.0
+        )
+        rc = mod.main([
+            "--registry", str(f), "--current-version", "v2.7.0", "--ci",
+        ])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "EXPIRED" in captured.err
+
+    def test_schema_error_exits_one(self, tmp_path, capsys):
+        f = tmp_path / "flakes.yaml"
+        _write_yaml(f,
+            "known_flakes:\n"
+            "  - test: TestX\n"
+            "    pattern: '^TestX$'\n"
+            "    max_retries: 1\n"
+            "    owner: '@team'\n"
+            "    # tracked_by missing\n"
+            "    expire_at: v2.9.0\n"
+        )
+        rc = mod.main([
+            "--registry", str(f), "--current-version", "v2.7.0", "--ci",
+        ])
+        assert rc == 1
+        assert "tracked_by" in capsys.readouterr().err
+
+    def test_invalid_yaml_exits_two(self, tmp_path, capsys):
+        f = tmp_path / "flakes.yaml"
+        _write_yaml(f, "known_flakes:\n  - test: [unclosed\n")
+        rc = mod.main([
+            "--registry", str(f), "--current-version", "v2.7.0",
+        ])
+        assert rc == 2
+        assert "cannot parse" in capsys.readouterr().err
+
+    def test_bad_current_version_exits_two(self, tmp_path):
+        rc = mod.main([
+            "--registry", str(tmp_path / "anything.yaml"),
+            "--current-version", "not-a-version",
+        ])
+        assert rc == 2
+
+    def test_changelog_fallback(self, tmp_path):
+        """When no --current-version, read CHANGELOG.md."""
+        c = tmp_path / "CHANGELOG.md"
+        c.write_text("## [v2.7.0] — title\n", encoding="utf-8")
+        f = tmp_path / "flakes.yaml"
+        _write_yaml(f,
+            "known_flakes:\n"
+            "  - test: TestStale\n"
+            "    pattern: '^TestStale$'\n"
+            "    max_retries: 1\n"
+            "    owner: '@team'\n"
+            "    tracked_by: 'HA-N description'\n"
+            "    expire_at: v2.5.0\n"  # past v2.7.0
+        )
+        rc = mod.main([
+            "--registry", str(f), "--changelog", str(c), "--ci",
+        ])
+        assert rc == 1
+
+
+# ============================================================
+# Repo registry passes its own validator (regression-style smoke test)
+# ============================================================
+
+class TestRepoRegistry:
+
+    def test_repo_registry_passes(self):
+        """The shipped flaky-tests.yaml + CHANGELOG.md must validate.
+
+        This is a regression guard: any future edit to flaky-tests.yaml
+        that violates schema or sets expire_at past current shipped
+        version trips this test (in addition to the pre-commit hook).
+        """
+        # Run against the repo's actual files
+        rc = mod.main(["--ci"])
+        assert rc == 0, "repo's flaky-tests.yaml fails its own validator"


### PR DESCRIPTION
## Summary

Closes the design loop on PR #325/#326 (HA-10 retry registry). Without this validator, the registry could grow unbounded — entries sit forever because no one notices when they should be removed. The \`expire_at\` field was already in the schema; this PR enforces it.

## What it validates

| Layer | Check | Severity |
|---|---|---|
| **Schema** | \`test\`, \`pattern\`, \`owner\`, \`tracked_by\`, \`expire_at\` non-empty strings | FATAL on missing |
| **Schema** | \`max_retries\` is integer in [1..5] | FATAL on shape |
| **Schema** | \`pattern\` is a valid regex | FATAL on parse |
| **Schema** | \`expire_at\` parses as \`vX.Y.Z\` or \`prefix/vX.Y.Z\` | FATAL on shape |
| **Lifecycle** | \`current_shipped >= expire_at\` | FATAL — \"EXPIRED, remove this entry\" |
| **Cross-line guard** | comparing \`exporter/v2.9.0\` against platform \`v2.7.0\` | FATAL (caller used wrong release line) |

## How current shipped version is determined

Reads CHANGELOG.md latest \`## [vX.Y.Z]\` heading. Override available via \`--current-version\` for tests / dev cycles. If CHANGELOG.md is missing or has no version heading, the lifecycle check is skipped (warns but doesn't fail) — schema check still applies.

## How it surfaces

### pre-commit hook (auto-stage)

Runs on every commit that touches \`flaky-tests.yaml\` **OR** \`CHANGELOG.md\`.

The CHANGELOG trigger is critical: a CHANGELOG bump shifts current shipped version forward, which can flip an entry from valid → EXPIRED. Catching that at commit time avoids surprise CI failure.

\`\`\`yaml
- id: flaky-registry-check
  name: Flaky-test registry schema + expire_at lifecycle (HA-10)
  entry: python3 -X utf8 scripts/tools/lint/check_flaky_registry.py --ci
  files: ^(flaky-tests\.yaml|CHANGELOG\.md)$
  additional_dependencies: ['pyyaml']
\`\`\`

### Pytest regression test

\`TestRepoRegistry::test_repo_registry_passes\` runs the validator against the live repo files. Belt-and-suspenders for \`--no-verify\` bypass.

## Behavior on empty registry

\`known_flakes: []\` (or missing key) is the **healthy** state. The validator accepts it and exits 0. Matches the HA-11 design intent: \"registry shrinks as bugs get fixed\".

## Verification

| Check | Result |
|---|---|
| \`pytest tests/lint/test_check_flaky_registry.py\` | **38 passed** |
| \`pytest tests/ops/test_ci_flake_retry.py\` | 28 passed (no regression) |
| \`pre-commit run flaky-registry-check --all-files\` | Passed |
| \`pre-commit run dev-rules-enforcement-check\` | Passed (no drift) |
| Synthetic \`--current-version v2.9.0\` against current registry | exit 1, \"EXPIRED — current shipped version v2.9.0 >= expire_at v2.9.0\" |

## What this advances

Audit ⑥ \"Legacy\" → ~97% → ~98%.

The HA-10 retry registry now has operational hygiene built-in: \`expire_at\` deadlines are enforced, schema errors fail fast at commit, and the validator's own tests pin the contract. Future flake entries can't sneak in without all required fields, and they can't outlive their stated deadline.

## Side note

\`docs/internal/tool-map{.en,}.md\` regenerated to register the new tool. Also picked up the previously-missing \`check_dist_source_consistency\` entry in the EN map — pre-existing drift, surfaced incidentally.

## Test plan

- [x] 38 validator unit tests pass (parse, compare, schema, lifecycle, CLI)
- [x] No regression in retry wrapper
- [x] pre-commit hook runs on flaky-tests.yaml OR CHANGELOG.md changes
- [x] Synthetic forced-expiry test correctly exits 1
- [x] Repo's own registry passes (TestRepoRegistry guard)
- [x] pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)