### PR TITLE
refactor(exporter): #4a-A+B — route metrics through ConfigManager + scanner injection

### DIFF
--- a/components/threshold-exporter/app/config.go
+++ b/components/threshold-exporter/app/config.go
@@ -167,16 +167,30 @@ func (m *ConfigManager) SetClock(c clockwork.Clock) {
 // SetMetrics swaps the *configMetrics instance this manager bumps.
 // Test-only — production code receives the package-level singleton
 // from the constructor. Tests use this to inject a fresh instance for
-// parallel-safe observation; mirrors SetClock. Foundation for #4a
-// (drop the withIsolatedMetrics global-swap pattern). Until the
-// follow-up PRs route ConfigManager methods through m.metrics +
-// thread *configMetrics through the top-level scanners, swapping
-// here only isolates the field access — code paths still using the
-// global helpers will keep racing on the singleton.
+// parallel-safe observation; mirrors SetClock. Foundation for #4a.
 func (m *ConfigManager) SetMetrics(metrics *configMetrics) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.metrics = metrics
+}
+
+// getMetrics returns m.getMetrics(), lazy-initializing to the global
+// singleton if the constructor was bypassed (test struct-literal
+// pattern). Always returns a non-nil pointer so callers can write
+// `m.getMetrics().IncReloadTrigger(...)` without nil-panic worry.
+func (m *ConfigManager) getMetrics() *configMetrics {
+	m.mu.RLock()
+	mm := m.metrics
+	m.mu.RUnlock()
+	if mm != nil {
+		return mm
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.metrics == nil {
+		m.metrics = getConfigMetrics()
+	}
+	return m.metrics
 }
 
 // Mode returns "directory" or "single-file" for diagnostics.
@@ -247,7 +261,7 @@ func (m *ConfigManager) Load() error {
 	var err error
 
 	if m.isDir {
-		cfg, hash, err = loadDir(m.path)
+		cfg, hash, err = loadDirWithMetrics(m.path, m.getMetrics())
 	} else {
 		cfg, hash, err = loadFile(m.path)
 	}
@@ -372,7 +386,7 @@ func (m *ConfigManager) IncrementalLoad() error {
 		if err := yaml.Unmarshal(data, &partial); err != nil {
 			// See loadDir — defaults parse failure silently nullifies the
 			// block; promote to ERROR + emit metric (cycle-6 RCA, archive §S#37d).
-			IncParseFailure(filepath.Base(fullPath))
+			m.getMetrics().IncParseFailure(filepath.Base(fullPath))
 			if strings.HasPrefix(name, "_") {
 				log.Printf("ERROR: skip unparseable defaults/profiles file %s: %v (entire block dropped — fix file or remove)", fullPath, err)
 			} else {
@@ -492,7 +506,7 @@ func (m *ConfigManager) fullDirLoad() error {
 		if err := yaml.Unmarshal(data, &partial); err != nil {
 			// See loadDir — defaults parse failure silently nullifies the
 			// block; promote to ERROR + emit metric (cycle-6 RCA, archive §S#37d).
-			IncParseFailure(filepath.Base(fullPath))
+			m.getMetrics().IncParseFailure(filepath.Base(fullPath))
 			if strings.HasPrefix(name, "_") {
 				log.Printf("ERROR: skip unparseable defaults/profiles file %s: %v (entire block dropped — fix file or remove)", fullPath, err)
 			} else {
@@ -536,7 +550,7 @@ func (m *ConfigManager) fullDirLoad() error {
 // merging in place so a failed scan doesn't leave torn state visible to
 // the /effective read path.
 func (m *ConfigManager) populateHierarchyState() error {
-	tenants, defaults, hashes, mtimes, graph, err := scanDirHierarchical(m.path, nil)
+	tenants, defaults, hashes, mtimes, graph, err := scanDirHierarchicalWithMetrics(m.path, nil, m.getMetrics())
 	if err != nil {
 		return err
 	}
@@ -732,7 +746,7 @@ func (m *ConfigManager) detectChange() (bool, string, error) {
 	m.mu.RUnlock()
 
 	if hierarchical {
-		_, _, newHashes, _, _, hErr := scanDirHierarchical(m.path, priorHierMtimes)
+		_, _, newHashes, _, _, hErr := scanDirHierarchicalWithMetrics(m.path, priorHierMtimes, m.getMetrics())
 		if hErr != nil {
 			return false, "", fmt.Errorf("hierarchical scan: %w", hErr)
 		}

--- a/components/threshold-exporter/app/config_debounce.go
+++ b/components/threshold-exporter/app/config_debounce.go
@@ -95,7 +95,7 @@ func (m *ConfigManager) triggerDebouncedReload(reason string) {
 		m.recordReason(reason)
 		t0 := time.Now()
 		m.diffAndReload()
-		ObserveReloadDuration(time.Since(t0))
+		m.getMetrics().ObserveReloadDuration(time.Since(t0))
 		return
 	}
 
@@ -156,11 +156,11 @@ func (m *ConfigManager) fireDebounced() {
 	// v2.8.0 B-3: observe debounce batch size (effectiveness signal)
 	// before the reload so the sample lands even if diffAndReload
 	// errors out. Sample count == fire count by construction.
-	ObserveDebounceBatch(len(reasons))
+	m.getMetrics().ObserveDebounceBatch(len(reasons))
 	atomic.AddUint64(&m.debounce.fired, 1)
 	t0 := time.Now()
 	_, _, err := m.diffAndReload()
-	ObserveReloadDuration(time.Since(t0))
+	m.getMetrics().ObserveReloadDuration(time.Since(t0))
 	if err != nil {
 		log.Printf("ERROR: debounced reload failed: %v", err)
 	}
@@ -271,7 +271,7 @@ func (m *ConfigManager) snapshotPriorState() reloadPriorState {
 // we keep using the hierarchical path because computeMergedHash with an
 // empty chain is well-defined.
 func (m *ConfigManager) scanAndCheckHierarchical(prior reloadPriorState) (reloadScanState, bool, error) {
-	tenants, defaults, hashes, mtimes, graph, scanErr := scanDirHierarchical(m.path, prior.mtimes)
+	tenants, defaults, hashes, mtimes, graph, scanErr := scanDirHierarchicalWithMetrics(m.path, prior.mtimes, m.getMetrics())
 	if scanErr != nil {
 		log.Printf("ERROR: hierarchical scan failed: %v", scanErr)
 		return reloadScanState{}, true, scanErr
@@ -394,10 +394,10 @@ func (m *ConfigManager) classifyAndCount(prior reloadPriorState, scan reloadScan
 		if sourceChanged {
 			res.reloaded++
 			if wasKnown {
-				IncReloadTrigger(ReloadReasonSource)
+				m.getMetrics().IncReloadTrigger(ReloadReasonSource)
 				buckets[emissionKey{ReloadReasonSource, "tenant", "applied"}]++
 			} else {
-				IncReloadTrigger(ReloadReasonNewTenant)
+				m.getMetrics().IncReloadTrigger(ReloadReasonNewTenant)
 				buckets[emissionKey{ReloadReasonNewTenant, "tenant", "applied"}]++
 			}
 		} else if defaultsChanged {
@@ -425,14 +425,14 @@ func (m *ConfigManager) classifyAndCount(prior reloadPriorState, scan reloadScan
 				}
 				switch effect {
 				case "shadowed":
-					IncDefaultsShadowed()
+					m.getMetrics().IncDefaultsShadowed()
 				default:
-					IncDefaultsNoop()
+					m.getMetrics().IncDefaultsNoop()
 				}
 				buckets[emissionKey{ReloadReasonDefaults, scope, effect}]++
 			} else {
 				res.reloaded++
-				IncReloadTrigger(ReloadReasonDefaults)
+				m.getMetrics().IncReloadTrigger(ReloadReasonDefaults)
 				buckets[emissionKey{ReloadReasonDefaults, scope, "applied"}]++
 			}
 		}
@@ -444,7 +444,7 @@ func (m *ConfigManager) classifyAndCount(prior reloadPriorState, scan reloadScan
 	for tid := range prior.tenantSources {
 		if _, stillKnown := scan.tenants[tid]; !stillKnown {
 			res.reloaded++
-			IncReloadTrigger(ReloadReasonDelete)
+			m.getMetrics().IncReloadTrigger(ReloadReasonDelete)
 			buckets[emissionKey{ReloadReasonDelete, "tenant", "applied"}]++
 		}
 	}
@@ -453,7 +453,7 @@ func (m *ConfigManager) classifyAndCount(prior reloadPriorState, scan reloadScan
 	// doesn't matter for Histogram observations; the per-key Observe
 	// is the only state mutation.
 	for k, n := range buckets {
-		ObserveBlastRadius(k.reason, k.scope, k.effect, n)
+		m.getMetrics().ObserveBlastRadius(k.reason, k.scope, k.effect, n)
 	}
 
 	return res
@@ -484,7 +484,7 @@ func (m *ConfigManager) installNewHierarchyState(scan reloadScanState, result re
 	m.hierarchy.parsedDefaults = result.newParsedDefaults
 	m.mu.Unlock()
 
-	SetLastReloadComplete(time.Now())
+	m.getMetrics().SetLastReloadComplete(time.Now())
 	return nil
 }
 
@@ -573,7 +573,7 @@ func (m *ConfigManager) recomputeMergedHash(tenantID, tenantFile string, default
 	}
 	h, mergeErr := computeMergedHash(tenantBytes, tenantID, chainBytes)
 	if mergeErr != nil {
-		emitParseFailureSignal(tenantID, tenantFile, defaultsChain, mergeErr)
+		emitParseFailureSignal(m.getMetrics(), tenantID, tenantFile, defaultsChain, mergeErr)
 	}
 	return h, mergeErr
 }
@@ -588,12 +588,16 @@ func (m *ConfigManager) recomputeMergedHash(tenantID, tenantFile string, default
 // with `parse defaults[%d]: %w` and tenant errors with `parse tenant: %w`
 // (config_inheritance.go). We string-match the prefix to map the index
 // back to defaultsChain[i] for filename attribution.
-func emitParseFailureSignal(tenantID, tenantFile string, defaultsChain []string, mergeErr error) {
+//
+// metrics is plumbed in (not the package global) so the caller's
+// ConfigManager.metrics instance is the bumped one — foundation for
+// per-test isolation (#4a).
+func emitParseFailureSignal(metrics *configMetrics, tenantID, tenantFile string, defaultsChain []string, mergeErr error) {
 	msg := mergeErr.Error()
 	for i, dp := range defaultsChain {
 		needle := fmt.Sprintf("parse defaults[%d]:", i)
 		if strings.Contains(msg, needle) {
-			IncParseFailure(filepath.Base(dp))
+			metrics.IncParseFailure(filepath.Base(dp))
 			log.Printf(
 				"ERROR: skip unparseable defaults/profiles file %s (chain index %d) for tenant=%s: %v (entire block dropped — fix file or remove)",
 				dp, i, tenantID, mergeErr,
@@ -605,6 +609,6 @@ func emitParseFailureSignal(tenantID, tenantFile string, defaultsChain []string,
 	// logMergeSkip caller path; still bump the per-file counter so ops
 	// can detect persistently broken tenant files.
 	if strings.Contains(msg, "parse tenant:") {
-		IncParseFailure(filepath.Base(tenantFile))
+		metrics.IncParseFailure(filepath.Base(tenantFile))
 	}
 }

--- a/components/threshold-exporter/app/config_hierarchy.go
+++ b/components/threshold-exporter/app/config_hierarchy.go
@@ -96,6 +96,11 @@ func (e *DuplicateTenantError) Error() string {
 // optimization layered in Phase 3; Phase 1 always re-reads and re-hashes
 // (parity first, perf later). When non-nil it is currently ignored; tests
 // should pass nil.
+//
+// Legacy wrapper that uses the package-level metrics singleton. Production
+// code should call scanDirHierarchicalWithMetrics with their owned
+// *configMetrics so per-test isolation works (#4a). Tests that don't
+// care about metric isolation keep calling this form unchanged.
 func scanDirHierarchical(rootPath string, priorMtimes map[string]fileStat) (
 	tenants map[string]string,
 	defaults map[string]bool,
@@ -104,13 +109,39 @@ func scanDirHierarchical(rootPath string, priorMtimes map[string]fileStat) (
 	graph *InheritanceGraph,
 	err error,
 ) {
+	return scanDirHierarchicalWithMetrics(rootPath, priorMtimes, getConfigMetrics())
+}
+
+// scanDirHierarchicalWithMetrics is the injectable variant of
+// scanDirHierarchical. Same behavior; metric observations route to the
+// caller-supplied *configMetrics instead of getConfigMetrics(). Use this
+// from production code paths that own a ConfigManager: pass m.metrics so
+// the test-side SetMetrics injection actually shows up here too.
+//
+// Foundation for #4a: production callers migrate first; the legacy
+// wrapper above keeps test files green during the transition.
+func scanDirHierarchicalWithMetrics(rootPath string, priorMtimes map[string]fileStat, metrics *configMetrics) (
+	tenants map[string]string,
+	defaults map[string]bool,
+	hashes map[string]string,
+	mtimes map[string]fileStat,
+	graph *InheritanceGraph,
+	err error,
+) {
+	// Defensive: callers using struct-literal ConfigManager (test
+	// shortcut) may pass m.metrics == nil. Fall back to the global
+	// singleton — same behavior as the legacy scanDirHierarchical
+	// wrapper. Production callers always pass a real *configMetrics.
+	if metrics == nil {
+		metrics = getConfigMetrics()
+	}
 	_ = priorMtimes // reserved for Phase 3 (mtime-skip optimization)
 
 	// v2.7.0 Phase 4: record wall-clock duration for the scan so operators
 	// can alert on slow scans (e.g., >1s = filesystem regression). Done
 	// first so even error returns are observed — a scan that errors out
 	// fast is itself useful signal.
-	defer ObserveScanDuration()()
+	defer metrics.ObserveScanDuration()()
 
 	tenants = make(map[string]string)
 	defaults = make(map[string]bool)
@@ -208,7 +239,7 @@ func scanDirHierarchical(rootPath string, priorMtimes map[string]fileStat) (
 			// v2.8.0 A-8d: expose parse failure as a Prometheus counter so
 			// ops can alert on "tenant file persistently broken". label is
 			// basename (not full path) to cap cardinality.
-			IncParseFailure(filepath.Base(path))
+			metrics.IncParseFailure(filepath.Base(path))
 			return nil
 		}
 		if len(doc.Tenants) == 0 {
@@ -274,7 +305,7 @@ func scanDirHierarchical(rootPath string, priorMtimes map[string]fileStat) (
 	// harness anchor T1 + production stuck-scanner detection. Stamped only
 	// on success — error returns above leave the gauge at its previous
 	// value so a transient failure doesn't look like a completion.
-	SetLastScanComplete(time.Now())
+	metrics.SetLastScanComplete(time.Now())
 	return tenants, defaults, hashes, mtimes, graph, nil
 }
 

--- a/components/threshold-exporter/app/flat_scanner.go
+++ b/components/threshold-exporter/app/flat_scanner.go
@@ -71,7 +71,24 @@ func loadFile(path string) (ThresholdConfig, string, error) {
 //
 // Boundary rule: state_filters should only be defined in _defaults.yaml.
 // Tenant files should only contain a 'tenants' block. This is enforced with warnings.
+//
+// Legacy wrapper that uses the package-level metrics singleton. Production
+// code should call loadDirWithMetrics with their owned *configMetrics so
+// per-test isolation works (#4a).
 func loadDir(dir string) (ThresholdConfig, string, error) {
+	return loadDirWithMetrics(dir, getConfigMetrics())
+}
+
+// loadDirWithMetrics is the injectable variant of loadDir. Same behavior;
+// metric observations route to the caller-supplied *configMetrics
+// instead of getConfigMetrics(). Use this from production code paths
+// that own a ConfigManager.
+func loadDirWithMetrics(dir string, metrics *configMetrics) (ThresholdConfig, string, error) {
+	// Defensive: see scanDirHierarchicalWithMetrics for the same
+	// nil-fallback rationale (struct-literal test shortcut).
+	if metrics == nil {
+		metrics = getConfigMetrics()
+	}
 	merged := ThresholdConfig{
 		Defaults:     make(map[string]float64),
 		StateFilters: make(map[string]StateFilter),
@@ -121,7 +138,7 @@ func loadDir(dir string) (ThresholdConfig, string, error) {
 			// §S#37d) cost 5+ hours wall-clock because this signal lived at
 			// WARN. Promote to ERROR for `_*` files; emit parse_failure_total
 			// (v2.8.0 A-8d metric) so ops can alert.
-			IncParseFailure(filepath.Base(path))
+			metrics.IncParseFailure(filepath.Base(path))
 			if strings.HasPrefix(name, "_") {
 				log.Printf("ERROR: skip unparseable defaults/profiles file %s: %v (entire block dropped — fix file or remove)", path, err)
 			} else {

--- a/scripts/ops/route_metrics_through_field.py
+++ b/scripts/ops/route_metrics_through_field.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Convert ConfigManager-method metric callsites to use m.metrics.X.
+
+For each top-level metric helper (IncParseFailure, ObserveScanDuration,
+IncReloadTrigger, etc.), replace bare calls like:
+    IncReloadTrigger(ReloadReasonSource)
+with the field-routed form:
+    m.metrics.IncReloadTrigger(ReloadReasonSource)
+
+ONLY rewrites callsites inside files this script is given on the command
+line. The replacement is naive substring — relies on the helpers having
+unique enough names that no false matches happen. Validated by `go build`.
+
+Helpers: see HELPERS list. Production wrapper functions in config_metrics.go
+that DEFINE these names are NOT modified (the script is only run on caller
+files).
+
+Run order:
+    python scripts/ops/route_metrics_through_field.py \\
+        components/threshold-exporter/app/config.go \\
+        components/threshold-exporter/app/config_debounce.go
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+HELPERS = (
+    "IncParseFailure",
+    "ObserveScanDuration",
+    "IncReloadTrigger",
+    "IncReloadTriggerBy",
+    "IncDefaultsNoop",
+    "IncDefaultsNoopBy",
+    "IncDefaultsShadowed",
+    "IncDefaultsShadowedBy",
+    "ObserveBlastRadius",
+    "ObserveReloadDuration",
+    "ObserveDebounceBatch",
+    "SetLastScanComplete",
+    "SetLastReloadComplete",
+)
+
+
+def process_file(path: Path) -> int:
+    text = path.read_text(encoding="utf-8")
+    n = 0
+    for h in HELPERS:
+        # Match `<helper>(` only when:
+        #  - preceded by whitespace, tab, or open-paren / start-of-line
+        #  - NOT preceded by `.` (to avoid double-rewriting `m.metrics.IncX`)
+        #  - NOT preceded by `func ` (to avoid touching the helper definition)
+        # The negative-lookbehind for `.` is the key safety check.
+        # `r"(?<!\.)\b<helper>\("` with extra guards.
+        pattern = re.compile(
+            r"(?<![.\w])" + re.escape(h) + r"\(",
+        )
+        new_text, count = pattern.subn(f"m.metrics.{h}(", text)
+        # Don't rewrite if the same line is the helper's own definition or
+        # a comment. The negative-lookbehind for `.` handles the most common
+        # false positive (already-routed callsites). Other false positives
+        # surface as build failures and get hand-fixed.
+        if count:
+            text = new_text
+            n += count
+    path.write_text(text, encoding="utf-8")
+    return n
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: route_metrics_through_field.py <file>...", file=sys.stderr)
+        return 2
+    total = 0
+    for arg in sys.argv[1:]:
+        n = process_file(Path(arg))
+        if n:
+            print(f"{arg}: +{n} routed")
+            total += n
+    print(f"Total: {total} call sites routed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ops/use_get_metrics.py
+++ b/scripts/ops/use_get_metrics.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Replace `m.metrics.X(...)` and `m.metrics)` / `m.metrics,` with the
+lazy-init getter `m.getMetrics()`. Skips lines inside the SetMetrics and
+getMetrics function bodies themselves (where direct field access is
+intentional).
+
+Run on a list of files; idempotent.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def process_file(path: Path) -> int:
+    text = path.read_text(encoding="utf-8")
+    lines = text.split("\n")
+    out: list[str] = []
+    inside_internals = False  # True while scanning SetMetrics or getMetrics body
+    depth_at_open = 0
+    depth = 0
+    n = 0
+    for line in lines:
+        # Track when we enter / leave the SetMetrics or getMetrics function
+        # bodies so we don't rewrite their internal references.
+        stripped = line.lstrip()
+        if stripped.startswith("func (m *ConfigManager) SetMetrics(") or \
+           stripped.startswith("func (m *ConfigManager) getMetrics()"):
+            inside_internals = True
+            depth_at_open = depth
+        # Update brace depth (crude — ignores braces inside strings/comments,
+        # acceptable for well-formatted Go).
+        code = line.split("//", 1)[0]
+        depth += code.count("{") - code.count("}")
+        if inside_internals and depth == depth_at_open and "}" in code:
+            # Closing brace of the function we were tracking — exit AFTER
+            # processing this line.
+            out.append(line)
+            inside_internals = False
+            continue
+        if inside_internals:
+            out.append(line)
+            continue
+        # Outside the off-limits zones — perform the substitution.
+        new_line = re.sub(r"\bm\.metrics\b", "m.getMetrics()", line)
+        if new_line != line:
+            n += 1
+        out.append(new_line)
+    if n:
+        path.write_text("\n".join(out), encoding="utf-8")
+    return n
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: use_get_metrics.py <file>...", file=sys.stderr)
+        return 2
+    total = 0
+    for arg in sys.argv[1:]:
+        n = process_file(Path(arg))
+        if n:
+            print(f"{arg}: +{n} m.metrics → m.getMetrics()")
+            total += n
+    print(f"Total: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Builds on PR #363 foundation (metrics field + helper methods + SetMetrics). This PR converts production callsites to **actually use** the injected metrics field instead of the package-level singleton.

## What changed

### ConfigManager methods → \`m.getMetrics().X(...)\` (19 callsites)

Across \`config.go\` + \`config_debounce.go\`, every \`IncReloadTrigger(...)\` / \`ObserveReloadDuration(...)\` / etc. now routes through a per-manager field via a lazy-init getter.

The getter handles the struct-literal test pattern (tests bypassing \`NewConfigManagerWithDebounce\`): falls back to \`getConfigMetrics()\` so existing tests work unchanged.

### Scanner free functions → injectable variants

Three top-level metric-emitting functions now have \`*WithMetrics\` siblings; legacy wrappers stay for tests:

| Original | Injectable variant |
|---|---|
| \`scanDirHierarchical\` | \`scanDirHierarchicalWithMetrics\` |
| \`loadDir\` | \`loadDirWithMetrics\` |
| \`emitParseFailureSignal\` | takes \`metrics\` arg directly (only 1 caller) |

Production callers (4 sites) pass \`m.getMetrics()\`; legacy wrappers delegate to \`getConfigMetrics()\` so the ~10 test callsites of the original signatures keep working.

## Why this works without breaking \`withIsolatedMetrics\` tests

Tests typically call \`withIsolatedMetrics(t)\` BEFORE constructing a ConfigManager. The constructor then reads \`getConfigMetrics()\` which returns the test's \`fresh\` instance — so \`m.metrics\` IS the test instance. Subsequent \`m.getMetrics().X(...)\` bumps fresh; assertions pass.

## What's deferred (PR-C)

Test files using \`withIsolatedMetrics\` are NOT migrated to \`SetMetrics()\` + \`t.Parallel()\` here. PR-C scope:
- 5 test files (blast_radius / debounce / metrics / mixed_mode / slow_write_stress)
- Replace global-swap with explicit \`SetMetrics()\`
- Add \`t.Parallel()\`
- Drop \`withIsolatedMetrics\` helper

Doing it in this PR would mix production refactor + test rewrite scopes.

## New tooling under scripts/ops/

- \`route_metrics_through_field.py\` — naive substring rewriter for the helper-call → field-route conversion (15 callsites)
- \`use_get_metrics.py\` — converts \`m.metrics.X\` field reads to \`m.getMetrics().X\` method calls. Skips lines inside SetMetrics/getMetrics bodies. Idempotent.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test -count=1 ./\` clean (exporter)
- [x] Linux dev container \`go test -count=3 -race ./\` clean (13.7s)
- [ ] CI Go Tests (1.26) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)