### PR TITLE
feat(ci): coverage_delta PR-comment workflow — Gap 5 closes

### DIFF
--- a/.github/workflows/coverage-delta.yml
+++ b/.github/workflows/coverage-delta.yml
@@ -1,0 +1,186 @@
+# Coverage delta — find-and-update PR comment with the per-file coverage
+# diff between this PR and the latest main-branch run.
+#
+# Wired in Gap 5 PR 2 (testing-quality memory roadmap). Consumes the
+# `coverage-py3.13` artifact uploaded by the existing python-tests job
+# in ci.yml; runs scripts/tools/dx/coverage_delta.py against this run's
+# coverage.xml + the latest main-branch run's coverage.xml; posts/updates
+# a PR comment using the stable `<!-- coverage-delta-bot -->` marker so
+# repeated pushes don't accumulate one comment per push.
+#
+# Failure handling
+# ----------------
+#
+# This workflow is INFORMATIONAL ONLY by design — it never fails the PR.
+# The script exits non-zero only if --max-{total,file}-regression is
+# passed; we deliberately omit those flags here. If a hard gate is
+# wanted later, add the flags + `continue-on-error: false`.
+#
+# Why a separate workflow (not a step in ci.yml)
+# ----------------------------------------------
+#
+# The job needs `pull-requests: write` to comment, but the rest of CI
+# runs with the default minimal token. Keeping this isolated avoids
+# expanding the blast radius of a compromised CI step that today only
+# needs read access. It also lets the job skip cleanly on push events
+# (where there's no PR to comment on) without complicating ci.yml's
+# job dependency graph.
+name: Coverage Delta
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  contents: read
+  actions: read
+
+jobs:
+  delta:
+    name: Post coverage delta comment
+    runs-on: ubuntu-latest
+    # Only proceed when the triggering CI run was on a pull_request and
+    # finished successfully. (A failed CI run usually means coverage.xml
+    # is missing or partial — running delta on a partial baseline would
+    # report misleading regressions.)
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          # Need the coverage_delta.py script + tests; full history not
+          # required.
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 1
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Download PR coverage artifact
+        # The triggering CI run uploaded `coverage-py3.13` as one of its
+        # artifacts. Fetch it into ./pr-coverage/.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p pr-coverage
+          gh run download "${{ github.event.workflow_run.id }}" \
+            --repo "${{ github.repository }}" \
+            --name coverage-py3.13 \
+            --dir pr-coverage \
+            || echo "::warning::PR coverage artifact missing — skipping delta"
+
+      - name: Find latest main-branch CI run with coverage
+        id: find-base
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # List recent successful CI runs on main and pick the most
+          # recent one that has the coverage-py3.13 artifact attached.
+          # Fall back to "no-base" if nothing usable found in the last
+          # 20 runs (workflow stays informational; no failure).
+          echo "base_run_id=" >> "$GITHUB_OUTPUT"
+          runs=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow "CI" \
+            --branch main \
+            --status success \
+            --limit 20 \
+            --json databaseId,headSha)
+          for row in $(echo "$runs" | jq -r '.[] | @base64'); do
+            id=$(echo "$row" | base64 --decode | jq -r '.databaseId')
+            sha=$(echo "$row" | base64 --decode | jq -r '.headSha')
+            # Check whether this run has the coverage artifact.
+            if gh api "repos/${{ github.repository }}/actions/runs/$id/artifacts" \
+                 --jq '.artifacts[].name' | grep -qx 'coverage-py3.13'; then
+              echo "base_run_id=$id" >> "$GITHUB_OUTPUT"
+              echo "base_sha=$sha" >> "$GITHUB_OUTPUT"
+              echo "Found base coverage run $id (sha=$sha)"
+              break
+            fi
+          done
+
+      - name: Download main-branch coverage artifact
+        if: steps.find-base.outputs.base_run_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p main-coverage
+          gh run download "${{ steps.find-base.outputs.base_run_id }}" \
+            --repo "${{ github.repository }}" \
+            --name coverage-py3.13 \
+            --dir main-coverage
+
+      - name: Compute coverage delta
+        if: steps.find-base.outputs.base_run_id != ''
+        id: delta
+        run: |
+          if [ ! -f main-coverage/coverage.xml ] || [ ! -f pr-coverage/coverage.xml ]; then
+            echo "::warning::missing coverage.xml on one side — skipping"
+            exit 0
+          fi
+          {
+            echo 'COMMENT<<COVERAGE_EOF'
+            python scripts/tools/dx/coverage_delta.py \
+              main-coverage/coverage.xml \
+              pr-coverage/coverage.xml \
+              --markdown
+            # Footer: link the base SHA so reviewers can verify which
+            # main-branch run we compared against.
+            echo ""
+            echo "_Base: \`${{ steps.find-base.outputs.base_sha }}\`_"
+            echo 'COVERAGE_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find PR number for this workflow_run
+        if: steps.delta.outputs.COMMENT != ''
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # workflow_run events don't expose the PR number directly;
+          # look it up by head SHA.
+          sha="${{ github.event.workflow_run.head_sha }}"
+          number=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --search "$sha" \
+            --json number \
+            --jq '.[0].number')
+          if [ -z "$number" ]; then
+            echo "::warning::no open PR found for sha=$sha — skipping comment"
+          fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update PR comment
+        if: steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          MARKER: "<!-- coverage-delta-bot -->"
+          BODY: ${{ steps.delta.outputs.COMMENT }}
+        run: |
+          # Find the existing bot comment (if any) by the stable marker.
+          existing=$(gh api \
+            "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" \
+            | head -n 1)
+
+          if [ -n "$existing" ]; then
+            echo "Updating existing comment $existing"
+            gh api \
+              --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/$existing" \
+              -f body="$BODY"
+          else
+            echo "Posting new comment"
+            gh api \
+              --method POST \
+              "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" \
+              -f body="$BODY"
+          fi

--- a/scripts/tools/dx/coverage_delta.py
+++ b/scripts/tools/dx/coverage_delta.py
@@ -313,6 +313,72 @@ def format_text_report(report: DeltaReport, top_n: int = 10) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
+def format_markdown_report(report: DeltaReport, top_n: int = 10) -> str:
+    """Format DeltaReport as a Markdown block suitable for a PR comment.
+
+    Distinct from format_text_report: uses Markdown tables + headings
+    instead of plain indented lines, and includes a stable
+    `<!-- coverage-delta-bot -->` HTML comment marker so the workflow
+    can find-and-update an existing comment instead of accumulating
+    one comment per push.
+    """
+    sign = "+" if report.total_delta >= 0 else ""
+    direction = "📈" if report.total_delta > 0 else (
+        "📉" if report.total_delta < 0 else "➡️"
+    )
+
+    lines: list = [
+        "<!-- coverage-delta-bot -->",
+        "## Coverage delta",
+        "",
+        f"{direction} **{report.total_before:.1f}%** → "
+        f"**{report.total_after:.1f}%** ({sign}{report.total_delta:.2f}%)",
+        "",
+    ]
+
+    def _table(title: str, items, marker_emoji: str):
+        if not items:
+            return
+        sorted_items = sorted(items, key=lambda d: -abs(d.delta))[:top_n]
+        suffix = (
+            f" (top {top_n} of {len(items)})"
+            if len(items) > top_n else f" ({len(items)})"
+        )
+        lines.append(f"### {marker_emoji} {title}{suffix}")
+        lines.append("")
+        lines.append("| File | Before | After | Δ |")
+        lines.append("|---|---:|---:|---:|")
+        for d in sorted_items:
+            sd = "+" if d.delta >= 0 else ""
+            lines.append(
+                f"| `{d.filename}` | {d.before:.1f}% | "
+                f"{d.after:.1f}% | {sd}{d.delta:.1f}% |"
+            )
+        lines.append("")
+
+    _table("Improved", report.improved, "✅")
+    _table("Regressed", report.regressed, "⚠️")
+    _table("Newly tracked", report.added, "🆕")
+    _table("Removed", report.removed, "🗑")
+
+    if report.unchanged_count:
+        lines.append(f"_Unchanged: {report.unchanged_count} files._")
+        lines.append("")
+
+    if not (report.improved or report.regressed
+            or report.added or report.removed):
+        lines.append("_No per-file coverage changes detected._")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# Stable marker the PR-comment workflow uses to find-and-update an
+# existing comment rather than accumulate one per push. Keep in sync
+# with the literal in format_markdown_report.
+PR_COMMENT_MARKER = "<!-- coverage-delta-bot -->"
+
+
 def evaluate_thresholds(
     report: DeltaReport,
     *,
@@ -363,8 +429,12 @@ def main(argv: Optional[list] = None) -> int:
         help="Emit JSON instead of human-readable text",
     )
     parser.add_argument(
+        "--markdown", action="store_true",
+        help="Emit Markdown PR-comment-ready output instead of text",
+    )
+    parser.add_argument(
         "--top", type=int, default=10,
-        help="Top N files per bucket to show in text mode (default: 10)",
+        help="Top N files per bucket to show in text/markdown mode (default: 10)",
     )
     parser.add_argument(
         "--max-total-regression", type=float, default=None,
@@ -385,8 +455,15 @@ def main(argv: Optional[list] = None) -> int:
 
     report = compute_delta(before, after)
 
+    if args.json and args.markdown:
+        print("ERROR: --json and --markdown are mutually exclusive",
+              file=sys.stderr)
+        return 2
+
     if args.json:
         print(json.dumps(report.to_dict(), indent=2))
+    elif args.markdown:
+        print(format_markdown_report(report, top_n=args.top))
     else:
         print(format_text_report(report, top_n=args.top))
 

--- a/tests/dx/test_coverage_delta.py
+++ b/tests/dx/test_coverage_delta.py
@@ -347,6 +347,88 @@ class TestFormatTextReport:
 
 
 # ============================================================
+# format_markdown_report
+# ============================================================
+
+
+class TestFormatMarkdownReport:
+
+    def _make(self, **kwargs):
+        defaults = dict(
+            total_before=80.0, total_after=85.0, total_delta=5.0,
+            improved=[], regressed=[], added=[], removed=[],
+            unchanged_count=0,
+        )
+        defaults.update(kwargs)
+        return cd.DeltaReport(**defaults)
+
+    def test_includes_pr_comment_marker(self):
+        # Property: every markdown report starts with the stable
+        # marker so the bot can find-and-update an existing comment.
+        out = cd.format_markdown_report(self._make())
+        assert out.startswith("<!-- coverage-delta-bot -->")
+        # Sanity: the marker constant matches the literal in the output.
+        assert cd.PR_COMMENT_MARKER in out
+
+    def test_uses_markdown_heading_and_bold(self):
+        out = cd.format_markdown_report(self._make())
+        assert "## Coverage delta" in out
+        assert "**80.0%**" in out
+        assert "**85.0%**" in out
+
+    def test_direction_emoji_positive(self):
+        out = cd.format_markdown_report(self._make())
+        # +5% delta → upward emoji
+        assert "📈" in out
+
+    def test_direction_emoji_negative(self):
+        out = cd.format_markdown_report(
+            self._make(total_before=85.0, total_after=80.0, total_delta=-5.0))
+        assert "📉" in out
+
+    def test_direction_emoji_zero(self):
+        out = cd.format_markdown_report(
+            self._make(total_before=85.0, total_after=85.0, total_delta=0.0))
+        # Neutral delta → sideways arrow.
+        assert "➡️" in out
+
+    def test_table_rendered_for_non_empty_bucket(self):
+        # Property: a non-empty bucket emits a Markdown table with
+        # | File | Before | After | Δ | header.
+        items = [cd.FileDelta("a.py", 70.0, 90.0, 20.0)]
+        out = cd.format_markdown_report(self._make(improved=items))
+        assert "### ✅ Improved" in out
+        assert "| File | Before | After | Δ |" in out
+        assert "| `a.py` |" in out
+        assert "+20.0%" in out
+
+    def test_empty_buckets_no_section(self):
+        out = cd.format_markdown_report(self._make())
+        assert "Improved" not in out
+        assert "Regressed" not in out
+        # The "no changes" footer fires.
+        assert "No per-file coverage changes detected" in out
+
+    def test_top_n_truncation_in_markdown(self):
+        items = [
+            cd.FileDelta(f"f{i}.py", 50.0, 50.0 + i, float(i))
+            for i in range(1, 16)
+        ]
+        out = cd.format_markdown_report(
+            self._make(improved=items, total_delta=0.0), top_n=5)
+        assert "(top 5 of 15)" in out
+        assert "f15.py" in out
+        # Lowest-delta file should be truncated out.
+        assert "f1.py" not in out
+
+    def test_unchanged_count_footer(self):
+        items = [cd.FileDelta("a.py", 70.0, 90.0, 20.0)]
+        out = cd.format_markdown_report(
+            self._make(improved=items, unchanged_count=42))
+        assert "Unchanged: 42 files" in out
+
+
+# ============================================================
 # evaluate_thresholds
 # ============================================================
 
@@ -461,6 +543,34 @@ class TestMainCLI:
         assert rc == 1
         err = capsys.readouterr().err
         assert "Threshold violations" in err
+
+    def test_markdown_flag_emits_marker(self, tmp_path, capsys):
+        b = _write_xml(
+            tmp_path / "b.xml",
+            _make_cobertura(0.80, 80, 100, {"a.py": (0.80, 80, 100)}),
+        )
+        a = _write_xml(
+            tmp_path / "a.xml",
+            _make_cobertura(0.85, 85, 100, {"a.py": (0.85, 85, 100)}),
+        )
+        rc = cd.main([str(b), str(a), "--markdown"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert cd.PR_COMMENT_MARKER in out
+        assert "## Coverage delta" in out
+
+    def test_json_and_markdown_mutually_exclusive(self, tmp_path, capsys):
+        b = _write_xml(
+            tmp_path / "b.xml",
+            _make_cobertura(0.80, 80, 100, {"a.py": (0.80, 80, 100)}),
+        )
+        a = _write_xml(
+            tmp_path / "a.xml",
+            _make_cobertura(0.85, 85, 100, {"a.py": (0.85, 85, 100)}),
+        )
+        rc = cd.main([str(b), str(a), "--json", "--markdown"])
+        assert rc == 2
+        assert "mutually exclusive" in capsys.readouterr().err
 
     def test_json_output_shape(self, tmp_path, capsys):
         b = _write_xml(


### PR DESCRIPTION
## Summary

Second and final Gap 5 PR per the testing-quality memory roadmap. Wires the \`coverage_delta\` script (#339) into a CI workflow that posts/updates a PR comment with the per-file coverage diff between this PR and the latest main-branch run.

## What's added

### \`scripts/tools/dx/coverage_delta.py\` (extended)

- **\`format_markdown_report()\`**: emits a PR-comment-ready Markdown block with a stable \`<!-- coverage-delta-bot -->\` marker, **direction emoji** (📈/📉/➡️), and Markdown tables per bucket.
- **\`--markdown\` CLI flag**.
- **\`--json\` + \`--markdown\` mutual exclusion check** (returns exit 2 with helpful error).
- **\`PR_COMMENT_MARKER\`** constant for the workflow to grep on.

### \`tests/dx/test_coverage_delta.py\` (extended)

+11 tests covering: marker presence, direction emoji per sign, Markdown table structure, top-N truncation, empty-state footer, --markdown CLI flag, --json/--markdown mutual exclusion. **Total: 39 tests, all green.**

### \`.github/workflows/coverage-delta.yml\` (new)

Runs on \`workflow_run\` after CI succeeds on a PR. Steps:
1. Download PR coverage artifact from the triggering run
2. Find latest successful main-branch CI run with the \`coverage-py3.13\` artifact (walks last 20 runs)
3. Download main-branch coverage
4. Run \`coverage_delta.py --markdown\`
5. Look up PR number by head SHA (workflow_run doesn't expose it directly)
6. Find existing bot comment by stable marker; PATCH if present, POST otherwise — **find-and-update, no comment accumulation**

## Design choices

- **Separate workflow, not a step in ci.yml**: the comment job needs \`pull-requests: write\` while the rest of CI runs with the default minimal token. Isolating the elevated permissions limits blast radius.
- **INFORMATIONAL-only by default**: the script's threshold flags (\`--max-total-regression\` / \`--max-file-regression\`) are deliberately NOT passed in the workflow. Promoting to a hard gate is a separate policy decision; the foundation is here when wanted.
- **Graceful skip on missing baseline**: if no recent main-branch run has a coverage artifact (e.g., first run after the workflow lands), the workflow logs a warning and exits cleanly without posting a misleading comment.
- **Stable marker for find-and-update**: \`<!-- coverage-delta-bot -->\` is both a constant in \`coverage_delta.py\` and grep'd in the workflow. The \`test_includes_pr_comment_marker\` test pins them in sync.

## Memory roadmap status — Gap 5 complete

- ✅ Gap 1 (HA-11 fake-clock): #327
- ✅ Gap 2 (property/mutation, 31 fns): #333
- ✅ Gap 3 (HA-10 observability): #328
- ✅ Gap 4 (lint self-tests, all P0/P1): #334–#338
- ✅ **Gap 5 (coverage trend / SLI dashboard)**: #339 + this PR
- 🟡 Gap 6 (pathlib wave 2): deferred, low ROI

After this PR lands, **5 of 6 testing-quality roadmap gaps closed**. Gap 6 was explicitly marked low-ROI in the roadmap; it's the natural pause point unless new gaps surface.

## Test plan

- [ ] CI green
- [ ] \`python -m pytest tests/dx/test_coverage_delta.py -q\` — 39 passed
- [ ] After this lands: the next PR opened against main should auto-receive a coverage-delta comment from the bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)