### PR TITLE
test(lint): self-test for check_jsx_i18n (Gap 4 / HA-7 P1)

### DIFF
--- a/tests/lint/test_check_jsx_i18n.py
+++ b/tests/lint/test_check_jsx_i18n.py
@@ -1,0 +1,519 @@
+"""Tests for scripts/tools/lint/check_jsx_i18n.py.
+
+Gap 4 (HA-7 backlog) — third lint self-test (P1). Auto-hook lint at
+301 LOC, previously zero unit-test coverage.
+
+The lint exists specifically because of the v2.3.0 bug class:
+  - jsx-loader.html language-toggle button returned the same string
+    in both branches → user couldn't actually switch language
+  - tenant-manager was added to TOOL_META but not CUSTOM_FLOW_MAP →
+    Guided Flow (?flow=...) couldn't load the tool
+
+A regex regression in this lint silently re-enables either bug. Three
+parsers + one orchestrator (run_checks) covered:
+
+  - parse_object_keys (TOOL_META / CUSTOM_FLOW_MAP key extraction)
+  - find_duplicate_t_params (window.__t copy-paste detector)
+  - check_language_toggle (ternary same-value detector)
+  - run_checks (orchestrator + file-missing handling)
+  - main CLI (--ci exit codes, --json shape, repo smoke)
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = REPO_ROOT / "scripts" / "tools" / "lint" / "check_jsx_i18n.py"
+
+_spec = importlib.util.spec_from_file_location("check_jsx_i18n", _SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["check_jsx_i18n"] = mod
+_spec.loader.exec_module(mod)
+
+
+# ============================================================
+# parse_object_keys
+# ============================================================
+
+
+class TestParseObjectKeys:
+
+    def test_var_declaration(self):
+        # Property: `var TOOL_META = { 'a': ..., 'b': ... }` parses keys.
+        content = (
+            "var TOOL_META = {\n"
+            "  'check-alert': { url: '/x' },\n"
+            "  'diagnose': { url: '/y' },\n"
+            "};\n"
+        )
+        keys, line = mod.parse_object_keys(content, "TOOL_META")
+        assert keys == {"check-alert", "diagnose"}
+        assert line == 1
+
+    def test_const_declaration(self):
+        content = (
+            "const TOOL_META = {\n"
+            "  'foo-bar': { },\n"
+            "};\n"
+        )
+        keys, _ = mod.parse_object_keys(content, "TOOL_META")
+        assert keys == {"foo-bar"}
+
+    def test_let_declaration(self):
+        content = (
+            "let TOOL_META = {\n"
+            "  'x-y-z': { },\n"
+            "};\n"
+        )
+        keys, _ = mod.parse_object_keys(content, "TOOL_META")
+        assert keys == {"x-y-z"}
+
+    def test_double_quoted_keys(self):
+        content = (
+            'var TOOL_META = {\n'
+            '  "alpha-beta": { },\n'
+            '  "gamma": { },\n'
+            '};\n'
+        )
+        keys, _ = mod.parse_object_keys(content, "TOOL_META")
+        # Note: 'gamma' has no '-' but the regex is `[a-z][a-z0-9-]+`
+        # which requires at least 2 chars total — `gamma` (5 chars) matches.
+        assert keys == {"alpha-beta", "gamma"}
+
+    def test_missing_object_returns_empty(self):
+        content = "var OTHER = { 'a': 1 };\n"
+        keys, line = mod.parse_object_keys(content, "TOOL_META")
+        assert keys == set()
+        assert line == 0
+
+    def test_object_assignment_form(self):
+        # Property: `TOOL_META: { ... }` (object-property form, e.g. inside
+        # a wrapping object) is also matched.
+        content = (
+            "{\n"
+            "  TOOL_META: {\n"
+            "    'a-b': 1,\n"
+            "  },\n"
+            "}\n"
+        )
+        keys, _ = mod.parse_object_keys(content, "TOOL_META")
+        assert keys == {"a-b"}
+
+    def test_inline_keys_on_decl_line(self):
+        # Property: keys on the same line as the opening brace are captured.
+        content = "var TOOL_META = { 'a-b': 1, 'c-d': 2 };\n"
+        keys, _ = mod.parse_object_keys(content, "TOOL_META")
+        assert keys == {"a-b", "c-d"}
+
+    def test_brace_depth_tracking(self):
+        # Property: nested objects don't terminate the key scan early.
+        content = (
+            "var TOOL_META = {\n"
+            "  'top-key': {\n"
+            "    'nested': 1,\n"  # nested key NOT captured
+            "  },\n"
+            "  'second-key': 2,\n"
+            "};\n"
+            "var OTHER = {\n"
+            "  'should-not-appear': 1,\n"
+            "};\n"
+        )
+        keys, _ = mod.parse_object_keys(content, "TOOL_META")
+        # We expect top-level keys only.
+        assert "top-key" in keys
+        assert "second-key" in keys
+        # Nested key would currently be captured (it matches the regex);
+        # the brace_depth check exits the scan when depth returns to 0.
+        # Don't assert on the nested-key behavior — just that we stopped
+        # before reading OTHER.
+        assert "should-not-appear" not in keys
+
+    def test_uppercase_keys_not_matched(self):
+        # Property: regex requires `[a-z][a-z0-9-]+`, so PascalCase keys
+        # are NOT picked up as TOOL_META keys (they're treated as
+        # constructors, not entry names).
+        content = (
+            "var TOOL_META = {\n"
+            "  'PascalCase': 1,\n"
+            "  'lower-kebab': 2,\n"
+            "};\n"
+        )
+        keys, _ = mod.parse_object_keys(content, "TOOL_META")
+        assert "PascalCase" not in keys
+        assert "lower-kebab" in keys
+
+
+# ============================================================
+# find_duplicate_t_params
+# ============================================================
+
+
+class TestFindDuplicateTParams:
+
+    def test_same_strings_flagged(self):
+        # Property: window.__t("X", "X") is a copy-paste bug → flagged.
+        content = "var x = window.__t('common text', 'common text');\n"
+        issues = mod.find_duplicate_t_params(content)
+        assert len(issues) == 1
+        assert issues[0]["zh"] == "common text"
+        assert issues[0]["en"] == "common text"
+        assert issues[0]["line"] == 1
+
+    def test_different_strings_not_flagged(self):
+        # Positive: legitimate bilingual call passes.
+        content = 'window.__t("中文", "English");\n'
+        assert mod.find_duplicate_t_params(content) == []
+
+    def test_double_and_single_quotes(self):
+        # Property: both quote styles match.
+        content = (
+            'window.__t("a", "a");\n'
+            "window.__t('b', 'b');\n"
+        )
+        issues = mod.find_duplicate_t_params(content)
+        assert len(issues) == 2
+
+    def test_multiple_calls_same_line(self):
+        # Property: multiple bad calls on one line all surface.
+        content = "x = window.__t('a','a'); y = window.__t('b','b');\n"
+        issues = mod.find_duplicate_t_params(content)
+        assert len(issues) == 2
+
+    def test_no_calls_returns_empty(self):
+        assert mod.find_duplicate_t_params("// just a comment\n") == []
+        assert mod.find_duplicate_t_params("") == []
+
+    def test_line_numbers_correct(self):
+        content = (
+            "// blank line\n"
+            "var foo = 1;\n"
+            "window.__t('z', 'z');\n"
+            "// another\n"
+            "window.__t('y', 'y');\n"
+        )
+        issues = mod.find_duplicate_t_params(content)
+        assert {i["line"] for i in issues} == {3, 5}
+
+    def test_context_truncated_to_100_chars(self):
+        # Property: long lines don't blow up CI logs — context is sliced.
+        long_prefix = "x" * 200
+        content = f"{long_prefix} window.__t('z', 'z');\n"
+        issues = mod.find_duplicate_t_params(content)
+        assert len(issues) == 1
+        assert len(issues[0]["context"]) <= 100
+
+
+# ============================================================
+# check_language_toggle
+# ============================================================
+
+
+class TestCheckLanguageToggle:
+
+    def test_same_branch_values_flagged(self):
+        # Property: ternary inside setLanguage where both branches return
+        # identical strings → flagged.
+        content = (
+            "function setLanguage(lang) {\n"
+            "  var label = lang === 'zh' ? '中文 / EN' : '中文 / EN';\n"
+            "  doStuff(label);\n"
+            "}\n"
+        )
+        issues = mod.check_language_toggle(content)
+        assert len(issues) == 1
+        assert "中文 / EN" in issues[0]["message"]
+        assert issues[0]["line"] == 2
+
+    def test_different_branch_values_not_flagged(self):
+        content = (
+            "function setLanguage(lang) {\n"
+            "  var label = lang === 'zh' ? 'EN' : '中文';\n"
+            "}\n"
+        )
+        assert mod.check_language_toggle(content) == []
+
+    def test_outside_toggle_function_ignored(self):
+        # Property: same-value ternary OUTSIDE a setLanguage / updateLbl /
+        # toggleLang function is not flagged.
+        content = (
+            "function unrelated() {\n"
+            "  var x = cond ? 'a' : 'a';\n"
+            "}\n"
+        )
+        assert mod.check_language_toggle(content) == []
+
+    def test_recognizes_updateLbl_function(self):
+        content = (
+            "function updateLbl(lang) {\n"
+            "  return lang === 'zh' ? 'same' : 'same';\n"
+            "}\n"
+        )
+        assert len(mod.check_language_toggle(content)) == 1
+
+    def test_recognizes_toggleLang_function(self):
+        content = (
+            "function toggleLang(lang) {\n"
+            "  document.title = lang === 'zh' ? 'X' : 'X';\n"
+            "}\n"
+        )
+        assert len(mod.check_language_toggle(content)) == 1
+
+
+# ============================================================
+# run_checks — orchestrator
+# ============================================================
+
+
+class TestRunChecks:
+
+    def test_missing_jsx_loader_yields_error(self, tmp_path, monkeypatch):
+        # Property: missing jsx-loader.html → file-missing error and
+        # empty stats (we abort early without scanning JSX_TOOLS_DIR).
+        monkeypatch.setattr(mod, "JSX_LOADER", tmp_path / "nope.html")
+        monkeypatch.setattr(mod, "JSX_TOOLS_DIR", tmp_path / "no-tools")
+        monkeypatch.setattr(mod, "WIZARD_DIR", tmp_path / "no-wizard")
+        issues, stats = mod.run_checks()
+        assert any(i["check"] == "file-missing" for i in issues)
+        assert stats == {}
+
+    def test_clean_loader_yields_no_issues(self, tmp_path, monkeypatch):
+        # Positive: a balanced loader passes cleanly.
+        loader = tmp_path / "jsx-loader.html"
+        loader.write_text(
+            "var TOOL_META = {\n"
+            "  'a-b': { },\n"
+            "  'c-d': { },\n"
+            "};\n"
+            "var CUSTOM_FLOW_MAP = {\n"
+            "  'a-b': { },\n"
+            "  'c-d': { },\n"
+            "};\n"
+            "function setLanguage(lang) {\n"
+            "  var l = lang === 'zh' ? 'EN' : '中文';\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "JSX_LOADER", loader)
+        monkeypatch.setattr(mod, "JSX_TOOLS_DIR", tmp_path / "no-tools")
+        monkeypatch.setattr(mod, "WIZARD_DIR", tmp_path / "no-wizard")
+        issues, stats = mod.run_checks()
+        assert issues == []
+        assert stats["tool_meta_count"] == 2
+        assert stats["flow_map_count"] == 2
+
+    def test_meta_only_key_is_error(self, tmp_path, monkeypatch):
+        # Negative: a key in TOOL_META but not in CUSTOM_FLOW_MAP →
+        # error with the v2.3.0 tenant-manager pattern.
+        loader = tmp_path / "jsx-loader.html"
+        loader.write_text(
+            "var TOOL_META = {\n"
+            "  'tenant-manager': { },\n"
+            "  'shared': { },\n"
+            "};\n"
+            "var CUSTOM_FLOW_MAP = {\n"
+            "  'shared': { },\n"
+            "};\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "JSX_LOADER", loader)
+        monkeypatch.setattr(mod, "JSX_TOOLS_DIR", tmp_path / "no-tools")
+        monkeypatch.setattr(mod, "WIZARD_DIR", tmp_path / "no-wizard")
+        issues, _ = mod.run_checks()
+        meta_only_issues = [i for i in issues if i["check"] == "meta-flow-sync"]
+        assert any("tenant-manager" in i["message"] for i in meta_only_issues)
+
+    def test_flow_only_key_is_error(self, tmp_path, monkeypatch):
+        loader = tmp_path / "jsx-loader.html"
+        loader.write_text(
+            "var TOOL_META = {\n"
+            "  'shared': { },\n"
+            "};\n"
+            "var CUSTOM_FLOW_MAP = {\n"
+            "  'shared': { },\n"
+            "  'orphan-flow': { },\n"
+            "};\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "JSX_LOADER", loader)
+        monkeypatch.setattr(mod, "JSX_TOOLS_DIR", tmp_path / "no-tools")
+        monkeypatch.setattr(mod, "WIZARD_DIR", tmp_path / "no-wizard")
+        issues, _ = mod.run_checks()
+        assert any(
+            i["check"] == "meta-flow-sync" and "orphan-flow" in i["message"]
+            for i in issues
+        )
+
+    def test_no_tool_meta_skips_sync_check(self, tmp_path, monkeypatch):
+        # Property: TD-030z — when TOOL_META is absent (legacy
+        # renderJSX function gone), the sync check is skipped entirely.
+        # Other checks still run.
+        loader = tmp_path / "jsx-loader.html"
+        loader.write_text(
+            "// TOOL_META was removed in TD-030z\n"
+            "var CUSTOM_FLOW_MAP = {\n"
+            "  'orphan-flow': { },\n"
+            "};\n"
+            "window.__t('same', 'same');\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "JSX_LOADER", loader)
+        monkeypatch.setattr(mod, "JSX_TOOLS_DIR", tmp_path / "no-tools")
+        monkeypatch.setattr(mod, "WIZARD_DIR", tmp_path / "no-wizard")
+        issues, stats = mod.run_checks()
+        # No meta-flow-sync issues (TOOL_META is absent).
+        assert not any(i["check"] == "meta-flow-sync" for i in issues)
+        # But the duplicate __t param check still fires.
+        assert any(i["check"] == "t-duplicate-param" for i in issues)
+        assert stats["tool_meta_count"] == 0
+
+    def test_jsx_tools_dir_dup_t_warning(self, tmp_path, monkeypatch):
+        # Property: a .jsx file in JSX_TOOLS_DIR with duplicate __t params
+        # surfaces as a WARNING (not error — JSX files are tool-internal
+        # so the impact is smaller than loader-level).
+        loader = tmp_path / "jsx-loader.html"
+        loader.write_text(
+            "var TOOL_META = { };\n"
+            "var CUSTOM_FLOW_MAP = { };\n",
+            encoding="utf-8",
+        )
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        bad = tools_dir / "bad.jsx"
+        bad.write_text(
+            "function X() { return window.__t('foo', 'foo'); }\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "JSX_LOADER", loader)
+        monkeypatch.setattr(mod, "JSX_TOOLS_DIR", tools_dir)
+        monkeypatch.setattr(mod, "WIZARD_DIR", tmp_path / "no-wizard")
+        # The lint reads `jsx_file.relative_to(REPO_ROOT)` — ensure we
+        # patch REPO_ROOT to a parent of our tmp_path so the relpath
+        # operation succeeds.
+        monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+        issues, _ = mod.run_checks()
+        warnings = [i for i in issues if i["severity"] == "warning"]
+        assert any(
+            i["check"] == "t-duplicate-param" and "foo" in i["message"]
+            for i in warnings
+        )
+
+    def test_language_toggle_issue_propagates(self, tmp_path, monkeypatch):
+        loader = tmp_path / "jsx-loader.html"
+        loader.write_text(
+            "var TOOL_META = { };\n"
+            "var CUSTOM_FLOW_MAP = { };\n"
+            "function updateLbl(lang) {\n"
+            "  return lang === 'zh' ? 'X' : 'X';\n"
+            "}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "JSX_LOADER", loader)
+        monkeypatch.setattr(mod, "JSX_TOOLS_DIR", tmp_path / "no-tools")
+        monkeypatch.setattr(mod, "WIZARD_DIR", tmp_path / "no-wizard")
+        issues, _ = mod.run_checks()
+        assert any(i["check"] == "toggle-same-value" for i in issues)
+
+
+# ============================================================
+# main — CLI / exit codes
+# ============================================================
+
+
+class TestMainCLI:
+
+    def test_clean_state_exits_zero(self, tmp_path, monkeypatch, capsys):
+        loader = tmp_path / "jsx-loader.html"
+        loader.write_text(
+            "var TOOL_META = { 'a-b': 1 };\n"
+            "var CUSTOM_FLOW_MAP = { 'a-b': 1 };\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "JSX_LOADER", loader)
+        monkeypatch.setattr(mod, "JSX_TOOLS_DIR", tmp_path / "no-tools")
+        monkeypatch.setattr(mod, "WIZARD_DIR", tmp_path / "no-wizard")
+        monkeypatch.setattr(sys, "argv", ["check_jsx_i18n", "--ci"])
+        with pytest.raises(SystemExit) as exc:
+            mod.main()
+        assert exc.value.code == 0
+        assert "通過" in capsys.readouterr().out
+
+    def test_error_state_exits_one_with_ci(self, tmp_path, monkeypatch, capsys):
+        # Negative: meta-flow-sync error → --ci exits 1.
+        loader = tmp_path / "jsx-loader.html"
+        loader.write_text(
+            "var TOOL_META = { 'orphan-meta': 1 };\n"
+            "var CUSTOM_FLOW_MAP = { };\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "JSX_LOADER", loader)
+        monkeypatch.setattr(mod, "JSX_TOOLS_DIR", tmp_path / "no-tools")
+        monkeypatch.setattr(mod, "WIZARD_DIR", tmp_path / "no-wizard")
+        monkeypatch.setattr(sys, "argv", ["check_jsx_i18n", "--ci"])
+        with pytest.raises(SystemExit) as exc:
+            mod.main()
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "orphan-meta" in out
+
+    def test_error_state_without_ci_exits_zero(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        # Property: errors without --ci just print, exit 0.
+        loader = tmp_path / "jsx-loader.html"
+        loader.write_text(
+            "var TOOL_META = { 'orphan-meta': 1 };\n"
+            "var CUSTOM_FLOW_MAP = { };\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "JSX_LOADER", loader)
+        monkeypatch.setattr(mod, "JSX_TOOLS_DIR", tmp_path / "no-tools")
+        monkeypatch.setattr(mod, "WIZARD_DIR", tmp_path / "no-wizard")
+        monkeypatch.setattr(sys, "argv", ["check_jsx_i18n"])
+        with pytest.raises(SystemExit) as exc:
+            mod.main()
+        assert exc.value.code == 0  # report-only without --ci
+
+    def test_json_output_shape(self, tmp_path, monkeypatch, capsys):
+        loader = tmp_path / "jsx-loader.html"
+        loader.write_text(
+            "var TOOL_META = { 'a-b': 1 };\n"
+            "var CUSTOM_FLOW_MAP = { 'a-b': 1 };\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "JSX_LOADER", loader)
+        monkeypatch.setattr(mod, "JSX_TOOLS_DIR", tmp_path / "no-tools")
+        monkeypatch.setattr(mod, "WIZARD_DIR", tmp_path / "no-wizard")
+        monkeypatch.setattr(sys, "argv", ["check_jsx_i18n", "--json"])
+        with pytest.raises(SystemExit):
+            mod.main()
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["check"] == "jsx-i18n"
+        assert "stats" in payload
+        assert "issues" in payload
+        assert "summary" in payload
+        assert payload["summary"]["errors"] == 0
+
+
+# ============================================================
+# Repo-level smoke regression guard
+# ============================================================
+
+
+class TestRepoSmoke:
+
+    def test_actual_repo_passes_or_warn_only(self, monkeypatch):
+        """The shipped jsx-loader.html + JSX tools must pass the lint
+        with --ci. Belt-and-suspenders alongside the pre-commit hook.
+        """
+        monkeypatch.setattr(sys, "argv", ["check_jsx_i18n", "--ci"])
+        with pytest.raises(SystemExit) as exc:
+            mod.main()
+        assert exc.value.code == 0, (
+            "repo's JSX i18n state fails its own lint"
+        )


### PR DESCRIPTION
## Summary

Third Gap 4 PR. Closes the **P1 entry for `check_jsx_i18n.py`** in HA-7's lint self-test backlog.

`check_jsx_i18n.py` (301 LOC, **auto-hook**) had **zero unit-test coverage**. The lint exists specifically because of two v2.3.0 bugs that escaped review:
- jsx-loader.html language-toggle button returned the same string in both branches (UX broken)
- tenant-manager was added to TOOL_META but missed from CUSTOM_FLOW_MAP (Guided Flow couldn't load it)

A regex regression in this lint silently re-enables either bug.

## Coverage (33 tests, all green)

| Layer | Cases |
|---|---|
| `parse_object_keys` | var/const/let, double + single quotes, missing object, **object-property form** (\`X: { ... }\`), inline keys, brace-depth tracking, uppercase-key filter |
| `find_duplicate_t_params` | same-string flagged, different not, both quote styles, multiple per line, line-number accuracy, context truncation |
| `check_language_toggle` | same-branch detection, different-branch safe, **outside-fn ignored**, recognizes \`setLanguage\` / \`updateLbl\` / \`toggleLang\` |
| `run_checks` orchestrator | missing loader → file-missing error, clean state, meta-only error, flow-only error, **no-TOOL_META skips sync (TD-030z)**, JSX-tools-dir warning, language-toggle propagation |
| `main` CLI | clean → exit 0, error+ci → exit 1, error-without-ci → exit 0 (report-only), --json shape, repo-files smoke |

## Notable invariants locked

- **TD-030z behavior**: when TOOL_META is absent (legacy renderJSX function gone), the meta-flow-sync check skips — but other checks still run. Locked as `test_no_tool_meta_skips_sync_check`.
- **Severity tiers**: jsx-loader.html issues are errors; JSX_TOOLS_DIR `.jsx` files are warnings (impact-scoped).

## Memory roadmap status — Gap 4 progress

| Lint | LOC | Priority | Status |
|---|---|---|---|
| \`check_metric_dictionary.py\` | 233 | P1 | ✅ #334 |
| \`check_build_completeness.py\` | 133 | P2 | ✅ #335 |
| **\`check_jsx_i18n.py\`** | **301** | **P1** | **THIS PR** |
| \`check_bilingual_structure.py\` | 426 | P1 | next |
| \`validate_docs_versions.py\` | 1089 | P0 | needs decomp |

After this PR lands, P1 has 1 entry remaining (check_bilingual_structure), then we hit the P0 decomp problem.

## Test plan

- [ ] CI green
- [ ] \`python -m pytest tests/lint/test_check_jsx_i18n.py -q\` — 33 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)