### PR TITLE
refactor(tools): pathlib wave 2B — 11 files (~17 sites)

### DIFF
--- a/scripts/tools/_lib_godispatch.py
+++ b/scripts/tools/_lib_godispatch.py
@@ -44,6 +44,7 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, _THIS_DIR)  # Docker flat layout
@@ -139,12 +140,12 @@ class GoBinaryDispatcher:
 
         if explicit:
             return (
-                explicit if os.path.isfile(explicit) else None
+                explicit if Path(explicit).is_file() else None
             ), cleaned
         env_override = os.environ.get(self.env_var, "").strip()
         if env_override:
             return (
-                env_override if os.path.isfile(env_override) else None
+                env_override if Path(env_override).is_file() else None
             ), cleaned
         return shutil.which(self.binary_name), cleaned
 

--- a/scripts/tools/dx/generate_doc_map.py
+++ b/scripts/tools/dx/generate_doc_map.py
@@ -255,9 +255,9 @@ def gather_docs(lang: str = "zh", include_adr: bool = False) -> list:
         for d in dirs:
             if d in effective_skip_dirs:
                 continue
-            dp = os.path.join(root, d)
+            dp = Path(root) / d
             try:
-                if os.path.islink(dp) and not os.path.exists(dp):
+                if dp.is_symlink() and not dp.exists():
                     continue
             except OSError:
                 continue

--- a/scripts/tools/ops/_grar_render.py
+++ b/scripts/tools/ops/_grar_render.py
@@ -23,6 +23,7 @@ import json
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import yaml
 
@@ -87,7 +88,7 @@ def load_base_config(path: str | None) -> dict:
     Returns dict with global, route, receivers, inhibit_rules.
     Falls back to _DEFAULT_BASE_CONFIG on any error.
     """
-    if not path or not os.path.isfile(path):
+    if not path or not Path(path).is_file():
         return dict(_DEFAULT_BASE_CONFIG)
     with open(path, encoding="utf-8") as fh:
         data = yaml.safe_load(fh) or {}

--- a/scripts/tools/ops/_grar_validate.py
+++ b/scripts/tools/ops/_grar_validate.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import fnmatch
 import os
 import sys
+from pathlib import Path
 from urllib.parse import urlparse
 
 import yaml
@@ -86,7 +87,7 @@ def validate_receiver_domains(receiver_obj: dict, tenant: str, allowed_domains: 
 
 def load_policy(policy_path: str | None) -> list[str]:
     """Load policy YAML and return allowed_domains list (may be empty)."""
-    if not policy_path or not os.path.isfile(policy_path):
+    if not policy_path or not Path(policy_path).is_file():
         return []
     with open(policy_path, encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}

--- a/scripts/tools/ops/blind_spot_discovery.py
+++ b/scripts/tools/ops/blind_spot_discovery.py
@@ -16,6 +16,7 @@ import os
 import re
 import sys
 import textwrap
+from pathlib import Path
 
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, _THIS_DIR)  # Docker flat layout
@@ -104,7 +105,7 @@ def load_monitored_db_types(config_dir):
     Returns {db_type: set(tenant_ids)}.
     """
     result = {}
-    if not os.path.isdir(config_dir):
+    if not Path(config_dir).is_dir():
         print(f"WARN: config-dir not found: {config_dir}", file=sys.stderr)
         return result
 

--- a/scripts/tools/ops/explain_route.py
+++ b/scripts/tools/ops/explain_route.py
@@ -18,6 +18,7 @@ import argparse
 import json
 import os
 import sys
+from pathlib import Path
 
 import yaml
 
@@ -497,7 +498,7 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
-    if not os.path.isdir(args.config_dir):
+    if not Path(args.config_dir).is_dir():
         print(f"ERROR: config directory not found: {args.config_dir}",
               file=sys.stderr)
         return 1

--- a/scripts/tools/ops/init_project.py
+++ b/scripts/tools/ops/init_project.py
@@ -1057,7 +1057,7 @@ def _ensure_dir(path: str) -> None:
 
 def _write_file(path: str, content: str, created_files: list[str]) -> None:
     """Write file with SAST-compliant writer, track in list."""
-    _ensure_dir(os.path.dirname(path))
+    _ensure_dir(str(Path(path).parent))
     write_text_secure(path, content)
     created_files.append(path)
 
@@ -1233,7 +1233,7 @@ def _print_summary(created: list[str], output_dir: str, config: dict) -> None:
     print()
 
     for f in created:
-        rel = os.path.relpath(f, output_dir)
+        rel = str(Path(f).relative_to(output_dir))
         print(f"  ✓ {rel}")
 
     # Show auto-enabled packs
@@ -1302,7 +1302,7 @@ def _print_summary(created: list[str], output_dir: str, config: dict) -> None:
 def _check_existing_init(output_dir: str, force: bool, parser: argparse.ArgumentParser) -> None:
     """Check if directory is already initialized."""
     marker_path = str(Path(output_dir) / '.da-init.yaml')
-    if os.path.isfile(marker_path) and not force:
+    if Path(marker_path).is_file() and not force:
         if _LANG == 'zh':
             print(f"⚠️  此目錄已初始化 ({marker_path})。", file=sys.stderr)
             print("   使用 --force 覆寫或手動刪除 .da-init.yaml。", file=sys.stderr)
@@ -1393,7 +1393,7 @@ def _handle_dry_run(config: dict, output_dir: str) -> None:
     print()
     files = _preview_files(config, output_dir)
     for f in files:
-        print(f"  {os.path.relpath(f, output_dir)}")
+        print(f"  {Path(f).relative_to(output_dir)}")
     print(f"\n  {'總計' if is_zh else 'Total'}: {len(files)}")
     sys.exit(0)
 
@@ -1438,7 +1438,7 @@ def main():
     config = _build_config_from_args(args, parser)
     _validate_config(config)
 
-    output_dir = os.path.abspath(args.output_dir)
+    output_dir = str(Path(args.output_dir).resolve())
 
     if args.dry_run:
         _handle_dry_run(config, output_dir)

--- a/scripts/tools/ops/notification_tester.py
+++ b/scripts/tools/ops/notification_tester.py
@@ -48,6 +48,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Any, Optional
 
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -740,7 +741,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if not os.path.isdir(args.config_dir):
+    if not Path(args.config_dir).is_dir():
         msg = f"配置目錄不存在: {args.config_dir}" if _LANG == 'zh' else f"Config directory not found: {args.config_dir}"
         print(msg, file=sys.stderr)
         sys.exit(1)

--- a/scripts/tools/ops/onboard_platform.py
+++ b/scripts/tools/ops/onboard_platform.py
@@ -36,6 +36,7 @@ import re
 import sys
 import textwrap
 from pathlib import Path
+from pathlib import Path
 
 import yaml
 
@@ -392,7 +393,7 @@ def scan_rule_files(pattern):
     Returns list of file paths.
     """
     files = glob.glob(pattern, recursive=True)
-    return sorted(f for f in files if os.path.isfile(f))
+    return sorted(f for f in files if Path(f).is_file())
 
 
 def classify_rule(rule):
@@ -560,12 +561,12 @@ def analyze_rule_files(file_paths, tenant_label=DEFAULT_TENANT_LABEL, metric_dic
                         "name": rule.get("record", ""),
                         "expr": rule.get("expr", ""),
                         "group": group_name,
-                        "file": os.path.basename(fpath),
+                        "file": Path(fpath).name,
                     })
                 elif rtype == "alert":
                     candidate = extract_threshold_candidates(rule, metric_dict)
                     candidate["group"] = group_name
-                    candidate["file"] = os.path.basename(fpath)
+                    candidate["file"] = Path(fpath).name
                     candidates.append(candidate)
 
     summary = {

--- a/scripts/tools/ops/operator_check.py
+++ b/scripts/tools/ops/operator_check.py
@@ -130,7 +130,7 @@ class OperatorChecker:
 
         expected = len(list(
             Path(self.args.rule_packs_dir).glob("rule-pack-*.yaml")
-        )) if os.path.isdir(self.args.rule_packs_dir) else 0
+        )) if Path(self.args.rule_packs_dir).is_dir() else 0
 
         status = "pass" if loaded == expected > 0 else ("warn" if loaded > 0 else "fail")
         detail = f"{loaded}/{expected}" if expected > 0 else f"{loaded}"

--- a/scripts/tools/ops/threshold_recommend.py
+++ b/scripts/tools/ops/threshold_recommend.py
@@ -42,6 +42,7 @@ import os
 import sys
 import urllib.parse
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Any, Optional
 
 _THIS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -655,7 +656,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if not os.path.isdir(args.config_dir):
+    if not Path(args.config_dir).is_dir():
         msg = f"配置目錄不存在: {args.config_dir}" if _LANG == 'zh' else f"Config directory not found: {args.config_dir}"
         print(msg, file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Summary

Last wave of the pathlib cleanup per the testing-quality memory roadmap. Wave 2A wrapped at #341+#342+#343 (16 files / ~80 sites); this is the **1-3-site tail** the roadmap described as "lower-ROI but cumulative cleanup makes the codebase consistently use pathlib."

## Files refactored

| File | Sites | Notes |
|---|---|---|
| \`_lib_godispatch.py\` | 2 | explicit/env-var binary probe in \`_resolve_binary\` (covered by batch 5 property tests, #331) |
| \`dx/generate_doc_map.py\` | 2 | broken-symlink prune in tree walk |
| \`ops/_grar_render.py\` | 1 | |
| \`ops/_grar_validate.py\` | 1 | |
| \`ops/blind_spot_discovery.py\` | 1 | |
| \`ops/explain_route.py\` | 1 | |
| \`ops/init_project.py\` | 5 | Also collapses \`os.path.abspath\` into \`Path.resolve()\` |
| \`ops/notification_tester.py\` | 1 | |
| \`ops/onboard_platform.py\` | 3 | |
| \`ops/operator_check.py\` | 1 | |
| \`ops/threshold_recommend.py\` | 1 | |

**Total: ~17 sites across 11 files.**

## What's deliberately NOT touched

\`sys.path\` bootstrap blocks at the top of \`ops/\` and \`dx/\` tools — load-bearing for Docker flat-layout vs repo subdir-layout dual support. Wave 1 (#324) and all wave 2A batches followed the same convention.

**Higher-count holdouts** (\`deprecate_rule.py\`: 9, \`diagnose.py\`: 7, \`generate_tenant_mapping_rules.py\`: 8, \`add_frontmatter.py\`: 13) are left for future targeted PRs since they exceed the wave-2 site budget per file. They're real candidates for "wave 2C" or one-off cleanups.

## Verification

**1799 tests pass** across the impacted modules + property tests (\`test_property_tools.py\` covers \`_lib_godispatch._resolve_binary\` exhaustively from batch 5) + \`test_sast.py\`.

## Memory roadmap status — Gap 6 wraps

| Wave | PRs | Files | Sites |
|---|---|---|---|
| Wave 1 | #324 | 5 | ~59 |
| Wave 2A | #341 + #342 + #343 | 16 | ~80 |
| **Wave 2B** | **THIS PR** | **11** | **~17** |
| **Cumulative** | — | **32** | **~156** |

All 6 gaps now covered:
- ✅ Gap 1 (HA-11 fake-clock): #327
- ✅ Gap 2 (property/mutation, 31 fns): #333
- ✅ Gap 3 (HA-10 observability): #328
- ✅ Gap 4 (lint self-tests, all P0/P1): #334-#338
- ✅ Gap 5 (coverage trend / SLI dashboard): #339 + #340
- ✅ **Gap 6 (pathlib wave 2)**: #341 + #342 + #343 + this PR

Per the roadmap, this is the **natural endpoint** of the testing-quality campaign. Higher-count pathlib holdouts can be addressed in future cleanup work as needed but aren't on the "good" critical path.

## Test plan

- [ ] CI green
- [ ] \`python -m pytest tests/ops/ tests/dx/ tests/shared/ -q\` — passes locally minus pre-existing Windows quirks

🤖 Generated with [Claude Code](https://claude.com/claude-code)