### PR TITLE
fix(dx): skip test_recover_index.py on Windows (same family as PR #346)

### DIFF
--- a/tests/dx/test_recover_index.py
+++ b/tests/dx/test_recover_index.py
@@ -9,9 +9,23 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
+
+# Same family as the 3 modules skipped by PR #346: Git Bash on Windows mangles
+# backslash arguments — `bash C:\path\file.sh` is parsed as
+# `bash C:Usersvencs...recover_index.sh` (backslashes eaten as escape chars),
+# so the script can never be located. Linux CI runs all 4 tests cross-platform
+# unaffected.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Git Bash on Windows mangles backslash path args to bash scripts; "
+           "Linux CI exercises this module fully (see PR #346 for the same "
+           "fix applied to test_verify_release.py / test_preflight_pass_gate.py / "
+           "test_preflight_marker.py).",
+)
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPT = _REPO_ROOT / "scripts" / "ops" / "recover_index.sh"


### PR DESCRIPTION
## Summary

Catches the one bash-script-on-Windows test module that PR #346 missed:
`tests/dx/test_recover_index.py`. Same root cause as the 3 modules PR #346
fixed (test_verify_release / test_preflight_pass_gate /
test_preflight_marker::TestGateScript) — Git Bash on Windows mangles
\`bash <C:\path\file.sh>\` arguments, eating backslashes as escape chars so
the script can never be located:

\`\`\`
/bin/bash: C:Usersvencsvibe-k8s-lab.claude...recover_index.sh: No such file or directory
exit 127
\`\`\`

Applied the same module-level \`pytestmark = pytest.mark.skipif(sys.platform == "win32", ...)\` pattern with an explicit reason citing PR #346 for context.

## Background

I discovered this while verifying that PR #346 had transparently fixed the
\`test_describe_tenant.py\` + \`test_migrate_conf_d.py\` failure pair I had
spawned as a follow-up chip from PR #350. That pair is now green on
zh-TW Windows thanks to PR #346's \`PYTHONIOENCODING=utf-8\` autouse fixture
(no fix needed). A wider \`pytest tests/dx tests/lint tests/ops\` sweep
surfaced this one stray case in the bash-script family.

## Test plan

- [x] On zh-TW Windows host: \`pytest tests/dx/test_recover_index.py -v\`
  → all 4 tests SKIPPED with the documented reason
- [ ] CI to verify Linux still runs all 4 tests (no platform guard there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)