### PR TITLE
fix(exporter): SimulateEffective drops inherited keys on Windows hosts

### DIFF
--- a/components/threshold-exporter/app/pkg/config/inheritance_graph.go
+++ b/components/threshold-exporter/app/pkg/config/inheritance_graph.go
@@ -16,7 +16,10 @@ package config
 //   - .yaml wins over .yml when both exist at the same level
 //   - filepath.Clean'd paths so equality compares stable across calls
 
-import "path/filepath"
+import (
+	"path"
+	"path/filepath"
+)
 
 // InheritanceGraph tracks the defaults↔tenants dependency for a
 // hierarchical conf.d layout (ADR-017).
@@ -116,6 +119,56 @@ func CollectDefaultsChain(leafDir, root string, defaults map[string]bool) []stri
 	// Reverse to make chain[0] the top-most (L0) defaults and the last
 	// entry the nearest-to-tenant (Ln). Matches describe_tenant.py
 	// line 152.
+	for i, j := 0, len(chain)-1; i < j; i, j = i+1, j-1 {
+		chain[i], chain[j] = chain[j], chain[i]
+	}
+	return chain
+}
+
+// CollectDefaultsChainPOSIX is the POSIX-only sibling of CollectDefaultsChain.
+// Identical semantics, but uses path.* (always /) instead of filepath.* (OS-aware).
+//
+// Why a separate function: the disk scanner walks real filesystem paths where
+// filepath.* is correct (handles \\ on Windows). The in-memory scanner
+// (ScanFromConfigSource → simulate) walks synthetic POSIX paths under /sim,
+// where filepath.* on Windows would convert / to \\ and break the prefix +
+// map-key semantics — InMemoryConfigSource is documented as POSIX-only.
+//
+// History: discovered while triaging Simulate Windows-host flake (4 tests in
+// config_simulate_test.go failed locally on zh-TW Windows but passed on
+// Linux/CI). filepath.Dir("/sim/foo") on Windows returns "\\sim", which
+// missed the POSIX-keyed defaults map → empty chain → inherited keys
+// silently dropped from the merged config.
+func CollectDefaultsChainPOSIX(leafDir, root string, defaults map[string]bool) []string {
+	var chain []string
+	current := path.Clean(leafDir)
+	rootClean := path.Clean(root)
+
+	for {
+		// Prefer .yaml over .yml when both exist at the same level
+		// (same precedence rule as describe_tenant.py).
+		yamlPath := path.Join(current, "_defaults.yaml")
+		ymlPath := path.Join(current, "_defaults.yml")
+		if defaults[yamlPath] {
+			chain = append(chain, yamlPath)
+		} else if defaults[ymlPath] {
+			chain = append(chain, ymlPath)
+		}
+
+		if current == rootClean {
+			break
+		}
+		parent := path.Dir(current)
+		if parent == current {
+			// Reached filesystem root without hitting rootClean —
+			// shouldn't happen given the precondition, but don't loop.
+			break
+		}
+		current = parent
+	}
+
+	// Reverse to make chain[0] the top-most (L0) defaults and the last
+	// entry the nearest-to-tenant (Ln). Same as CollectDefaultsChain.
 	for i, j := 0, len(chain)-1; i < j; i, j = i+1, j-1 {
 		chain[i], chain[j] = chain[j], chain[i]
 	}

--- a/components/threshold-exporter/app/pkg/config/source.go
+++ b/components/threshold-exporter/app/pkg/config/source.go
@@ -39,7 +39,7 @@ package config
 import (
 	"crypto/sha256"
 	"fmt"
-	"path/filepath"
+	"path"
 	"sort"
 	"strings"
 
@@ -50,9 +50,13 @@ import (
 // header for why this is a single-method interface.
 type ConfigSource interface {
 	// YAMLFiles returns every *.yaml/*.yml file the source wants the
-	// merge engine to consider, keyed by absolute filepath.Clean'd
-	// path. The map is owned by the source — callers must treat byte
-	// slices as read-only.
+	// merge engine to consider, keyed by absolute Cleaned path. The
+	// path-cleaning scheme MUST match the caller's expectation — for
+	// InMemoryConfigSource, paths are POSIX (path.Clean); for any
+	// future disk-backed source, OS-native (filepath.Clean) would be
+	// appropriate. ScanFromConfigSource currently treats them as POSIX
+	// (only InMemory caller exists today). The map is owned by the
+	// source — callers must treat byte slices as read-only.
 	//
 	// rootPath is the conf.d/ root the caller intends to scan.
 	// In-memory sources may use it to filter their corpus; disk
@@ -80,19 +84,29 @@ func NewInMemoryConfigSource(files map[string][]byte) *InMemoryConfigSource {
 }
 
 // YAMLFiles returns the subset of the corpus whose paths are at or
-// under rootPath. Filtering is by string prefix on Cleaned paths;
-// callers should use forward slashes for in-memory paths to match
-// filepath.Clean on POSIX. On Windows the source still works because
-// filepath.Clean canonicalises both.
+// under rootPath. Filtering is by string prefix on POSIX-Cleaned paths
+// (path.Clean, not filepath.Clean) — InMemoryConfigSource is documented
+// as POSIX-only (see type comment) and `filepath.Clean` would convert
+// `/sim/x` to `\sim\x` on Windows, breaking the prefix match against
+// caller-supplied POSIX keys.
+//
+// History: original implementation used filepath.Clean here. On Windows
+// hosts that produced backslash-separated keys in the returned map,
+// which then mismatched the POSIX-keyed `files` map in
+// SimulateEffective when looking up DefaultsChain paths — the chain
+// resolved to nil bytes and inherited keys silently dropped from the
+// merged config. CI passed because Linux runners coincidentally share
+// the POSIX separator. Tracked under "Simulate Windows-host flake"
+// chip; fixed by switching to path.Clean.
 func (s *InMemoryConfigSource) YAMLFiles(rootPath string) (map[string][]byte, error) {
-	root := filepath.Clean(rootPath)
+	root := path.Clean(rootPath)
 	out := make(map[string][]byte, len(s.files))
 	for p, b := range s.files {
-		clean := filepath.Clean(p)
-		if clean != root && !strings.HasPrefix(clean, root+string(filepath.Separator)) {
+		clean := path.Clean(p)
+		if clean != root && !strings.HasPrefix(clean, root+"/") {
 			continue
 		}
-		lower := strings.ToLower(filepath.Base(clean))
+		lower := strings.ToLower(path.Base(clean))
 		if !strings.HasSuffix(lower, ".yaml") && !strings.HasSuffix(lower, ".yml") {
 			continue
 		}
@@ -116,7 +130,13 @@ func ScanFromConfigSource(src ConfigSource, rootPath string) (
 	graph *InheritanceGraph,
 	err error,
 ) {
-	absRoot := filepath.Clean(rootPath)
+	// path.Clean (POSIX) not filepath.Clean (OS-aware) — ScanFromConfigSource
+	// only feeds InMemoryConfigSource today (verified via `grep -rn
+	// ScanFromConfigSource components/threshold-exporter/app/`), and its
+	// contract is POSIX-only paths. Same Windows-host bug as YAMLFiles:
+	// filepath.Clean would convert `/sim` → `\sim` and break the prefix
+	// match against POSIX-keyed callers.
+	absRoot := path.Clean(rootPath)
 
 	corpus, cerr := src.YAMLFiles(absRoot)
 	if cerr != nil {
@@ -133,18 +153,22 @@ func ScanFromConfigSource(src ConfigSource, rootPath string) (
 	}
 	var decls []tenantDecl
 
-	for path, data := range corpus {
-		name := filepath.Base(path)
+	for p, data := range corpus {
+		// path.Base (POSIX) not filepath.Base — the loop variable was
+		// renamed from `path` to `p` to avoid shadowing the `path`
+		// package; same Windows-host fix family as YAMLFiles +
+		// CollectDefaultsChainPOSIX above.
+		name := path.Base(p)
 		// Hidden files skipped — match scanDirHierarchical.
 		if strings.HasPrefix(name, ".") {
 			continue
 		}
-		hashes[path] = fmt.Sprintf("%x", sha256.Sum256(data))
+		hashes[p] = fmt.Sprintf("%x", sha256.Sum256(data))
 
 		lower := strings.ToLower(name)
 		if strings.HasPrefix(name, "_") {
 			if lower == "_defaults.yaml" || lower == "_defaults.yml" {
-				defaults[path] = true
+				defaults[p] = true
 			}
 			// Other `_*.yaml` are hashed for completeness but not part
 			// of the inheritance graph (mirrors scanDirHierarchical).
@@ -164,13 +188,13 @@ func ScanFromConfigSource(src ConfigSource, rootPath string) (
 			// Production scanDirHierarchical logs+skips because a
 			// single broken file shouldn't take down the WatchLoop;
 			// here we want the 400 response.
-			return nil, nil, nil, nil, fmt.Errorf("parse %s: %w", path, perr)
+			return nil, nil, nil, nil, fmt.Errorf("parse %s: %w", p, perr)
 		}
 		if len(doc.Tenants) == 0 {
 			continue
 		}
 		for tid := range doc.Tenants {
-			decls = append(decls, tenantDecl{ID: tid, FilePath: path})
+			decls = append(decls, tenantDecl{ID: tid, FilePath: p})
 		}
 	}
 
@@ -193,10 +217,15 @@ func ScanFromConfigSource(src ConfigSource, rootPath string) (
 
 	for _, tid := range tenantIDs {
 		srcPath := tenants[tid]
-		dir := filepath.Dir(srcPath)
+		// path.Dir + CollectDefaultsChainPOSIX: in-memory contract is
+		// POSIX-only; filepath.Dir on Windows would convert /sim/foo to
+		// \sim and break the chain lookup against the POSIX-keyed
+		// defaults map (Simulate Windows-host flake — see
+		// CollectDefaultsChainPOSIX docstring for the full triage).
+		dir := path.Dir(srcPath)
 		chain, cached := chainCache[dir]
 		if !cached {
-			chain = CollectDefaultsChain(dir, absRoot, defaults)
+			chain = CollectDefaultsChainPOSIX(dir, absRoot, defaults)
 			chainCache[dir] = chain
 		}
 		graph.AddTenant(tid, chain)


### PR DESCRIPTION
## Summary

Closes the "Simulate Windows-host flake" chip spawned during PR #356 audit. \`config.SimulateEffective\` returned a merged config map missing all inherited keys when called on Windows. Linux CI passed because POSIX hosts share \`/\` between Go's \`path\` and \`filepath\` packages.

## Root cause

\`InMemoryConfigSource\` + \`ScanFromConfigSource\` used \`filepath.Clean\` / \`filepath.Dir\` / \`filepath.Base\` / \`string(filepath.Separator)\` internally. On Windows these convert POSIX \`/sim/foo\` to backslash \`\sim\foo\`. \`SimulateEffective\` populates its \`files\` map with POSIX keys (via \`path.Join\`), so when the scan returned backslash keys, the chain lookup \`files[dp]\` missed and \`chainBytes\` resolved to nil — defaults silently dropped from the merged config.

## Symptoms (Windows-only, 4 tests)

- \`TestSimulate_BasicHierarchy\`: \`cpu_threshold = <nil>\`, want 75 (inherited)
- \`TestSimulate_DeepChainOrdering\`: \`Y = <nil>\`, \`Z = <nil>\`, want 10/20 (inherited)
- \`TestSimulateHandler_MalformedDefaults\`
- \`TestSimulate_VsResolve_ParityHash\`

## Fix

\`InMemoryConfigSource\` is documented as POSIX-only. All path ops on the in-memory path now use the \`path\` package (always \`/\`) instead of OS-aware \`filepath\`:

| Site | Before | After |
|---|---|---|
| InMemoryConfigSource.YAMLFiles | filepath.Clean / filepath.Separator / filepath.Base | path.Clean / "/" / path.Base |
| ScanFromConfigSource absRoot | filepath.Clean | path.Clean |
| ScanFromConfigSource corpus loop | filepath.Base | path.Base |
| ScanFromConfigSource tenant dir | filepath.Dir | path.Dir |
| Defaults chain walker | CollectDefaultsChain (filepath-based) | new sibling **CollectDefaultsChainPOSIX** (path-based) |

Loop variable \`path\` in ScanFromConfigSource renamed to \`p\` to avoid shadowing the newly-imported package. \`ConfigSource\` interface docstring updated to document the path-scheme contract.

The original \`CollectDefaultsChain\` is unchanged — the disk scanner (\`config_hierarchy.go\`) genuinely needs OS-native paths.

## Test plan

- [x] Windows host (zh-TW Cowork VM): all 4 originally-failing tests PASS
- [x] Linux dev container \`-count=3 -race\` for \`./pkg/config/...\` + \`./\` (main package): clean (1.1s + 13.6s)
- [ ] CI Go Tests (1.26) green on this PR

## Out of scope

- Disk-backed \`ConfigSource\` implementation: only InMemory exists today; if/when a disk variant lands it will use \`filepath.Clean\` and call \`CollectDefaultsChain\` (not the POSIX sibling).
- The 15-LOC duplication between the two chain helpers: small enough that parameterizing with a path-ops interface would add more cognitive overhead than it saves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)