### PR TITLE
test(lint): property-pilot coverage drift detector (Gap 2)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -174,6 +174,20 @@ repos:
         files: ^(flaky-tests\.yaml|CHANGELOG\.md)$
         additional_dependencies: ['pyyaml']
 
+      # Property-pilot coverage drift: every top-level function in the
+      # in-scope modules must be triaged (covered with a property test
+      # OR excluded with a reason). Catches the "I added a new pure
+      # helper but forgot to property-test it" failure mode at commit
+      # time. Fires when any in-scope source, the manifest, or the
+      # property test file changes.
+      - id: property-coverage-check
+        name: Property-pilot coverage drift detector (Gap 2)
+        entry: python3 -X utf8 scripts/tools/lint/check_property_coverage.py --ci
+        language: python
+        pass_filenames: false
+        files: ^(tests/shared/property-coverage\.yaml|tests/shared/test_property_tools\.py|scripts/tools/(_lib_.*\.py|dx/(generate_doc_map|generate_changelog|axe_lite_static)\.py|ops/(generate_rule_pack_split|_grar_merge|_grar_validate)\.py|lint/(_lint_helpers|check_flaky_registry)\.py))$
+        additional_dependencies: ['pyyaml']
+
       - id: includes-sync
         name: Include snippet zh/en sync
         entry: python3 -X utf8 scripts/tools/lint/check_includes_sync.py --check

--- a/docs/internal/tool-map.en.md
+++ b/docs/internal/tool-map.en.md
@@ -158,6 +158,7 @@ lang: en
 | `check_portal_bundle_size.py` | Portal dist bundle size budget gate. |
 | `check_portal_i18n.py` | Portal JSX i18n hardcoded string detector |
 | `check_pr_scope_drift.py` | PR scope drift 偵測（pr-preflight 級）。 |
+| `check_property_coverage.py` | Property-pilot coverage drift detector. |
 | `check_repo_name.py` | Prevent wrong repository name in source files. |
 | `check_routing_profiles.py` | Lint routing profiles and domain policies (ADR-007). |
 | `check_skip_a11y_justification.py` | Require ticket-justification for `skipA11y: true` in E2E specs (testing-playbook §LL §5, TD-039). |

--- a/docs/internal/tool-map.md
+++ b/docs/internal/tool-map.md
@@ -158,6 +158,7 @@ lang: zh
 | `check_portal_bundle_size.py` | Portal dist bundle size budget gate. |
 | `check_portal_i18n.py` | Portal JSX i18n hardcoded string detector |
 | `check_pr_scope_drift.py` | PR scope drift 偵測（pr-preflight 級）。 |
+| `check_property_coverage.py` | Property-pilot coverage drift detector. |
 | `check_repo_name.py` | Prevent wrong repository name in source files. |
 | `check_routing_profiles.py` | Lint routing profiles and domain policies (ADR-007). |
 | `check_skip_a11y_justification.py` | Require ticket-justification for `skipA11y: true` in E2E specs (testing-playbook §LL §5, TD-039). |

--- a/scripts/tools/lint/check_property_coverage.py
+++ b/scripts/tools/lint/check_property_coverage.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""check_property_coverage.py — Property-pilot coverage drift detector.
+
+Gap 2 of the testing-quality memory roadmap. The property + mutation
+pilot landed at 31 functions across 12 modules (see PRs #329-#333),
+but with no enforcement, future-added pure helpers wouldn't get
+flagged for property tests. This lint is the ratchet.
+
+What this validates
+-------------------
+
+For each module declared in `tests/shared/property-coverage.yaml`:
+
+  1. **Every top-level function in the module is triaged.** Either
+     listed under `covered:` (with a property test in
+     test_property_tools.py + a mutation entry in _mutation_pilot.py)
+     OR listed under `excluded:` (with a one-line reason).
+
+     Functions in the source that are in NEITHER list cause the lint
+     to fail — forcing the author to consciously decide.
+
+  2. **Every `covered:` claim is real.** The function actually exists
+     in the source AND is referenced by name in
+     `tests/shared/test_property_tools.py`. (Catches typos and stale
+     manifest entries.)
+
+  3. **Every `excluded:` reason is non-empty.** Prevents drive-by
+     `excluded: foo:` exclusions without justification.
+
+  4. **No orphan manifest entries.** Functions listed but missing
+     from the source file → manifest is stale.
+
+Usage
+-----
+
+    python3 scripts/tools/lint/check_property_coverage.py
+    python3 scripts/tools/lint/check_property_coverage.py --ci
+    python3 scripts/tools/lint/check_property_coverage.py --json
+
+Exit codes
+----------
+
+  0  manifest in sync with source + tests
+  1  drift detected (functions need triage / manifest stale)
+  2  configuration error (manifest missing, source unparseable, etc.)
+
+Why a separate manifest, not inline test scanning
+-------------------------------------------------
+
+Could be tempting to just scan `test_property_tools.py` for
+`Test{FuncName}Properties` class names and infer coverage. Two
+reasons against:
+
+  - **`excluded:` with reasons** is the load-bearing part. Inferring
+    coverage doesn't capture WHY a function isn't tested (I/O-bound,
+    orchestrator, argparse helper). The reasons are documentation.
+  - **The manifest forces a triage decision** at the moment a new
+    function is added. Implicit inference would silently miss
+    additions until a quarterly audit.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_MANIFEST = REPO_ROOT / "tests" / "shared" / "property-coverage.yaml"
+DEFAULT_TEST_FILE = REPO_ROOT / "tests" / "shared" / "test_property_tools.py"
+
+
+def _safe_relative(path: Path, base: Path) -> str:
+    """Best-effort `path.relative_to(base).as_posix()`; falls back to
+    the absolute string if the path is outside the base. Used in
+    diagnostic messages where we'd rather not crash on
+    monkeypatch-driven tests that pass an unrelated tmp_path."""
+    try:
+        return path.relative_to(base).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+@dataclass
+class Issue:
+    """One drift finding."""
+    module: str
+    severity: str  # "error" or "warn"
+    kind: str  # missing-triage / stale-covered / stale-excluded / no-reason / no-test-ref
+    detail: str
+
+    def format(self) -> str:
+        return f"  [{self.kind}] {self.module}: {self.detail}"
+
+
+def _module_top_level_functions(source_path: Path) -> list[str]:
+    """Return names of top-level `def` functions AND class methods in *source_path*.
+
+    Top-level functions are returned as bare names (`foo`).
+    Class methods are returned as `ClassName.method_name`.
+
+    Skips:
+      - dunder methods (`__init__`, `__str__`, etc.) — they're protocol
+        glue, not value computations worth a property test
+      - typing-stub bodies (anywhere)
+
+    Includes:
+      - public functions (no leading underscore)
+      - single-underscore-prefixed helpers (load-bearing in this codebase
+        per scripts/tools convention; many `_audience_str` / `_parse_front_matter`
+        ARE in pilot scope)
+      - class methods (e.g., `GoBinaryDispatcher._resolve_binary`)
+    """
+    try:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"),
+                         filename=str(source_path))
+    except (OSError, SyntaxError) as e:
+        raise ValueError(f"cannot parse {source_path}: {e}") from e
+
+    names: list[str] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name.startswith("__"):
+                continue
+            names.append(node.name)
+        elif isinstance(node, ast.ClassDef):
+            for item in node.body:
+                if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if item.name.startswith("__"):
+                    continue
+                names.append(f"{node.name}.{item.name}")
+    return names
+
+
+def _test_file_function_names(test_path: Path) -> set[str]:
+    """Names referenced in test_property_tools.py.
+
+    We use a generous heuristic: any identifier that appears either
+    as a `mod.<name>(`, `mod.<name>` attribute access, or simply as
+    a bare word in the file is considered "referenced".
+
+    The strict alternative — looking for `Test{Pascal(name)}Properties`
+    — is brittle to test class naming conventions and would
+    false-fail on parameterised cases (TestParseDurationSecondsProperties
+    parametrises over multiple aspects of parse_duration_seconds).
+    """
+    if not test_path.is_file():
+        return set()
+    text = test_path.read_text(encoding="utf-8")
+    # Crude word-boundary scan for any identifier
+    import re
+    return set(re.findall(r"\b[a-zA-Z_][a-zA-Z0-9_]*\b", text))
+
+
+def validate_manifest(
+    manifest: dict,
+    repo_root: Path,
+    test_path: Path,
+) -> list[Issue]:
+    """Run all checks. Returns list of Issues (empty = clean)."""
+    issues: list[Issue] = []
+    modules = manifest.get("modules") or {}
+    if not isinstance(modules, dict):
+        issues.append(Issue(
+            module="<root>", severity="error", kind="bad-manifest",
+            detail=f"`modules:` must be a mapping, got {type(modules).__name__}",
+        ))
+        return issues
+
+    referenced_names = _test_file_function_names(test_path)
+
+    for rel_path, scope in sorted(modules.items()):
+        source_path = repo_root / rel_path
+        if not source_path.is_file():
+            issues.append(Issue(
+                module=rel_path, severity="error", kind="missing-source",
+                detail=f"manifest lists module {rel_path!r} but the file doesn't exist",
+            ))
+            continue
+
+        if not isinstance(scope, dict):
+            issues.append(Issue(
+                module=rel_path, severity="error", kind="bad-scope",
+                detail=f"module entry must be a mapping, got {type(scope).__name__}",
+            ))
+            continue
+
+        covered = scope.get("covered") or []
+        excluded = scope.get("excluded") or {}
+        if not isinstance(covered, list):
+            issues.append(Issue(
+                module=rel_path, severity="error", kind="bad-covered",
+                detail="`covered:` must be a list of function names",
+            ))
+            continue
+        if not isinstance(excluded, dict):
+            issues.append(Issue(
+                module=rel_path, severity="error", kind="bad-excluded",
+                detail="`excluded:` must be a mapping of function-name → reason",
+            ))
+            continue
+
+        # Source AST scan
+        try:
+            source_funcs = set(_module_top_level_functions(source_path))
+        except ValueError as e:
+            issues.append(Issue(
+                module=rel_path, severity="error", kind="parse-error",
+                detail=str(e),
+            ))
+            continue
+
+        covered_set = set(covered)
+        excluded_set = set(excluded.keys())
+        manifest_set = covered_set | excluded_set
+
+        # 1. Functions in source but not in manifest
+        untriaged = source_funcs - manifest_set
+        for name in sorted(untriaged):
+            issues.append(Issue(
+                module=rel_path, severity="error", kind="missing-triage",
+                detail=(
+                    f"function {name!r} exists in {rel_path} but is not "
+                    "listed in property-coverage.yaml. Either add a "
+                    "property test (and list under `covered:`) OR list "
+                    "under `excluded:` with a one-line reason."
+                ),
+            ))
+
+        # 2. Manifest entries with no source backing (stale)
+        stale = manifest_set - source_funcs
+        for name in sorted(stale):
+            issues.append(Issue(
+                module=rel_path, severity="error", kind="stale-manifest",
+                detail=(
+                    f"manifest lists {name!r} but it doesn't exist in "
+                    f"{rel_path}. Remove the entry — it's stale."
+                ),
+            ))
+
+        # 3. Covered claims must have a test reference. For
+        # `Class.method` entries we accept either the dotted form OR
+        # the bare method name in the test source (tests typically call
+        # `instance.method(...)`, which surfaces as bare `method` in
+        # the regex word scan).
+        for name in sorted(covered_set):
+            if name not in source_funcs:
+                continue  # already flagged as stale above
+            bare_name = name.split(".", 1)[1] if "." in name else name
+            if name not in referenced_names and bare_name not in referenced_names:
+                issues.append(Issue(
+                    module=rel_path, severity="error", kind="no-test-ref",
+                    detail=(
+                        f"function {name!r} is listed under `covered:` "
+                        "but no reference found in "
+                        f"{_safe_relative(test_path, repo_root)}. "
+                        "Add a property test."
+                    ),
+                ))
+
+        # 4. Excluded entries must have a non-empty reason
+        for name, reason in sorted(excluded.items()):
+            if not isinstance(reason, str) or not reason.strip():
+                issues.append(Issue(
+                    module=rel_path, severity="error", kind="no-reason",
+                    detail=(
+                        f"function {name!r} is listed under `excluded:` "
+                        "with empty / non-string reason. Add one-line "
+                        "justification (I/O-bound / orchestrator / "
+                        "argparse helper / etc.)."
+                    ),
+                ))
+
+    return issues
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate property-pilot coverage manifest vs source + tests.",
+    )
+    parser.add_argument(
+        "--manifest", default=str(DEFAULT_MANIFEST),
+        help="Manifest YAML path (default: tests/shared/property-coverage.yaml)",
+    )
+    parser.add_argument(
+        "--test-file", default=str(DEFAULT_TEST_FILE),
+        help="Property-test file path (default: tests/shared/test_property_tools.py)",
+    )
+    parser.add_argument(
+        "--ci", action="store_true",
+        help="CI mode (terse output; default behavior is to exit 1 on findings).",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit JSON instead of text.",
+    )
+    args = parser.parse_args(argv)
+
+    manifest_path = Path(args.manifest)
+    if not manifest_path.is_file():
+        print(f"ERROR: manifest not found: {manifest_path}", file=sys.stderr)
+        return 2
+
+    try:
+        import yaml
+    except ImportError:
+        print("ERROR: pyyaml not installed", file=sys.stderr)
+        return 2
+
+    try:
+        with open(manifest_path, encoding="utf-8") as f:
+            manifest = yaml.safe_load(f) or {}
+    except yaml.YAMLError as e:
+        print(f"ERROR: cannot parse {manifest_path}: {e}", file=sys.stderr)
+        return 2
+
+    test_path = Path(args.test_file)
+    issues = validate_manifest(manifest, REPO_ROOT, test_path)
+
+    if args.json:
+        import dataclasses
+        print(json.dumps({
+            "check": "property-coverage",
+            "manifest": _safe_relative(manifest_path, REPO_ROOT),
+            "modules_scanned": len(manifest.get("modules") or {}),
+            "issues": [dataclasses.asdict(i) for i in issues],
+            "summary": {"errors": len(issues)},
+        }, indent=2, ensure_ascii=False))
+    else:
+        if not issues:
+            count = len(manifest.get("modules") or {})
+            if not args.ci:
+                print(
+                    f"property-coverage.yaml: {count} modules in scope, "
+                    "all functions triaged, all covered claims backed by tests."
+                )
+            return 0
+
+        print(
+            f"property-coverage drift detected: {len(issues)} finding(s)",
+            file=sys.stderr,
+        )
+        for issue in issues:
+            print(issue.format(), file=sys.stderr)
+        print(
+            "\nTo fix: edit tests/shared/property-coverage.yaml to triage "
+            "each function (covered: + property test, OR excluded: with reason).",
+            file=sys.stderr,
+        )
+
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/lint/test_check_property_coverage.py
+++ b/tests/lint/test_check_property_coverage.py
@@ -1,0 +1,434 @@
+"""Tests for scripts/tools/lint/check_property_coverage.py.
+
+Process-enforcement lint that ratchets the property + mutation pilot
+(see Gap 2 of testing-quality memory roadmap closure). Without this
+lint, new pure helpers added to in-scope modules wouldn't get
+flagged for property tests; the pilot's 31-function snapshot would
+silently drift.
+
+Coverage:
+  - _module_top_level_functions: top-level def, class methods as
+    Class.method, dunder skip, public + _private helpers
+  - validate_manifest: clean / missing-source / bad-scope shapes /
+    bad-covered / bad-excluded / missing-triage / stale-manifest /
+    no-test-ref / no-reason / bare method-name acceptance for
+    Class.method covered claims
+  - main CLI: missing manifest / bad YAML / valid run / drift
+    detection / --json shape / repo smoke
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = REPO_ROOT / "scripts" / "tools" / "lint" / "check_property_coverage.py"
+
+_spec = importlib.util.spec_from_file_location("check_property_coverage", _SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["check_property_coverage"] = mod
+_spec.loader.exec_module(mod)
+
+
+# ============================================================
+# Helpers
+# ============================================================
+
+
+def _write(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+
+
+# ============================================================
+# _module_top_level_functions — AST walker
+# ============================================================
+
+
+class TestModuleTopLevelFunctions:
+
+    def test_top_level_def(self, tmp_path):
+        f = tmp_path / "m.py"
+        _write(f, """
+            def foo(): pass
+            def bar(): pass
+        """)
+        assert sorted(mod._module_top_level_functions(f)) == ["bar", "foo"]
+
+    def test_class_methods_use_dotted_form(self, tmp_path):
+        f = tmp_path / "m.py"
+        _write(f, """
+            class Dispatcher:
+                def resolve(self): pass
+                def dispatch(self): pass
+        """)
+        names = mod._module_top_level_functions(f)
+        assert sorted(names) == ["Dispatcher.dispatch", "Dispatcher.resolve"]
+
+    def test_dunder_methods_excluded(self, tmp_path):
+        f = tmp_path / "m.py"
+        _write(f, """
+            class Version:
+                def __init__(self): pass
+                def __lt__(self, other): pass
+                def compare(self, other): pass
+        """)
+        names = mod._module_top_level_functions(f)
+        assert names == ["Version.compare"]
+
+    def test_public_and_private_helpers_both_included(self, tmp_path):
+        # Property: leading-underscore helpers (`_audience_str` style)
+        # are in scope by codebase convention.
+        f = tmp_path / "m.py"
+        _write(f, """
+            def public_fn(): pass
+            def _private_helper(): pass
+            def _audience_str(audience_list): pass
+        """)
+        names = mod._module_top_level_functions(f)
+        assert sorted(names) == ["_audience_str", "_private_helper", "public_fn"]
+
+    def test_async_def_recognized(self, tmp_path):
+        f = tmp_path / "m.py"
+        _write(f, """
+            async def fetch_url(url): pass
+            def sync_helper(): pass
+        """)
+        names = mod._module_top_level_functions(f)
+        assert sorted(names) == ["fetch_url", "sync_helper"]
+
+    def test_top_level_assignments_skipped(self, tmp_path):
+        # Property: only `def` constructs count, not constants /
+        # imports / dataclass field defaults.
+        f = tmp_path / "m.py"
+        _write(f, """
+            from dataclasses import dataclass
+
+            CONSTANT = 42
+
+            @dataclass
+            class Config:
+                threshold: int = 100
+
+            def real_function(): pass
+        """)
+        names = mod._module_top_level_functions(f)
+        assert names == ["real_function"]
+
+    def test_syntax_error_raises_value_error(self, tmp_path):
+        f = tmp_path / "m.py"
+        _write(f, "def foo(:\n    bad syntax\n")
+        with pytest.raises(ValueError, match="cannot parse"):
+            mod._module_top_level_functions(f)
+
+
+# ============================================================
+# validate_manifest — top-level orchestration
+# ============================================================
+
+
+class TestValidateManifest:
+
+    @pytest.fixture
+    def fake_repo(self, tmp_path):
+        """Create a tmp repo with a sample source module + test file."""
+        src = tmp_path / "scripts" / "tools" / "_lib_demo.py"
+        _write(src, """
+            def covered_fn(x):
+                return x + 1
+
+            def excluded_fn(path):
+                with open(path) as f:
+                    return f.read()
+        """)
+        test = tmp_path / "tests" / "shared" / "test_property_tools.py"
+        _write(test, """
+            def test_covered_fn():
+                # references covered_fn name
+                pass
+        """)
+        return tmp_path, src, test
+
+    def test_clean_manifest(self, fake_repo):
+        repo, _, test = fake_repo
+        manifest = {
+            "modules": {
+                "scripts/tools/_lib_demo.py": {
+                    "covered": ["covered_fn"],
+                    "excluded": {"excluded_fn": "I/O-bound"},
+                },
+            },
+        }
+        issues = mod.validate_manifest(manifest, repo, test)
+        assert issues == []
+
+    def test_missing_source_flagged(self, fake_repo):
+        repo, _, test = fake_repo
+        manifest = {
+            "modules": {
+                "scripts/tools/nonexistent.py": {"covered": [], "excluded": {}},
+            },
+        }
+        issues = mod.validate_manifest(manifest, repo, test)
+        assert len(issues) == 1
+        assert issues[0].kind == "missing-source"
+
+    def test_untriaged_function_flagged(self, fake_repo):
+        repo, _, test = fake_repo
+        manifest = {
+            "modules": {
+                "scripts/tools/_lib_demo.py": {
+                    "covered": ["covered_fn"],
+                    # excluded_fn deliberately missing
+                },
+            },
+        }
+        issues = mod.validate_manifest(manifest, repo, test)
+        triage_issues = [i for i in issues if i.kind == "missing-triage"]
+        assert len(triage_issues) == 1
+        assert "excluded_fn" in triage_issues[0].detail
+
+    def test_stale_covered_entry_flagged(self, fake_repo):
+        repo, _, test = fake_repo
+        manifest = {
+            "modules": {
+                "scripts/tools/_lib_demo.py": {
+                    "covered": ["covered_fn", "ghost_fn"],
+                    "excluded": {"excluded_fn": "I/O"},
+                },
+            },
+        }
+        issues = mod.validate_manifest(manifest, repo, test)
+        stale = [i for i in issues if i.kind == "stale-manifest"]
+        assert len(stale) == 1
+        assert "ghost_fn" in stale[0].detail
+
+    def test_no_test_ref_flagged(self, fake_repo):
+        # Property: covered:foo but foo never appears in test file.
+        repo, src, test = fake_repo
+        # Test file references covered_fn but NOT excluded_fn — so
+        # if we list excluded_fn under `covered:`, it should fail no-test-ref.
+        # Build a fresh source where excluded_fn isn't in test.
+        manifest = {
+            "modules": {
+                "scripts/tools/_lib_demo.py": {
+                    "covered": ["covered_fn", "excluded_fn"],  # both claimed
+                    # No excluded section: must triage every function
+                },
+            },
+        }
+        issues = mod.validate_manifest(manifest, repo, test)
+        no_ref = [i for i in issues if i.kind == "no-test-ref"]
+        assert len(no_ref) == 1
+        assert "excluded_fn" in no_ref[0].detail
+
+    def test_empty_excluded_reason_flagged(self, fake_repo):
+        repo, _, test = fake_repo
+        manifest = {
+            "modules": {
+                "scripts/tools/_lib_demo.py": {
+                    "covered": ["covered_fn"],
+                    "excluded": {"excluded_fn": ""},  # empty reason
+                },
+            },
+        }
+        issues = mod.validate_manifest(manifest, repo, test)
+        no_reason = [i for i in issues if i.kind == "no-reason"]
+        assert len(no_reason) == 1
+        assert "excluded_fn" in no_reason[0].detail
+
+    def test_non_string_reason_flagged(self, fake_repo):
+        repo, _, test = fake_repo
+        manifest = {
+            "modules": {
+                "scripts/tools/_lib_demo.py": {
+                    "covered": ["covered_fn"],
+                    "excluded": {"excluded_fn": None},  # null reason
+                },
+            },
+        }
+        issues = mod.validate_manifest(manifest, repo, test)
+        no_reason = [i for i in issues if i.kind == "no-reason"]
+        assert len(no_reason) == 1
+
+    def test_bad_modules_top_level(self, tmp_path):
+        repo = tmp_path
+        manifest = {"modules": ["should-be-mapping"]}
+        issues = mod.validate_manifest(manifest, repo, tmp_path / "x")
+        assert len(issues) == 1
+        assert issues[0].kind == "bad-manifest"
+
+    def test_bad_covered_type(self, fake_repo):
+        repo, _, test = fake_repo
+        manifest = {
+            "modules": {
+                "scripts/tools/_lib_demo.py": {
+                    "covered": "should-be-list",
+                    "excluded": {},
+                },
+            },
+        }
+        issues = mod.validate_manifest(manifest, repo, test)
+        assert any(i.kind == "bad-covered" for i in issues)
+
+    def test_class_method_dotted_form_accepted(self, tmp_path):
+        # Property: covered:Class.method must accept a test ref to
+        # bare `method` (test code calls `instance.method(...)`).
+        src = tmp_path / "scripts" / "tools" / "_lib_demo.py"
+        _write(src, """
+            class Dispatcher:
+                def resolve(self):
+                    pass
+        """)
+        test = tmp_path / "tests" / "shared" / "test_property_tools.py"
+        _write(test, """
+            def test_resolve_property():
+                d = make_dispatcher()
+                d.resolve()  # bare 'resolve' reference
+        """)
+        manifest = {
+            "modules": {
+                "scripts/tools/_lib_demo.py": {
+                    "covered": ["Dispatcher.resolve"],
+                },
+            },
+        }
+        issues = mod.validate_manifest(manifest, tmp_path, test)
+        assert issues == []
+
+    def test_class_method_no_test_ref_flagged(self, tmp_path):
+        # Property: if NEITHER `Class.method` NOR bare `method` appears
+        # in the test file, no-test-ref still fires.
+        src = tmp_path / "scripts" / "tools" / "_lib_demo.py"
+        _write(src, """
+            class Dispatcher:
+                def untested_method(self):
+                    pass
+        """)
+        test = tmp_path / "tests" / "shared" / "test_property_tools.py"
+        _write(test, "# no references here\n")
+        manifest = {
+            "modules": {
+                "scripts/tools/_lib_demo.py": {
+                    "covered": ["Dispatcher.untested_method"],
+                },
+            },
+        }
+        issues = mod.validate_manifest(manifest, tmp_path, test)
+        no_ref = [i for i in issues if i.kind == "no-test-ref"]
+        assert len(no_ref) == 1
+
+
+# ============================================================
+# main — CLI / exit codes
+# ============================================================
+
+
+class TestMainCLI:
+
+    def test_missing_manifest_exits_two(self, tmp_path, capsys):
+        rc = mod.main([
+            "--manifest", str(tmp_path / "nope.yaml"),
+            "--test-file", str(tmp_path / "no.py"),
+        ])
+        assert rc == 2
+        assert "ERROR" in capsys.readouterr().err
+
+    def test_clean_manifest_exits_zero(self, tmp_path, capsys, monkeypatch):
+        # Build a fake repo with manifest + clean source + test
+        manifest_path = tmp_path / "manifest.yaml"
+        src_path = tmp_path / "scripts" / "tools" / "_lib_demo.py"
+        test_path = tmp_path / "tests" / "shared" / "test_property_tools.py"
+        _write(src_path, "def foo(): pass\n")
+        _write(test_path, "# foo is referenced here in code-comment form\ndef test_foo(): pass\n")
+        manifest_path.write_text(
+            "modules:\n"
+            "  scripts/tools/_lib_demo.py:\n"
+            "    covered:\n"
+            "      - foo\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+        rc = mod.main([
+            "--manifest", str(manifest_path),
+            "--test-file", str(test_path),
+        ])
+        assert rc == 0
+
+    def test_drift_exits_one(self, tmp_path, capsys, monkeypatch):
+        manifest_path = tmp_path / "manifest.yaml"
+        src_path = tmp_path / "scripts" / "tools" / "_lib_demo.py"
+        test_path = tmp_path / "tests" / "shared" / "test_property_tools.py"
+        _write(src_path, "def foo(): pass\ndef untriaged_bar(): pass\n")
+        _write(test_path, "def test_foo(): pass\n")
+        manifest_path.write_text(
+            "modules:\n"
+            "  scripts/tools/_lib_demo.py:\n"
+            "    covered:\n"
+            "      - foo\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+        rc = mod.main([
+            "--manifest", str(manifest_path),
+            "--test-file", str(test_path),
+        ])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "drift detected" in err
+        assert "untriaged_bar" in err
+
+    def test_json_shape(self, tmp_path, capsys, monkeypatch):
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text(
+            "modules:\n"
+            "  scripts/tools/nonexistent.py:\n"
+            "    covered: []\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+        rc = mod.main([
+            "--manifest", str(manifest_path),
+            "--test-file", str(tmp_path / "no.py"),
+            "--json",
+        ])
+        assert rc == 1  # missing source = 1 issue
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["check"] == "property-coverage"
+        assert "modules_scanned" in payload
+        assert "issues" in payload
+        assert "summary" in payload
+        assert payload["summary"]["errors"] >= 1
+
+    def test_malformed_yaml_exits_two(self, tmp_path, capsys):
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("not: [yaml\n", encoding="utf-8")
+        rc = mod.main([
+            "--manifest", str(manifest_path),
+            "--test-file", str(tmp_path / "no.py"),
+        ])
+        assert rc == 2
+        assert "cannot parse" in capsys.readouterr().err
+
+
+# ============================================================
+# Repo-level smoke regression guard
+# ============================================================
+
+
+class TestRepoSmoke:
+
+    def test_repo_manifest_passes(self):
+        """The shipped tests/shared/property-coverage.yaml must validate
+        against the actual repo source + test files. Belt-and-suspenders
+        alongside the pre-commit hook: any drift introduced by adding a
+        new function (or removing one) trips this test locally before
+        pre-commit fires.
+        """
+        rc = mod.main([])
+        assert rc == 0, "shipped property-coverage.yaml has drift"

--- a/tests/shared/property-coverage.yaml
+++ b/tests/shared/property-coverage.yaml
@@ -1,0 +1,190 @@
+# property-coverage.yaml — Property + mutation pilot coverage manifest.
+#
+# Per-module declaration of which top-level functions ARE in the
+# property-pilot (`tests/shared/test_property_tools.py` +
+# `tests/shared/_mutation_pilot.py`). The companion lint
+# `scripts/tools/lint/check_property_coverage.py` enforces:
+#
+#   1. Every function listed under `covered:` must have at least one
+#      `test_*` reference in test_property_tools.py.
+#   2. Every function in the source file that's NOT in `covered:` must
+#      be in `excluded:` with a reason (so additions force triage).
+#   3. Listed-but-missing-from-source functions error (manifest stale).
+#
+# Why this exists
+# ---------------
+#
+# Gap 2 of the testing-quality memory roadmap (#327 - #345 closure):
+# the pilot landed at 31 functions, but with no enforcement, new
+# pure helpers added to these modules wouldn't get flagged for
+# property tests. This file is the ratchet — every function in scope
+# must be triaged (covered OR excluded with reason).
+#
+# Adding new functions
+# --------------------
+#
+# When you add a new top-level function to a module listed below,
+# the pre-commit lint will fail until you either:
+#
+#   - Add a property test in test_property_tools.py and a mutation
+#     entry in _mutation_pilot.py, then list the function under
+#     `covered:` here, OR
+#   - List it under `excluded:` with a one-line reason explaining
+#     why property testing isn't applicable (I/O-bound, orchestrator,
+#     argparse helper, etc.).
+#
+# Adding a new module to scope
+# ----------------------------
+#
+# To bring a new module into pilot scope, add it as a top-level key
+# under `modules:` and triage every existing function. The lint will
+# then enforce drift detection going forward.
+
+modules:
+  # ── Pure-helper libraries (high-leverage, broad-blast-radius) ────
+
+  scripts/tools/_lib_validation.py:
+    covered:
+      - parse_duration_seconds
+      - format_duration
+      - is_disabled
+      - validate_and_clamp
+      - detect_cli_lang
+      - i18n_text
+
+  scripts/tools/_lib_io.py:
+    covered:
+      - load_yaml_file
+      - iter_yaml_files
+      - format_json_report
+    excluded:
+      load_tenant_configs: "Orchestrator over iter_yaml_files + load_yaml_file (both covered); composite contract is exercised by integration tests"
+      write_text_secure: "Side-effecting I/O; SAST guard ensures chmod pairing"
+      write_json_secure: "Side-effecting I/O; same SAST guarantee as write_text_secure"
+      write_onboard_hints: "Thin wrapper over write_json_secure"
+      read_onboard_hints: "I/O-bound; covered by integration test"
+      add_config_dir_arg: "argparse boilerplate; not a value computation"
+      add_json_arg: "argparse boilerplate"
+      add_ci_arg: "argparse boilerplate"
+      add_prometheus_arg: "argparse boilerplate"
+
+  scripts/tools/_lib_prometheus.py:
+    covered:
+      - _validate_url_scheme
+    excluded:
+      http_get_json: "I/O-bound; covered by integration via tools that consume it"
+      http_post_json: "I/O-bound; same as http_get_json"
+      http_request_with_retry: "I/O + retry policy; covered by retry-specific integration tests"
+      query_prometheus_instant: "I/O-bound; thin wrapper over http_get_json"
+
+  scripts/tools/_lib_godispatch.py:
+    # Note: members of this module are class methods on
+    # GoBinaryDispatcher, so the manifest uses dotted Class.method
+    # notation. The lint's AST walker recognises both bare-function
+    # names and Class.method names.
+    covered:
+      - GoBinaryDispatcher._resolve_binary
+    excluded:
+      GoBinaryDispatcher._msg: "Trivial bilingual selector; covered transitively by detect_cli_lang"
+      GoBinaryDispatcher._recover_explicit_attempt: "Defensive helper for error messages; structurally simpler than _resolve_binary"
+      GoBinaryDispatcher._print_binary_missing: "Side-effecting (prints to stderr); error-message templating"
+      GoBinaryDispatcher.dispatch: "Side-effecting (subprocess.run); covered by integration tests of guard/batchpr/parser shims"
+
+  # ── DX tools (doc/changelog/scaffold) ─────────────────────────────
+
+  scripts/tools/dx/generate_doc_map.py:
+    covered:
+      - _audience_str
+      - _parse_front_matter
+    excluded:
+      _extract_h1_title: "Trivial regex on first '# ' line; surface too small to property-test meaningfully"
+      _has_en_pair: "Pure path stem check; trivial enough that tests would over-specify Path API behavior"
+      _get_map_path: "Constant lookup over MAP_PATHS; would just re-state the dict"
+      gather_docs: "Walks docs/ tree; I/O-bound, covered by integration via main()"
+      generate_doc_map: "Orchestrator combining gather_docs + _audience_str + write; integration-test territory"
+      main: "CLI entry point; covered by tests/dx/test_generate_doc_map.py CLI tests"
+
+  scripts/tools/dx/generate_changelog.py:
+    covered:
+      - parse_commit
+    excluded:
+      git_cmd: "Side-effecting subprocess.run wrapper"
+      get_latest_tag: "Side-effecting (git subprocess); covered by integration"
+      get_commits_since: "Side-effecting (git subprocess); covered by integration"
+      load_ignored_commits: "I/O (reads .changelog-lint-ignore)"
+      lint_changelog: "Multi-rule walker over commit list; covered by tests/dx/test_generate_changelog* unit tests"
+      format_changelog: "Pure but template-heavy; output churn would dominate; covered by snapshot/golden tests"
+      main: "CLI entry point; covered by CLI integration tests"
+
+  scripts/tools/dx/axe_lite_static.py:
+    covered:
+      - strip_frontmatter
+      - scan_unicode_status
+      - scan_buttons_without_name
+      - scan_unlabeled_inputs
+      - scan_color_only_severity
+    excluded:
+      _find_opening_tag: "Substring-search helper; trivial bracket-balance logic, transitively covered by every scanner that uses it"
+      check_file: "Orchestrator combining all scan_* functions on a file; covered by integration"
+      main: "CLI entry point"
+
+  # ── Ops: routing pipeline + rule-pack split ──────────────────────
+
+  scripts/tools/ops/generate_rule_pack_split.py:
+    covered:
+      - extract_metrics_from_expr
+    excluded:
+      get_lang: "Trivial env-var dispatcher; covered transitively by detect_cli_lang"
+      t: "Bilingual string selector wrapper around get_lang"
+      _safe_write: "I/O wrapper around write_text_secure"
+      dump_yaml: "Serialization helper; thin wrapper over yaml.safe_dump"
+      load_rule_pack: "I/O (yaml load)"
+      extract_recording_outputs: "Pure but tightly coupled to PrometheusRule CRD shape; covered by tests/ops/test_generate_rule_pack_split.py with realistic fixtures"
+      to_prometheus_rule_crd: "Output-shape transformation; covered by snapshot tests"
+      validate_central_references_edge: "Multi-rule validator; covered by tests/ops/test_generate_rule_pack_split.py"
+      split_rule_pack: "Orchestrator combining extract_metrics_from_expr + extract_recording_outputs + to_prometheus_rule_crd"
+      process_rule_packs: "Top-level orchestrator over directory walk + split_rule_pack"
+      main: "CLI entry point"
+
+  scripts/tools/ops/_grar_merge.py:
+    covered:
+      - _substitute_tenant
+      - _contains_tenant_placeholder
+      - merge_routing_with_defaults
+      - _apply_timing_params
+    excluded:
+      build_receiver_config: "Heavy state-machine over RECEIVER_TYPES; covered by test_generate_alertmanager_routes.py integration"
+
+  scripts/tools/ops/_grar_validate.py:
+    covered:
+      - _extract_host
+      - validate_receiver_domains
+      - validate_tenant_keys
+    excluded:
+      load_policy: "I/O-bound; thin wrapper over load_yaml_file (covered)"
+      _validate_profile_refs: "Covered by test_e2e_routing_profile.py integration"
+      check_domain_policies: "Multi-branch policy validator; covered by test_e2e_routing_profile.py + test_domain_policy.py"
+
+  # ── Lint helpers (small but load-bearing) ─────────────────────────
+
+  scripts/tools/lint/_lint_helpers.py:
+    covered:
+      - parse_command_map
+      - parse_build_sh_tools
+    excluded:
+      parse_command_map_keys: "Trivial wrapper around parse_command_map; covered transitively"
+
+  scripts/tools/lint/check_flaky_registry.py:
+    covered:
+      - parse_version
+      - latest_version_from_changelog
+    excluded:
+      validate_entry: "Multi-rule schema validator; covered by 28 unit tests in test_check_flaky_registry.py"
+      validate_registry: "Top-level dispatcher; covered by 28 unit tests"
+      main: "CLI entry point; covered by CLI tests in test_check_flaky_registry.py"
+      Issue.format: "Trivial f-string templating on dataclass; covered transitively by validate_entry/validate_registry tests"
+      # Note: dunder methods (Version.__lt__/__ge__/__str__) are
+      # filtered out by the AST walker (they're not "function-shaped"
+      # value computations worth a separate manifest entry). Coverage
+      # for these is provided indirectly via TestParseVersionProperties
+      # tests of `<` / `>=` / round-trip.


### PR DESCRIPTION
## Summary

Process-enforcement ratchet for the property + mutation pilot (closed at 31 functions in #333). **Without this lint, new pure helpers added to in-scope modules wouldn't get flagged for property tests** — the pilot's coverage would silently drift.

## What's added

### \`tests/shared/property-coverage.yaml\` — manifest

For each of 12 in-scope modules, every top-level function (and class method) must be triaged:
- \`covered:\` (with a property test in \`test_property_tools.py\` + a mutation entry in \`_mutation_pilot.py\`), OR
- \`excluded:\` with a one-line reason explaining why property testing isn't applicable (I/O-bound, orchestrator, argparse helper, etc.)

### \`scripts/tools/lint/check_property_coverage.py\` — AST-driven lint

Five rules enforced:

1. **Untriaged function in source** → ERROR (forces triage on every new function added to in-scope modules)
2. **Stale manifest entry** (function listed but not in source) → ERROR
3. **\`covered:\` claim with no test reference** → ERROR
4. **\`excluded:\` with empty / non-string reason** → ERROR
5. **Class methods supported via \`Class.method\` notation**; the lint accepts either dotted or bare-method names in test references (since \`instance.method(...)\` surfaces as bare \`method\` in source)

### \`tests/lint/test_check_property_coverage.py\` — 24 tests

| Layer | Cases |
|---|---|
| AST walker | top-level def, class methods, dunder skip, public + \`_private\` inclusion, async def, syntax error |
| validate_manifest | clean, missing-source, **untriaged-function flagged**, stale-covered, **no-test-ref**, no-reason, bad-shape variants, **class-method bare-ref acceptance** |
| CLI | missing manifest exits 2, malformed YAML exits 2, clean exits 0, drift exits 1, --json shape, repo-files smoke |

## Wiring

Pre-commit hook \`property-coverage-check\` fires when:
- \`tests/shared/property-coverage.yaml\` changes
- \`tests/shared/test_property_tools.py\` changes  
- Any in-scope source file changes (covers 12 modules across \`_lib_*.py\`, \`dx/\`, \`ops/\`, \`lint/\`)

Linux CI runs the lint via the same hook chain.

## Why a manifest file (not test-file scanning)

\`excluded:\` reasons are the load-bearing part. Implicit inference from \`test_property_tools.py\` class names would silently miss new functions until a quarterly audit, AND would lose the why-not documentation for excluded entries. **The manifest forces a triage decision at the moment a new function is added.**

## Verification

194 tests pass (24 new lint tests + 170 existing test_property_tools.py tests). Repo's \`property-coverage.yaml\` validates cleanly: 12 modules in scope, **31 covered**, all backed by tests; remaining functions in those modules all triaged with exclusion reasons.

## Memory roadmap status

This is **PR 2 of 3** in the revised top-3 (after surveying showed my original Gap 1 + Gap 3 were overstated):

- ✅ PR 1 (#346): Windows test infra
- ✅ **PR 2 (this)**: Process enforcement (Gap 2 ratchet)
- 🟡 PR 3 (next): Go mutation pilot — first batch of mutations against threshold-exporter

## Test plan

- [ ] CI green
- [ ] \`python -m pytest tests/lint/test_check_property_coverage.py -q\` — 24 passed
- [ ] \`python scripts/tools/lint/check_property_coverage.py\` against repo — 12 modules in scope, all functions triaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)