### PR TITLE
fix(tenant-api): remove t.Parallel from slog.SetDefault tests + codify pattern

### DIFF
--- a/components/tenant-api/internal/handler/middleware_test.go
+++ b/components/tenant-api/internal/handler/middleware_test.go
@@ -382,7 +382,13 @@ func TestRateLimitConfigFromEnv_Negative(t *testing.T) {
 // output by swapping in a JSON handler over a bytes.Buffer for the
 // duration of the test.
 func TestSlogRequestLogger_EmitsStructuredLine(t *testing.T) {
-	t.Parallel()
+	// Intentionally NOT t.Parallel(): swaps the package-level slog
+	// default logger via slog.SetDefault. Other parallel tests calling
+	// production code that does slog.Warn / slog.Info race against
+	// this test's bytes.Buffer (CI run #25605708926 surfaced the race
+	// via TestPutTenant_DirectMode → gitops.commitFileChange → slog.Warn
+	// writing into our captured buffer). Same global-swap concern as
+	// log.SetOutput; keep sequential.
 	t.Helper()
 	// Save + restore default logger.
 	origLogger := slog.Default()
@@ -436,7 +442,8 @@ func TestSlogRequestLogger_EmitsStructuredLine(t *testing.T) {
 // TestSlogRequestLogger_5xxLogsAtWarn ensures server errors get
 // elevated to WARN so log aggregators can alert on level alone.
 func TestSlogRequestLogger_5xxLogsAtWarn(t *testing.T) {
-	t.Parallel()
+	// Intentionally NOT t.Parallel(): same slog.SetDefault global-swap
+	// concern as TestSlogRequestLogger_EmitsStructuredLine above.
 	origLogger := slog.Default()
 	defer slog.SetDefault(origLogger)
 

--- a/scripts/ops/add_t_parallel.py
+++ b/scripts/ops/add_t_parallel.py
@@ -38,6 +38,15 @@ RISKY = (
     "os.Chdir",
     "t.Setenv",
     "Metrics.",
+    # slog.SetDefault swaps the package-level slog default logger.
+    # Tests installing custom slog handler over a captured bytes.Buffer
+    # race against any other parallel test that calls production code
+    # which logs via slog.Warn / slog.Info — production writes into the
+    # captured buffer, racing the test's bytes.Buffer access. Caught
+    # by CI run #25605708926 in TestSlogRequestLogger_EmitsStructuredLine
+    # → TestPutTenant_DirectMode race; this pattern was the PR #350
+    # tenant-api sweep's missed RISKY case.
+    "slog.SetDefault",
 )
 
 


### PR DESCRIPTION
## Summary

Fixes the race detector failure on PR #356 CI run #25605708926. PR #350's general t.Parallel sweep added \`t.Parallel()\` to \`TestSlogRequestLogger_EmitsStructuredLine\` and \`TestSlogRequestLogger_5xxLogsAtWarn\` in \`tenant-api/internal/handler/middleware_test.go\`. Both call \`slog.SetDefault\` to install a JSON handler over a captured \`bytes.Buffer\` — same global-swap anti-pattern as \`log.SetOutput\` (caught in PR #356) and \`Metrics.requestsTotal\` (caught in PR #350's own follow-up).

## Why CI didn't catch it on PR #350

Race-detector failures depend on Go scheduler ordering — PR #350's CI run got lucky and didn't interleave the slog write paths. PR #356 (which only touches \`components/threshold-exporter/app/config_*_test.go\`) doesn't change tenant-api code at all, but its CI run rolled the dice differently and surfaced this latent race.

DATA RACE stack from PR #356 CI:
\`\`\`
bytes.(*Buffer).grow → log/slog.(*JSONHandler).Handle → slog.Warn →
gitops.(*Writer).commitFileChange → handler.TestPutTenant_DirectMode
\`\`\`

So 4 unrelated tests failed because they all call production code that writes to slog while \`TestSlogRequestLogger_*\` had installed a captured-buffer handler.

## Fix

- Remove \`t.Parallel()\` from \`TestSlogRequestLogger_EmitsStructuredLine\` and \`TestSlogRequestLogger_5xxLogsAtWarn\`. Comments cite this PR's CI run and explain the slog.SetDefault constraint so future maintainers don't mechanically re-add it.
- Add \`slog.SetDefault\` to \`scripts/ops/add_t_parallel.py\` RISKY pattern list. Future re-sweep will skip these tests automatically.

## Test plan

- [x] \`go test -count=5 -race -run "TestSlogRequestLogger|TestPutTenant_DirectMode|TestPutView_Conflict|TestBatchTenants_Async_TaskCompletes" ./internal/handler/...\` clean in Linux dev container (1.3s)
- [ ] CI Go Tests (1.26) green on this PR

## Effect on PR #356

After this merges, PR #356 will rebase onto new main. The slog race that was failing PR #356's CI will be gone. PR #356 itself doesn't need any changes — its scope (exporter sweep) was unrelated to this race.

## Pre-existing local-container findings (NOT this PR's scope)

While verifying the fix in dev container, two other tests showed local-container-only failures (CI green on main):
- \`TestDiffTenant_RawYAML\` — assertion fail "expected HasDiff=true"
- \`TestRateLimit_RejectionsCounter\` — counter delta wrong

Both fail 100% on bare main in my container. Worth a separate triage chip; not blocking either PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)