### PR TITLE
test(audit): property + mutation pilot batch 4 — _lib_io + 2 real test gaps closed

### DIFF
--- a/tests/shared/_mutation_pilot.py
+++ b/tests/shared/_mutation_pilot.py
@@ -295,6 +295,65 @@ MUTATIONS: list[Mutation] = [
         old='                "font-bold",\n                "font-semibold",',
         new='                "font-semibold",',
     ),
+    # ── load_yaml_file (_lib_io) ─────────────────────────────────
+    Mutation(
+        target_file="scripts/tools/_lib_io.py",
+        test_file="tests/shared/test_property_tools.py tests/shared/test_lib_python.py",
+        label="load_yaml: drop isfile check (would attempt to open missing path)",
+        fn_name="load_yaml_file",
+        old="    if not path or not os.path.isfile(path):\n        return default",
+        new="    if not path:\n        return default",
+    ),
+    Mutation(
+        target_file="scripts/tools/_lib_io.py",
+        test_file="tests/shared/test_property_tools.py tests/shared/test_lib_python.py",
+        label="load_yaml: drop None-coalesce (empty file returns None instead of default)",
+        fn_name="load_yaml_file",
+        old="    return data if data is not None else default",
+        new="    return data",
+    ),
+    # ── iter_yaml_files (_lib_io) ────────────────────────────────
+    Mutation(
+        target_file="scripts/tools/_lib_io.py",
+        test_file="tests/shared/test_property_tools.py tests/shared/test_lib_python.py",
+        label="iter_yaml: drop .yml from extension check",
+        fn_name="iter_yaml_files",
+        old='        if not (fname.endswith(".yaml") or fname.endswith(".yml")):',
+        new='        if not fname.endswith(".yaml"):',
+    ),
+    Mutation(
+        target_file="scripts/tools/_lib_io.py",
+        test_file="tests/shared/test_property_tools.py tests/shared/test_lib_python.py",
+        label="iter_yaml: drop dotfile filter (.hidden.yaml leaks through)",
+        fn_name="iter_yaml_files",
+        old='        if skip_reserved and (fname.startswith("_") or fname.startswith(".")):',
+        new='        if skip_reserved and fname.startswith("_"):',
+    ),
+    Mutation(
+        target_file="scripts/tools/_lib_io.py",
+        test_file="tests/shared/test_property_tools.py tests/shared/test_lib_python.py",
+        label="iter_yaml: drop isfile filter (directories ending in .yaml leak through)",
+        fn_name="iter_yaml_files",
+        old="        fpath = os.path.join(config_dir, fname)\n        if os.path.isfile(fpath):\n            result.append((fname, fpath))",
+        new="        fpath = os.path.join(config_dir, fname)\n        result.append((fname, fpath))",
+    ),
+    # ── format_json_report (_lib_io) ─────────────────────────────
+    Mutation(
+        target_file="scripts/tools/_lib_io.py",
+        test_file="tests/shared/test_property_tools.py",
+        label="format_json: drop pretty-print default (indent=0 → no newlines)",
+        fn_name="format_json_report",
+        old='    kwargs.setdefault("indent", 2)',
+        new='    kwargs.setdefault("indent", 0)',
+    ),
+    Mutation(
+        target_file="scripts/tools/_lib_io.py",
+        test_file="tests/shared/test_property_tools.py",
+        label="format_json: drop ensure_ascii default (Unicode gets escaped)",
+        fn_name="format_json_report",
+        old='    kwargs.setdefault("ensure_ascii", False)',
+        new='    kwargs.setdefault("ensure_ascii", True)',
+    ),
 ]
 
 

--- a/tests/shared/test_property_tools.py
+++ b/tests/shared/test_property_tools.py
@@ -59,6 +59,7 @@ import generate_rule_pack_split as grps  # noqa: E402
 import generate_doc_map as gdm  # noqa: E402
 import generate_changelog as gc  # noqa: E402
 import _lib_validation as lv  # noqa: E402
+import _lib_io as lio  # noqa: E402
 import axe_lite_static as axe  # noqa: E402
 
 
@@ -125,19 +126,23 @@ class TestExtractMetricsFromExprProperties:
 
     def test_uppercase_label_tokens_excluded(self):
         # Mutation-pilot kill-test: dropping the `not m[0].isupper()` filter
-        # would let labels like `Tenant` (PromQL convention: uppercase =
-        # label, lowercase = metric) leak into the metrics output. The
-        # property test_no_uppercase_starting_tokens covers this in
-        # principle, but Hypothesis's random text strategy doesn't reliably
-        # generate uppercase-prefixed tokens followed by `{`/`[`/whitespace.
-        # This deterministic case pins the behavior.
-        expr = 'rate(http_requests_total{Tenant="db-a"}[5m])'
+        # would let labels like `Foo` / `Bar` (PromQL convention: uppercase =
+        # custom-named recording rule or label, lowercase = metric name)
+        # leak into the metrics output.
+        #
+        # IMPORTANT: the test expression MUST contain uppercase tokens
+        # immediately followed by `{`, `[`, or whitespace — otherwise the
+        # regex `\b([a-zA-Z_:]...)\b(?=[{\[\s])` won't even capture them
+        # in the first place, and the uppercase filter never fires (which
+        # was the bug in this test's earlier version pre-batch-4).
+        expr = 'Foo{label="x"} + Bar[5m]'
         result = grps.extract_metrics_from_expr(expr)
-        assert "Tenant" not in result, (
-            f"uppercase label `Tenant` leaked into metrics: {result!r}"
+        assert "Foo" not in result, (
+            f"uppercase token `Foo` leaked into metrics: {result!r}"
         )
-        # And confirm the lowercase metric does pass through.
-        assert "http_requests_total" in result
+        assert "Bar" not in result, (
+            f"uppercase token `Bar` leaked into metrics: {result!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -701,3 +706,159 @@ class TestScanColorOnlySeverityProperties:
         src = '<div className="text-[color:var(--da-color-error)]">err</div>'
         out = axe.scan_color_only_severity(src)
         assert len(out) == 1
+
+
+# ---------------------------------------------------------------------------
+# _lib_io — file IO + YAML helpers used by 20+ tools
+# ---------------------------------------------------------------------------
+# Pilot batch 4: the file-IO seam everything else depends on. Mutations
+# here would cascade into every tool that reads tenant config; property
+# tests pin the filtering / sorting / fallback contracts.
+
+class TestLoadYamlFileProperties:
+
+    @given(st.one_of(
+        st.none(),
+        st.just(""),
+        st.text(alphabet=string.ascii_letters, min_size=1, max_size=20).map(
+            lambda s: f"/nonexistent/{s}.yaml"
+        ),
+    ))
+    @PILOT_SETTINGS
+    def test_missing_path_returns_default(self, path):
+        # Property: None / empty string / nonexistent path → default.
+        assert lio.load_yaml_file(path) is None
+        sentinel = object()
+        assert lio.load_yaml_file(path, default=sentinel) is sentinel
+
+    @given(st.dictionaries(
+        keys=st.text(alphabet=string.ascii_letters, min_size=1, max_size=8),
+        values=st.text(alphabet=string.ascii_letters, min_size=1, max_size=20),
+        min_size=1, max_size=5,
+    ))
+    @PILOT_SETTINGS
+    def test_round_trip(self, tmp_path_factory, kv):
+        # Hypothesis fixture-ordering rule: pytest fixtures BEFORE
+        # @given strategy params.
+        # Property: write a dict as YAML, load_yaml_file returns the same dict.
+        import yaml
+        d = tmp_path_factory.mktemp("yaml")
+        f = d / "x.yaml"
+        f.write_text(yaml.safe_dump(kv), encoding="utf-8")
+        assert lio.load_yaml_file(str(f)) == kv
+
+    def test_empty_file_returns_default(self, tmp_path):
+        # Property: empty YAML file → default (yaml.safe_load returns None).
+        f = tmp_path / "empty.yaml"
+        f.write_text("", encoding="utf-8")
+        assert lio.load_yaml_file(str(f)) is None
+        assert lio.load_yaml_file(str(f), default={}) == {}
+        assert lio.load_yaml_file(str(f), default=[]) == []
+
+
+class TestIterYamlFilesProperties:
+
+    @given(st.one_of(
+        st.none(),
+        st.just(""),
+        st.text(alphabet=string.ascii_letters, min_size=1, max_size=10).map(
+            lambda s: f"/nonexistent/{s}"
+        ),
+    ))
+    @PILOT_SETTINGS
+    def test_missing_dir_returns_empty(self, path):
+        # Property: None / empty / nonexistent dir → empty list.
+        assert lio.iter_yaml_files(path) == []
+
+    @given(st.lists(
+        st.text(alphabet=string.ascii_lowercase, min_size=1, max_size=8),
+        min_size=1, max_size=10, unique=True,
+    ))
+    @PILOT_SETTINGS
+    def test_output_sorted_by_filename(self, tmp_path_factory, names):
+        # Property: returned list is sorted by filename ascending.
+        d = tmp_path_factory.mktemp("yaml")
+        for n in names:
+            (d / f"{n}.yaml").write_text("k: v\n", encoding="utf-8")
+        result = lio.iter_yaml_files(str(d))
+        filenames = [fn for fn, _ in result]
+        assert filenames == sorted(filenames)
+
+    def test_filters_non_yaml_extensions(self, tmp_path):
+        for fn in ["a.yaml", "b.yml", "c.txt", "d.md", "e.json"]:
+            (tmp_path / fn).write_text("x", encoding="utf-8")
+        result = lio.iter_yaml_files(str(tmp_path))
+        names = {fn for fn, _ in result}
+        assert names == {"a.yaml", "b.yml"}
+
+    def test_skip_reserved_default_excludes_underscore(self, tmp_path):
+        for fn in ["tenant.yaml", "_defaults.yaml", ".hidden.yaml"]:
+            (tmp_path / fn).write_text("x", encoding="utf-8")
+        result = lio.iter_yaml_files(str(tmp_path))
+        names = {fn for fn, _ in result}
+        assert names == {"tenant.yaml"}
+
+    def test_skip_reserved_false_includes_all(self, tmp_path):
+        for fn in ["tenant.yaml", "_defaults.yaml", ".hidden.yaml"]:
+            (tmp_path / fn).write_text("x", encoding="utf-8")
+        result = lio.iter_yaml_files(str(tmp_path), skip_reserved=False)
+        names = {fn for fn, _ in result}
+        assert names == {"tenant.yaml", "_defaults.yaml", ".hidden.yaml"}
+
+    def test_filters_directories(self, tmp_path):
+        # Property: directories with .yaml-like names don't sneak through
+        # (the os.path.isfile check matters).
+        (tmp_path / "tenant.yaml").write_text("x", encoding="utf-8")
+        (tmp_path / "subdir.yaml").mkdir()  # a DIRECTORY ending in .yaml
+        result = lio.iter_yaml_files(str(tmp_path))
+        names = {fn for fn, _ in result}
+        assert names == {"tenant.yaml"}
+
+
+class TestFormatJsonReportProperties:
+
+    @given(st.dictionaries(
+        keys=st.text(alphabet=string.ascii_letters, min_size=1, max_size=8),
+        values=st.one_of(
+            st.text(alphabet=string.ascii_letters, max_size=20),
+            st.integers(),
+            st.booleans(),
+        ),
+        max_size=5,
+    ))
+    @PILOT_SETTINGS
+    def test_round_trip_via_json_loads(self, data):
+        # Property: format_json_report output parses back to the same data.
+        import json
+        s = lio.format_json_report(data)
+        assert json.loads(s) == data
+
+    @given(st.dictionaries(
+        keys=st.text(alphabet=string.ascii_letters, min_size=1, max_size=8),
+        values=st.text(min_size=1, max_size=20),
+        min_size=1, max_size=3,
+    ))
+    @PILOT_SETTINGS
+    def test_pretty_printed_default(self, data):
+        # Property: default output uses indent=2 — i.e. has a newline
+        # followed by exactly 2 spaces. Just checking for `\n` is too
+        # weak (json.dumps with indent=0 ALSO emits newlines, just no
+        # spaces) — that mismatch surfaced as a surviving mutation in
+        # batch-4 mutation pilot.
+        s = lio.format_json_report(data)
+        assert "\n  " in s, (
+            f"output {s!r} has no `\\n  ` (newline + 2 spaces); "
+            f"indent=2 default not honored?"
+        )
+
+    def test_unicode_not_escaped_default(self):
+        # Property: default ensure_ascii=False keeps Unicode bytes in output.
+        s = lio.format_json_report({"k": "中文"})
+        assert "中文" in s
+        assert "\\u" not in s
+
+    def test_kwargs_override_defaults(self):
+        # ensure_ascii=True can be re-enabled via kwarg.
+        s = lio.format_json_report({"k": "中文"}, ensure_ascii=True)
+        assert "中文" not in s
+        assert "\\u" in s


### PR DESCRIPTION
## Summary

Continuation of #302 / #323 / #329. Extends the pilot to 3 \`_lib_io\` functions (\`load_yaml_file\`, \`iter_yaml_files\`, \`format_json_report\`) — the file-IO seam that 20+ tools depend on.

**The interesting part of this PR**: 2 mutations initially survived that revealed real test logic gaps (not equivalents). Both are now closed. This is what mutation testing is FOR.

## Property tests added (13 new in 3 \`TestProperty*\` classes)

| Class | Tests | What it pins |
|---|---|---|
| \`TestLoadYamlFileProperties\` | 3 | None / \"\" / nonexistent path → default; round-trip; empty file → default |
| \`TestIterYamlFilesProperties\` | 6 | missing dir empty, sorted output, .yaml/.yml only, skip_reserved=True/False, directories filtered out |
| \`TestFormatJsonReportProperties\` | 4 | round-trip via json.loads, indent=2 default (FIXED), Unicode not escaped, kwargs override |

## Mutation entries added (7 new)

| Function | Mutation |
|---|---|
| \`load_yaml_file\` | drop \`isfile\` check (would attempt missing path) |
| \`load_yaml_file\` | drop None-coalesce (empty file → None instead of default) |
| \`iter_yaml_files\` | drop \`.yml\` from extension check |
| \`iter_yaml_files\` | drop dotfile filter |
| \`iter_yaml_files\` | drop \`isfile\` filter (dir leakage) |
| \`format_json_report\` | drop pretty-print default (indent=2 → 0) |
| \`format_json_report\` | drop ensure_ascii=False default |

## Two real test gaps surfaced + closed

### Gap 1: \`format_json_report::test_pretty_printed_default\`

| | |
|---|---|
| **Was** | \`assert \"\n\" in s\` |
| **Bug** | \`json.dumps(d, indent=0)\` ALSO emits newlines (between elements). Mutation slipped past. |
| **Fix** | \`assert \"\n  \" in s\` (newline + 2 spaces) |

### Gap 2: \`extract_metrics_from_expr::test_uppercase_label_tokens_excluded\`

| | |
|---|---|
| **Was** | \`expr = 'rate(http_requests_total{Tenant=\"db-a\"}[5m])'\` |
| **Bug** | Regex \`\b(...)\b(?=[{\[\s])\` requires token followed by \`{\`/\`[\`/whitespace. \`Tenant=\` (followed by \`=\`) is NEVER captured. The uppercase filter was never being exercised by this test. |
| **Fix** | \`expr = 'Foo{label=\"x\"} + Bar[5m]'\` — uppercase tokens DO match the regex's lookahead now. |

Both fixes are minimal and obvious in hindsight; mutation testing is the discipline that surfaced them despite them existing in the test suite the whole time.

## Cumulative pilot

| | Before | After |
|---|---|---|
| Property-based functions | 13 | **16** |
| Mutation pilot functions | 13 | **16** |
| Mutations crafted | 27 | **34** |
| Mutation score | 89% | **91%** |
| **Real gaps closed (cumulative)** | 3 | **5** |

3 surviving mutations, all documented EQUIVALENT mutations:
- \`_parse_front_matter\` skip prefix check
- \`parse_duration_seconds\` drop type-check
- \`strip_frontmatter\` search from index 0

All 7 NEW mutations on \`_lib_io\` functions are caught.

## Verification

\`\`\`
python tests/shared/_mutation_pilot.py
  → 31/34 caught, 3 SURVIVED (all equivalent), 0 setup-fails

pytest tests/shared/test_property_tools.py tests/shared/test_lib_python.py
       tests/dx/test_axe_lite_static.py tests/ops/test_generate_rule_pack_split.py
  → 280 passed, 4 skipped (Windows mode-bit, pre-existing)
  → 0 regressions
\`\`\`

## What this advances

Audit ④ \"Better Methods\" dimension: ~70% → ~75%.

Plus 2 latent test gaps surfaced + closed — exactly the bug-finding methodology mutation testing is supposed to deliver.

## Test plan

- [x] All 13 new property tests pass
- [x] Mutation pilot reports 31/34 caught
- [x] 2 real test gaps surfaced + fixed
- [x] No regression in adjacent tests
- [x] pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)