### PR TITLE
test(audit): Go mutation pilot — 15 mutations across 5 functions in pkg/config

### DIFF
--- a/tests/shared/_go_mutation_pilot.py
+++ b/tests/shared/_go_mutation_pilot.py
@@ -31,9 +31,21 @@ Targets
   - deepMerge         — ADR-018 inheritance, _metadata skip, nil-delete (3 muts)
   - extractDefaultsBlock — pulls `defaults:` sub-tree, falls back to root (1 mut)
 
-Total: 15 mutations across 5 functions. Existing Go tests
-(`parse_test.go`, `hierarchy_test.go`, `config_dimensional_test.go`,
-golden-parity tests) are the kill targets.
+Total: 14 mutations across 5 functions. Existing Go tests in the
+parent `package main` (e.g., config_hierarchy_test.go,
+config_dimensional_test.go, golden-parity tests) are the kill
+targets — the lowercase functions in `pkg/config` are exercised
+indirectly via the lowercase wrappers in
+`app/config_inheritance.go`. That's why the runner uses
+`go test ./...` from `app/` instead of `./pkg/config/...`: the
+in-package tests for `pkg/config` only cover scope-resolution +
+benchmarks, not the parse/merge primitives.
+
+Latest run (Dev Container, on PR #348): 12/14 caught (~86%). The
+2 survivors are real test gaps — the existing Go suite doesn't
+cover (a) negative hour values in HH:MM (`"-5:00"`) and
+(b) HH:MM with leading whitespace (`" 12:30"`). Filed as
+follow-on for a future Go test addition.
 
 Usage
 -----
@@ -98,7 +110,7 @@ MUTATIONS: list[Mutation] = [
     # ── parseHHMM (parse.go) ─────────────────────────────────────────
     Mutation(
         target_file="pkg/config/parse.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="parseHHMM: drop hour upper bound (h>23 accepted)",
         fn_name="parseHHMM",
         old="if err != nil || h < 0 || h > 23 {",
@@ -106,7 +118,7 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         target_file="pkg/config/parse.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="parseHHMM: drop minute upper bound (m>59 accepted)",
         fn_name="parseHHMM",
         old="if err != nil || m < 0 || m > 59 {",
@@ -114,7 +126,7 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         target_file="pkg/config/parse.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="parseHHMM: drop hour lower bound (h<0 accepted, e.g. -5)",
         fn_name="parseHHMM",
         old="if err != nil || h < 0 || h > 23 {",
@@ -122,7 +134,7 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         target_file="pkg/config/parse.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="parseHHMM: drop format split check (single-token input passes)",
         fn_name="parseHHMM",
         old='if len(parts) != 2 {\n\t\treturn 0, 0, fmt.Errorf("invalid HH:MM format: %q", s)\n\t}',
@@ -130,7 +142,7 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         target_file="pkg/config/parse.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="parseHHMM: drop TrimSpace (leading whitespace breaks parse)",
         fn_name="parseHHMM",
         old="s = strings.TrimSpace(s)\n\tparts := strings.SplitN(s, \":\", 2)",
@@ -139,7 +151,7 @@ MUTATIONS: list[Mutation] = [
     # ── matchTimeWindow (parse.go) ───────────────────────────────────
     Mutation(
         target_file="pkg/config/parse.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="matchTimeWindow: invert same-day end-bound (< → <=)",
         fn_name="matchTimeWindow",
         old="return nowMinutes >= startMinutes && nowMinutes < endMinutes",
@@ -147,7 +159,7 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         target_file="pkg/config/parse.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="matchTimeWindow: invert cross-midnight branch (or → and)",
         fn_name="matchTimeWindow",
         old="return nowMinutes >= startMinutes || nowMinutes < endMinutes",
@@ -155,7 +167,7 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         target_file="pkg/config/parse.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="matchTimeWindow: swap branch condition (always cross-midnight)",
         fn_name="matchTimeWindow",
         old="if startMinutes <= endMinutes {",
@@ -164,7 +176,7 @@ MUTATIONS: list[Mutation] = [
     # ── parsePromDuration (parse.go) ─────────────────────────────────
     Mutation(
         target_file="pkg/config/parse.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="parsePromDuration: 'd' unit returns hours instead of days",
         fn_name="parsePromDuration",
         old="return time.Duration(num * 24 * float64(time.Hour)), nil",
@@ -172,7 +184,7 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         target_file="pkg/config/parse.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="parsePromDuration: drop length check (1-char input crashes)",
         fn_name="parsePromDuration",
         old="if len(s) < 2 {\n\t\treturn 0, fmt.Errorf(\"duration too short: %q\", s)\n\t}",
@@ -181,7 +193,7 @@ MUTATIONS: list[Mutation] = [
     # ── deepMerge (hierarchy.go) ─────────────────────────────────────
     Mutation(
         target_file="pkg/config/hierarchy.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="deepMerge: drop _metadata skip (override _metadata leaks into base)",
         fn_name="deepMerge",
         old='if k == "_metadata" {\n\t\t\tcontinue\n\t\t}',
@@ -189,7 +201,7 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         target_file="pkg/config/hierarchy.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="deepMerge: drop nil-delete (override:nil overwrites with nil instead of deleting)",
         fn_name="deepMerge",
         old="if v == nil {\n\t\t\tdelete(result, k)\n\t\t\tcontinue\n\t\t}",
@@ -197,16 +209,24 @@ MUTATIONS: list[Mutation] = [
     ),
     Mutation(
         target_file="pkg/config/hierarchy.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="deepMerge: skip recursive merge for nested maps (override replaces wholesale)",
         fn_name="deepMerge",
-        old="if overrideMap, ok := v.(map[string]any); ok {\n\t\t\tif baseMap, ok2 := result[k].(map[string]any); ok2 {\n\t\t\t\tresult[k] = deepMerge(baseMap, overrideMap)\n\t\t\t\tcontinue\n\t\t\t}\n\t\t}",
-        new="if false {\n\t\t\tif baseMap, ok2 := result[k].(map[string]any); ok2 {\n\t\t\t\tresult[k] = deepMerge(baseMap, overrideMap)\n\t\t\t\tcontinue\n\t\t\t}\n\t\t}",
+        # Drop the entire `if overrideMap, ok := ...` scope. Code falls
+        # through to the existing `result[k] = deepCopyValue(v)` line,
+        # which is the "always overwrite" semantic — same Go syntax,
+        # different runtime behavior. (The previous version of this
+        # mutation just stubbed the outer if to `if false`, leaving an
+        # unused `overrideMap` reference inside that triggered a Go
+        # compile error — that's a "caught for the wrong reason" false
+        # positive.)
+        old="if overrideMap, ok := v.(map[string]any); ok {\n\t\t\tif baseMap, ok2 := result[k].(map[string]any); ok2 {\n\t\t\t\tresult[k] = deepMerge(baseMap, overrideMap)\n\t\t\t\tcontinue\n\t\t\t}\n\t\t}\n\t\tresult[k] = deepCopyValue(v)",
+        new="result[k] = deepCopyValue(v)",
     ),
     # ── extractDefaultsBlock (hierarchy.go) ──────────────────────────
     Mutation(
         target_file="pkg/config/hierarchy.go",
-        test_target="./pkg/config/...",
+        test_target="./...",
         label="extractDefaults: return nil instead of root fallback (no `defaults:` key → nil)",
         fn_name="extractDefaultsBlock",
         old='if inner, ok := m["defaults"].(map[string]any); ok {\n\t\treturn inner\n\t}\n\treturn m',
@@ -230,10 +250,13 @@ def _go_executable() -> str:
 def run_tests(test_target: str) -> tuple[int, str]:
     """Run `go test` against the package; return (returncode, output_tail)."""
     go = _go_executable()
-    cmd = [go, "test", test_target, "-count=1", "-timeout", "60s"]
+    # `./...` from app/ runs the full Go test suite (parent `package
+    # main` + nested pkg/config). The integration tests use fsnotify
+    # debounce loops so allow several minutes per mutation.
+    cmd = [go, "test", test_target, "-count=1", "-timeout", "180s"]
     proc = subprocess.run(
         cmd, capture_output=True, text=True, cwd=str(GO_APP_DIR),
-        timeout=180, encoding="utf-8", errors="replace",
+        timeout=360, encoding="utf-8", errors="replace",
     )
     tail_lines = (proc.stdout + proc.stderr).splitlines()[-3:]
     return proc.returncode, " | ".join(tail_lines)

--- a/tests/shared/_go_mutation_pilot.py
+++ b/tests/shared/_go_mutation_pilot.py
@@ -1,0 +1,294 @@
+"""Mutation-test pilot runner for Go-side pure functions in
+`components/threshold-exporter/app/pkg/config`.
+
+Mirrors the design of `_mutation_pilot.py` (Python pilot, 67/70
+caught at 31 functions per #333). Underscored prefix → pytest does
+NOT collect this module; it's a re-runnable research artifact, not
+part of the test suite.
+
+Why hand-crafted vs `gremlins.dev` / `go-mutesting`
+---------------------------------------------------
+
+Same rationale as the Python pilot:
+
+  - Avoid adding a dev-only Go dependency for a pilot whose value
+    is the methodology demo + the catalog of MEANINGFUL mutations.
+  - Hand-crafted mutations focus on constants / operators / control
+    flow that map to real bug classes (off-by-one in time-window
+    boundary, missing nil check, swapped merge priority). Auto
+    mutators produce many equivalent-mutant noise.
+  - Output of this script is the audit's reproducible evidence.
+
+Targets
+-------
+
+`pkg/config/parse.go`
+  - parseHHMM         — pure HH:MM parser, range-checked (5 muts)
+  - matchTimeWindow   — same/cross-midnight branch (4 muts)
+  - parsePromDuration — Prometheus-style "5m" / "4h" / "2d" parser (2 muts)
+
+`pkg/config/hierarchy.go`
+  - deepMerge         — ADR-018 inheritance, _metadata skip, nil-delete (3 muts)
+  - extractDefaultsBlock — pulls `defaults:` sub-tree, falls back to root (1 mut)
+
+Total: 15 mutations across 5 functions. Existing Go tests
+(`parse_test.go`, `hierarchy_test.go`, `config_dimensional_test.go`,
+golden-parity tests) are the kill targets.
+
+Usage
+-----
+
+  # In Dev Container (preferred — Go toolchain available):
+  make dc-run CMD="python tests/shared/_go_mutation_pilot.py"
+
+  # Local (requires Go installed at /usr/local/go or PATH):
+  python tests/shared/_go_mutation_pilot.py [--target FUNC]
+
+The runner expects to be invoked from the repo root. It chdirs into
+`components/threshold-exporter/app/` to run `go test ./pkg/config/...`.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GO_APP_DIR = REPO_ROOT / "components" / "threshold-exporter" / "app"
+
+
+@dataclass
+class Mutation:
+    target_file: str        # source file relative to GO_APP_DIR
+    test_target: str        # `go test` package selector
+    label: str              # short description
+    old: str                # exact string to find
+    new: str                # replacement
+    fn_name: str            # which target function
+
+    def apply(self) -> None:
+        path = GO_APP_DIR / self.target_file
+        with open(path, encoding="utf-8", newline="") as f:
+            src = f.read()
+        if self.old not in src:
+            raise ValueError(
+                f"old_string not found in {self.target_file}: {self.label}"
+            )
+        if src.count(self.old) > 1:
+            raise ValueError(
+                f"old_string ambiguous (>1 match) in {self.target_file}: {self.label}"
+            )
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write(src.replace(self.old, self.new))
+
+    def revert(self, original: str) -> None:
+        path = GO_APP_DIR / self.target_file
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write(original)
+
+
+# ── Mutation catalog ──────────────────────────────────────────────────
+
+MUTATIONS: list[Mutation] = [
+    # ── parseHHMM (parse.go) ─────────────────────────────────────────
+    Mutation(
+        target_file="pkg/config/parse.go",
+        test_target="./pkg/config/...",
+        label="parseHHMM: drop hour upper bound (h>23 accepted)",
+        fn_name="parseHHMM",
+        old="if err != nil || h < 0 || h > 23 {",
+        new="if err != nil || h < 0 {",
+    ),
+    Mutation(
+        target_file="pkg/config/parse.go",
+        test_target="./pkg/config/...",
+        label="parseHHMM: drop minute upper bound (m>59 accepted)",
+        fn_name="parseHHMM",
+        old="if err != nil || m < 0 || m > 59 {",
+        new="if err != nil || m < 0 {",
+    ),
+    Mutation(
+        target_file="pkg/config/parse.go",
+        test_target="./pkg/config/...",
+        label="parseHHMM: drop hour lower bound (h<0 accepted, e.g. -5)",
+        fn_name="parseHHMM",
+        old="if err != nil || h < 0 || h > 23 {",
+        new="if err != nil || h > 23 {",
+    ),
+    Mutation(
+        target_file="pkg/config/parse.go",
+        test_target="./pkg/config/...",
+        label="parseHHMM: drop format split check (single-token input passes)",
+        fn_name="parseHHMM",
+        old='if len(parts) != 2 {\n\t\treturn 0, 0, fmt.Errorf("invalid HH:MM format: %q", s)\n\t}',
+        new='if false {\n\t\treturn 0, 0, fmt.Errorf("invalid HH:MM format: %q", s)\n\t}',
+    ),
+    Mutation(
+        target_file="pkg/config/parse.go",
+        test_target="./pkg/config/...",
+        label="parseHHMM: drop TrimSpace (leading whitespace breaks parse)",
+        fn_name="parseHHMM",
+        old="s = strings.TrimSpace(s)\n\tparts := strings.SplitN(s, \":\", 2)",
+        new="parts := strings.SplitN(s, \":\", 2)",
+    ),
+    # ── matchTimeWindow (parse.go) ───────────────────────────────────
+    Mutation(
+        target_file="pkg/config/parse.go",
+        test_target="./pkg/config/...",
+        label="matchTimeWindow: invert same-day end-bound (< → <=)",
+        fn_name="matchTimeWindow",
+        old="return nowMinutes >= startMinutes && nowMinutes < endMinutes",
+        new="return nowMinutes >= startMinutes && nowMinutes <= endMinutes",
+    ),
+    Mutation(
+        target_file="pkg/config/parse.go",
+        test_target="./pkg/config/...",
+        label="matchTimeWindow: invert cross-midnight branch (or → and)",
+        fn_name="matchTimeWindow",
+        old="return nowMinutes >= startMinutes || nowMinutes < endMinutes",
+        new="return nowMinutes >= startMinutes && nowMinutes < endMinutes",
+    ),
+    Mutation(
+        target_file="pkg/config/parse.go",
+        test_target="./pkg/config/...",
+        label="matchTimeWindow: swap branch condition (always cross-midnight)",
+        fn_name="matchTimeWindow",
+        old="if startMinutes <= endMinutes {",
+        new="if startMinutes > endMinutes {",
+    ),
+    # ── parsePromDuration (parse.go) ─────────────────────────────────
+    Mutation(
+        target_file="pkg/config/parse.go",
+        test_target="./pkg/config/...",
+        label="parsePromDuration: 'd' unit returns hours instead of days",
+        fn_name="parsePromDuration",
+        old="return time.Duration(num * 24 * float64(time.Hour)), nil",
+        new="return time.Duration(num * float64(time.Hour)), nil",
+    ),
+    Mutation(
+        target_file="pkg/config/parse.go",
+        test_target="./pkg/config/...",
+        label="parsePromDuration: drop length check (1-char input crashes)",
+        fn_name="parsePromDuration",
+        old="if len(s) < 2 {\n\t\treturn 0, fmt.Errorf(\"duration too short: %q\", s)\n\t}",
+        new="if false {\n\t\treturn 0, fmt.Errorf(\"duration too short: %q\", s)\n\t}",
+    ),
+    # ── deepMerge (hierarchy.go) ─────────────────────────────────────
+    Mutation(
+        target_file="pkg/config/hierarchy.go",
+        test_target="./pkg/config/...",
+        label="deepMerge: drop _metadata skip (override _metadata leaks into base)",
+        fn_name="deepMerge",
+        old='if k == "_metadata" {\n\t\t\tcontinue\n\t\t}',
+        new='if false {\n\t\t\tcontinue\n\t\t}',
+    ),
+    Mutation(
+        target_file="pkg/config/hierarchy.go",
+        test_target="./pkg/config/...",
+        label="deepMerge: drop nil-delete (override:nil overwrites with nil instead of deleting)",
+        fn_name="deepMerge",
+        old="if v == nil {\n\t\t\tdelete(result, k)\n\t\t\tcontinue\n\t\t}",
+        new="if false {\n\t\t\tdelete(result, k)\n\t\t\tcontinue\n\t\t}",
+    ),
+    Mutation(
+        target_file="pkg/config/hierarchy.go",
+        test_target="./pkg/config/...",
+        label="deepMerge: skip recursive merge for nested maps (override replaces wholesale)",
+        fn_name="deepMerge",
+        old="if overrideMap, ok := v.(map[string]any); ok {\n\t\t\tif baseMap, ok2 := result[k].(map[string]any); ok2 {\n\t\t\t\tresult[k] = deepMerge(baseMap, overrideMap)\n\t\t\t\tcontinue\n\t\t\t}\n\t\t}",
+        new="if false {\n\t\t\tif baseMap, ok2 := result[k].(map[string]any); ok2 {\n\t\t\t\tresult[k] = deepMerge(baseMap, overrideMap)\n\t\t\t\tcontinue\n\t\t\t}\n\t\t}",
+    ),
+    # ── extractDefaultsBlock (hierarchy.go) ──────────────────────────
+    Mutation(
+        target_file="pkg/config/hierarchy.go",
+        test_target="./pkg/config/...",
+        label="extractDefaults: return nil instead of root fallback (no `defaults:` key → nil)",
+        fn_name="extractDefaultsBlock",
+        old='if inner, ok := m["defaults"].(map[string]any); ok {\n\t\treturn inner\n\t}\n\treturn m',
+        new='if inner, ok := m["defaults"].(map[string]any); ok {\n\t\treturn inner\n\t}\n\treturn nil',
+    ),
+]
+
+
+def _go_executable() -> str:
+    """Locate `go` on PATH; fail fast with helpful error otherwise."""
+    go = shutil.which("go")
+    if not go:
+        sys.stderr.write(
+            "ERROR: `go` not on PATH. Run inside Dev Container:\n"
+            "  make dc-run CMD=\"python tests/shared/_go_mutation_pilot.py\"\n"
+        )
+        sys.exit(2)
+    return go
+
+
+def run_tests(test_target: str) -> tuple[int, str]:
+    """Run `go test` against the package; return (returncode, output_tail)."""
+    go = _go_executable()
+    cmd = [go, "test", test_target, "-count=1", "-timeout", "60s"]
+    proc = subprocess.run(
+        cmd, capture_output=True, text=True, cwd=str(GO_APP_DIR),
+        timeout=180, encoding="utf-8", errors="replace",
+    )
+    tail_lines = (proc.stdout + proc.stderr).splitlines()[-3:]
+    return proc.returncode, " | ".join(tail_lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--target",
+        help="Filter to mutations whose fn_name contains this substring",
+    )
+    args = parser.parse_args()
+
+    selected = [m for m in MUTATIONS if not args.target or args.target in m.fn_name]
+    print(f"Running {len(selected)} Go mutations from {GO_APP_DIR}\n")
+
+    results: list[tuple[Mutation, str]] = []
+    for i, m in enumerate(selected, 1):
+        path = GO_APP_DIR / m.target_file
+        with open(path, encoding="utf-8", newline="") as f:
+            original = f.read()
+
+        try:
+            m.apply()
+        except ValueError as e:
+            results.append((m, f"SETUP-FAIL: {e}"))
+            continue
+
+        try:
+            rc, tail = run_tests(m.test_target)
+            verdict = "CAUGHT" if rc != 0 else "SURVIVED"
+            results.append((m, f"{verdict} (rc={rc}) :: {tail[:160]}"))
+        finally:
+            m.revert(original)
+
+        print(f"[{i:2d}/{len(selected)}] {m.fn_name}: {m.label[:60]}")
+        print(f"      → {results[-1][1]}\n")
+
+    # Summary
+    caught = sum(1 for _, v in results if v.startswith("CAUGHT"))
+    survived = sum(1 for _, v in results if v.startswith("SURVIVED"))
+    setup_fail = sum(1 for _, v in results if v.startswith("SETUP-FAIL"))
+    print(
+        f"\n=== SUMMARY: {caught}/{len(results)} caught, "
+        f"{survived} survived, {setup_fail} setup-failures ===\n"
+    )
+
+    if survived:
+        print("SURVIVING MUTATIONS (test gaps):")
+        for m, v in results:
+            if v.startswith("SURVIVED"):
+                print(f"  - {m.fn_name}: {m.label}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/shared/test_go_mutation_pilot.py
+++ b/tests/shared/test_go_mutation_pilot.py
@@ -1,0 +1,163 @@
+"""Smoke tests for the Go mutation-pilot catalog.
+
+Validates the static contract of `_go_mutation_pilot.py` without
+actually running `go test` (which requires the Go toolchain to be
+present, e.g., Dev Container). The actual pilot run happens via:
+
+    make dc-run CMD="python tests/shared/_go_mutation_pilot.py"
+
+These tests catch catalog-level errors at commit time:
+
+  - Each `Mutation.old` string is present in its `target_file`
+  - Each `Mutation.old` is unique within the file (no ambiguous match)
+  - Each `Mutation.new` is different from `Mutation.old`
+  - Each target file actually exists
+  - Test_target package selectors are well-formed
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_PILOT_PATH = REPO_ROOT / "tests" / "shared" / "_go_mutation_pilot.py"
+
+_spec = importlib.util.spec_from_file_location("_go_mutation_pilot", _PILOT_PATH)
+_pilot = importlib.util.module_from_spec(_spec)
+sys.modules["_go_mutation_pilot"] = _pilot
+_spec.loader.exec_module(_pilot)
+
+
+# ============================================================
+# Catalog validation
+# ============================================================
+
+
+class TestCatalog:
+
+    def test_mutations_list_non_empty(self):
+        # Property: catalog has at least 10 mutations (otherwise the
+        # pilot is below the threshold for being a meaningful demo).
+        assert len(_pilot.MUTATIONS) >= 10
+
+    def test_each_mutation_has_required_fields(self):
+        for m in _pilot.MUTATIONS:
+            assert m.target_file, f"empty target_file: {m.label}"
+            assert m.test_target, f"empty test_target: {m.label}"
+            assert m.label, f"empty label for {m.fn_name}"
+            assert m.old, f"empty old for {m.label}"
+            assert m.new, f"empty new for {m.label}"
+            assert m.fn_name, f"empty fn_name for {m.label}"
+
+    def test_old_differs_from_new(self):
+        for m in _pilot.MUTATIONS:
+            assert m.old != m.new, (
+                f"mutation {m.label} has identical old/new — would be a no-op"
+            )
+
+    def test_target_files_exist(self):
+        for m in _pilot.MUTATIONS:
+            path = _pilot.GO_APP_DIR / m.target_file
+            assert path.is_file(), (
+                f"target file {m.target_file} not found "
+                f"(referenced by mutation {m.label})"
+            )
+
+    def test_test_targets_use_package_selector_form(self):
+        # Property: test_target should be a Go package selector (./pkg/...
+        # or `./...` etc.). Catches typos like "/pkg" or "pkg/config".
+        for m in _pilot.MUTATIONS:
+            assert m.test_target.startswith("./"), (
+                f"test_target {m.test_target!r} should start with './' "
+                f"(mutation {m.label})"
+            )
+
+
+class TestOldStringsExist:
+    """Every Mutation.old must appear exactly once in its target file —
+    otherwise apply() would either no-op or raise. Catches catalog drift
+    when the source file is refactored.
+    """
+
+    @pytest.fixture(scope="class")
+    def file_contents(self):
+        # Pre-load each unique target file once.
+        cache: dict[str, str] = {}
+        for m in _pilot.MUTATIONS:
+            path = _pilot.GO_APP_DIR / m.target_file
+            if m.target_file not in cache:
+                cache[m.target_file] = path.read_text(encoding="utf-8")
+        return cache
+
+    @pytest.mark.parametrize(
+        "mutation",
+        _pilot.MUTATIONS,
+        ids=[f"{m.fn_name}: {m.label[:40]}" for m in _pilot.MUTATIONS],
+    )
+    def test_old_string_present_and_unique(self, mutation, file_contents):
+        src = file_contents[mutation.target_file]
+        count = src.count(mutation.old)
+        assert count == 1, (
+            f"old_string for {mutation.label!r} appears {count} times "
+            f"in {mutation.target_file} (expected exactly 1). "
+            "Either the source was refactored — update the mutation's "
+            "old= to the new shape — or the string is too generic and "
+            "needs more context."
+        )
+
+
+class TestApplyRevertRoundTrip:
+    """apply() + revert() should leave the source file byte-identical
+    to its starting state. Catches accidental \\r\\n / encoding drift.
+    """
+
+    def test_round_trip_preserves_bytes(self, tmp_path):
+        # Pick the first mutation (any will do — they all use the same
+        # apply/revert plumbing).
+        m = _pilot.MUTATIONS[0]
+        path = _pilot.GO_APP_DIR / m.target_file
+        original = path.read_bytes()
+
+        with open(path, encoding="utf-8", newline="") as f:
+            original_text = f.read()
+
+        m.apply()
+        try:
+            after_apply = path.read_text(encoding="utf-8")
+            assert after_apply != original_text, (
+                "apply() didn't change the file — old/new must differ"
+            )
+        finally:
+            m.revert(original_text)
+
+        assert path.read_bytes() == original, (
+            "revert() didn't restore byte-identical content "
+            "(possibly due to newline normalisation)"
+        )
+
+
+class TestReachableFunctions:
+    """Every mutation's fn_name should be findable in the target file
+    (via `func <name>(`). Catches catalog→source drift when a function
+    is renamed."""
+
+    @pytest.mark.parametrize(
+        "mutation",
+        _pilot.MUTATIONS,
+        ids=[f"{m.fn_name}: {m.label[:40]}" for m in _pilot.MUTATIONS],
+    )
+    def test_fn_name_findable_in_source(self, mutation):
+        path = _pilot.GO_APP_DIR / mutation.target_file
+        src = path.read_text(encoding="utf-8")
+        # Match either bare `func <name>(...)` or `func (recv) <name>(...)`.
+        # The pilot targets are all standalone funcs in pkg/config so the
+        # bare form is sufficient.
+        marker = f"func {mutation.fn_name}("
+        assert marker in src, (
+            f"could not find {marker!r} in {mutation.target_file}. "
+            "Was the function renamed or moved? Update the catalog's "
+            "fn_name field accordingly."
+        )


### PR DESCRIPTION
## Summary

Mirrors the Python mutation pilot's design (#329-#333, 67/70 caught at 31 functions) for **Go-side pure functions** in \`components/threshold-exporter/app/pkg/config\`. Closes the "Go mutation testing absent" gap from my post-campaign reassessment.

## Pilot results — 12/14 caught (~86%), 2 real Go test gaps surfaced

Verified end-to-end via:

\`\`\`bash
make dc-run CMD="python tests/shared/_go_mutation_pilot.py"
\`\`\`

**Survivors are real test gaps in the existing Go suite**:

1. \`parseHHMM\`: no test passes \`h < 0\` (e.g., \`"-5:00"\`)
2. \`parseHHMM\`: no test passes leading whitespace (e.g., \`" 12:30"\`)

Both are filed in the docstring's "Latest run" section. Adding the kill-tests is intentionally out of scope for this PR — the value here is the methodology + catalog, and writing tests to fix the gaps would muddy what the pilot demonstrated.

## What's added

### \`tests/shared/_go_mutation_pilot.py\` — runner with hand-crafted catalog

**14 mutations across 5 functions**:

| Function | Mutations | Mutation classes |
|---|---|---|
| \`parseHHMM\` | 5 | Drop hour upper/lower bounds, drop minute upper bound, drop format check, drop TrimSpace |
| \`matchTimeWindow\` | 3 | Invert end-bound \`<→<=\`, invert cross-midnight \`or→and\`, swap branch condition |
| \`parsePromDuration\` | 2 | 'd' returns hours not days, drop length-check guard |
| \`deepMerge\` | 3 | Drop \`_metadata\` skip, drop nil-delete, **skip recursive merge (semantic, not compile error)** |
| \`extractDefaultsBlock\` | 1 | Return nil instead of root fallback |

**Test target is `./...` from app/** — broad enough to exercise the parent \`package main\` tests that actually cover these primitives via the lowercase wrappers in \`config_inheritance.go\`. (First run with \`./pkg/config/...\` got 1/14 caught because pkg/config in-package tests only cover scope/benchmarks. Sharper test target was the fix.)

### \`tests/shared/test_go_mutation_pilot.py\` — 34 catalog smoke tests

Cross-platform (no Go toolchain required) catalog hygiene checks. Each parametrised over all 14 mutations:

- Each \`old=\` appears EXACTLY ONCE in target file (catches refactor drift)
- Each \`fn_name\` findable via \`func <name>(\`
- \`apply()+revert()\` round-trips byte-identically
- Each \`test_target\` uses Go-package selector form

## Why a catalog smoke test (not the runner itself in CI)

The actual mutation runner needs the Go toolchain (Cowork VM doesn't have it); it runs in Dev Container via \`make dc-run\`. But the **catalog can drift** — old strings becoming stale on refactor, fn_names being renamed — and that's what the smoke tests catch at commit time, cross-platform.

Same split as the Python pilot: \`_mutation_pilot.py\` is invocation-only (no pytest collection due to underscore prefix), companion test file enforces hygiene.

## Memory roadmap status

This is **PR 3 of 3** in the revised top-3:

- ✅ PR 1 (#346): Windows test infra
- ✅ PR 2 (#347): Process enforcement (property-coverage drift lint)
- ✅ **PR 3 (this)**: Go mutation pilot — 14 mutations / 5 functions / 12 caught / 2 real gaps surfaced

After this lands, follow-on tier (still in honest-assessment list):

- **Close the 2 Go gaps** (add parseHHMM tests for negative hours + whitespace)
- Coverage delta promote informational→hard gate (#340 foundation)
- Lint P3 self-tests (9 manual-stage hooks)
- Hypothesis nightly higher-budget run
- mutmut full sweep

## Test plan

- [ ] CI green (catalog smoke tests pass cross-platform)
- [ ] \`python -m pytest tests/shared/test_go_mutation_pilot.py -q\` — 34 passed
- [ ] \`make dc-run CMD="python tests/shared/_go_mutation_pilot.py"\` — 12/14 caught, 2 documented survivors

🤖 Generated with [Claude Code](https://claude.com/claude-code)