### PR TITLE
chore(e2e): activate visual regression baselines + fix workflow upload path

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -49,3 +49,17 @@ Makefile    text eol=lf
 *.zip   binary
 *.woff  binary
 *.woff2 binary
+
+# Git LFS — visual regression baselines
+# ====================================
+# Playwright `toHaveScreenshot()` stores per-spec baselines under
+# `tests/e2e/<spec>-snapshots/`. Routing these PNGs through Git LFS keeps
+# the main pack lean even as baselines accumulate over time. Refines the
+# 2026-05-05 VR strategy decision (commit-to-git via Playwright built-in)
+# by activating the documented LFS escape route earlier than the original
+# >30-snapshots threshold — chosen to avoid lock-in to bloated history
+# now that VR is going live.
+#
+# `-text` overrides the earlier `* text=auto eol=lf` default so LFS sees
+# raw bytes (no line-ending normalization on what's logically opaque blobs).
+tests/e2e/*-snapshots/*.png filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -54,6 +54,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          # LFS-tracked visual regression baselines under
+          # tests/e2e/*-snapshots/ must be materialized for Playwright
+          # toHaveScreenshot() to compare against. Without this, checkout
+          # leaves 130-byte pointer files on disk and Playwright sees the
+          # LFS metadata instead of the baseline PNG.
+          lfs: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/visual-baseline.yaml
+++ b/.github/workflows/visual-baseline.yaml
@@ -37,6 +37,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # LFS materialization needed so existing baselines (under
+          # tests/e2e/*-snapshots/) are real PNGs when --update-snapshots
+          # decides whether to overwrite them. Without this, the workflow
+          # would compare against pointer-file "baselines" and always
+          # rewrite, even for unchanged visuals.
+          lfs: true
 
       - name: Set up Node.js 20
         uses: actions/setup-node@v5

--- a/.github/workflows/visual-baseline.yaml
+++ b/.github/workflows/visual-baseline.yaml
@@ -74,8 +74,16 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: visual-baselines-${{ github.run_id }}
-          path: tests/e2e/__snapshots__/
+          # Playwright's default snapshotPathTemplate writes baselines to
+          # `<spec>-snapshots/<name>-<project>-<platform>.png`, NOT
+          # `__snapshots__/`. The earlier path was wrong — first activation
+          # attempt (run 25603462985) generated 3 PNGs but uploaded 0
+          # because this glob found nothing. Use a glob covering ALL
+          # `*-snapshots/` dirs under tests/e2e/ so future spec additions
+          # are auto-included.
+          path: tests/e2e/*-snapshots/
           retention-days: 14
+          if-no-files-found: error
 
       - name: Print next steps
         run: |
@@ -86,7 +94,8 @@ jobs:
 
           1. Download the artifact `visual-baselines-${{ github.run_id }}`
              from this run page.
-          2. Unzip into `tests/e2e/__snapshots__/` on a fresh branch.
+          2. Unzip into `tests/e2e/` on a fresh branch — preserves the
+             `<spec>-snapshots/` subdirectory layout that Playwright expects.
           3. Open a PR titled "chore(e2e): refresh visual baselines —
              ${{ inputs.reason }}".
           4. CI on the PR will compare current behaviour against these

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -3,7 +3,7 @@
   "version": "2.6.0",
   "description": "Playwright smoke tests for Dynamic Alerting Portal",
   "scripts": {
-    "test": "playwright test --grep-invert @visual",
+    "test": "playwright test",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed",
     "test:debug": "playwright test --debug",

--- a/tests/e2e/visual.spec.ts
+++ b/tests/e2e/visual.spec.ts
@@ -19,10 +19,17 @@
  *   - Baselines MUST be generated on the same Ubuntu image CI uses.
  *     Don't run `--update-snapshots` on a Windows host — font rendering
  *     differs and you'll commit baselines that fail in CI.
- *   - To refresh a baseline: trigger the workflow_dispatch run of
- *     `nightly-race.yaml`-style updater (TODO: separate workflow), or
- *     run on a Linux dev container with: `npx playwright test visual.spec.ts --update-snapshots`
- *   - Commit the resulting PNGs in `tests/e2e/__snapshots__/visual.spec.ts/`
+ *   - To refresh a baseline:
+ *       gh workflow run visual-baseline.yaml \
+ *           --ref <branch> \
+ *           -f reason="<why>" \
+ *           -f spec="visual.spec.ts"
+ *     Then download the resulting `visual-baselines-<run_id>` artifact
+ *     and unzip into `tests/e2e/` (preserves the `<spec>-snapshots/`
+ *     subdir layout Playwright writes by default).
+ *   - Or run on a Linux dev container with:
+ *       npx playwright test visual.spec.ts --update-snapshots
+ *   - Commit the resulting PNGs in `tests/e2e/visual.spec.ts-snapshots/`.
  */
 import { test, expect, Page } from '@playwright/test';
 
@@ -148,13 +155,18 @@ test.describe('Visual regression baselines @visual', () => {
    *   2. fixme guard prevents the usual "skip until baseline lands" pattern
    *
    * Activation flow when ready:
-   *   1. Maintainer runs `Visual Regression Baseline Update` workflow
-   *      (.github/workflows/visual-baseline.yaml, workflow_dispatch).
-   *      Workflow updates ALL specs in visual.spec.ts on ubuntu-latest +
-   *      uploads __snapshots__/ folder as artifact.
-   *   2. Maintainer downloads + commits baselines under
-   *      tests/e2e/__snapshots__/visual.spec.ts/.
-   *   3. Same PR un-comments these blocks (delete the surrounding `/* ... *\/`).
+   *   1. Un-comment a block here (delete the surrounding `/* ... *\/`),
+   *      commit on a new branch, push.
+   *   2. Run the workflow against that branch:
+   *        gh workflow run visual-baseline.yaml --ref <branch> \
+   *            -f reason="<why>" -f spec="visual.spec.ts"
+   *      It uploads the regenerated `tests/e2e/*-snapshots/` dir as
+   *      `visual-baselines-<run_id>` artifact.
+   *   3. Download + unzip into `tests/e2e/` on the same branch.
+   *      `git add tests/e2e/visual.spec.ts-snapshots/<new>.png`, commit,
+   *      push, open PR.
+   *   4. CI on the PR runs the un-commented test against the new baseline;
+   *      should be green.
    *
    * Selection rationale: one tool per visual category, maximize catch-rate
    * per baseline. Skipping rich-data tools that change frequently

--- a/tests/e2e/visual.spec.ts-snapshots/alert-builder-step1-chromium-linux.png
+++ b/tests/e2e/visual.spec.ts-snapshots/alert-builder-step1-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0da428f3fc5afd2c341fc7fc8a715a1b3cf960251a7091e81dd0a11988ca0e83
+size 47748

--- a/tests/e2e/visual.spec.ts-snapshots/saved-views-panel-populated-chromium-linux.png
+++ b/tests/e2e/visual.spec.ts-snapshots/saved-views-panel-populated-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0921ad478c0fd9d003af878da9961685b068f8d3497cfb15f973416c13610509
+size 6083

--- a/tests/e2e/visual.spec.ts-snapshots/tenant-manager-landing-chromium-linux.png
+++ b/tests/e2e/visual.spec.ts-snapshots/tenant-manager-landing-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb8d336d8b3b6debac7bad679fb2848c46f69416da8e9dde32cea8fb99777913
+size 73970


### PR DESCRIPTION
## Summary

Activates the previously-dormant visual regression framework end-to-end. Three commits land together because the activation is atomic — none of them is useful in isolation:

1. **Workflow upload-path fix** (\`bf52eac9\`): \`visual-baseline.yaml\` upload step pointed at \`tests/e2e/__snapshots__/\` but Playwright actually writes baselines to \`tests/e2e/<spec>-snapshots/\`. First activation attempt (run 25603462985) silently uploaded 0 artifacts. Fix uses a glob (\`tests/e2e/*-snapshots/\`) plus \`if-no-files-found: error\` so silent zero-upload can never recur.
2. **Initial baselines** (\`394eda5a\`): 3 PNGs for the active \`@visual\` specs in \`visual.spec.ts\`, generated by workflow run 25603530159 on ubuntu-latest using the fixed workflow:
   - \`alert-builder-step1-chromium-linux.png\` (1280×720)
   - \`saved-views-panel-populated-chromium-linux.png\` (1182×28, panel locator)
   - \`tenant-manager-landing-chromium-linux.png\` (1280×1080, full page)
   Same commit also flips \`tests/e2e/package.json\` \`test\` script to stop excluding \`@visual\` (was defensive while baselines missing; now baselines exist).
3. **Git LFS infrastructure** (\`11441b9e\`): The 3 baselines from commit 2 are stored as LFS pointers (converted via \`git lfs migrate import\`). This commit codifies the system going forward:
   - \`.gitattributes\`: \`tests/e2e/*-snapshots/*.png filter=lfs ... -text\` so future PNG additions auto-LFS without contributor effort.
   - \`actions/checkout@v6\` with \`lfs: true\` in \`playwright.yml\` and \`visual-baseline.yaml\` so CI materializes pointers into real PNGs before Playwright reads them.

## Why LFS now (not later)

Per project memory's 2026-05-05 VR strategy, Argos was the documented escape hatch only when snapshots > 30 OR review pain emerged. Switched to LFS preemptively (still using Playwright's built-in toHaveScreenshot, just routing PNG storage through LFS) to avoid locking in raw-binary-in-git from day 1. Each UI iteration that refreshes baselines stacks new PNG versions in the pack; LFS keeps the main pack lean across that trajectory. Decision rationale:
- 127 KB now × every refresh → real cost in 1-2 years
- Cost to switch later (rewrite history) > cost to set up LFS now (one .gitattributes line + one checkout flag)
- LFS preserves the entire toHaveScreenshot user experience — no churn to spec files

## Documentation cleanup (in commit 2)

- \`tests/e2e/visual.spec.ts\` docstring: corrected stale \`__snapshots__/\` references (the path was always wrong; Playwright defaults to \`<spec>-snapshots/\`).
- TD-038 PARKED-test activation flow rewritten to use the \`gh workflow run\` path this PR validates end-to-end.

## Out of scope

- The 5 PARKED test blocks at the bottom of \`visual.spec.ts\` (TD-038 — one spec per visual category). Activation flow is documented inline + the LFS infrastructure now in place will auto-handle their PNG baselines.

## Test plan

- [x] Workflow run 25603530159 produced 3 PNGs of expected dimensions on ubuntu-latest
- [x] Baselines are real images: \`file\` reports \`PNG image data, ...\` (not 0-byte)
- [x] \`git lfs ls-files\` confirms 3 LFS-tracked entries
- [x] \`git lfs push\` to GitHub LFS storage succeeded (3 objects, 128 KB)
- [x] \`npm run lint\` clean in tests/e2e/ (pre-commit hook passes)
- [ ] CI on this PR: Playwright smoke job runs the 3 \`@visual\` tests (no longer excluded) — expect PASS
- [ ] CI on this PR: \`actions/checkout@v6 with lfs: true\` materializes real PNGs in CI runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)