### PR TITLE
refactor(tools): pathlib wave 2a batch 2 — 5 more files (~30 sites)

### DIFF
--- a/scripts/tools/dx/inject_related_docs.py
+++ b/scripts/tools/dx/inject_related_docs.py
@@ -214,8 +214,12 @@ def process_file(
         lang = fm.get("lang", "zh")
         title = fm.get("title", Path(file_path).stem)
 
-        # Compute related docs
-        rel_path = os.path.relpath(file_path, os.path.dirname(file_path))
+        # Compute related docs.
+        # NOTE: this is `relpath(file, file's parent)` which always equals
+        # `Path(file).name`. Preserved as-is during the pathlib refactor;
+        # if the original intent was relpath against a higher directory,
+        # that's a separate latent bug to address in a behavior-changing PR.
+        rel_path = Path(file_path).name
         related = get_related_docs(rel_path, fm, all_docs, min_score)
 
         new_section = generate_related_section(related, lang)
@@ -274,31 +278,32 @@ def main():
     mode = "update" if args.update else ("check" if args.check else "dry-run")
     docs_dir = args.docs_dir
 
-    if not os.path.isdir(docs_dir):
+    docs_root = Path(docs_dir)
+    if not docs_root.is_dir():
         print(f"Error: docs directory not found: {docs_dir}", file=sys.stderr)
         sys.exit(1)
 
     # Scan all markdown files
     all_docs = {}
-    for root, dirs, files in os.walk(docs_dir):
-        for fname in files:
-            if fname.endswith(".md"):
-                fpath = os.path.join(root, fname)
-                try:
-                    with open(fpath, "r", encoding="utf-8") as f:
-                        content = f.read()
-                    fm, _ = extract_frontmatter(content)
-                    title = fm.get("title", fname.replace(".md", ""))
-                    rel_path = os.path.relpath(fpath, docs_dir)
-                    all_docs[rel_path] = (title, fm)
-                except OSError:
-                    pass
+    for fpath in docs_root.rglob("*.md"):
+        if not fpath.is_file():
+            continue
+        fname = fpath.name
+        try:
+            with open(fpath, "r", encoding="utf-8") as f:
+                content = f.read()
+            fm, _ = extract_frontmatter(content)
+            title = fm.get("title", fname.replace(".md", ""))
+            rel_path = str(fpath.relative_to(docs_root))
+            all_docs[rel_path] = (title, fm)
+        except OSError:
+            pass
 
     # Process each file
     changed_count = 0
     error_count = 0
     for file_path in all_docs.keys():
-        full_path = os.path.join(docs_dir, file_path)
+        full_path = str(docs_root / file_path)
         changed, error = process_file(full_path, all_docs, args.min_score, mode)
         if error:
             print(f"Error processing {file_path}: {error}", file=sys.stderr)

--- a/scripts/tools/ops/gitops_check.py
+++ b/scripts/tools/ops/gitops_check.py
@@ -33,6 +33,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Optional
 
 import yaml
@@ -201,9 +202,10 @@ def check_repo(
 def check_local(dir_path: str) -> CheckResult:
     """Check local configuration directory structure and validity."""
     details = {"directory": dir_path}
+    base = Path(dir_path)
 
     # Check directory exists
-    if not os.path.isdir(dir_path):
+    if not base.is_dir():
         return CheckResult(
             check="local",
             status="fail",
@@ -215,8 +217,8 @@ def check_local(dir_path: str) -> CheckResult:
         )
 
     # Check _defaults.yaml exists
-    defaults_path = os.path.join(dir_path, "_defaults.yaml")
-    if not os.path.isfile(defaults_path):
+    defaults_path = str(base / "_defaults.yaml")
+    if not Path(defaults_path).is_file():
         return CheckResult(
             check="local",
             status="fail",
@@ -248,12 +250,13 @@ def check_local(dir_path: str) -> CheckResult:
     total_alerts = 0
 
     try:
-        for filename in sorted(os.listdir(dir_path)):
+        for entry in sorted(base.iterdir(), key=lambda p: p.name):
+            filename = entry.name
             if not filename.endswith(".yaml") or filename.startswith("_"):
                 continue
 
-            file_path = os.path.join(dir_path, filename)
-            if not os.path.isfile(file_path):
+            file_path = str(entry)
+            if not entry.is_file():
                 continue
 
             try:

--- a/scripts/tools/ops/grafana_import.py
+++ b/scripts/tools/ops/grafana_import.py
@@ -36,6 +36,7 @@ import json
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 
 def run_cmd(cmd, dry_run=False):
@@ -58,7 +59,8 @@ def import_dashboard(dashboard_path, cm_name, namespace, dry_run=False):
     """Import a single Grafana dashboard JSON as a labeled ConfigMap."""
     results = []
 
-    if not os.path.isfile(dashboard_path):
+    dashboard_p = Path(dashboard_path)
+    if not dashboard_p.is_file():
         results.append({
             "action": "import",
             "status": "fail",
@@ -70,7 +72,7 @@ def import_dashboard(dashboard_path, cm_name, namespace, dry_run=False):
     try:
         with open(dashboard_path, encoding="utf-8") as f:
             dashboard = json.load(f)
-        title = dashboard.get("title", os.path.basename(dashboard_path))
+        title = dashboard.get("title", dashboard_p.name)
     except (json.JSONDecodeError, Exception) as e:
         results.append({
             "action": "import",
@@ -79,7 +81,7 @@ def import_dashboard(dashboard_path, cm_name, namespace, dry_run=False):
         })
         return results
 
-    filename = os.path.basename(dashboard_path)
+    filename = dashboard_p.name
 
     # Step 1: Create ConfigMap (using --dry-run=client to generate, then apply)
     create_cmd = [
@@ -228,7 +230,7 @@ def verify_dashboards(namespace):
 
 def auto_name(dashboard_path):
     """Generate a ConfigMap name from a dashboard filename."""
-    base = os.path.splitext(os.path.basename(dashboard_path))[0]
+    base = Path(dashboard_path).stem
     # Convert to safe k8s name: lowercase, hyphens
     safe = base.lower().replace("_", "-").replace(" ", "-")
     return f"grafana-{safe}"
@@ -283,13 +285,13 @@ def main():
         cm_name = args.name or auto_name(args.dashboard)
         dashboards.append((args.dashboard, cm_name))
     elif args.dashboard_dir:
-        if not os.path.isdir(args.dashboard_dir):
+        dash_dir = Path(args.dashboard_dir)
+        if not dash_dir.is_dir():
             print(f"ERROR: Directory not found: {args.dashboard_dir}", file=sys.stderr)
             sys.exit(1)
-        for fname in sorted(os.listdir(args.dashboard_dir)):
-            if fname.endswith(".json"):
-                fpath = os.path.join(args.dashboard_dir, fname)
-                dashboards.append((fpath, auto_name(fpath)))
+        for entry in sorted(dash_dir.glob("*.json")):
+            fpath = str(entry)
+            dashboards.append((fpath, auto_name(fpath)))
     else:
         parser.error("Provide --dashboard, --dashboard-dir, or --verify")
 

--- a/scripts/tools/ops/shadow_verify.py
+++ b/scripts/tools/ops/shadow_verify.py
@@ -39,6 +39,7 @@ import sys
 import urllib.parse
 from collections import defaultdict
 from datetime import datetime, timezone
+from pathlib import Path
 
 import yaml
 
@@ -67,7 +68,7 @@ def check_preflight(args):
 
     # 1. Mapping file exists
     if args.mapping:
-        if os.path.isfile(args.mapping):
+        if Path(args.mapping).is_file():
             with open(args.mapping, encoding="utf-8") as f:
                 mapping = yaml.safe_load(f) or {}
             pair_count = sum(1 for v in mapping.values()
@@ -169,7 +170,7 @@ def check_runtime(args):
 
     # 1. CSV report analysis
     csv_path = args.report_csv
-    if csv_path and os.path.isfile(csv_path):
+    if csv_path and Path(csv_path).is_file():
         mismatch_count = 0
         total_rows = 0
         tenants = set()
@@ -250,7 +251,7 @@ def check_convergence(args):
 
     # 1. cutover-readiness.json
     readiness_path = args.readiness_json
-    if readiness_path and os.path.isfile(readiness_path):
+    if readiness_path and Path(readiness_path).is_file():
         with open(readiness_path, encoding="utf-8") as f:
             report = json.load(f)
         ready = report.get("ready", False)
@@ -271,7 +272,7 @@ def check_convergence(args):
 
     # 2. 7-day zero-mismatch (from CSV)
     csv_path = args.report_csv
-    if csv_path and os.path.isfile(csv_path):
+    if csv_path and Path(csv_path).is_file():
         now = datetime.now(timezone.utc)
         recent_mismatches = 0
         recent_rows = 0

--- a/scripts/tools/ops/validate_migration.py
+++ b/scripts/tools/ops/validate_migration.py
@@ -49,6 +49,7 @@ import json
 import time
 import argparse
 from datetime import datetime, timezone
+from pathlib import Path
 
 import yaml
 
@@ -200,8 +201,9 @@ def print_summary(all_results):
 
 def write_csv_report(all_results, output_dir):
     """將比對結果寫入 CSV。"""
-    os.makedirs(output_dir, exist_ok=True)
-    csv_path = os.path.join(output_dir, "validation-report.csv")
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = str(out_dir / "validation-report.csv")
 
     buf = io.StringIO()
     # lineterminator='\n' — write_text_secure opens in text mode, which on
@@ -415,10 +417,11 @@ def main():
                 report = tracker.print_status()
                 if report["ready"]:
                     # Write convergence report and stop
-                    conv_path = args.convergence_output or os.path.join(
-                        args.output_dir, "cutover-readiness.json"
+                    conv_path = args.convergence_output or str(
+                        Path(args.output_dir) / "cutover-readiness.json"
                     )
-                    os.makedirs(os.path.dirname(conv_path) if os.path.dirname(conv_path) else ".", exist_ok=True)
+                    parent = Path(conv_path).parent
+                    parent.mkdir(parents=True, exist_ok=True)
                     write_json_secure(conv_path, report)
                     print(f"\n  Cutover readiness report: {conv_path}")
                     break
@@ -429,10 +432,11 @@ def main():
         if tracker and not tracker.compute_report()["ready"]:
             print(f"\n  Watch completed ({args.rounds} rounds) without full convergence.")
             final = tracker.compute_report()
-            conv_path = args.convergence_output or os.path.join(
-                args.output_dir, "cutover-readiness.json"
+            conv_path = args.convergence_output or str(
+                Path(args.output_dir) / "cutover-readiness.json"
             )
-            os.makedirs(os.path.dirname(conv_path) if os.path.dirname(conv_path) else ".", exist_ok=True)
+            parent = Path(conv_path).parent
+            parent.mkdir(parents=True, exist_ok=True)
             write_json_secure(conv_path, final)
             print(f"  Partial convergence report: {conv_path}")
 

--- a/tests/ops/test_gitops_check.py
+++ b/tests/ops/test_gitops_check.py
@@ -1040,8 +1040,11 @@ class TestErrorRecovery:
         with open(os.path.join(config_dir, "_defaults.yaml"), "w") as f:
             yaml.dump(defaults, f)
 
-        # Mock os.listdir to raise OSError
-        with patch("os.listdir", side_effect=OSError("Permission denied")):
+        # Mock Path.iterdir to raise OSError. (Earlier versions used
+        # os.listdir; the pathlib refactor switched to Path.iterdir,
+        # which raises identically on permission errors.)
+        with patch("pathlib.Path.iterdir",
+                    side_effect=OSError("Permission denied")):
             result = gc.check_local(config_dir)
 
         assert result.status == "fail"


### PR DESCRIPTION
## Summary

Continues #341 with the next cohort of "4-7 sites per file" tools.

## Files refactored

| File | Sites | Notes |
|---|---|---|
| \`ops/grafana_import.py\` | 6 | **Drops \`os.listdir + os.path.join\` pair** in dashboard-dir scan, replaced with \`Path.glob("*.json")\` |
| \`ops/gitops_check.py\` | 4 + 1 test | See test-contract update below |
| \`ops/shadow_verify.py\` | 4 | |
| \`ops/validate_migration.py\` | 6 | **Collapses \`os.makedirs + os.path.dirname\` dance** into \`Path.parent.mkdir\` |
| \`dx/inject_related_docs.py\` | 4 | **\`os.walk\` → \`rglob("*.md")\`**; flagged a latent bug at line 218 (\`relpath(file, dirname(file))\` always equals \`basename\`) — preserved for a behavior-changing PR |

**Total: ~30 sites across 5 files.**

## Test contract update

\`test_gitops_check.py::test_local_with_permission_error\` mocked \`os.listdir\` to raise \`OSError\`. The pathlib refactor switched the production code to \`Path.iterdir()\` (which raises identically on permission errors), so the mock no longer triggered and the test silently passed instead of exercising the error path.

Updated to mock \`pathlib.Path.iterdir\` directly. Behavior under test is unchanged; the test now exercises what it claims to.

## What's deliberately NOT touched

\`sys.path\` bootstrap blocks at the top of \`ops/\` tools — load-bearing for Docker flat-layout vs repo subdir-layout dual support. Wave 1 (#324) and the previous batch (#341) followed the same convention.

## Verification

**1207 tests pass** across the impacted modules including \`test_sast.py\` (the previous batch's chmod refactor needed SAST-test adjustment in #341; this batch added no new chmod calls so SAST is undisturbed).

Pre-existing Windows-specific test failures (cp950 console-encoding decode errors, symlink-permission-denied) are unrelated and verified pre-PR via \`git stash\` reproduction on main.

## Memory roadmap status — Gap 6 progress

- ✅ Gap 1 / 2 / 3 / 4 / 5 — closed
- 🟡 **Gap 6 (pathlib wave 2)** — wave 2A batch 2

Cumulative wave 2A so far: **11 files, ~55 sites** (#341 + this PR). Roadmap estimated wave 2A as "15-20 files / ~70 sites" — close to wrap. Wave 2B (1-3 site tail across ~40 files) remains.

## Test plan

- [ ] CI green
- [ ] \`python -m pytest tests/ops/ tests/dx/ tests/shared/ -q\` — passes locally minus pre-existing Windows quirks

🤖 Generated with [Claude Code](https://claude.com/claude-code)