### PR TITLE
test(exporter): selective t.Parallel sweep on config_*_test.go (10/22 files, 165 injections)

### DIFF
--- a/components/threshold-exporter/app/config_defaults_diff_test.go
+++ b/components/threshold-exporter/app/config_defaults_diff_test.go
@@ -12,6 +12,7 @@ import (
 // ============================================================
 
 func TestDefaultsPathLevel_RootIsGlobal(t *testing.T) {
+	t.Parallel()
 	root := filepath.FromSlash("/conf.d")
 	got := defaultsPathLevel(filepath.FromSlash("/conf.d/_defaults.yaml"), root)
 	if got != "global" {
@@ -20,6 +21,7 @@ func TestDefaultsPathLevel_RootIsGlobal(t *testing.T) {
 }
 
 func TestDefaultsPathLevel_OneLevelDeepIsDomain(t *testing.T) {
+	t.Parallel()
 	root := filepath.FromSlash("/conf.d")
 	got := defaultsPathLevel(filepath.FromSlash("/conf.d/finance/_defaults.yaml"), root)
 	if got != "domain" {
@@ -28,6 +30,7 @@ func TestDefaultsPathLevel_OneLevelDeepIsDomain(t *testing.T) {
 }
 
 func TestDefaultsPathLevel_TwoLevelsDeepIsRegion(t *testing.T) {
+	t.Parallel()
 	root := filepath.FromSlash("/conf.d")
 	got := defaultsPathLevel(filepath.FromSlash("/conf.d/finance/us-east/_defaults.yaml"), root)
 	if got != "region" {
@@ -36,6 +39,7 @@ func TestDefaultsPathLevel_TwoLevelsDeepIsRegion(t *testing.T) {
 }
 
 func TestDefaultsPathLevel_ThreeLevelsDeepIsEnv(t *testing.T) {
+	t.Parallel()
 	root := filepath.FromSlash("/conf.d")
 	got := defaultsPathLevel(filepath.FromSlash("/conf.d/finance/us-east/prod/_defaults.yaml"), root)
 	if got != "env" {
@@ -44,6 +48,7 @@ func TestDefaultsPathLevel_ThreeLevelsDeepIsEnv(t *testing.T) {
 }
 
 func TestDefaultsPathLevel_DeeperThanFourIsUnknown(t *testing.T) {
+	t.Parallel()
 	root := filepath.FromSlash("/conf.d")
 	got := defaultsPathLevel(filepath.FromSlash("/conf.d/a/b/c/d/e/_defaults.yaml"), root)
 	if got != "unknown" {
@@ -52,6 +57,7 @@ func TestDefaultsPathLevel_DeeperThanFourIsUnknown(t *testing.T) {
 }
 
 func TestDefaultsPathLevel_NonDescendantIsUnknown(t *testing.T) {
+	t.Parallel()
 	root := filepath.FromSlash("/conf.d")
 	got := defaultsPathLevel(filepath.FromSlash("/elsewhere/_defaults.yaml"), root)
 	if got != "unknown" {
@@ -66,6 +72,7 @@ func TestDefaultsPathLevel_NonDescendantIsUnknown(t *testing.T) {
 // path classifies as "global" not "domain". Production-named dirs
 // never start with `..`.
 func TestDefaultsPathLevel_SkipsK8sConfigMapSymlinkSegments(t *testing.T) {
+	t.Parallel()
 	root := filepath.FromSlash("/etc/config")
 	cases := []struct {
 		path string
@@ -90,6 +97,7 @@ func TestDefaultsPathLevel_SkipsK8sConfigMapSymlinkSegments(t *testing.T) {
 // ============================================================
 
 func TestWidestChangedScope_PicksShallowestChanged(t *testing.T) {
+	t.Parallel()
 	root := filepath.FromSlash("/conf.d")
 	chain := []string{
 		filepath.FromSlash("/conf.d/_defaults.yaml"),
@@ -112,6 +120,7 @@ func TestWidestChangedScope_PicksShallowestChanged(t *testing.T) {
 }
 
 func TestWidestChangedScope_NoneChangedReturnsEmpty(t *testing.T) {
+	t.Parallel()
 	root := filepath.FromSlash("/conf.d")
 	chain := []string{filepath.FromSlash("/conf.d/_defaults.yaml")}
 	hashes := map[string]string{chain[0]: "h-stable"}
@@ -125,6 +134,7 @@ func TestWidestChangedScope_NoneChangedReturnsEmpty(t *testing.T) {
 // ============================================================
 
 func TestParseDefaultsBytes_WrappedDefaultsKey(t *testing.T) {
+	t.Parallel()
 	b := []byte("defaults:\n  mysql_connections: 80\n")
 	got, err := parseDefaultsBytes(b)
 	if err != nil {
@@ -136,6 +146,7 @@ func TestParseDefaultsBytes_WrappedDefaultsKey(t *testing.T) {
 }
 
 func TestParseDefaultsBytes_NakedDict(t *testing.T) {
+	t.Parallel()
 	b := []byte("mysql_connections: 80\n")
 	got, err := parseDefaultsBytes(b)
 	if err != nil {
@@ -147,6 +158,7 @@ func TestParseDefaultsBytes_NakedDict(t *testing.T) {
 }
 
 func TestParseDefaultsBytes_EmptyReturnsEmptyMap(t *testing.T) {
+	t.Parallel()
 	got, err := parseDefaultsBytes([]byte("   \n  \n"))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
@@ -157,6 +169,7 @@ func TestParseDefaultsBytes_EmptyReturnsEmptyMap(t *testing.T) {
 }
 
 func TestParseDefaultsBytes_InvalidYAMLReturnsError(t *testing.T) {
+	t.Parallel()
 	if _, err := parseDefaultsBytes([]byte("not: : valid: yaml: :\n")); err == nil {
 		t.Errorf("expected error for malformed YAML, got nil")
 	}
@@ -173,6 +186,7 @@ func sortedKeys(s []string) []string {
 }
 
 func TestChangedDefaultsKeys_IdenticalReturnsEmpty(t *testing.T) {
+	t.Parallel()
 	a := map[string]any{"x": 1, "y": "z"}
 	b := map[string]any{"x": 1, "y": "z"}
 	if got := changedDefaultsKeys(a, b); len(got) != 0 {
@@ -181,6 +195,7 @@ func TestChangedDefaultsKeys_IdenticalReturnsEmpty(t *testing.T) {
 }
 
 func TestChangedDefaultsKeys_AddedKey(t *testing.T) {
+	t.Parallel()
 	a := map[string]any{}
 	b := map[string]any{"new_key": 1}
 	got := sortedKeys(changedDefaultsKeys(a, b))
@@ -190,6 +205,7 @@ func TestChangedDefaultsKeys_AddedKey(t *testing.T) {
 }
 
 func TestChangedDefaultsKeys_RemovedKey(t *testing.T) {
+	t.Parallel()
 	a := map[string]any{"old_key": 1}
 	b := map[string]any{}
 	got := sortedKeys(changedDefaultsKeys(a, b))
@@ -199,6 +215,7 @@ func TestChangedDefaultsKeys_RemovedKey(t *testing.T) {
 }
 
 func TestChangedDefaultsKeys_ScalarValueChange(t *testing.T) {
+	t.Parallel()
 	a := map[string]any{"mysql_connections": 80}
 	b := map[string]any{"mysql_connections": 100}
 	got := sortedKeys(changedDefaultsKeys(a, b))
@@ -208,6 +225,7 @@ func TestChangedDefaultsKeys_ScalarValueChange(t *testing.T) {
 }
 
 func TestChangedDefaultsKeys_NestedSubkeyChangeDoesNotReportParent(t *testing.T) {
+	t.Parallel()
 	a := map[string]any{"thresholds": map[string]any{"cpu": 80, "memory": 70}}
 	b := map[string]any{"thresholds": map[string]any{"cpu": 90, "memory": 70}}
 	got := sortedKeys(changedDefaultsKeys(a, b))
@@ -217,6 +235,7 @@ func TestChangedDefaultsKeys_NestedSubkeyChangeDoesNotReportParent(t *testing.T)
 }
 
 func TestChangedDefaultsKeys_ArrayReplaceIsLeafChange(t *testing.T) {
+	t.Parallel()
 	a := map[string]any{"x": []any{1, 2}}
 	b := map[string]any{"x": []any{1, 2, 3}}
 	got := sortedKeys(changedDefaultsKeys(a, b))
@@ -226,12 +245,14 @@ func TestChangedDefaultsKeys_ArrayReplaceIsLeafChange(t *testing.T) {
 }
 
 func TestChangedDefaultsKeys_BothNilReturnsEmpty(t *testing.T) {
+	t.Parallel()
 	if got := changedDefaultsKeys(nil, nil); len(got) != 0 {
 		t.Errorf("expected empty, got %v", got)
 	}
 }
 
 func TestChangedDefaultsKeys_TypeChangeIsLeafChange(t *testing.T) {
+	t.Parallel()
 	a := map[string]any{"x": 80}                      // scalar
 	b := map[string]any{"x": map[string]any{"a": 1}}  // map
 	got := sortedKeys(changedDefaultsKeys(a, b))
@@ -245,6 +266,7 @@ func TestChangedDefaultsKeys_TypeChangeIsLeafChange(t *testing.T) {
 // ============================================================
 
 func TestTenantOverridesAll_AllTopLevelOverridden(t *testing.T) {
+	t.Parallel()
 	tenant := map[string]any{"mysql_connections": 100, "redis_connections": 50}
 	if !tenantOverridesAll(tenant, []string{"mysql_connections", "redis_connections"}) {
 		t.Errorf("expected true (all overridden)")
@@ -252,6 +274,7 @@ func TestTenantOverridesAll_AllTopLevelOverridden(t *testing.T) {
 }
 
 func TestTenantOverridesAll_PartialOverrideReturnsFalse(t *testing.T) {
+	t.Parallel()
 	tenant := map[string]any{"mysql_connections": 100}
 	if tenantOverridesAll(tenant, []string{"mysql_connections", "redis_connections"}) {
 		t.Errorf("expected false (redis_connections missing)")
@@ -259,6 +282,7 @@ func TestTenantOverridesAll_PartialOverrideReturnsFalse(t *testing.T) {
 }
 
 func TestTenantOverridesAll_NestedExactPath(t *testing.T) {
+	t.Parallel()
 	tenant := map[string]any{"thresholds": map[string]any{"cpu": 85}}
 	if !tenantOverridesAll(tenant, []string{"thresholds.cpu"}) {
 		t.Errorf("expected true (exact nested override)")
@@ -266,6 +290,7 @@ func TestTenantOverridesAll_NestedExactPath(t *testing.T) {
 }
 
 func TestTenantOverridesAll_ParentScalarOverridesWholeSubtree(t *testing.T) {
+	t.Parallel()
 	// Tenant replaces the whole `thresholds` block with a scalar →
 	// any path beneath `thresholds` is considered overridden.
 	tenant := map[string]any{"thresholds": "any-scalar"}
@@ -275,6 +300,7 @@ func TestTenantOverridesAll_ParentScalarOverridesWholeSubtree(t *testing.T) {
 }
 
 func TestTenantOverridesAll_NoOverlapReturnsFalse(t *testing.T) {
+	t.Parallel()
 	tenant := map[string]any{"unrelated_key": 1}
 	if tenantOverridesAll(tenant, []string{"thresholds.cpu"}) {
 		t.Errorf("expected false (tenant doesn't touch thresholds)")
@@ -282,12 +308,14 @@ func TestTenantOverridesAll_NoOverlapReturnsFalse(t *testing.T) {
 }
 
 func TestTenantOverridesAll_EmptyPathsReturnsTrue(t *testing.T) {
+	t.Parallel()
 	if !tenantOverridesAll(map[string]any{}, nil) {
 		t.Errorf("expected true (vacuous on empty paths)")
 	}
 }
 
 func TestTenantOverridesAll_NilValueIsNotOverride(t *testing.T) {
+	t.Parallel()
 	// YAML null → deepMerge "delete key" semantics → defaults still
 	// visible → not an override.
 	tenant := map[string]any{"mysql_connections": nil}
@@ -301,6 +329,7 @@ func TestTenantOverridesAll_NilValueIsNotOverride(t *testing.T) {
 // ============================================================
 
 func TestClassifyDefaultsNoOpEffect_CosmeticWhenNoKeyChanged(t *testing.T) {
+	t.Parallel()
 	dp := "/conf.d/_defaults.yaml"
 	chain := []string{dp}
 	prior := map[string]map[string]any{dp: {"mysql_connections": 80}}
@@ -316,6 +345,7 @@ func TestClassifyDefaultsNoOpEffect_CosmeticWhenNoKeyChanged(t *testing.T) {
 }
 
 func TestClassifyDefaultsNoOpEffect_ShadowedWhenTenantOverridesChangedKey(t *testing.T) {
+	t.Parallel()
 	dp := "/conf.d/_defaults.yaml"
 	chain := []string{dp}
 	prior := map[string]map[string]any{dp: {"mysql_connections": 80}}
@@ -332,6 +362,7 @@ func TestClassifyDefaultsNoOpEffect_ShadowedWhenTenantOverridesChangedKey(t *tes
 }
 
 func TestClassifyDefaultsNoOpEffect_CosmeticWhenTenantSourceUnparseable(t *testing.T) {
+	t.Parallel()
 	dp := "/conf.d/_defaults.yaml"
 	chain := []string{dp}
 	prior := map[string]map[string]any{dp: {"mysql_connections": 80}}
@@ -347,6 +378,7 @@ func TestClassifyDefaultsNoOpEffect_CosmeticWhenTenantSourceUnparseable(t *testi
 }
 
 func TestClassifyDefaultsNoOpEffect_CosmeticWhenPriorParseMissing(t *testing.T) {
+	t.Parallel()
 	dp := "/conf.d/_defaults.yaml"
 	chain := []string{dp}
 	// Cache miss for prior — simulates first tick after restart with
@@ -364,6 +396,7 @@ func TestClassifyDefaultsNoOpEffect_CosmeticWhenPriorParseMissing(t *testing.T) 
 }
 
 func TestClassifyDefaultsNoOpEffect_ShadowedAcrossMultipleChainEntries(t *testing.T) {
+	t.Parallel()
 	// Two defaults files in chain both moved; tenant overrides every
 	// changed key across both → shadowed.
 	dp1 := "/conf.d/_defaults.yaml"

--- a/components/threshold-exporter/app/config_dimensional_test.go
+++ b/components/threshold-exporter/app/config_dimensional_test.go
@@ -20,6 +20,7 @@ import (
 // ============================================================
 
 func TestParseKeyWithLabels(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input       string
 		wantBase    string
@@ -84,6 +85,7 @@ func TestParseKeyWithLabels(t *testing.T) {
 }
 
 func TestResolve_DimensionalBasic(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{
 			"redis_memory": 80,
@@ -152,6 +154,7 @@ func TestResolve_DimensionalBasic(t *testing.T) {
 }
 
 func TestResolve_DimensionalDisable(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{},
 		Tenants: map[string]map[string]ScheduledValue{
@@ -172,6 +175,7 @@ func TestResolve_DimensionalDisable(t *testing.T) {
 }
 
 func TestResolve_DimensionalBackwardCompat(t *testing.T) {
+	t.Parallel()
 	// Non-dimensional config should still work identically
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{
@@ -204,6 +208,7 @@ func TestResolve_DimensionalBackwardCompat(t *testing.T) {
 }
 
 func TestResolve_DimensionalWithDirMode(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	writeTestFile(t, dir, "_defaults.yaml", `
@@ -251,6 +256,7 @@ tenants:
 // ============================================================
 
 func TestParseLabelsStringWithOp(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input     string
 		wantExact map[string]string
@@ -282,6 +288,7 @@ func TestParseLabelsStringWithOp(t *testing.T) {
 }
 
 func TestResolve_RegexDimensional(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{
 			"oracle_tablespace": 80,
@@ -343,6 +350,7 @@ func TestResolve_RegexDimensional(t *testing.T) {
 }
 
 func TestResolve_RegexDimensionalWithYAML(t *testing.T) {
+	t.Parallel()
 	content := `
 defaults:
   oracle_tablespace: 80
@@ -379,6 +387,7 @@ tenants:
 }
 
 func TestResolve_RegexScheduled(t *testing.T) {
+	t.Parallel()
 	// B1 + B4 combined: regex dimensional with time-window override
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"oracle_tablespace": 80},
@@ -421,6 +430,7 @@ func TestResolve_RegexScheduled(t *testing.T) {
 // _critical suffix on regex dimensional keys has no effect.
 // Regex dimensional keys must use "value:severity" syntax instead.
 func TestResolve_RegexDimensionalCriticalNotSupported(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{
 			"oracle_tablespace": 90,

--- a/components/threshold-exporter/app/config_golden_parity_test.go
+++ b/components/threshold-exporter/app/config_golden_parity_test.go
@@ -77,6 +77,7 @@ func loadGolden(t *testing.T) []goldenEntry {
 // newline?). Fixture files are built by Python — parity is about reading the
 // exact same bytes.
 func TestGoldenParity_SourceHash(t *testing.T) {
+	t.Parallel()
 	entries := loadGolden(t)
 	root := goldenRepoRoot(t)
 
@@ -100,6 +101,7 @@ func TestGoldenParity_SourceHash(t *testing.T) {
 // TestGoldenParity_MergedHash is THE test — every drift here maps to one of
 // the 8 semantic traps in §8.11.2. Run this first when debugging parity.
 func TestGoldenParity_MergedHash(t *testing.T) {
+	t.Parallel()
 	entries := loadGolden(t)
 	root := goldenRepoRoot(t)
 
@@ -147,6 +149,7 @@ func TestGoldenParity_MergedHash(t *testing.T) {
 // by coincidence but different structural output). If merged_hash passes
 // but this fails, something semantically equivalent has shifted.
 func TestGoldenParity_EffectiveConfig(t *testing.T) {
+	t.Parallel()
 	entries := loadGolden(t)
 	root := goldenRepoRoot(t)
 
@@ -198,6 +201,7 @@ func TestGoldenParity_EffectiveConfig(t *testing.T) {
 // up the same defaults_chain that Python captured. Catches walker / chain
 // bugs independently of hash computation.
 func TestGoldenParity_ScannerChainOrder(t *testing.T) {
+	t.Parallel()
 	entries := loadGolden(t)
 	root := goldenRepoRoot(t)
 

--- a/components/threshold-exporter/app/config_incremental_test.go
+++ b/components/threshold-exporter/app/config_incremental_test.go
@@ -20,6 +20,7 @@ import (
 // ============================================================
 
 func TestScanDirFileHashes(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
 defaults:
@@ -50,6 +51,7 @@ tenants:
 }
 
 func TestScanDirFileHashes_SkipsHiddenAndSubdirs(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `defaults: {}`)
 	writeTestFile(t, dir, ".hidden.yaml", `defaults: {}`)
@@ -66,6 +68,7 @@ func TestScanDirFileHashes_SkipsHiddenAndSubdirs(t *testing.T) {
 }
 
 func TestScanDirFileHashes_StableComposite(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "a.yaml", `defaults: {x: 1}`)
 	writeTestFile(t, dir, "b.yaml", `tenants: {t1: {}}`)
@@ -78,6 +81,7 @@ func TestScanDirFileHashes_StableComposite(t *testing.T) {
 }
 
 func TestIncrementalLoad_InitialLoad(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
 defaults:
@@ -112,6 +116,7 @@ tenants:
 }
 
 func TestIncrementalLoad_FileModified(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
 defaults:
@@ -149,6 +154,7 @@ tenants:
 }
 
 func TestIncrementalLoad_FileAdded(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
 defaults:
@@ -186,6 +192,7 @@ tenants:
 }
 
 func TestIncrementalLoad_FileRemoved(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
 defaults:
@@ -229,6 +236,7 @@ tenants:
 }
 
 func TestIncrementalLoad_NoChange(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
 defaults:
@@ -254,6 +262,7 @@ defaults:
 }
 
 func TestIncrementalLoad_SingleFileModeFallback(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
 	writeTestFile(t, dir, "config.yaml", `
@@ -279,6 +288,7 @@ tenants:
 }
 
 func TestIncrementalLoad_BoundaryEnforcement(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
 defaults:
@@ -310,6 +320,7 @@ tenants:
 }
 
 func TestIncrementalLoad_ProfilesAfterIncremental(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
 defaults:
@@ -354,6 +365,7 @@ profiles:
 }
 
 func TestMergePartialConfigs_Empty(t *testing.T) {
+	t.Parallel()
 	merged := mergePartialConfigs(map[string]ThresholdConfig{})
 	if len(merged.Defaults) != 0 || len(merged.Tenants) != 0 {
 		t.Error("empty merge should produce empty config")
@@ -361,6 +373,7 @@ func TestMergePartialConfigs_Empty(t *testing.T) {
 }
 
 func TestMergePartialConfigs_DeterministicOrder(t *testing.T) {
+	t.Parallel()
 	configs := map[string]ThresholdConfig{
 		"b.yaml": {
 			Defaults: map[string]float64{"mysql_connections": 90},
@@ -377,6 +390,7 @@ func TestMergePartialConfigs_DeterministicOrder(t *testing.T) {
 }
 
 func TestApplyBoundaryRules_DefaultsFile(t *testing.T) {
+	t.Parallel()
 	partial := ThresholdConfig{
 		Defaults:     map[string]float64{"x": 1},
 		StateFilters: map[string]StateFilter{"f": {Severity: "warning"}},
@@ -391,6 +405,7 @@ func TestApplyBoundaryRules_DefaultsFile(t *testing.T) {
 }
 
 func TestApplyBoundaryRules_TenantFile(t *testing.T) {
+	t.Parallel()
 	partial := ThresholdConfig{
 		Defaults:     map[string]float64{"x": 1},
 		StateFilters: map[string]StateFilter{"f": {Severity: "warning"}},
@@ -409,6 +424,7 @@ func TestApplyBoundaryRules_TenantFile(t *testing.T) {
 }
 
 func TestFullDirLoad_InitializesCache(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
 defaults:
@@ -435,6 +451,7 @@ tenants:
 // TestIncrementalLoad_MultiOp verifies correct handling when multiple
 // operations occur in a single reload cycle: add + modify + remove.
 func TestIncrementalLoad_MultiOp(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
 defaults:
@@ -513,6 +530,7 @@ tenants:
 // TestIncrementalLoad_ScheduledValues verifies that scheduled (time-window)
 // values survive incremental reload correctly.
 func TestIncrementalLoad_ScheduledValues(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
 defaults:
@@ -568,6 +586,7 @@ tenants:
 // TestIncrementalLoad_DefaultsModified verifies that modifying _defaults.yaml
 // propagates correctly through incremental reload.
 func TestIncrementalLoad_DefaultsModified(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
 defaults:
@@ -616,6 +635,7 @@ defaults:
 // TestIncrementalLoad_CacheOnlyReparses verifies that only changed files
 // get re-parsed, not the entire directory.
 func TestIncrementalLoad_CacheOnlyReparses(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
 defaults:

--- a/components/threshold-exporter/app/config_inheritance_test.go
+++ b/components/threshold-exporter/app/config_inheritance_test.go
@@ -13,6 +13,7 @@ import (
 
 // TestDeepMerge_ScalarOverride — child scalar overwrites parent scalar.
 func TestDeepMerge_ScalarOverride(t *testing.T) {
+	t.Parallel()
 	base := map[string]any{"cpu": 70, "memory": 75}
 	over := map[string]any{"cpu": 85}
 	got := deepMerge(base, over)
@@ -31,6 +32,7 @@ func TestDeepMerge_ScalarOverride(t *testing.T) {
 
 // TestDeepMerge_NestedDictRecurse — nested dicts merge field-by-field.
 func TestDeepMerge_NestedDictRecurse(t *testing.T) {
+	t.Parallel()
 	base := map[string]any{
 		"threshold": map[string]any{"cpu": 70, "memory": 75},
 	}
@@ -54,6 +56,7 @@ func TestDeepMerge_NestedDictRecurse(t *testing.T) {
 // TestDeepMerge_ArrayReplaceNotConcat — KEY trap #7 from §8.11.2.
 // Arrays are REPLACED by the override, not concatenated.
 func TestDeepMerge_ArrayReplaceNotConcat(t *testing.T) {
+	t.Parallel()
 	base := map[string]any{
 		"receivers": []any{"email", "slack"},
 	}
@@ -74,6 +77,7 @@ func TestDeepMerge_ArrayReplaceNotConcat(t *testing.T) {
 // TestDeepMerge_NilDeletesKey — KEY trap #6 from §8.11.2.
 // YAML null (`~`) in override removes the key from result.
 func TestDeepMerge_NilDeletesKey(t *testing.T) {
+	t.Parallel()
 	base := map[string]any{
 		"alert_group": "baseline",
 		"threshold":   map[string]any{"cpu": 70, "memory": 75},
@@ -102,6 +106,7 @@ func TestDeepMerge_NilDeletesKey(t *testing.T) {
 // TestDeepMerge_MetadataNeverInherited — KEY trap #4 from §8.11.2.
 // `_metadata` in a parent is dropped when merging into a child.
 func TestDeepMerge_MetadataNeverInherited(t *testing.T) {
+	t.Parallel()
 	base := map[string]any{"threshold": map[string]any{"cpu": 70}}
 	// _metadata in the "override" side (which is where describe_tenant.py
 	// checks) should be ignored. But describe_tenant.py applies `merged =
@@ -127,6 +132,7 @@ func TestDeepMerge_MetadataNeverInherited(t *testing.T) {
 // fixture depth). Confirms recursion terminates and copies don't share
 // backing state.
 func TestDeepMerge_DeepNesting(t *testing.T) {
+	t.Parallel()
 	base := map[string]any{
 		"a": map[string]any{
 			"b": map[string]any{
@@ -167,6 +173,7 @@ func TestDeepMerge_DeepNesting(t *testing.T) {
 // a dict (or vice versa), child wins wholesale. This prevents a "dict expected"
 // panic and matches Python's `isinstance(... dict)` guard.
 func TestDeepMerge_TypeMismatchOverrides(t *testing.T) {
+	t.Parallel()
 	base := map[string]any{"x": "scalar"}
 	over := map[string]any{"x": map[string]any{"y": 1}}
 	got := deepMerge(base, over)
@@ -186,6 +193,7 @@ func TestDeepMerge_TypeMismatchOverrides(t *testing.T) {
 // TestCanonicalJSON_SortsKeysAndNoSpaces verifies byte-for-byte parity with
 // Python's json.dumps(..., sort_keys=True, separators=(",", ":"), ensure_ascii=False).
 func TestCanonicalJSON_SortsKeysAndNoSpaces(t *testing.T) {
+	t.Parallel()
 	data := map[string]any{
 		"z": 1,
 		"a": 2,
@@ -205,6 +213,7 @@ func TestCanonicalJSON_SortsKeysAndNoSpaces(t *testing.T) {
 // match Python's ensure_ascii=False (Go encoding/json's default SetEscapeHTML
 // would emit \u003c \u003e \u0026).
 func TestCanonicalJSON_NoHTMLEscape(t *testing.T) {
+	t.Parallel()
 	data := map[string]any{"s": "a<b>c&d"}
 	got, err := canonicalJSON(data)
 	if err != nil {
@@ -222,6 +231,7 @@ func TestCanonicalJSON_NoHTMLEscape(t *testing.T) {
 // maps must still have each element's keys sorted. This is trap #9 from
 // §8.11.2 (Python `sort_keys=True` recurses; we need Go to do the same).
 func TestCanonicalJSON_NestedArraysSortInnerMaps(t *testing.T) {
+	t.Parallel()
 	data := map[string]any{
 		"xs": []any{
 			map[string]any{"z": 1, "a": 2},
@@ -241,6 +251,7 @@ func TestCanonicalJSON_NestedArraysSortInnerMaps(t *testing.T) {
 // TestComputeMergedHash_NoDefaults — tenant with empty chain produces a
 // hash of just its own config. Mirrors the `flat` golden scenario.
 func TestComputeMergedHash_NoDefaults(t *testing.T) {
+	t.Parallel()
 	tenantYAML := []byte(`tenants:
   tenant-a:
     threshold:
@@ -262,6 +273,7 @@ func TestComputeMergedHash_NoDefaults(t *testing.T) {
 // TestComputeMergedHash_Deterministic — same input → same hash across calls.
 // Protects against map-iteration-order leaking into output.
 func TestComputeMergedHash_Deterministic(t *testing.T) {
+	t.Parallel()
 	tenantYAML := []byte(`tenants:
   t:
     a: 1
@@ -290,6 +302,7 @@ func TestComputeMergedHash_Deterministic(t *testing.T) {
 // TestComputeMergedHash_MissingTenantErrors — unknown tenant ID returns a
 // typed error rather than "" + silent success.
 func TestComputeMergedHash_MissingTenantErrors(t *testing.T) {
+	t.Parallel()
 	tenantYAML := []byte(`tenants:
   tenant-a:
     x: 1
@@ -307,6 +320,7 @@ func TestComputeMergedHash_MissingTenantErrors(t *testing.T) {
 // map[any]any when unmarshalling into `any`. We must convert so encoding/json
 // can sort keys (encoding/json errors on map[any]any).
 func TestNormalizeYAMLToJSON_MapAnyAnyConversion(t *testing.T) {
+	t.Parallel()
 	input := map[any]any{
 		"a": 1,
 		"b": map[any]any{"c": 2},
@@ -328,6 +342,7 @@ func TestNormalizeYAMLToJSON_MapAnyAnyConversion(t *testing.T) {
 // TestExtractDefaultsBlock_BothShapes — `defaults:` wrapper + naked dict
 // both supported per trap #3.
 func TestExtractDefaultsBlock_BothShapes(t *testing.T) {
+	t.Parallel()
 	wrapped := map[string]any{
 		"defaults": map[string]any{"cpu": 70},
 	}

--- a/components/threshold-exporter/app/config_resolve_test.go
+++ b/components/threshold-exporter/app/config_resolve_test.go
@@ -12,6 +12,7 @@ import (
 // region ThresholdResolution — basic Resolve/ResolveAt tests
 
 func TestResolve_ThreeState(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{
 			"mysql_connections": 80,
@@ -61,6 +62,7 @@ func TestResolve_ThreeState(t *testing.T) {
 }
 
 func TestResolve_DisableVariants(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
 		Tenants: map[string]map[string]ScheduledValue{
@@ -79,6 +81,7 @@ func TestResolve_DisableVariants(t *testing.T) {
 }
 
 func TestResolve_CustomSeverity(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
 		Tenants: map[string]map[string]ScheduledValue{
@@ -96,6 +99,7 @@ func TestResolve_CustomSeverity(t *testing.T) {
 }
 
 func TestResolve_EmptyTenants(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
 		Tenants:  map[string]map[string]ScheduledValue{},
@@ -108,6 +112,7 @@ func TestResolve_EmptyTenants(t *testing.T) {
 }
 
 func TestResolve_TenantWithNoOverrides(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{
 			"mysql_connections": 80,
@@ -135,6 +140,7 @@ func TestResolve_TenantWithNoOverrides(t *testing.T) {
 // region MetricKeyParsing — test helpers and key parsing
 
 func TestParseMetricKey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input              string
 		wantComp, wantMet string
@@ -160,6 +166,7 @@ func TestParseMetricKey(t *testing.T) {
 // --- Scenario C: State Filter Tests ---
 
 func TestResolveStateFilters_AllEnabled(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
 		StateFilters: map[string]StateFilter{
@@ -200,6 +207,7 @@ func TestResolveStateFilters_AllEnabled(t *testing.T) {
 }
 
 func TestResolveStateFilters_PerTenantDisable(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults:     map[string]float64{"mysql_connections": 80},
 		StateFilters: map[string]StateFilter{"container_crashloop": {Reasons: []string{"CrashLoopBackOff"}, Severity: "critical"}},
@@ -219,6 +227,7 @@ func TestResolveStateFilters_PerTenantDisable(t *testing.T) {
 }
 
 func TestResolveStateFilters_DisableVariants(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults:     map[string]float64{},
 		StateFilters: map[string]StateFilter{"container_crashloop": {Reasons: []string{"CrashLoopBackOff"}, Severity: "critical"}},
@@ -238,6 +247,7 @@ func TestResolveStateFilters_DisableVariants(t *testing.T) {
 }
 
 func TestResolveStateFilters_NoFilters(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
 		Tenants:  map[string]map[string]ScheduledValue{"db-a": {"mysql_connections": SV("70")}},
@@ -252,6 +262,7 @@ func TestResolveStateFilters_NoFilters(t *testing.T) {
 }
 
 func TestResolveStateFilters_DefaultSeverity(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults:     map[string]float64{},
 		StateFilters: map[string]StateFilter{"container_crashloop": {Reasons: []string{"CrashLoopBackOff"}}},
@@ -265,6 +276,7 @@ func TestResolveStateFilters_DefaultSeverity(t *testing.T) {
 }
 
 func TestResolve_IgnoresStateKeys(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults:     map[string]float64{"mysql_connections": 80},
 		StateFilters: map[string]StateFilter{"container_crashloop": {Reasons: []string{"CrashLoopBackOff"}, Severity: "critical"}},

--- a/components/threshold-exporter/app/config_routing_test.go
+++ b/components/threshold-exporter/app/config_routing_test.go
@@ -13,6 +13,7 @@ import (
 // region ProfilesAndRouting — profile resolution, routing configuration, and profile merging
 
 func TestValidateTenantKeys_MetadataReservedKey(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
 		Tenants: map[string]map[string]ScheduledValue{
@@ -33,6 +34,7 @@ func TestValidateTenantKeys_MetadataReservedKey(t *testing.T) {
 // ============================================================
 
 func TestResolve_ProfileBasic(t *testing.T) {
+	t.Parallel()
 	// Profile provides value, tenant does NOT override → use profile value
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
@@ -54,6 +56,7 @@ func TestResolve_ProfileBasic(t *testing.T) {
 }
 
 func TestResolve_ProfileOverriddenByTenant(t *testing.T) {
+	t.Parallel()
 	// Tenant overrides profile value → tenant wins
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
@@ -78,6 +81,7 @@ func TestResolve_ProfileOverriddenByTenant(t *testing.T) {
 }
 
 func TestResolve_ProfileFallbackToDefaults(t *testing.T) {
+	t.Parallel()
 	// Profile does NOT define a metric → fall back to defaults
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80, "mysql_cpu": 70},
@@ -109,6 +113,7 @@ func TestResolve_ProfileFallbackToDefaults(t *testing.T) {
 }
 
 func TestResolve_ProfileDisable(t *testing.T) {
+	t.Parallel()
 	// Tenant sets "disable" on a profile-defined metric → no metric exposed
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
@@ -130,6 +135,7 @@ func TestResolve_ProfileDisable(t *testing.T) {
 }
 
 func TestResolve_ProfileNotFound(t *testing.T) {
+	t.Parallel()
 	// _profile references unknown profile → WARN + ignore, fall back to defaults
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
@@ -149,6 +155,7 @@ func TestResolve_ProfileNotFound(t *testing.T) {
 }
 
 func TestResolve_ProfileWithSilentMode(t *testing.T) {
+	t.Parallel()
 	// Profile includes _silent_mode → tenant inherits
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
@@ -173,6 +180,7 @@ func TestResolve_ProfileWithSilentMode(t *testing.T) {
 }
 
 func TestResolve_ProfileWithRouting(t *testing.T) {
+	t.Parallel()
 	// Profile includes _routing → tenant inherits routing config
 	routingYAML := "receiver:\n  type: \"webhook\"\n  url: \"https://noc.example.com/alerts\"\ngroup_wait: \"30s\""
 	cfg := &ThresholdConfig{
@@ -197,6 +205,7 @@ func TestResolve_ProfileWithRouting(t *testing.T) {
 }
 
 func TestResolve_ProfileWithMetadata(t *testing.T) {
+	t.Parallel()
 	// Profile includes _metadata → tenant inherits metadata
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
@@ -229,6 +238,7 @@ func TestResolve_ProfileWithMetadata(t *testing.T) {
 }
 
 func TestResolve_ProfileWithScheduledValue(t *testing.T) {
+	t.Parallel()
 	// Profile value is a ScheduledValue → time windows resolve correctly
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
@@ -261,6 +271,7 @@ func TestResolve_ProfileWithScheduledValue(t *testing.T) {
 }
 
 func TestResolve_ProfileWithCritical(t *testing.T) {
+	t.Parallel()
 	// Profile defines <metric>_critical → tenant inherits multi-tier severity
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
@@ -294,6 +305,7 @@ func TestResolve_ProfileWithCritical(t *testing.T) {
 }
 
 func TestLoadDir_ProfilesBoundary(t *testing.T) {
+	t.Parallel()
 	// _profiles.yaml loads correctly; tenant file with profiles → WARN + ignore
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
@@ -336,6 +348,7 @@ profiles:
 }
 
 func TestLoadDir_ProfilesMergeWithDefaults(t *testing.T) {
+	t.Parallel()
 	// Profile + defaults + tenant override coexist correctly
 	dir := t.TempDir()
 	writeTestFile(t, dir, "_defaults.yaml", `
@@ -397,6 +410,7 @@ tenants:
 }
 
 func TestValidateTenantKeys_ProfileRef(t *testing.T) {
+	t.Parallel()
 	// _profile referencing existing profile → no warning
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},

--- a/components/threshold-exporter/app/config_silent_mode_test.go
+++ b/components/threshold-exporter/app/config_silent_mode_test.go
@@ -22,6 +22,7 @@ import (
 // ============================================================
 
 func TestResolveSilentModes(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		tenants    map[string]map[string]ScheduledValue
@@ -67,6 +68,7 @@ func TestResolveSilentModes(t *testing.T) {
 }
 
 func TestResolveAt_SkipsSilentKey(t *testing.T) {
+	t.Parallel()
 	// _silent_mode must NOT produce a user_threshold metric
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
@@ -89,6 +91,7 @@ func TestResolveAt_SkipsSilentKey(t *testing.T) {
 }
 
 func TestResolveSilentModes_MixedTenants(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Tenants: map[string]map[string]ScheduledValue{
 			"db-a": {"_silent_mode": SV("warning")},
@@ -127,6 +130,7 @@ func TestResolveSilentModes_MixedTenants(t *testing.T) {
 // ============================================================
 
 func TestResolveSeverityDedup(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		tenants    map[string]map[string]ScheduledValue
@@ -177,6 +181,7 @@ func TestResolveSeverityDedup(t *testing.T) {
 }
 
 func TestResolveAt_SkipsSeverityDedupKey(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
 		Tenants: map[string]map[string]ScheduledValue{
@@ -202,6 +207,7 @@ func TestResolveAt_SkipsSeverityDedupKey(t *testing.T) {
 // ============================================================
 
 func TestResolveRouting_ValidConfig(t *testing.T) {
+	t.Parallel()
 	routingYAML := `receiver:
   type: "webhook"
   url: "https://webhook.example.com/alerts"
@@ -249,6 +255,7 @@ repeat_interval: "4h"`
 }
 
 func TestResolveRouting_GuardrailClamp(t *testing.T) {
+	t.Parallel()
 	// group_wait below minimum (5s), repeat_interval above maximum (72h)
 	routingYAML := `receiver:
   type: "webhook"
@@ -280,6 +287,7 @@ repeat_interval: "100h"`
 }
 
 func TestResolveRouting_MissingReceiver(t *testing.T) {
+	t.Parallel()
 	routingYAML := `group_wait: "30s"`
 
 	cfg := &ThresholdConfig{
@@ -298,6 +306,7 @@ func TestResolveRouting_MissingReceiver(t *testing.T) {
 }
 
 func TestResolveRouting_NoRoutingKey(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
 		Tenants: map[string]map[string]ScheduledValue{
@@ -314,6 +323,7 @@ func TestResolveRouting_NoRoutingKey(t *testing.T) {
 }
 
 func TestResolveRouting_MultiTenant(t *testing.T) {
+	t.Parallel()
 	routingA := `receiver:
   type: "webhook"
   url: "https://webhook-a.example.com/alerts"
@@ -359,6 +369,7 @@ repeat_interval: "2h"`
 }
 
 func TestResolveRouting_MinimalConfig(t *testing.T) {
+	t.Parallel()
 	routingYAML := `receiver:
   type: "webhook"
   url: "https://webhook.example.com/alerts"`
@@ -395,6 +406,7 @@ func TestResolveRouting_MinimalConfig(t *testing.T) {
 }
 
 func TestResolveAt_SkipsRoutingKey(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
 		Tenants: map[string]map[string]ScheduledValue{
@@ -419,6 +431,7 @@ func TestResolveAt_SkipsRoutingKey(t *testing.T) {
 // survive YAML unmarshalling → ScheduledValue → ResolveRouting pipeline.
 // This is the integration path: YAML file → UnmarshalYAML → ResolveRouting.
 func TestScheduledValue_RoutingMapRoundTrip(t *testing.T) {
+	t.Parallel()
 	yamlInput := `
 defaults:
   mysql_connections: 80
@@ -469,6 +482,7 @@ tenants:
 // TestFormatDuration_NoDay verifies formatDuration never outputs "d" suffix
 // (Prometheus/Alertmanager only supports s/m/h).
 func TestFormatDuration_NoDay(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input time.Duration
 		want  string
@@ -493,6 +507,7 @@ func TestFormatDuration_NoDay(t *testing.T) {
 // ============================================================
 
 func TestCardinalityGuard(t *testing.T) {
+	t.Parallel()
 	defsWith20 := make(map[string]float64)
 	for i := 0; i < 20; i++ {
 		defsWith20[fmt.Sprintf("metric_%d", i)] = float64(i)
@@ -527,6 +542,7 @@ func TestCardinalityGuard(t *testing.T) {
 // ============================================================
 
 func TestValidateTenantKeys(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		cfg     ThresholdConfig
@@ -575,6 +591,7 @@ func TestValidateTenantKeys(t *testing.T) {
 // ============================================================
 
 func TestResolveSilentModes_Structured(t *testing.T) {
+	t.Parallel()
 	future := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
 	past := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
 	tests := []struct {
@@ -641,6 +658,7 @@ func TestResolveSilentModes_Structured(t *testing.T) {
 // ============================================================
 
 func TestResolveMaintenanceExpiries(t *testing.T) {
+	t.Parallel()
 	future := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
 	past := time.Now().Add(-2 * time.Hour).Format(time.RFC3339)
 	tests := []struct {
@@ -684,6 +702,7 @@ func TestResolveMaintenanceExpiries(t *testing.T) {
 }
 
 func TestResolveStateFilters_MaintenanceExpired(t *testing.T) {
+	t.Parallel()
 	// When structured _state_maintenance has expired, the state filter should NOT be emitted
 	past := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
 	yamlStr := "expires: " + past + "\ntarget: enable\n"
@@ -702,6 +721,7 @@ func TestResolveStateFilters_MaintenanceExpired(t *testing.T) {
 }
 
 func TestResolveStateFilters_MaintenanceActive(t *testing.T) {
+	t.Parallel()
 	// When structured _state_maintenance has future expires, the state filter should be emitted
 	future := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
 	yamlStr := "expires: " + future + "\ntarget: enable\n"
@@ -723,6 +743,7 @@ func TestResolveStateFilters_MaintenanceActive(t *testing.T) {
 }
 
 func TestResolveStateFilters_MaintenanceScalarBackwardCompat(t *testing.T) {
+	t.Parallel()
 	// Scalar "enable" should still work as before
 	cfg := &ThresholdConfig{
 		StateFilters: map[string]StateFilter{
@@ -739,6 +760,7 @@ func TestResolveStateFilters_MaintenanceScalarBackwardCompat(t *testing.T) {
 }
 
 func TestIsMaintenanceActive(t *testing.T) {
+	t.Parallel()
 	future := time.Now().Add(24 * time.Hour).Format(time.RFC3339)
 	past := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
 	tests := []struct {

--- a/components/threshold-exporter/app/config_simulate_test.go
+++ b/components/threshold-exporter/app/config_simulate_test.go
@@ -35,6 +35,7 @@ import (
 // --- Layer 1: config.SimulateEffective unit tests ---------------------------
 
 func TestSimulate_BasicHierarchy(t *testing.T) {
+	t.Parallel()
 	defaults := []byte("defaults:\n  mysql_connections: 80\n  cpu_threshold: 75\n")
 	tenantBytes := []byte("tenants:\n  tenant-a:\n    mysql_connections: \"90\"\n")
 
@@ -68,6 +69,7 @@ func TestSimulate_BasicHierarchy(t *testing.T) {
 }
 
 func TestSimulate_NoDefaults(t *testing.T) {
+	t.Parallel()
 	tenantBytes := []byte("tenants:\n  tenant-flat:\n    cpu_threshold: 80\n")
 	resp, err := config.SimulateEffective(config.SimulateRequest{
 		TenantID:   "tenant-flat",
@@ -85,6 +87,7 @@ func TestSimulate_NoDefaults(t *testing.T) {
 }
 
 func TestSimulate_DeepChainOrdering(t *testing.T) {
+	t.Parallel()
 	// L0 sets X=1, L1 sets X=2, tenant overrides X=3 → expect X=3.
 	// Also: L0 sets Y=10, L1 inherits but overrides Z=20 → tenant
 	// inherits Y=10 from L0 and Z=20 from L1.
@@ -115,6 +118,7 @@ func TestSimulate_DeepChainOrdering(t *testing.T) {
 }
 
 func TestSimulate_TenantNotFound(t *testing.T) {
+	t.Parallel()
 	tenantBytes := []byte("tenants:\n  someone-else:\n    foo: 1\n")
 	_, err := config.SimulateEffective(config.SimulateRequest{
 		TenantID:   "missing",
@@ -126,6 +130,7 @@ func TestSimulate_TenantNotFound(t *testing.T) {
 }
 
 func TestSimulate_EmptyTenantID(t *testing.T) {
+	t.Parallel()
 	_, err := config.SimulateEffective(config.SimulateRequest{
 		TenantYAML: []byte("tenants:\n  t1:\n    x: 1\n"),
 	})
@@ -135,6 +140,7 @@ func TestSimulate_EmptyTenantID(t *testing.T) {
 }
 
 func TestSimulate_EmptyTenantYAML(t *testing.T) {
+	t.Parallel()
 	_, err := config.SimulateEffective(config.SimulateRequest{
 		TenantID: "t1",
 	})
@@ -144,6 +150,7 @@ func TestSimulate_EmptyTenantYAML(t *testing.T) {
 }
 
 func TestSimulate_MalformedTenantYAML(t *testing.T) {
+	t.Parallel()
 	_, err := config.SimulateEffective(config.SimulateRequest{
 		TenantID:   "t1",
 		TenantYAML: []byte("tenants:\n  t1:\n    [unclosed-bracket\n"),
@@ -156,6 +163,7 @@ func TestSimulate_MalformedTenantYAML(t *testing.T) {
 // --- Layer 2: simulateHandler HTTP tests -----------------------------
 
 func TestSimulateHandler_Happy(t *testing.T) {
+	t.Parallel()
 	body := config.SimulateRequest{
 		TenantID:          "tenant-a",
 		TenantYAML:        []byte("tenants:\n  tenant-a:\n    cpu_threshold: 70\n"),
@@ -188,6 +196,7 @@ func TestSimulateHandler_Happy(t *testing.T) {
 }
 
 func TestSimulateHandler_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/tenants/simulate", nil)
 	rec := httptest.NewRecorder()
 	simulateHandler()(rec, req)
@@ -197,6 +206,7 @@ func TestSimulateHandler_MethodNotAllowed(t *testing.T) {
 }
 
 func TestSimulateHandler_BadJSON(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants/simulate",
 		strings.NewReader("not-json"))
 	rec := httptest.NewRecorder()
@@ -207,6 +217,7 @@ func TestSimulateHandler_BadJSON(t *testing.T) {
 }
 
 func TestSimulateHandler_TenantNotFound(t *testing.T) {
+	t.Parallel()
 	body := config.SimulateRequest{
 		TenantID:   "ghost",
 		TenantYAML: []byte("tenants:\n  alive:\n    x: 1\n"),
@@ -222,6 +233,7 @@ func TestSimulateHandler_TenantNotFound(t *testing.T) {
 }
 
 func TestSimulateHandler_BodyTooLarge(t *testing.T) {
+	t.Parallel()
 	// Build an oversized payload: 2 MiB of tenant YAML padding.
 	pad := strings.Repeat("a", 2<<20)
 	body := config.SimulateRequest{
@@ -239,6 +251,7 @@ func TestSimulateHandler_BodyTooLarge(t *testing.T) {
 }
 
 func TestSimulateHandler_EmptyBody(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants/simulate", nil)
 	rec := httptest.NewRecorder()
 	simulateHandler()(rec, req)
@@ -251,6 +264,7 @@ func TestSimulateHandler_EmptyBody(t *testing.T) {
 }
 
 func TestSimulateHandler_MalformedDefaults(t *testing.T) {
+	t.Parallel()
 	// Defaults bytes that don't parse as YAML must surface as 400 from
 	// the handler — the contract is "preview will fail the same way a
 	// commit would fail".
@@ -270,6 +284,7 @@ func TestSimulateHandler_MalformedDefaults(t *testing.T) {
 }
 
 func TestSimulateHandler_UnknownField(t *testing.T) {
+	t.Parallel()
 	// DisallowUnknownFields surfaces typos in the request shape.
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/tenants/simulate",
 		strings.NewReader(`{"tenant_id":"t1","tenant_yaml":"YQ==","oops":1}`))
@@ -293,6 +308,7 @@ func TestSimulateHandler_UnknownField(t *testing.T) {
 // override at every level, plus a `_metadata` block in the tenant file
 // (which must be stripped by both paths).
 func TestSimulate_VsResolve_ParityHash(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	// Layout:
@@ -361,6 +377,7 @@ func TestSimulate_VsResolve_ParityHash(t *testing.T) {
 // --- Source layer tests ---------------------------------------------
 
 func TestInMemoryConfigSource_FiltersByRoot(t *testing.T) {
+	t.Parallel()
 	files := map[string][]byte{
 		"/sim/a.yaml":         []byte("tenants:\n  a:\n    x: 1\n"),
 		"/sim/sub/b.yaml":     []byte("tenants:\n  b:\n    x: 2\n"),
@@ -392,6 +409,7 @@ func TestInMemoryConfigSource_FiltersByRoot(t *testing.T) {
 }
 
 func TestScanFromConfigSource_DuplicateTenantError(t *testing.T) {
+	t.Parallel()
 	files := map[string][]byte{
 		"/sim/team-a.yaml": []byte("tenants:\n  shared:\n    x: 1\n"),
 		"/sim/team-b.yaml": []byte("tenants:\n  shared:\n    x: 2\n"),

--- a/components/threshold-exporter/app/config_three_state_test.go
+++ b/components/threshold-exporter/app/config_three_state_test.go
@@ -22,6 +22,7 @@ import (
 // ============================================================
 
 func TestScheduledValue_UnmarshalYAML_Scalar(t *testing.T) {
+	t.Parallel()
 	content := `
 tenants:
   db-a:
@@ -43,6 +44,7 @@ tenants:
 }
 
 func TestScheduledValue_UnmarshalYAML_Structured(t *testing.T) {
+	t.Parallel()
 	content := `
 tenants:
   db-a:
@@ -75,6 +77,7 @@ tenants:
 }
 
 func TestScheduledValue_UnmarshalYAML_MixedFormats(t *testing.T) {
+	t.Parallel()
 	content := `
 tenants:
   db-a:
@@ -102,6 +105,7 @@ tenants:
 }
 
 func TestScheduledValue_ResolveValue_NoOverrides(t *testing.T) {
+	t.Parallel()
 	sv := SV("70")
 	now := time.Date(2026, 1, 15, 3, 0, 0, 0, time.UTC) // 03:00 UTC
 	if got := sv.ResolveValue(now); got != "70" {
@@ -110,6 +114,7 @@ func TestScheduledValue_ResolveValue_NoOverrides(t *testing.T) {
 }
 
 func TestScheduledValue_ResolveValue_WindowMatch(t *testing.T) {
+	t.Parallel()
 	sv := SVScheduled("70",
 		TimeWindowOverride{Window: "01:00-09:00", Value: "1000"},
 	)
@@ -128,6 +133,7 @@ func TestScheduledValue_ResolveValue_WindowMatch(t *testing.T) {
 }
 
 func TestScheduledValue_ResolveValue_CrossMidnight(t *testing.T) {
+	t.Parallel()
 	sv := SVScheduled("70",
 		TimeWindowOverride{Window: "22:00-06:00", Value: "500"},
 	)
@@ -159,6 +165,7 @@ func TestScheduledValue_ResolveValue_CrossMidnight(t *testing.T) {
 }
 
 func TestScheduledValue_ResolveValue_FirstMatchWins(t *testing.T) {
+	t.Parallel()
 	sv := SVScheduled("70",
 		TimeWindowOverride{Window: "01:00-09:00", Value: "1000"},
 		TimeWindowOverride{Window: "03:00-06:00", Value: "2000"},
@@ -171,6 +178,7 @@ func TestScheduledValue_ResolveValue_FirstMatchWins(t *testing.T) {
 }
 
 func TestScheduledValue_ResolveValue_DisableWindow(t *testing.T) {
+	t.Parallel()
 	sv := SVScheduled("70",
 		TimeWindowOverride{Window: "01:00-09:00", Value: "disable"},
 	)
@@ -182,6 +190,7 @@ func TestScheduledValue_ResolveValue_DisableWindow(t *testing.T) {
 }
 
 func TestResolveAt_ScheduledOverride(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
 		Tenants: map[string]map[string]ScheduledValue{
@@ -215,6 +224,7 @@ func TestResolveAt_ScheduledOverride(t *testing.T) {
 }
 
 func TestResolveAt_ScheduledDisable(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
 		Tenants: map[string]map[string]ScheduledValue{
@@ -242,6 +252,7 @@ func TestResolveAt_ScheduledDisable(t *testing.T) {
 }
 
 func TestResolveAt_ScheduledCritical(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults: map[string]float64{"mysql_connections": 80},
 		Tenants: map[string]map[string]ScheduledValue{
@@ -278,6 +289,7 @@ func TestResolveAt_ScheduledCritical(t *testing.T) {
 }
 
 func TestResolveAt_ScheduledWithYAML(t *testing.T) {
+	t.Parallel()
 	content := `
 defaults:
   mysql_connections: 80
@@ -327,6 +339,7 @@ tenants:
 }
 
 func TestMatchTimeWindow(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		window string
 		hour   int
@@ -371,6 +384,7 @@ func TestMatchTimeWindow(t *testing.T) {
 }
 
 func TestMatchTimeWindow_NonUTCInput(t *testing.T) {
+	t.Parallel()
 	// Input in JST (+9), window is UTC. 03:00 JST = 18:00 UTC
 	jst := time.FixedZone("JST", 9*3600)
 	now := time.Date(2026, 1, 15, 3, 0, 0, 0, jst) // 18:00 UTC
@@ -387,6 +401,7 @@ func TestMatchTimeWindow_NonUTCInput(t *testing.T) {
 }
 
 func TestParseHHMM(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input  string
 		wantH  int
@@ -432,6 +447,7 @@ func TestParseHHMM(t *testing.T) {
 // ============================================================
 
 func TestScheduledValue_String(t *testing.T) {
+	t.Parallel()
 	sv := SV("70")
 	if sv.String() != "70" {
 		t.Errorf("expected 70, got %q", sv.String())
@@ -448,6 +464,7 @@ func TestScheduledValue_String(t *testing.T) {
 // ============================================================
 
 func TestConfigManager_LoadDir_ScheduledValueMerge(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	// _defaults.yaml: platform-managed defaults

--- a/scripts/ops/add_t_parallel.py
+++ b/scripts/ops/add_t_parallel.py
@@ -44,9 +44,29 @@ RISKY = (
     # which logs via slog.Warn / slog.Info — production writes into the
     # captured buffer, racing the test's bytes.Buffer access. Caught
     # by CI run #25605708926 in TestSlogRequestLogger_EmitsStructuredLine
-    # → TestPutTenant_DirectMode race; this pattern was the PR #350
-    # tenant-api sweep's missed RISKY case.
+    # → TestPutTenant_DirectMode race; PR #350 tenant-api sweep's missed
+    # RISKY case (codified by PR #357).
     "slog.SetDefault",
+    # `withIsolatedMetrics(t)` in components/threshold-exporter/app/
+    # implements the global-swap pattern — saves+sets+restores a
+    # package-level `configMetrics` singleton via setConfigMetrics().
+    # Two parallel tests both calling it would race on the global, with
+    # whichever test ran second's `fresh` registry receiving observations
+    # from the first test's reload. Caught by PR #356 (config_* sweep)
+    # before landing.
+    "withIsolatedMetrics",
+    "setConfigMetrics",
+    # log.SetOutput / log.SetFlags swap the package-level stdlib logger.
+    # Tests that capture log output via `log.SetOutput(&buf)` race on the
+    # logger destination if multiple parallel tests do it — and worse, any
+    # other parallel test that calls log.Printf will write into whichever
+    # buffer happened to be set last, corrupting captured output and
+    # tripping the race detector on the &buf bytes.Buffer. Caught by
+    # PR #356 when -race surfaced bytes.Buffer races in
+    # TestMixedMode_DuplicateAcrossModes_RejectedAtLoad in the Linux
+    # dev container.
+    "log.SetOutput",
+    "log.SetFlags",
 )
 
 


### PR DESCRIPTION
## Summary

Final installment of the t.Parallel sweep started in PR #350 / #355. Selective coverage of \`config_*_test.go\` — the largest deferred risky-cluster.

**Result**: 10 of 22 files swept (165 t.Parallel injections), 12 deliberately skipped after per-file audit + race detection in dev container.

## Per-file audit + classification

| Disposition | Files | Reason |
|---|---|---|
| ✅ Swept (10 files, 165 inj) | defaults_diff / dimensional / golden_parity / incremental / inheritance / resolve / routing / silent_mode / simulate / three_state | Pure-function tests, no shared global state |
| ⛔ log.SetOutput global swap (3 files) | hierarchy / loaddir / mixed_mode | Race on bytes.Buffer detected by -race; helper-level swap not catchable by add_t_parallel.py's body-grep |
| ⛔ withIsolatedMetrics global swap (2 files) | blast_radius / metrics | Same family as PR #350's TestMetricsMiddleware metrics-singleton race |
| ⛔ wall-clock / watcher coupled (3 files) | debounce / hierarchy_integration / slow_write_stress | Tests genuinely depend on real time/watch-loop fixtures |
| ⛔ Bench-only (3 files) | bench / hierarchy_bench / mixed_mode_bench | t.Parallel doesn't apply to b.* tests |
| ✓ Already had t.Parallel (1 file) | metadata | No action needed |

## How the global-swap issues were caught

**withIsolatedMetrics**: caught at \`go test -count=1\` immediately after the first sweep — \`TestBlastRadius_*\` failed with \"want count=1 sum=2, got count=0 sum=0\" because parallel tests raced the configMetrics singleton via setConfigMetrics().

**log.SetOutput**: caught only at \`-race\` (not -count=1) — \`TestMixedMode_DuplicateAcrossModes_RejectedAtLoad\` race-detected reading a bytes.Buffer that another parallel test was mutating. The swap pattern (save → set → restore) works sequentially but is fundamentally unsafe under t.Parallel.

Both patterns are now codified in \`scripts/ops/add_t_parallel.py\`'s RISKY list so a future re-sweep would skip them automatically. The 3 files using log.SetOutput in HELPERS (not test bodies) are skipped at file-level here since the script grep is per-test-body.

## Test plan

- [x] \`go test -count=10 ./\` in Linux dev container — clean (39.5s)
- [x] \`go test -count=10 -race ./\` in Linux dev container — clean (42.1s) — matches CI Go Tests 1.26 config
- [x] Pre-commit hooks all pass
- [ ] CI race detector validates on actual ubuntu-latest

## Out of scope (not blockers)

- The 5 skipped global-swap files (3 log.SetOutput + 2 withIsolatedMetrics) could be refactored to inject loggers/metrics explicitly instead of mutating package globals. That would unlock t.Parallel for them. Tracked here for any future maintainer wanting the speedup.

## Spawned chip (separate triage)

While running this audit on Cowork VM Windows host: 4 tests in \`config_simulate_test.go\` fail on Windows but pass on Linux. \`config.SimulateEffective\` drops inherited config keys on Windows — possibly YAML CRLF handling. **Pre-existing on main, NOT caused by this sweep.** Spawned as a follow-up chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)