### PR TITLE
refactor(exporter): inject clockwork.Clock into ConfigManager (foundation for #4c)

### DIFF
--- a/components/threshold-exporter/app/config.go
+++ b/components/threshold-exporter/app/config.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"gopkg.in/yaml.v3"
 )
 
@@ -75,10 +76,10 @@ type hierarchyState struct {
 // fast (just append to pendingReasons + reset timer).
 type debouncerState struct {
 	window         time.Duration
-	timer          *time.Timer // current pending reload; nil when idle
-	mu             sync.Mutex  // guards timer + pendingReasons
-	pendingReasons []string    // accumulates reload triggers during a window
-	fired          uint64      // count of fires; read via DebounceFiredCount()
+	timer          clockwork.Timer // current pending reload; nil when idle
+	mu             sync.Mutex      // guards timer + pendingReasons
+	pendingReasons []string        // accumulates reload triggers during a window
+	fired          uint64          // count of fires; read via DebounceFiredCount()
 }
 
 type ConfigManager struct {
@@ -93,6 +94,15 @@ type ConfigManager struct {
 	// Config info metric state (v2.3.0)
 	configSource string // "configmap", "operator", or "git-sync"
 	gitCommit    string // git commit hash from .git-revision file, or ""
+
+	// clock abstracts time.NewTicker / time.AfterFunc so tests can drive
+	// the WatchLoop ticker + debounce timer deterministically with a
+	// clockwork.FakeClock instead of time.Sleep'ing for real wall-clock
+	// elapses. Production constructors plug in clockwork.NewRealClock();
+	// test code uses SetClock to swap in a FakeClock and then
+	// `Advance(window)` to fire timers synchronously. Origin: HA-11
+	// deeper applied to exporter (mirrors PR #354 in tenant-api).
+	clock clockwork.Clock
 
 	// Sub-struct field groups — v2.8.0 PR-5 decomposed the original
 	// 14-mixed-fields ConfigManager into named concerns. Field accesses
@@ -125,8 +135,20 @@ func NewConfigManagerWithDebounce(path string, debounceWindow time.Duration) *Co
 	return &ConfigManager{
 		path:     path,
 		isDir:    isDir,
+		clock:    clockwork.NewRealClock(),
 		debounce: debouncerState{window: debounceWindow},
 	}
+}
+
+// SetClock swaps the clock used by WatchLoop's ticker + the debounce
+// timer. Test-only — production code constructs managers via
+// NewConfigManagerWithDebounce which installs a real clock. Calling
+// this AFTER WatchLoop has started is undefined (the ticker is bound
+// to whichever clock was current at NewTicker time).
+func (m *ConfigManager) SetClock(c clockwork.Clock) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clock = c
 }
 
 // Mode returns "directory" or "single-file" for diagnostics.
@@ -581,7 +603,14 @@ func logConfigStats(cfg *ThresholdConfig, prefix string) {
 }
 
 func (m *ConfigManager) WatchLoop(interval time.Duration, stopCh <-chan struct{}) {
-	ticker := time.NewTicker(interval)
+	// Defensive: ConfigManager constructed via struct literal (test
+	// shortcut) wouldn't have called NewConfigManagerWithDebounce, so the
+	// clock field is nil. Fall back to a real clock; tests that want a
+	// fake clock must call SetClock before WatchLoop.
+	if m.clock == nil {
+		m.clock = clockwork.NewRealClock()
+	}
+	ticker := m.clock.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
@@ -589,7 +618,7 @@ func (m *ConfigManager) WatchLoop(interval time.Duration, stopCh <-chan struct{}
 		case <-stopCh:
 			log.Println("WatchLoop stopped")
 			return
-		case <-ticker.C:
+		case <-ticker.Chan():
 		}
 		m.tickOnce()
 	}

--- a/components/threshold-exporter/app/config_debounce.go
+++ b/components/threshold-exporter/app/config_debounce.go
@@ -47,6 +47,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/jonboulle/clockwork"
 )
 
 // Reload trigger reasons — label values for the
@@ -79,6 +81,12 @@ const (
 // unfiltered for duplicates — a storm of 10 "source" events is itself a
 // signal and we want to count them as 10 increments.
 func (m *ConfigManager) triggerDebouncedReload(reason string) {
+	// Defensive: tests that build ConfigManager via struct literal won't
+	// have a clock; install a real one rather than nil-panic. Production
+	// constructors set it up via NewConfigManagerWithDebounce.
+	if m.clock == nil {
+		m.clock = clockwork.NewRealClock()
+	}
 	if m.debounce.window <= 0 {
 		// Synchronous fallback — useful for v2.6.0 parity tests and for
 		// the initial Load() bootstrap where we don't want to gate startup
@@ -95,7 +103,7 @@ func (m *ConfigManager) triggerDebouncedReload(reason string) {
 	m.debounce.pendingReasons = append(m.debounce.pendingReasons, reason)
 	if m.debounce.timer == nil {
 		// First event in this window — arm the timer.
-		m.debounce.timer = time.AfterFunc(m.debounce.window, m.fireDebounced)
+		m.debounce.timer = m.clock.AfterFunc(m.debounce.window, m.fireDebounced)
 		m.debounce.mu.Unlock()
 		return
 	}
@@ -114,7 +122,7 @@ func (m *ConfigManager) triggerDebouncedReload(reason string) {
 		// the same one. If Stop() returned false AND the timer was already
 		// nil'd by a completed fire, arm a fresh one.
 		if m.debounce.timer == nil {
-			m.debounce.timer = time.AfterFunc(m.debounce.window, m.fireDebounced)
+			m.debounce.timer = m.clock.AfterFunc(m.debounce.window, m.fireDebounced)
 		} else {
 			m.debounce.timer.Reset(m.debounce.window)
 		}

--- a/components/threshold-exporter/app/go.mod
+++ b/components/threshold-exporter/app/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/components/threshold-exporter/app/go.sum
+++ b/components/threshold-exporter/app/go.sum
@@ -79,6 +79,8 @@ github.com/googleapis/gax-go/v2 v2.18.0 h1:jxP5Uuo3bxm3M6gGtV94P4lliVetoCB4Wk2x8
 github.com/googleapis/gax-go/v2 v2.18.0/go.mod h1:uSzZN4a356eRG985CzJ3WfbFSpqkLTjsnhWGJR6EwrE=
 github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 h1:cLN4IBkmkYZNnk7EAJ0BHIethd+J6LqxFNw5mSiI2bM=
 github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
+github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=


### PR DESCRIPTION
## Summary

Mirrors the HA-11 deeper pattern from PR #354 (tenant-api). Adds a \`clockwork.Clock\` seam into exporter's \`ConfigManager\` so future test refactors can swap in \`clockwork.FakeClock\` + \`Advance(window)\` instead of waiting on real wall-clock elapses.

## Production changes

- New \`clock clockwork.Clock\` field on \`ConfigManager\`
- \`NewConfigManagerWithDebounce\` plugs in \`clockwork.NewRealClock()\`
- \`SetClock(c)\` test-only setter
- \`WatchLoop\`: \`time.NewTicker\` → \`m.clock.NewTicker\`, \`<-ticker.C\` → \`<-ticker.Chan()\`
- \`triggerDebouncedReload\`: \`time.AfterFunc\` → \`m.clock.AfterFunc\`. \`debouncerState.timer\` field type changes from \`*time.Timer\` to \`clockwork.Timer\` interface
- Defensive nil-clock check so ConfigManager constructed via struct literal (test shortcut) gets a real clock instead of nil-panic

## What this PR does NOT do (deferred to #4a)

The 3 wall-clock test files (\`config_debounce_test.go\`, \`config_hierarchy_integration_test.go\`, \`config_slow_write_stress_test.go\`) are **NOT rewritten** to use FakeClock here.

Reason: 2 of those also use \`withIsolatedMetrics\` (the global-swap pattern that #4a addresses), so refactoring the test side now would touch the same files again in #4a. Bundle them into #4a where both global-swap concerns get removed at once — cleaner per-file diff for review.

The third file (\`hierarchy_integration_test.go\`) uses \`time.Sleep\` only for goroutine-settle waits + \`waitFor\` polling, not for debounce-window timing. Marginal benefit from FakeClock; left as-is.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test -count=1\` clean (existing tests pass via defensive nil-clock fallback)
- [x] Linux dev container \`-count=3 -race ./\` clean (16.9s)
- [ ] CI Go Tests (1.26) green

## Dependencies

\`github.com/jonboulle/clockwork v0.5.0\` — already in tenant-api (PR #354), now pulled into exporter's go.mod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)