### PR TITLE
feat(dx): coverage_delta script — Gap 5 foundation (per-PR + trend)

### DIFF
--- a/docs/internal/tool-map.en.md
+++ b/docs/internal/tool-map.en.md
@@ -82,6 +82,7 @@ lang: en
 | `bump_docs.py` | 版號一致性管理工具 |
 | `bump_playbook_versions.py` | Bump `verified-at-version:` front-matter across the 4 operational playbooks. |
 | `check_aria_references.py` | Static JSX ARIA reference closure validator (Phase .a0 Day 5 verification). |
+| `coverage_delta.py` | Per-file + total coverage delta between two runs. |
 | `coverage_gap_analysis.py` | Per-file coverage ranking report |
 | `describe_tenant.py` | Describe effective tenant config — resolve _defaults.yaml inheritance chain. |
 | `doc_coverage.py` | 文件覆蓋率 Dashboard |

--- a/docs/internal/tool-map.md
+++ b/docs/internal/tool-map.md
@@ -82,6 +82,7 @@ lang: zh
 | `bump_docs.py` | 版號一致性管理工具 |
 | `bump_playbook_versions.py` | Bump `verified-at-version:` front-matter across the 4 operational playbooks. |
 | `check_aria_references.py` | Static JSX ARIA reference closure validator (Phase .a0 Day 5 verification). |
+| `coverage_delta.py` | Per-file + total coverage delta between two runs. |
 | `coverage_gap_analysis.py` | Per-file coverage ranking report |
 | `describe_tenant.py` | Describe effective tenant config — resolve _defaults.yaml inheritance chain. |
 | `doc_coverage.py` | 文件覆蓋率 Dashboard |

--- a/scripts/tools/dx/coverage_delta.py
+++ b/scripts/tools/dx/coverage_delta.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""coverage_delta.py — Per-file + total coverage delta between two runs.
+
+Gap 5 (testing-quality memory roadmap) — first PR. Builds the
+foundation for both per-PR delta gating ("coverage went down by N%
+in this file") and weekly trend aggregation. Both consume this
+script's structured output.
+
+What this is NOT
+----------------
+
+This is the COMPARISON layer, not the storage layer. CI already
+uploads `coverage.xml` as an artifact (see `.github/workflows/ci.yml`,
+`coverage-py${{ matrix.python }}` step). A future PR will wire this
+script into a workflow step that:
+
+  1. Downloads the previous run's `coverage.xml` (e.g., from
+     main-branch latest, or the user's PR base SHA), and
+  2. Runs this script to compute the delta, posting a comment.
+
+Output (text mode)
+------------------
+
+  Coverage delta: 84.5% → 86.2% (+1.7%)
+
+  Improved (3 files):
+    + scripts/tools/dx/foo.py        72.0% → 88.0% (+16.0%)
+    + scripts/tools/lint/bar.py      45.0% →  60.0% (+15.0%)
+    + ...
+
+  Regressed (1 file):
+    - scripts/tools/ops/qux.py       95.0% →  82.0% (-13.0%)
+
+  Newly tracked (2 files):
+    * scripts/tools/dx/new_a.py      80.0%
+    * ...
+
+  Removed (1 file):
+    ! scripts/tools/dx/gone.py       (was 100.0%)
+
+Output (--json mode)
+--------------------
+
+Emits a structured payload suitable for a PR-comment bot:
+
+  {
+    "total": {"before": 84.5, "after": 86.2, "delta": 1.7},
+    "improved": [{"file": "...", "before": 72.0, "after": 88.0,
+                   "delta": 16.0}, ...],
+    "regressed": [...],
+    "added": [...],
+    "removed": [...],
+    "unchanged_count": 47
+  }
+
+Usage
+-----
+
+  # Compare two coverage.xml files
+  python3 scripts/tools/dx/coverage_delta.py BEFORE.xml AFTER.xml
+
+  # JSON output for downstream consumers
+  python3 scripts/tools/dx/coverage_delta.py BEFORE.xml AFTER.xml --json
+
+  # Fail on regression > N% (for CI gating)
+  python3 scripts/tools/dx/coverage_delta.py BEFORE.xml AFTER.xml \\
+      --max-total-regression 1.0 --max-file-regression 5.0
+
+Exit codes
+----------
+
+  0  no regression, or regression within thresholds
+  1  regression beyond a configured threshold
+  2  configuration error (file missing, malformed XML, etc.)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class FileCov:
+    """Per-file coverage extracted from a Cobertura XML report."""
+    filename: str
+    line_rate: float  # 0.0 - 1.0
+    lines_covered: int
+    lines_valid: int
+
+    @property
+    def percent(self) -> float:
+        """Coverage as a 0-100 percentage."""
+        return round(self.line_rate * 100, 1)
+
+
+@dataclass(frozen=True)
+class CoverageReport:
+    """Parsed Cobertura XML report — total + per-file breakdown."""
+    total_line_rate: float  # 0.0 - 1.0
+    total_lines_covered: int
+    total_lines_valid: int
+    files: dict  # filename → FileCov
+
+    @property
+    def total_percent(self) -> float:
+        return round(self.total_line_rate * 100, 1)
+
+
+def parse_cobertura(path: Path) -> CoverageReport:
+    """Parse a Cobertura XML coverage report.
+
+    Cobertura's structure (relevant subset):
+
+      <coverage line-rate="0.85" lines-covered="850" lines-valid="1000">
+        <packages>
+          <package name="...">
+            <classes>
+              <class filename="..." line-rate="0.9"
+                     lines-covered="..." lines-valid="...">
+                <lines>...</lines>
+              </class>
+            </classes>
+          </package>
+        </packages>
+      </coverage>
+
+    pytest-cov omits `lines-covered` / `lines-valid` from `<class>` —
+    we synthesize them from the `<line>` children when missing.
+    """
+    if not path.is_file():
+        raise FileNotFoundError(f"coverage report not found: {path}")
+    try:
+        tree = ET.parse(path)
+    except ET.ParseError as e:
+        raise ValueError(f"malformed Cobertura XML at {path}: {e}") from e
+    root = tree.getroot()
+    if root.tag != "coverage":
+        raise ValueError(
+            f"unexpected root element {root.tag!r} (expected 'coverage') in {path}"
+        )
+
+    files: dict = {}
+    for cls in root.iter("class"):
+        filename = cls.attrib.get("filename")
+        if not filename:
+            continue
+        line_rate = float(cls.attrib.get("line-rate", 0.0))
+        # pytest-cov omits these on <class>; recompute from <line> hits.
+        lines = list(cls.iter("line"))
+        lines_valid = int(cls.attrib.get("lines-valid", len(lines)))
+        if "lines-covered" in cls.attrib:
+            lines_covered = int(cls.attrib["lines-covered"])
+        else:
+            lines_covered = sum(
+                1 for ln in lines if int(ln.attrib.get("hits", 0)) > 0
+            )
+        # If a file appears in multiple <package> sections, take the
+        # union of covered lines (max per file). Cobertura producers
+        # don't typically duplicate, but be defensive.
+        existing = files.get(filename)
+        if existing is None or lines_valid > existing.lines_valid:
+            files[filename] = FileCov(
+                filename=filename,
+                line_rate=line_rate,
+                lines_covered=lines_covered,
+                lines_valid=lines_valid,
+            )
+
+    total_line_rate = float(root.attrib.get("line-rate", 0.0))
+    total_lines_covered = int(root.attrib.get("lines-covered", 0))
+    total_lines_valid = int(root.attrib.get("lines-valid", 0))
+
+    return CoverageReport(
+        total_line_rate=total_line_rate,
+        total_lines_covered=total_lines_covered,
+        total_lines_valid=total_lines_valid,
+        files=files,
+    )
+
+
+@dataclass
+class FileDelta:
+    """Per-file delta between before / after."""
+    filename: str
+    before: float  # percentage
+    after: float
+    delta: float
+
+
+@dataclass
+class DeltaReport:
+    """Full delta result — total + four buckets of file changes."""
+    total_before: float
+    total_after: float
+    total_delta: float
+    improved: list  # list[FileDelta]
+    regressed: list  # list[FileDelta]
+    added: list  # list[FileDelta] (after-only; before=0)
+    removed: list  # list[FileDelta] (before-only; after=0)
+    unchanged_count: int
+
+    def to_dict(self) -> dict:
+        def _serialize(items):
+            return [asdict(d) for d in items]
+
+        return {
+            "total": {
+                "before": self.total_before,
+                "after": self.total_after,
+                "delta": round(self.total_delta, 2),
+            },
+            "improved": _serialize(self.improved),
+            "regressed": _serialize(self.regressed),
+            "added": _serialize(self.added),
+            "removed": _serialize(self.removed),
+            "unchanged_count": self.unchanged_count,
+        }
+
+
+def compute_delta(before: CoverageReport, after: CoverageReport) -> DeltaReport:
+    """Compute per-file + total coverage delta."""
+    improved: list = []
+    regressed: list = []
+    added: list = []
+    removed: list = []
+    unchanged = 0
+
+    before_files = before.files
+    after_files = after.files
+    all_filenames = set(before_files) | set(after_files)
+
+    for fn in sorted(all_filenames):
+        b = before_files.get(fn)
+        a = after_files.get(fn)
+        if a is None:  # file was removed (or excluded) in after
+            removed.append(FileDelta(
+                filename=fn, before=b.percent, after=0.0, delta=-b.percent,
+            ))
+            continue
+        if b is None:  # file is new in after
+            added.append(FileDelta(
+                filename=fn, before=0.0, after=a.percent, delta=a.percent,
+            ))
+            continue
+        diff = round(a.percent - b.percent, 1)
+        if diff > 0:
+            improved.append(FileDelta(fn, b.percent, a.percent, diff))
+        elif diff < 0:
+            regressed.append(FileDelta(fn, b.percent, a.percent, diff))
+        else:
+            unchanged += 1
+
+    total_delta = round(after.total_percent - before.total_percent, 2)
+    return DeltaReport(
+        total_before=before.total_percent,
+        total_after=after.total_percent,
+        total_delta=total_delta,
+        improved=improved,
+        regressed=regressed,
+        added=added,
+        removed=removed,
+        unchanged_count=unchanged,
+    )
+
+
+def format_text_report(report: DeltaReport, top_n: int = 10) -> str:
+    """Format DeltaReport as a human-readable text block.
+
+    Limits each non-empty bucket to the top *top_n* entries by absolute
+    delta (so a CI comment doesn't get hundreds of lines).
+    """
+    lines: list = []
+    sign = "+" if report.total_delta >= 0 else ""
+    lines.append(
+        f"Coverage delta: {report.total_before:.1f}% → "
+        f"{report.total_after:.1f}% ({sign}{report.total_delta:.2f}%)"
+    )
+    lines.append("")
+
+    def _section(title: str, items, marker: str, sort_key=None):
+        if not items:
+            return
+        if sort_key is None:
+            sort_key = lambda d: -abs(d.delta)
+        sorted_items = sorted(items, key=sort_key)[:top_n]
+        suffix = (
+            f" (showing top {top_n} of {len(items)})"
+            if len(items) > top_n else f" ({len(items)} files)"
+        )
+        lines.append(f"{title}{suffix}:")
+        for d in sorted_items:
+            sign_d = "+" if d.delta >= 0 else ""
+            lines.append(
+                f"  {marker} {d.filename}  "
+                f"{d.before:5.1f}% → {d.after:5.1f}% "
+                f"({sign_d}{d.delta:.1f}%)"
+            )
+        lines.append("")
+
+    _section("Improved", report.improved, "+")
+    _section("Regressed", report.regressed, "-")
+    _section("Newly tracked", report.added, "*")
+    _section("Removed", report.removed, "!")
+
+    if report.unchanged_count:
+        lines.append(f"Unchanged: {report.unchanged_count} files")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def evaluate_thresholds(
+    report: DeltaReport,
+    *,
+    max_total_regression: Optional[float] = None,
+    max_file_regression: Optional[float] = None,
+) -> list:
+    """Evaluate threshold violations against the delta report.
+
+    Args:
+        max_total_regression: Fail if total coverage drops by more than
+            this percentage (e.g. ``1.0`` blocks a -1.5% drop).
+        max_file_regression: Fail if any single file drops by more than
+            this percentage.
+
+    Returns:
+        List of human-readable violation strings (empty = OK).
+    """
+    violations: list = []
+    if max_total_regression is not None and report.total_delta < -max_total_regression:
+        violations.append(
+            f"total coverage dropped by {-report.total_delta:.2f}% "
+            f"(threshold: {max_total_regression:.2f}%)"
+        )
+    if max_file_regression is not None:
+        for d in report.regressed:
+            if -d.delta > max_file_regression:
+                violations.append(
+                    f"{d.filename} dropped by {-d.delta:.1f}% "
+                    f"(threshold: {max_file_regression:.1f}%)"
+                )
+    return violations
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compute per-file + total coverage delta between two "
+            "Cobertura XML reports."
+        ),
+    )
+    parser.add_argument("before", help="Path to BEFORE coverage.xml")
+    parser.add_argument("after", help="Path to AFTER coverage.xml")
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit JSON instead of human-readable text",
+    )
+    parser.add_argument(
+        "--top", type=int, default=10,
+        help="Top N files per bucket to show in text mode (default: 10)",
+    )
+    parser.add_argument(
+        "--max-total-regression", type=float, default=None,
+        help="Fail if total coverage drops by more than N%% (default: no gate)",
+    )
+    parser.add_argument(
+        "--max-file-regression", type=float, default=None,
+        help="Fail if any single file drops by more than N%% (default: no gate)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        before = parse_cobertura(Path(args.before))
+        after = parse_cobertura(Path(args.after))
+    except (FileNotFoundError, ValueError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    report = compute_delta(before, after)
+
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        print(format_text_report(report, top_n=args.top))
+
+    violations = evaluate_thresholds(
+        report,
+        max_total_regression=args.max_total_regression,
+        max_file_regression=args.max_file_regression,
+    )
+    if violations:
+        print("Threshold violations:", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/dx/test_coverage_delta.py
+++ b/tests/dx/test_coverage_delta.py
@@ -1,0 +1,482 @@
+"""Tests for scripts/tools/dx/coverage_delta.py.
+
+Gap 5 (testing-quality memory roadmap) — first PR. The delta script
+is the foundation for both per-PR delta gating and weekly trend
+aggregation. Both consume its structured output, so a regression
+here cascades into both planned features. Pin the contract before
+the consumers exist.
+
+Coverage:
+  - parse_cobertura: missing file / malformed XML / bad root /
+    pytest-cov shape (lines synthesized) / dedup-by-filename
+  - compute_delta: clean (no changes), improved, regressed, added,
+    removed, unchanged_count, total computation
+  - format_text_report: total line, section headers, top-N truncation,
+    sign formatting
+  - evaluate_thresholds: no gates / total-only gate / file-only gate /
+    both gates / no violation under threshold
+  - main CLI: missing input → exit 2, malformed → exit 2, clean delta
+    → exit 0, threshold violation → exit 1, --json shape
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(__file__), "..", "..", "scripts", "tools", "dx",
+))
+import coverage_delta as cd  # noqa: E402
+
+
+# ============================================================
+# XML fixture helpers
+# ============================================================
+
+
+def _make_cobertura(
+    total_rate: float,
+    total_covered: int,
+    total_valid: int,
+    files: dict,  # filename → (line_rate, lines_covered, lines_valid)
+) -> str:
+    """Build a minimal Cobertura XML report from per-file numbers."""
+    classes = []
+    for fn, (rate, cov, valid) in files.items():
+        classes.append(
+            f'      <class name="{fn}" filename="{fn}" '
+            f'line-rate="{rate}" lines-covered="{cov}" '
+            f'lines-valid="{valid}">\n'
+            f'        <lines/>\n'
+            f'      </class>'
+        )
+    body = "\n".join(classes)
+    return (
+        f'<?xml version="1.0" ?>\n'
+        f'<coverage line-rate="{total_rate}" '
+        f'lines-covered="{total_covered}" lines-valid="{total_valid}">\n'
+        f'  <packages>\n'
+        f'    <package name="default" line-rate="{total_rate}">\n'
+        f'      <classes>\n{body}\n      </classes>\n'
+        f'    </package>\n'
+        f'  </packages>\n'
+        f'</coverage>\n'
+    )
+
+
+def _write_xml(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ============================================================
+# parse_cobertura
+# ============================================================
+
+
+class TestParseCobertura:
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            cd.parse_cobertura(tmp_path / "nope.xml")
+
+    def test_malformed_xml_raises_value_error(self, tmp_path):
+        f = _write_xml(tmp_path / "bad.xml", "not even <xml>")
+        with pytest.raises(ValueError, match="malformed"):
+            cd.parse_cobertura(f)
+
+    def test_wrong_root_raises_value_error(self, tmp_path):
+        f = _write_xml(tmp_path / "bad.xml", "<wrong-root/>")
+        with pytest.raises(ValueError, match="unexpected root"):
+            cd.parse_cobertura(f)
+
+    def test_basic_shape(self, tmp_path):
+        f = _write_xml(
+            tmp_path / "cov.xml",
+            _make_cobertura(0.85, 850, 1000, {
+                "a.py": (0.9, 90, 100),
+                "b.py": (0.8, 80, 100),
+            }),
+        )
+        report = cd.parse_cobertura(f)
+        assert report.total_line_rate == pytest.approx(0.85)
+        assert report.total_percent == pytest.approx(85.0)
+        assert report.total_lines_covered == 850
+        assert report.total_lines_valid == 1000
+        assert set(report.files.keys()) == {"a.py", "b.py"}
+        assert report.files["a.py"].line_rate == pytest.approx(0.9)
+        assert report.files["a.py"].percent == pytest.approx(90.0)
+
+    def test_synthesizes_lines_covered_when_missing(self, tmp_path):
+        # Property: when pytest-cov omits `lines-covered`/`lines-valid`
+        # on <class>, we recompute from the <line hits="..."> children.
+        xml_body = (
+            '<?xml version="1.0" ?>\n'
+            '<coverage line-rate="0.5" lines-covered="2" lines-valid="4">\n'
+            '  <packages>\n'
+            '    <package name="x">\n'
+            '      <classes>\n'
+            '        <class name="x.py" filename="x.py" line-rate="0.5">\n'
+            '          <lines>\n'
+            '            <line number="1" hits="1"/>\n'
+            '            <line number="2" hits="0"/>\n'
+            '            <line number="3" hits="3"/>\n'
+            '            <line number="4" hits="0"/>\n'
+            '          </lines>\n'
+            '        </class>\n'
+            '      </classes>\n'
+            '    </package>\n'
+            '  </packages>\n'
+            '</coverage>\n'
+        )
+        f = _write_xml(tmp_path / "x.xml", xml_body)
+        report = cd.parse_cobertura(f)
+        x = report.files["x.py"]
+        # 2 of 4 lines have hits > 0.
+        assert x.lines_covered == 2
+        assert x.lines_valid == 4
+
+    def test_class_without_filename_skipped(self, tmp_path):
+        # Property: a <class> tag missing `filename=` is not parseable
+        # → silently skipped (defensive against odd Cobertura producers).
+        xml_body = (
+            '<?xml version="1.0" ?>\n'
+            '<coverage line-rate="1.0" lines-covered="1" lines-valid="1">\n'
+            '  <packages>\n'
+            '    <package name="x">\n'
+            '      <classes>\n'
+            '        <class line-rate="0.5"/>\n'
+            '        <class filename="real.py" line-rate="1.0" '
+            '               lines-covered="1" lines-valid="1"/>\n'
+            '      </classes>\n'
+            '    </package>\n'
+            '  </packages>\n'
+            '</coverage>\n'
+        )
+        f = _write_xml(tmp_path / "x.xml", xml_body)
+        report = cd.parse_cobertura(f)
+        assert set(report.files.keys()) == {"real.py"}
+
+
+# ============================================================
+# compute_delta
+# ============================================================
+
+
+class TestComputeDelta:
+
+    def test_no_changes_yields_empty_buckets(self, tmp_path):
+        # Property: identical reports → all buckets empty,
+        # unchanged_count = N, total_delta = 0.
+        before = cd.parse_cobertura(_write_xml(
+            tmp_path / "b.xml",
+            _make_cobertura(0.85, 85, 100, {"a.py": (0.9, 90, 100),
+                                              "b.py": (0.8, 80, 100)}),
+        ))
+        after = cd.parse_cobertura(_write_xml(
+            tmp_path / "a.xml",
+            _make_cobertura(0.85, 85, 100, {"a.py": (0.9, 90, 100),
+                                              "b.py": (0.8, 80, 100)}),
+        ))
+        report = cd.compute_delta(before, after)
+        assert report.improved == []
+        assert report.regressed == []
+        assert report.added == []
+        assert report.removed == []
+        assert report.unchanged_count == 2
+        assert report.total_delta == 0
+
+    def test_improved_bucket(self, tmp_path):
+        # Property: a file whose coverage went up appears in `improved`.
+        before = cd.parse_cobertura(_write_xml(
+            tmp_path / "b.xml",
+            _make_cobertura(0.7, 70, 100, {"a.py": (0.7, 70, 100)}),
+        ))
+        after = cd.parse_cobertura(_write_xml(
+            tmp_path / "a.xml",
+            _make_cobertura(0.9, 90, 100, {"a.py": (0.9, 90, 100)}),
+        ))
+        report = cd.compute_delta(before, after)
+        assert len(report.improved) == 1
+        assert report.improved[0].filename == "a.py"
+        assert report.improved[0].before == pytest.approx(70.0)
+        assert report.improved[0].after == pytest.approx(90.0)
+        assert report.improved[0].delta == pytest.approx(20.0)
+        assert report.regressed == []
+        assert report.total_delta == pytest.approx(20.0)
+
+    def test_regressed_bucket(self, tmp_path):
+        before = cd.parse_cobertura(_write_xml(
+            tmp_path / "b.xml",
+            _make_cobertura(0.95, 95, 100, {"a.py": (0.95, 95, 100)}),
+        ))
+        after = cd.parse_cobertura(_write_xml(
+            tmp_path / "a.xml",
+            _make_cobertura(0.82, 82, 100, {"a.py": (0.82, 82, 100)}),
+        ))
+        report = cd.compute_delta(before, after)
+        assert report.regressed
+        assert report.regressed[0].delta < 0
+        assert report.regressed[0].delta == pytest.approx(-13.0)
+
+    def test_added_bucket(self, tmp_path):
+        # Property: a file present only in `after` appears in `added`
+        # (with before=0, delta=after).
+        before = cd.parse_cobertura(_write_xml(
+            tmp_path / "b.xml",
+            _make_cobertura(1.0, 0, 0, {}),
+        ))
+        after = cd.parse_cobertura(_write_xml(
+            tmp_path / "a.xml",
+            _make_cobertura(1.0, 50, 50, {"new.py": (1.0, 50, 50)}),
+        ))
+        report = cd.compute_delta(before, after)
+        assert len(report.added) == 1
+        assert report.added[0].filename == "new.py"
+        assert report.added[0].before == 0.0
+        assert report.added[0].after == pytest.approx(100.0)
+        assert report.improved == []  # not "improved" — first appearance
+
+    def test_removed_bucket(self, tmp_path):
+        before = cd.parse_cobertura(_write_xml(
+            tmp_path / "b.xml",
+            _make_cobertura(1.0, 50, 50, {"gone.py": (1.0, 50, 50)}),
+        ))
+        after = cd.parse_cobertura(_write_xml(
+            tmp_path / "a.xml",
+            _make_cobertura(1.0, 0, 0, {}),
+        ))
+        report = cd.compute_delta(before, after)
+        assert len(report.removed) == 1
+        assert report.removed[0].filename == "gone.py"
+        assert report.removed[0].before == pytest.approx(100.0)
+        assert report.removed[0].after == 0.0
+        assert report.regressed == []  # removed isn't a "regression"
+
+    def test_mixed_buckets(self, tmp_path):
+        before = cd.parse_cobertura(_write_xml(
+            tmp_path / "b.xml",
+            _make_cobertura(0.8, 80, 100, {
+                "improved.py":  (0.5, 50, 100),
+                "regressed.py": (0.9, 90, 100),
+                "stable.py":    (0.95, 95, 100),
+                "gone.py":      (0.7, 70, 100),
+            }),
+        ))
+        after = cd.parse_cobertura(_write_xml(
+            tmp_path / "a.xml",
+            _make_cobertura(0.85, 85, 100, {
+                "improved.py":  (0.85, 85, 100),
+                "regressed.py": (0.7, 70, 100),
+                "stable.py":    (0.95, 95, 100),
+                "new.py":       (1.0, 100, 100),
+            }),
+        ))
+        report = cd.compute_delta(before, after)
+        assert {d.filename for d in report.improved} == {"improved.py"}
+        assert {d.filename for d in report.regressed} == {"regressed.py"}
+        assert {d.filename for d in report.added} == {"new.py"}
+        assert {d.filename for d in report.removed} == {"gone.py"}
+        assert report.unchanged_count == 1  # stable.py
+
+
+# ============================================================
+# format_text_report
+# ============================================================
+
+
+class TestFormatTextReport:
+
+    def _make(self, **kwargs):
+        defaults = dict(
+            total_before=80.0, total_after=85.0, total_delta=5.0,
+            improved=[], regressed=[], added=[], removed=[],
+            unchanged_count=0,
+        )
+        defaults.update(kwargs)
+        return cd.DeltaReport(**defaults)
+
+    def test_total_line_includes_arrow_and_sign(self):
+        r = self._make()
+        out = cd.format_text_report(r)
+        assert "80.0%" in out
+        assert "85.0%" in out
+        assert "→" in out
+        assert "+5.00%" in out
+
+    def test_negative_total_no_plus_sign(self):
+        r = self._make(total_before=85.0, total_after=80.0, total_delta=-5.0)
+        out = cd.format_text_report(r)
+        # Negative: no '+' prefix on the value.
+        assert "-5.00%" in out
+        assert "+5" not in out
+
+    def test_section_headers_appear_only_when_non_empty(self):
+        # Property: empty buckets don't print their section headers.
+        r = self._make(improved=[], regressed=[], added=[], removed=[])
+        out = cd.format_text_report(r)
+        assert "Improved" not in out
+        assert "Regressed" not in out
+        assert "Newly tracked" not in out
+        assert "Removed" not in out
+
+    def test_top_n_truncation(self):
+        # Property: when more than `top_n` items are in a bucket, the
+        # output is limited and indicates the truncation.
+        items = [
+            cd.FileDelta(f"file{i}.py", 50.0, 50.0 + i, float(i))
+            for i in range(1, 16)
+        ]
+        r = self._make(improved=items, total_delta=0.0)
+        out = cd.format_text_report(r, top_n=5)
+        # All 15 files exist but only top 5 are listed.
+        assert "showing top 5 of 15" in out
+        # file15.py (highest delta) is shown.
+        assert "file15.py" in out
+        # file1.py (smallest delta) is NOT shown.
+        assert "file1.py" not in out
+
+    def test_unchanged_count_line(self):
+        r = self._make(unchanged_count=42)
+        out = cd.format_text_report(r)
+        assert "Unchanged: 42 files" in out
+
+
+# ============================================================
+# evaluate_thresholds
+# ============================================================
+
+
+class TestEvaluateThresholds:
+
+    def test_no_gates_returns_empty(self):
+        r = cd.DeltaReport(
+            80.0, 75.0, -5.0, [], [], [], [], 0,
+        )
+        # No thresholds → no violations even though total dropped.
+        assert cd.evaluate_thresholds(r) == []
+
+    def test_total_regression_violation(self):
+        r = cd.DeltaReport(
+            80.0, 75.0, -5.0, [], [], [], [], 0,
+        )
+        v = cd.evaluate_thresholds(r, max_total_regression=2.0)
+        assert len(v) == 1
+        assert "total coverage dropped" in v[0]
+        assert "5.00%" in v[0]
+
+    def test_total_regression_within_threshold(self):
+        r = cd.DeltaReport(
+            80.0, 79.5, -0.5, [], [], [], [], 0,
+        )
+        # -0.5% drop with a 1.0% threshold → no violation.
+        assert cd.evaluate_thresholds(r, max_total_regression=1.0) == []
+
+    def test_file_regression_violation(self):
+        r = cd.DeltaReport(
+            80.0, 80.0, 0.0,
+            [], [cd.FileDelta("x.py", 95.0, 80.0, -15.0)],
+            [], [], 0,
+        )
+        v = cd.evaluate_thresholds(r, max_file_regression=10.0)
+        assert len(v) == 1
+        assert "x.py" in v[0]
+        assert "15.0%" in v[0]
+
+    def test_file_regression_within_threshold_no_violation(self):
+        r = cd.DeltaReport(
+            80.0, 80.0, 0.0,
+            [], [cd.FileDelta("x.py", 95.0, 90.0, -5.0)],
+            [], [], 0,
+        )
+        # -5% drop with a 10% threshold → no violation.
+        assert cd.evaluate_thresholds(r, max_file_regression=10.0) == []
+
+    def test_both_gates_independent(self):
+        # Property: total threshold and file threshold are evaluated
+        # independently — both can fire at once.
+        r = cd.DeltaReport(
+            80.0, 75.0, -5.0,
+            [], [cd.FileDelta("x.py", 95.0, 80.0, -15.0)],
+            [], [], 0,
+        )
+        v = cd.evaluate_thresholds(
+            r, max_total_regression=1.0, max_file_regression=5.0,
+        )
+        assert len(v) == 2
+
+
+# ============================================================
+# main — CLI / exit codes
+# ============================================================
+
+
+class TestMainCLI:
+
+    def test_missing_before_exits_two(self, tmp_path, capsys):
+        rc = cd.main([str(tmp_path / "nope.xml"),
+                       str(tmp_path / "also-nope.xml")])
+        assert rc == 2
+        assert "ERROR" in capsys.readouterr().err
+
+    def test_malformed_xml_exits_two(self, tmp_path, capsys):
+        bad = _write_xml(tmp_path / "bad.xml", "not xml")
+        ok = _write_xml(
+            tmp_path / "ok.xml",
+            _make_cobertura(0.8, 80, 100, {"a.py": (0.8, 80, 100)}),
+        )
+        rc = cd.main([str(bad), str(ok)])
+        assert rc == 2
+
+    def test_clean_delta_exits_zero(self, tmp_path, capsys):
+        b = _write_xml(
+            tmp_path / "b.xml",
+            _make_cobertura(0.85, 85, 100, {"a.py": (0.85, 85, 100)}),
+        )
+        a = _write_xml(
+            tmp_path / "a.xml",
+            _make_cobertura(0.85, 85, 100, {"a.py": (0.85, 85, 100)}),
+        )
+        rc = cd.main([str(b), str(a)])
+        assert rc == 0
+        assert "Coverage delta" in capsys.readouterr().out
+
+    def test_threshold_violation_exits_one(self, tmp_path, capsys):
+        b = _write_xml(
+            tmp_path / "b.xml",
+            _make_cobertura(0.90, 90, 100, {"a.py": (0.90, 90, 100)}),
+        )
+        a = _write_xml(
+            tmp_path / "a.xml",
+            _make_cobertura(0.80, 80, 100, {"a.py": (0.80, 80, 100)}),
+        )
+        rc = cd.main([
+            str(b), str(a),
+            "--max-total-regression", "1.0",
+        ])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Threshold violations" in err
+
+    def test_json_output_shape(self, tmp_path, capsys):
+        b = _write_xml(
+            tmp_path / "b.xml",
+            _make_cobertura(0.80, 80, 100, {"a.py": (0.80, 80, 100)}),
+        )
+        a = _write_xml(
+            tmp_path / "a.xml",
+            _make_cobertura(0.85, 85, 100, {"a.py": (0.85, 85, 100)}),
+        )
+        rc = cd.main([str(b), str(a), "--json"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert "total" in payload
+        assert {"before", "after", "delta"} <= set(payload["total"])
+        for bucket in ("improved", "regressed", "added", "removed"):
+            assert bucket in payload
+            assert isinstance(payload[bucket], list)
+        assert "unchanged_count" in payload


### PR DESCRIPTION
## Summary

First Gap 5 PR per the testing-quality memory roadmap. Adds the **comparison layer** that both planned consumers (per-PR delta gating + weekly trend aggregation) need.

## What's new

\`scripts/tools/dx/coverage_delta.py\` — parses two Cobertura XML files (the format pytest-cov emits as \`coverage.xml\`), buckets per-file changes into improved / regressed / added / removed, computes total delta, optionally fails on configurable regression thresholds.

### Modes

- **Text mode** (default): human-readable report with **top-N truncation per bucket** so a CI comment doesn't get hundreds of lines on a large refactor.
- **\`--json\` mode**: structured payload suitable for a future PR-comment bot.
- **\`--max-total-regression\` / \`--max-file-regression\`**: opt-in CI gates. Without flags the script is informational only.

### Example

\`\`\`
Coverage delta: 84.5% → 86.2% (+1.7%)

Improved (3 files):
  + scripts/tools/dx/foo.py        72.0% → 88.0% (+16.0%)
  + ...

Regressed (1 file):
  - scripts/tools/ops/qux.py       95.0% → 82.0% (-13.0%)

Newly tracked (2 files):
  * scripts/tools/dx/new_a.py       0.0% → 80.0% (+80.0%)

Removed (1 file):
  ! scripts/tools/dx/gone.py      100.0% →  0.0% (-100.0%)

Unchanged: 47 files
\`\`\`

## What's NOT included (deliberately)

This is the **comparison** layer, not the **storage** layer. CI already uploads \`coverage.xml\` as an artifact (\`ci.yml\` \`coverage-py\${{ matrix.python }}\` step, 7-day retention). Future PRs will:

1. Wire this script into a workflow step that downloads the base SHA's \`coverage.xml\` and posts a PR comment.
2. (Optional) Persist longer-retention snapshots for trend aggregation.

Splitting the foundation from the consumers keeps the diff small, lets the contract get reviewed in isolation, and means the consumers can be built / iterated independently.

## Tests

\`tests/dx/test_coverage_delta.py\` — **28 tests, all green**:

| Layer | Cases |
|---|---|
| \`parse_cobertura\` | missing file, malformed XML, wrong root, basic shape, **line-count synthesis** (pytest-cov omits \`lines-covered\`/\`lines-valid\` on \`<class>\`), no-filename skip |
| \`compute_delta\` | clean / improved / regressed / **added (first appearance, not "improved")** / **removed (not "regressed")** / unchanged_count / mixed |
| \`format_text_report\` | total line, conditional section headers, top-N truncation, sign formatting |
| \`evaluate_thresholds\` | 5 cases including independent total + file gate composition |
| \`main\` CLI | missing input → exit 2, malformed → exit 2, clean → exit 0, threshold violation → exit 1, --json shape |

Smoke-tested against a real pytest-cov \`coverage.xml\` (15 files, 41.4% baseline) — self-compare yielded the expected zero delta.

## Memory roadmap status

- ✅ Gap 1 (HA-11 fake-clock): #327
- ✅ Gap 2 (property/mutation, 31 fns): #333
- ✅ Gap 3 (HA-10 observability): #328
- ✅ Gap 4 (lint self-tests, all P0/P1): #334–#338
- 🟡 **Gap 5 (coverage trend / SLI dashboard)**: this PR is **1 of 2** in the chain
- 🟡 Gap 6 (pathlib wave 2): deferred, low ROI

## Test plan

- [ ] CI green
- [ ] \`python -m pytest tests/dx/test_coverage_delta.py -q\` — 28 passed
- [ ] \`python scripts/tools/dx/coverage_delta.py --help\` lists all flags
- [ ] Smoke: self-compare produces zero delta and exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)