### PR TITLE
fix(tenant-api): HA-11 deeper — fakeClock for platform/tracker WatchLoop test

### DIFF
--- a/components/tenant-api/go.mod
+++ b/components/tenant-api/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect

--- a/components/tenant-api/go.sum
+++ b/components/tenant-api/go.sum
@@ -12,6 +12,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.30.2 h1:JiFIMtSSHb2/XBUbWM4i/MpeQm9ZK2xqPNk8vgvu5JQ=
 github.com/go-playground/validator/v10 v10.30.2/go.mod h1:mAf2pIOVXjTEBrwUMGKkCWKKPs9NheYGabeB04txQSc=
+github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/components/tenant-api/internal/platform/tracker.go
+++ b/components/tenant-api/internal/platform/tracker.go
@@ -4,6 +4,8 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/jonboulle/clockwork"
 )
 
 // Lister fetches the current open PRs/MRs from a Git hosting platform.
@@ -29,8 +31,18 @@ var _ Tracker = (*PollingTracker)(nil)
 // (which usually triggers rate limits and earns the deployment a
 // platform-side IP block).
 type PollingTracker struct {
-	lister       Lister
-	provider     string // "github" / "gitlab" — used in log lines only
+	lister   Lister
+	provider string // "github" / "gitlab" — used in log lines only
+
+	// clock abstracts time.Now() / time.NewTicker so tests can drive the
+	// WatchLoop ticker deterministically with a clockwork.FakeClock instead
+	// of waiting for real wall-clock ticks. Production constructors plug in
+	// clockwork.NewRealClock(); test code can use SetClock to swap in
+	// clockwork.NewFakeClock and then `Advance(syncInterval)` to fire ticks
+	// synchronously. Origin: HA-11 deeper (TestWatchLoop_TickerTriggersAdditionalSyncs
+	// flake on GH-hosted runners; PR #350 caught the symptom, this fix
+	// addresses the root cause).
+	clock clockwork.Clock
 
 	mu           sync.RWMutex
 	pendingPRs   []PRInfo
@@ -58,9 +70,21 @@ func NewPollingTracker(lister Lister, provider string, syncInterval time.Duratio
 	return &PollingTracker{
 		lister:       lister,
 		provider:     provider,
+		clock:        clockwork.NewRealClock(),
 		byTenant:     make(map[string]PRInfo),
 		syncInterval: syncInterval,
 	}
+}
+
+// SetClock swaps the clock used by WatchLoop's ticker + Sync's lastSync
+// stamp. Test-only — production code constructs trackers via
+// NewPollingTracker which installs a real clock. Calling this after
+// WatchLoop has started is undefined (the ticker is bound to whichever
+// clock was current at NewTicker time).
+func (t *PollingTracker) SetClock(c clockwork.Clock) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.clock = c
 }
 
 // WatchLoop runs an initial sync, then re-syncs every syncInterval.
@@ -69,12 +93,12 @@ func NewPollingTracker(lister Lister, provider string, syncInterval time.Duratio
 func (t *PollingTracker) WatchLoop(stopCh <-chan struct{}) {
 	t.Sync()
 
-	ticker := time.NewTicker(t.syncInterval)
+	ticker := t.clock.NewTicker(t.syncInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case <-ticker.C:
+		case <-ticker.Chan():
 			t.Sync()
 		case <-stopCh:
 			return
@@ -110,7 +134,7 @@ func (t *PollingTracker) Sync() {
 	t.mu.Lock()
 	t.pendingPRs = prs
 	t.byTenant = byTenant
-	t.lastSync = time.Now()
+	t.lastSync = t.clock.Now()
 	t.mu.Unlock()
 
 	slog.Info("tracker synced", "provider", t.provider, "pending", len(prs))

--- a/components/tenant-api/internal/platform/tracker_test.go
+++ b/components/tenant-api/internal/platform/tracker_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/jonboulle/clockwork"
 )
 
 // fixedLister returns the same PR list every call.
@@ -46,6 +48,31 @@ func countingLister(prs []PRInfo) (Lister, func() int) {
 		return count
 	}
 	return lister, snapshot
+}
+
+// signalingLister wraps a Lister with both a counter AND a signal channel
+// that emits AFTER each call. Used by deterministic ticker tests that
+// need to wait for the WatchLoop goroutine to have finished consuming a
+// fakeClock.Advance() before asserting on call count. Buffered so the
+// lister never blocks on a slow-consumer test.
+func signalingLister(prs []PRInfo) (lister Lister, snapshot func() int, done <-chan struct{}) {
+	var mu sync.Mutex
+	count := 0
+	signal := make(chan struct{}, 64) // buffer = many ticks even if test is slow
+	lister = func() ([]PRInfo, error) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		signal <- struct{}{}
+		return prs, nil
+	}
+	snapshot = func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return count
+	}
+	done = signal
+	return lister, snapshot, done
 }
 
 // ---------------------------------------------------------------------------
@@ -370,13 +397,20 @@ func TestWatchLoop_RunsInitialSync(t *testing.T) {
 
 func TestWatchLoop_TickerTriggersAdditionalSyncs(t *testing.T) {
 	t.Parallel()
-	lister, count := countingLister(nil)
-	// Bypass the constructor's clamp so we can exercise the ticker
-	// quickly without waiting 30s. This is safe because we're testing
-	// the LOOP behaviour, not the clamp logic.
+	// HA-11 deeper: this test was a documented flake on GH-hosted runners
+	// (CI run 25602108441 saw "lister call count = 1, want >= 2"). The old
+	// version slept 180ms hoping for at least one 50ms ticker fire — under
+	// CPU steal / GC pauses on shared runners, the sleep could return before
+	// any tick processed. Replaced with clockwork.FakeClock + per-call
+	// signal channel so each tick is fired AND awaited deterministically.
+	lister, count, syncDone := signalingLister(nil)
+	clock := clockwork.NewFakeClock()
+	// Bypass the constructor's interval clamp + plug in the fake clock.
+	// Safe because we're testing LOOP behaviour, not the clamp logic.
 	tk := &PollingTracker{
 		lister:       lister,
 		provider:     "github",
+		clock:        clock,
 		byTenant:     map[string]PRInfo{},
 		syncInterval: 50 * time.Millisecond,
 	}
@@ -388,8 +422,24 @@ func TestWatchLoop_TickerTriggersAdditionalSyncs(t *testing.T) {
 		close(done)
 	}()
 
-	// Wait long enough for at least 2 ticks (initial sync + 1+ ticker).
-	time.Sleep(180 * time.Millisecond)
+	// 1. Wait for the initial Sync (called before the ticker starts).
+	waitForSync(t, syncDone, "initial sync")
+
+	// 2. Wait for the WatchLoop goroutine to register its ticker on the
+	//    fake clock. Without this, an early Advance() can fire before the
+	//    ticker exists and be swallowed.
+	clock.BlockUntil(1)
+
+	// 3. Advance the fake clock by syncInterval to fire one tick, then
+	//    wait for the goroutine to consume it (signaled by the lister
+	//    being called for the second time).
+	clock.Advance(50 * time.Millisecond)
+	waitForSync(t, syncDone, "sync after tick 1")
+
+	// 4. Advance again — proves the ticker is repeating, not single-shot.
+	clock.Advance(50 * time.Millisecond)
+	waitForSync(t, syncDone, "sync after tick 2")
+
 	close(stopCh)
 	select {
 	case <-done:
@@ -397,9 +447,23 @@ func TestWatchLoop_TickerTriggersAdditionalSyncs(t *testing.T) {
 		t.Fatal("WatchLoop did not exit after stopCh close")
 	}
 
-	// Initial sync (1) + at least one ticker fire (>=2 total).
-	if got := count(); got < 2 {
-		t.Errorf("lister call count = %d, want >= 2 (initial + ticker)", got)
+	// Initial + 2 deterministic tick-driven syncs = exactly 3.
+	if got := count(); got != 3 {
+		t.Errorf("lister call count = %d, want 3 (initial + 2 ticks)", got)
+	}
+}
+
+// waitForSync drains one signal from the signalingLister's done channel
+// or fails fast with a contextual message. The 2-second budget is generous
+// — fakeClock.Advance is synchronous and the goroutine should consume the
+// tick within microseconds; the deadline only protects against a regression
+// that breaks the signaling contract.
+func waitForSync(t *testing.T, done <-chan struct{}, label string) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s (lister never called)", label)
 	}
 }
 
@@ -408,8 +472,9 @@ func TestWatchLoop_StopChanTerminatesPromptly(t *testing.T) {
 	tk := &PollingTracker{
 		lister:       fixedLister(nil),
 		provider:     "github",
+		clock:        clockwork.NewRealClock(), // 1h interval — clock identity doesn't matter
 		byTenant:     map[string]PRInfo{},
-		syncInterval: 1 * time.Hour, // never tick
+		syncInterval: 1 * time.Hour,            // never tick
 	}
 
 	stopCh := make(chan struct{})


### PR DESCRIPTION
## Summary

Replaces a flaky \`time.Sleep\`-based ticker assertion in \`platform/tracker_test.go\` with a deterministic \`clockwork.FakeClock\` + per-call signal pattern. Closes the documented HA-11 ticker flake observed in CI run 25602108441 ("lister call count = 1, want >= 2 (initial + ticker)").

## Background

PR #327's HA-11 lite extracted a \`tickOnce()\` seam in the **exporter's** WatchLoop — that solved the equivalent flake there without introducing a clock library. This PR addresses the same class of flake in **tenant-api**'s \`PollingTracker.WatchLoop\` via the deeper architectural fix originally noted as a stretch goal: full Clock interface injection.

The exporter pattern (tickOnce seam) didn't translate cleanly here because PollingTracker.WatchLoop's tick handler is a single \`Sync()\` call (already exported); the only flaky bit was the test's wait-for-tick logic, not the production loop shape. So the test is the one that gets the clock.

## Root cause of the original flake

\`\`\`go
// Old test (lines 391-393):
time.Sleep(180 * time.Millisecond)  // hope for ≥1 of the 50ms ticks to fire
close(stopCh)
\`\`\`

On GH-hosted runners under CPU steal / GC pause / shared-runner contention, the 180ms sleep can return before the consumer goroutine has processed any ticker fire — \`count()\` stays at 1 (just the initial sync) and the assertion \`count() >= 2\` fails.

## What changed

| File | Change |
|---|---|
| \`go.mod\` / \`go.sum\` | Added \`github.com/jonboulle/clockwork v0.5.0\` (Apache-2.0, used by knative) |
| \`internal/platform/tracker.go\` | New \`clock clockwork.Clock\` field; \`NewPollingTracker\` plugs in real clock; \`WatchLoop\` uses \`t.clock.NewTicker\`; \`Sync\` uses \`t.clock.Now()\`; \`SetClock(c)\` test-only setter |
| \`internal/platform/tracker_test.go\` | New \`signalingLister\` helper (per-call signal channel); \`TestWatchLoop_TickerTriggersAdditionalSyncs\` rewritten with FakeClock + BlockUntil + Advance + waitForSync; \`TestWatchLoop_StopChanTerminatesPromptly\` gets a \`clock\` field on its struct literal |

## Test plan

- [x] \`go test -count=1 ./internal/platform/...\` clean (0.4s)
- [x] \`go test -count=20 -run TestWatchLoop_TickerTriggersAdditionalSyncs ./internal/platform/...\` clean (**0.197s** total — was 3.6s minimum + flake risk)
- [x] Production-side build clean (\`go build ./internal/platform/...\`)
- [x] Pre-commit + commit-msg hooks pass
- [ ] CI race detector (Go Tests 1.26) — expect green; the rewrite removed the timing-dependent assertion entirely

## Out of scope

- Other \`time.NewTicker\` / \`time.After\` sites in tenant-api outside \`platform/\` — none currently surface as flaky tests; defer until needed.
- Backporting clockwork to the exporter's WatchLoop — the \`tickOnce()\` seam from PR #327 already serves the same purpose there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)