### PR TITLE
refactor(exporter): #4a-C — drop withIsolatedMetrics + add t.Parallel

### DIFF
--- a/components/threshold-exporter/app/config_blast_radius_test.go
+++ b/components/threshold-exporter/app/config_blast_radius_test.go
@@ -8,8 +8,9 @@ package main
 // fixture → cold Load (populates parsedDefaults) → mutate → diffAndReload
 // → assert (reason, scope, effect, N) bucket observations.
 //
-// Each test runs with its own withIsolatedMetrics + t.TempDir so
-// counters don't bleed across runs (especially under -count=N -race).
+// Each test runs with its own freshMetrics (routed via SetMetrics) +
+// t.TempDir so counters don't bleed across runs (especially under
+// -count=N -race) and tests can run in parallel.
 
 import (
 	"os"
@@ -118,11 +119,13 @@ func reloadOnce(t *testing.T, m *ConfigManager) (int, int) {
 // We trigger ONE post-change reload so the assertion is: count=1,
 // sum=2 (two tenants in the bucket for that single observation).
 func TestBlastRadius_AppliedOnDefaultsChange(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 	dir := t.TempDir()
 	writeBlastRadiusFixture(t, dir)
 
 	m := NewConfigManagerWithDebounce(dir, 0)
+	m.SetMetrics(fresh)
 	defer m.Close()
 	if err := m.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
@@ -159,11 +162,13 @@ defaults:
 // tenant-naive does not → merged_hash moves → applied (1).
 // Two distinct observations, one per (effect) bucket.
 func TestBlastRadius_ShadowedSplitFromApplied(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 	dir := t.TempDir()
 	writeBlastRadiusFixture(t, dir)
 
 	m := NewConfigManagerWithDebounce(dir, 0)
+	m.SetMetrics(fresh)
 	defer m.Close()
 	if err := m.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
@@ -194,11 +199,13 @@ defaults:
 // with identical content + a YAML comment so the file hash moves but
 // no key changes. Both tenants land in cosmetic.
 func TestBlastRadius_CosmeticOnCommentEdit(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 	dir := t.TempDir()
 	writeBlastRadiusFixture(t, dir)
 
 	m := NewConfigManagerWithDebounce(dir, 0)
+	m.SetMetrics(fresh)
 	defer m.Close()
 	if err := m.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
@@ -241,7 +248,8 @@ defaults:
 // defaults change resolved as `applied`. Adding tenant-third (which
 // overrides redis_connections only) closes the gap.
 func TestBlastRadius_MixedTickEmitsThreeDistinctBuckets(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 	dir := t.TempDir()
 	writeBlastRadiusFixture(t, dir)
 
@@ -255,6 +263,7 @@ tenants:
 `)
 
 	m := NewConfigManagerWithDebounce(dir, 0)
+	m.SetMetrics(fresh)
 	defer m.Close()
 	if err := m.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
@@ -297,11 +306,13 @@ defaults:
 // TestBlastRadius_DeleteEmitsDeleteBucket — remove a tenant file → one
 // observation in (delete, tenant, applied) with sum=1.
 func TestBlastRadius_DeleteEmitsDeleteBucket(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 	dir := t.TempDir()
 	writeBlastRadiusFixture(t, dir)
 
 	m := NewConfigManagerWithDebounce(dir, 0)
+	m.SetMetrics(fresh)
 	defer m.Close()
 	if err := m.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
@@ -322,11 +333,13 @@ func TestBlastRadius_DeleteEmitsDeleteBucket(t *testing.T) {
 // TestBlastRadius_NewTenantEmitsNewBucket — add a new tenant file → one
 // observation in (new, tenant, applied).
 func TestBlastRadius_NewTenantEmitsNewBucket(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 	dir := t.TempDir()
 	writeBlastRadiusFixture(t, dir)
 
 	m := NewConfigManagerWithDebounce(dir, 0)
+	m.SetMetrics(fresh)
 	defer m.Close()
 	if err := m.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
@@ -349,11 +362,13 @@ tenants:
 // TestBlastRadius_UnchangedTickEmitsNothing — a diffAndReload with no
 // underlying file mutation produces zero observations across the board.
 func TestBlastRadius_UnchangedTickEmitsNothing(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 	dir := t.TempDir()
 	writeBlastRadiusFixture(t, dir)
 
 	m := NewConfigManagerWithDebounce(dir, 0)
+	m.SetMetrics(fresh)
 	defer m.Close()
 	if err := m.Load(); err != nil {
 		t.Fatalf("Load: %v", err)

--- a/components/threshold-exporter/app/config_debounce_test.go
+++ b/components/threshold-exporter/app/config_debounce_test.go
@@ -356,24 +356,26 @@ func TestPendingDebounceReasons_AccumulatesThenClears(t *testing.T) {
 // drive a fixed number of triggers, wait for quiescence, and
 // assert the contract directly.
 func TestFireDebounced_EmitsBatchAndDuration(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 	dir := t.TempDir()
 	writeHierarchicalFixture(t, dir, "90")
 
 	const numTriggers = 4
 	m := NewConfigManagerWithDebounce(dir, 50*time.Millisecond)
+	m.SetMetrics(fresh)
 	defer m.Close()
 	if err := m.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
 	}
 
-	// Snapshot baseline samples — a prior test may have a leaked
-	// fireDebounced goroutine still mid-diffAndReload that lands its
-	// ObserveReloadDuration on `fresh` AFTER withIsolatedMetrics
-	// swapped (the global metric pointer was already `fresh` by the
-	// time the late goroutine called getConfigMetrics()). Asserting
-	// deltas instead of absolute counts isolates this test from any
-	// such leak.
+	// Snapshot baseline samples — even though we now own a per-test
+	// *configMetrics (no global swap), an in-flight fireDebounced
+	// goroutine from THIS test (started before t.Cleanup ran) can land
+	// an ObserveReloadDuration on `fresh` after our final read. Delta
+	// assertions tolerate that intra-test late observation. Cross-test
+	// leak is no longer a concern post-#4a (sibling tests use their
+	// own fresh).
 	baseReload := histogramSampleCount(t, fresh.reloadDuration)
 	baseBatchCount := histogramSampleCount(t, fresh.debounceBatch)
 	baseFire := m.DebounceFiredCount()
@@ -405,12 +407,13 @@ func TestFireDebounced_EmitsBatchAndDuration(t *testing.T) {
 		t.Fatalf("expected at least 1 fire, got %d (base=%d)", deltaFire, baseFire)
 	}
 
-	// Goroutine-leak race (per S#32 / S#35 / S#37): a prior test's
-	// fireDebounced may complete AFTER our withIsolatedMetrics swap. The
-	// S#35 fix asserted "deltaReload == deltaBatch lockstep" but that
-	// claim was WRONG — only batch + DebounceFiredCount() are atomic
-	// (Step 1+2 of fireDebounced under m.debounce.mu). Reload is observed
-	// AFTER diffAndReload (Step 4), making its leak window much wider:
+	// Goroutine-late-observation race (per S#32 / S#35 / S#37): an
+	// in-flight fireDebounced from earlier in THIS test may complete
+	// after our final read. The S#35 fix asserted "deltaReload ==
+	// deltaBatch lockstep" but that claim was WRONG — only batch +
+	// DebounceFiredCount() are atomic (Step 1+2 of fireDebounced under
+	// m.debounce.mu). Reload is observed AFTER diffAndReload (Step 4),
+	// making its leak window much wider:
 	//
 	//   fireDebounced steps:
 	//     1. ObserveDebounceBatch(len(reasons))   ← batch leaks here
@@ -465,11 +468,13 @@ func TestFireDebounced_EmitsBatchAndDuration(t *testing.T) {
 // stay accurate) but skips the batch histogram (no batching to
 // observe — folding "1" samples in would skew p50).
 func TestSyncFallback_EmitsReloadDurationButNoBatch(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 	dir := t.TempDir()
 	writeHierarchicalFixture(t, dir, "90")
 
 	m := NewConfigManagerWithDebounce(dir, 0)
+	m.SetMetrics(fresh)
 	defer m.Close()
 	if err := m.Load(); err != nil {
 		t.Fatalf("Load: %v", err)

--- a/components/threshold-exporter/app/config_hierarchy_test.go
+++ b/components/threshold-exporter/app/config_hierarchy_test.go
@@ -429,16 +429,13 @@ func TestScanDirHierarchical_K8sSymlinkLayout(t *testing.T) {
 // (config_hierarchy.go yaml.Unmarshal warn+return nil). This test nails
 // the behavior down AND exposes the observability hook.
 func TestScanDirHierarchical_MixedValidInvalid(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 
-	// Reset metrics so the parseFailures counter is fresh for assertion.
-	// Save+restore rather than nil-out in cleanup — getConfigMetrics does
-	// not re-init after sync.Once fires, so a nil substitution would crash
-	// subsequent tests in the same process.
-	origMetrics := getConfigMetrics()
-	freshMetrics := newConfigMetrics()
-	setConfigMetrics(freshMetrics)
-	t.Cleanup(func() { setConfigMetrics(origMetrics) })
+	// Per-test metrics instance — passed explicitly to the scanner via
+	// scanDirHierarchicalWithMetrics so observations land on `fresh` and
+	// not on the package-level singleton (parallel-safe; #4a).
+	fresh, _ := freshMetrics(t)
 
 	// Valid sibling — must survive the broken neighbor.
 	writeFile(t, filepath.Join(root, "team-a", "t-good.yaml"), `tenants:
@@ -459,7 +456,7 @@ func TestScanDirHierarchical_MixedValidInvalid(t *testing.T) {
       cpu: 70
 `)
 
-	tenants, _, hashes, _, _, err := scanDirHierarchical(root, nil)
+	tenants, _, hashes, _, _, err := scanDirHierarchicalWithMetrics(root, nil, fresh)
 	if err != nil {
 		t.Fatalf("scan should not return error on per-file parse failure: %v", err)
 	}
@@ -497,7 +494,7 @@ func TestScanDirHierarchical_MixedValidInvalid(t *testing.T) {
 	// the broken file's basename. Pulls counter value via the test-only
 	// collector API.
 	ch := make(chan prometheus.Metric, 1)
-	freshMetrics.parseFailures.WithLabelValues("broken.yaml").Collect(ch)
+	fresh.parseFailures.WithLabelValues("broken.yaml").Collect(ch)
 	close(ch)
 	var count float64
 	for m := range ch {
@@ -530,13 +527,14 @@ func TestScanDirHierarchical_MixedValidInvalid(t *testing.T) {
 // "_defaults.yaml"}[5m])) > 0` fires identically regardless of count
 // scale, so duplication is a feature (blast-radius signal), not noise.
 func TestRecomputeMergedHash_DefaultsParseFailureEmitsErrorAndMetric(t *testing.T) {
+	// NOT t.Parallel — log.SetOutput swaps a global stdlib logger; #4b
+	// will move this off the global eventually.
 	root := t.TempDir()
 
-	// Reset metrics + capture log output.
-	origMetrics := getConfigMetrics()
-	freshMetrics := newConfigMetrics()
-	setConfigMetrics(freshMetrics)
-	t.Cleanup(func() { setConfigMetrics(origMetrics) })
+	// Per-test metrics instance — routed via mgr.SetMetrics so the
+	// scanner observations land on `fresh` instead of the package
+	// singleton (parallel-friendly when paired with #4b).
+	fresh, _ := freshMetrics(t)
 
 	var logBuf bytes.Buffer
 	origOutput := log.Writer()
@@ -554,6 +552,7 @@ func TestRecomputeMergedHash_DefaultsParseFailureEmitsErrorAndMetric(t *testing.
 		"tenants:\n  t-b:\n    threshold:\n      cpu: 70\n")
 
 	mgr := NewConfigManager(root)
+	mgr.SetMetrics(fresh)
 	// Trigger the hierarchical recompute path. Load fails (or partially
 	// succeeds) — we don't care about the return value, only the
 	// observability side-effects (ERROR log + metric).
@@ -576,7 +575,7 @@ func TestRecomputeMergedHash_DefaultsParseFailureEmitsErrorAndMetric(t *testing.
 	// >= 2 for two tenants — but the metric API quirk makes >= 1 the
 	// safe assertion across both initial-scan and debounced-reload paths).
 	ch := make(chan prometheus.Metric, 1)
-	freshMetrics.parseFailures.WithLabelValues("_defaults.yaml").Collect(ch)
+	fresh.parseFailures.WithLabelValues("_defaults.yaml").Collect(ch)
 	close(ch)
 	var count float64
 	for m := range ch {

--- a/components/threshold-exporter/app/config_loaddir_test.go
+++ b/components/threshold-exporter/app/config_loaddir_test.go
@@ -236,13 +236,14 @@ func TestConfigManager_LoadDir_EmptyDir(t *testing.T) {
 // same invariant as TestScanDirHierarchical_MixedValidInvalid for the
 // hierarchical path).
 func TestConfigManager_LoadDir_UnparseableDefaultsErrorAndMetric(t *testing.T) {
+	// NOT t.Parallel — log.SetOutput swaps a global stdlib logger; #4b
+	// will move this off the global eventually.
 	dir := t.TempDir()
 
-	// Reset metrics so parseFailures counter is fresh.
-	origMetrics := getConfigMetrics()
-	freshMetrics := newConfigMetrics()
-	setConfigMetrics(freshMetrics)
-	t.Cleanup(func() { setConfigMetrics(origMetrics) })
+	// Per-test metrics instance — routed via mgr.SetMetrics so the
+	// scanner observations land on `fresh` (parallel-friendly when
+	// paired with #4b).
+	fresh, _ := freshMetrics(t)
 
 	// Capture log output to verify ERROR-level promotion.
 	var logBuf bytes.Buffer
@@ -268,6 +269,7 @@ tenants:
 `)
 
 	mgr := NewConfigManager(dir)
+	mgr.SetMetrics(fresh)
 	// Load may succeed (defaults dropped, sibling tenant parses) — what we
 	// care about is the ERROR log + the metric.
 	_ = mgr.Load()
@@ -286,7 +288,7 @@ tenants:
 	// basename. This may run via loadDir (initial scan) — the counter
 	// pattern matches A-8d.
 	ch := make(chan prometheus.Metric, 1)
-	freshMetrics.parseFailures.WithLabelValues("_defaults.yaml").Collect(ch)
+	fresh.parseFailures.WithLabelValues("_defaults.yaml").Collect(ch)
 	close(ch)
 	var count float64
 	for m := range ch {

--- a/components/threshold-exporter/app/config_metrics.go
+++ b/components/threshold-exporter/app/config_metrics.go
@@ -77,8 +77,12 @@ type configMetrics struct {
 }
 
 // Default metric instance used by the production server. Tests that want
-// isolation construct a fresh instance via newConfigMetrics() and install
-// it via setConfigMetrics before exercising scan paths.
+// isolation construct a fresh instance via newConfigMetrics() (or the
+// freshMetrics test helper) and inject it on the consumer via
+// ConfigManager.SetMetrics or scanDirHierarchicalWithMetrics — see #4a
+// for the global-swap migration. setConfigMetrics was removed; reading
+// from the singleton via getConfigMetrics is the only legitimate
+// production access path.
 var (
 	configMetricsOnce sync.Once
 	configMetricsInst *configMetrics
@@ -172,15 +176,6 @@ func getConfigMetrics() *configMetrics {
 	inst = configMetricsInst
 	configMetricsMu.RUnlock()
 	return inst
-}
-
-// setConfigMetrics swaps the active instance. Intended for tests that
-// need a fresh counter/histogram set per parallel run. Production code
-// should not call this.
-func setConfigMetrics(m *configMetrics) {
-	configMetricsMu.Lock()
-	configMetricsInst = m
-	configMetricsMu.Unlock()
 }
 
 // registerConfigMetrics installs all metrics on the given registry.
@@ -393,7 +388,8 @@ func (cm *configMetrics) SetLastScanComplete(t time.Time) {
 //
 // Called only on success — error paths leave the gauge at its previous
 // value so a transient scan failure does not look like a successful
-// completion. Tests that want a clean baseline observe via withIsolatedMetrics.
+// completion. Tests that want a clean baseline observe via freshMetrics
+// + m.SetMetrics injection (see config_metrics_test.go).
 func SetLastScanComplete(t time.Time) {
 	getConfigMetrics().SetLastScanComplete(t)
 }

--- a/components/threshold-exporter/app/config_metrics_test.go
+++ b/components/threshold-exporter/app/config_metrics_test.go
@@ -19,24 +19,31 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
-// withIsolatedMetrics swaps in a fresh metrics instance for the duration
-// of t, restoring the previous instance on cleanup. The returned registry
-// has the fresh metrics pre-registered so testutil.CollectAndCount works.
-func withIsolatedMetrics(t *testing.T) (*configMetrics, *prometheus.Registry) {
+// freshMetrics creates a new *configMetrics + registers it in a fresh
+// prometheus.Registry. Does NOT swap the package-level singleton —
+// caller is responsible for routing the fresh instance to the code
+// under test, via one of:
+//   - m.SetMetrics(fresh)        — for ConfigManager-driven tests
+//   - scanDirHierarchicalWithMetrics(dir, nil, fresh)  — for scanner tests
+//   - fresh.IncReloadTrigger(...)                       — for direct
+//                                                          method-form helper tests
+//
+// Replaces the previous withIsolatedMetrics global-swap pattern (#4a).
+// Multiple parallel tests can each own their own *configMetrics
+// without racing the package-level singleton, unblocking t.Parallel.
+func freshMetrics(t *testing.T) (*configMetrics, *prometheus.Registry) {
 	t.Helper()
-	prev := getConfigMetrics()
 	fresh := newConfigMetrics()
-	setConfigMetrics(fresh)
 	reg := prometheus.NewRegistry()
 	registerConfigMetrics(reg, fresh)
-	t.Cleanup(func() { setConfigMetrics(prev) })
 	return fresh, reg
 }
 
 func TestObserveScanDuration_RecordsOneSample(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
-	done := ObserveScanDuration()
+	done := fresh.ObserveScanDuration()
 	// Minimum sleep to avoid a zero-duration sample that could confuse
 	// bucket boundary assertions. 1ms is the smallest bucket.
 	done()
@@ -47,15 +54,16 @@ func TestObserveScanDuration_RecordsOneSample(t *testing.T) {
 }
 
 func TestScanDirHierarchical_IncrementsScanDuration(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
 	dir := t.TempDir()
 	writeHierarchicalFixture(t, dir, "90")
 
-	if _, _, _, _, _, err := scanDirHierarchical(dir, nil); err != nil {
+	if _, _, _, _, _, err := scanDirHierarchicalWithMetrics(dir, nil, fresh); err != nil {
 		t.Fatalf("scan: %v", err)
 	}
-	if _, _, _, _, _, err := scanDirHierarchical(dir, nil); err != nil {
+	if _, _, _, _, _, err := scanDirHierarchicalWithMetrics(dir, nil, fresh); err != nil {
 		t.Fatalf("scan: %v", err)
 	}
 
@@ -79,13 +87,14 @@ func TestScanDirHierarchical_IncrementsScanDuration(t *testing.T) {
 }
 
 func TestIncReloadTrigger_AccumulatesPerReason(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
-	IncReloadTrigger(ReloadReasonSource)
-	IncReloadTrigger(ReloadReasonSource)
-	IncReloadTrigger(ReloadReasonDefaults)
-	IncReloadTriggerBy(ReloadReasonNewTenant, 3)
-	IncReloadTriggerBy(ReloadReasonDelete, 0) // no-op
+	fresh.IncReloadTrigger(ReloadReasonSource)
+	fresh.IncReloadTrigger(ReloadReasonSource)
+	fresh.IncReloadTrigger(ReloadReasonDefaults)
+	fresh.IncReloadTriggerBy(ReloadReasonNewTenant, 3)
+	fresh.IncReloadTriggerBy(ReloadReasonDelete, 0) // no-op
 
 	checks := map[string]float64{
 		ReloadReasonSource:    2,
@@ -105,13 +114,14 @@ func TestIncReloadTrigger_AccumulatesPerReason(t *testing.T) {
 }
 
 func TestIncDefaultsNoop_AccumulatesTotal(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
-	IncDefaultsNoop()
-	IncDefaultsNoop()
-	IncDefaultsNoopBy(5)
-	IncDefaultsNoopBy(0) // no-op
-	IncDefaultsNoopBy(-1) // no-op (defensive)
+	fresh.IncDefaultsNoop()
+	fresh.IncDefaultsNoop()
+	fresh.IncDefaultsNoopBy(5)
+	fresh.IncDefaultsNoopBy(0) // no-op
+	fresh.IncDefaultsNoopBy(-1) // no-op (defensive)
 
 	if got := testutil.ToFloat64(fresh.defaultsNoop); got != 7 {
 		t.Errorf("expected noop=7, got %v", got)
@@ -123,13 +133,14 @@ func TestIncDefaultsNoop_AccumulatesTotal(t *testing.T) {
 // ============================================================
 
 func TestIncDefaultsShadowed_AccumulatesTotal(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
-	IncDefaultsShadowed()
-	IncDefaultsShadowed()
-	IncDefaultsShadowedBy(4)
-	IncDefaultsShadowedBy(0)  // no-op
-	IncDefaultsShadowedBy(-2) // no-op (defensive)
+	fresh.IncDefaultsShadowed()
+	fresh.IncDefaultsShadowed()
+	fresh.IncDefaultsShadowedBy(4)
+	fresh.IncDefaultsShadowedBy(0)  // no-op
+	fresh.IncDefaultsShadowedBy(-2) // no-op (defensive)
 
 	if got := testutil.ToFloat64(fresh.defaultsShadowed); got != 6 {
 		t.Errorf("expected shadowed=6, got %v", got)
@@ -137,10 +148,11 @@ func TestIncDefaultsShadowed_AccumulatesTotal(t *testing.T) {
 }
 
 func TestObserveBlastRadius_RecordsBucketAndSumCount(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
 	// One observation: 21 tenants in (defaults, region, applied).
-	ObserveBlastRadius("defaults", "region", "applied", 21)
+	fresh.ObserveBlastRadius("defaults", "region", "applied", 21)
 
 	text, err := prometheusTextExport(fresh.blastRadius)
 	if err != nil {
@@ -162,10 +174,11 @@ func TestObserveBlastRadius_RecordsBucketAndSumCount(t *testing.T) {
 }
 
 func TestObserveBlastRadius_BucketBoundary(t *testing.T) {
+	t.Parallel()
 	// Verify N=21 lands in bucket le=25 (not le=5) by reading the
 	// Histogram's underlying proto via a per-test registry.
-	fresh, _ := withIsolatedMetrics(t)
-	ObserveBlastRadius("defaults", "region", "applied", 21)
+	fresh, _ := freshMetrics(t)
+	fresh.ObserveBlastRadius("defaults", "region", "applied", 21)
 
 	reg := prometheus.NewRegistry()
 	if err := reg.Register(fresh.blastRadius); err != nil {
@@ -208,10 +221,11 @@ func TestObserveBlastRadius_BucketBoundary(t *testing.T) {
 }
 
 func TestObserveBlastRadius_ZeroIsNoOp(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
-	ObserveBlastRadius("defaults", "global", "applied", 0)
-	ObserveBlastRadius("defaults", "global", "applied", -5)
+	fresh.ObserveBlastRadius("defaults", "global", "applied", 0)
+	fresh.ObserveBlastRadius("defaults", "global", "applied", -5)
 
 	if got := testutil.CollectAndCount(fresh.blastRadius); got != 0 {
 		t.Errorf("expected 0 metric series after no-op observes, got %d", got)
@@ -219,12 +233,13 @@ func TestObserveBlastRadius_ZeroIsNoOp(t *testing.T) {
 }
 
 func TestObserveBlastRadius_DistinctLabelsCreateDistinctSeries(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
-	ObserveBlastRadius("defaults", "region", "applied", 1)
-	ObserveBlastRadius("defaults", "region", "shadowed", 1)
-	ObserveBlastRadius("defaults", "region", "cosmetic", 1)
-	ObserveBlastRadius("source", "tenant", "applied", 1)
+	fresh.ObserveBlastRadius("defaults", "region", "applied", 1)
+	fresh.ObserveBlastRadius("defaults", "region", "shadowed", 1)
+	fresh.ObserveBlastRadius("defaults", "region", "cosmetic", 1)
+	fresh.ObserveBlastRadius("source", "tenant", "applied", 1)
 
 	if got := testutil.CollectAndCount(fresh.blastRadius); got != 4 {
 		t.Errorf("expected 4 distinct series, got %d", got)
@@ -236,9 +251,10 @@ func TestObserveBlastRadius_DistinctLabelsCreateDistinctSeries(t *testing.T) {
 // ============================================================
 
 func TestObserveReloadDuration_RecordsOneSample(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
-	ObserveReloadDuration(150 * time.Millisecond)
+	fresh.ObserveReloadDuration(150 * time.Millisecond)
 
 	text, err := prometheusTextExport(fresh.reloadDuration)
 	if err != nil {
@@ -278,13 +294,14 @@ func TestObserveReloadDuration_RecordsOneSample(t *testing.T) {
 }
 
 func TestObserveDebounceBatch_RecordsBucketBoundary(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
 	// Three observations across two buckets: 1, 7, 47.
 	// le=1 → 1; le=2 → 1; le=5 → 1; le=10 → 2 (1+7); le=50 → 3 (all);
-	ObserveDebounceBatch(1)
-	ObserveDebounceBatch(7)
-	ObserveDebounceBatch(47)
+	fresh.ObserveDebounceBatch(1)
+	fresh.ObserveDebounceBatch(7)
+	fresh.ObserveDebounceBatch(47)
 
 	reg := prometheus.NewRegistry()
 	if err := reg.Register(fresh.debounceBatch); err != nil {
@@ -323,9 +340,10 @@ func TestObserveDebounceBatch_RecordsBucketBoundary(t *testing.T) {
 }
 
 func TestObserveDebounceBatch_NegativeIsNoOp(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
-	ObserveDebounceBatch(-1)
+	fresh.ObserveDebounceBatch(-1)
 
 	// Plain Histogram (not HistogramVec) is always present after
 	// registration; assert via sample count, not series count.
@@ -361,10 +379,11 @@ func histogramSampleCount(t *testing.T, h prometheus.Histogram) uint64 {
 // ============================================================
 
 func TestSetLastScanComplete_StoresUnixSeconds(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
 	t0 := time.Now()
-	SetLastScanComplete(t0)
+	fresh.SetLastScanComplete(t0)
 
 	got := testutil.ToFloat64(fresh.lastScanComplete)
 	if int64(got) != t0.Unix() {
@@ -373,10 +392,11 @@ func TestSetLastScanComplete_StoresUnixSeconds(t *testing.T) {
 }
 
 func TestSetLastReloadComplete_StoresUnixSeconds(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
 	t0 := time.Now()
-	SetLastReloadComplete(t0)
+	fresh.SetLastReloadComplete(t0)
 
 	got := testutil.ToFloat64(fresh.lastReloadComplete)
 	if int64(got) != t0.Unix() {
@@ -394,15 +414,16 @@ func TestSetLastReloadComplete_StoresUnixSeconds(t *testing.T) {
 // equal IF the sleep happens to span no second boundary, so the
 // assertion is `>=` not `>`.
 func TestSetLastScanComplete_MonotonicAdvance(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
 	t1 := time.Now()
-	SetLastScanComplete(t1)
+	fresh.SetLastScanComplete(t1)
 	got1 := testutil.ToFloat64(fresh.lastScanComplete)
 
 	time.Sleep(10 * time.Millisecond)
 	t2 := time.Now()
-	SetLastScanComplete(t2)
+	fresh.SetLastScanComplete(t2)
 	got2 := testutil.ToFloat64(fresh.lastScanComplete)
 
 	if got2 < got1 {
@@ -415,13 +436,14 @@ func TestSetLastScanComplete_MonotonicAdvance(t *testing.T) {
 // (per S#32 lesson) — only assert "advanced past scan-start", not
 // "equals exact value".
 func TestScanDirHierarchical_StampsLastScanCompleteOnSuccess(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 	dir := t.TempDir()
 	writeHierarchicalFixture(t, dir, "90")
 
 	scanStart := time.Now().Unix()
 
-	if _, _, _, _, _, err := scanDirHierarchical(dir, nil); err != nil {
+	if _, _, _, _, _, err := scanDirHierarchicalWithMetrics(dir, nil, fresh); err != nil {
 		t.Fatalf("scan: %v", err)
 	}
 
@@ -436,13 +458,14 @@ func TestScanDirHierarchical_StampsLastScanCompleteOnSuccess(t *testing.T) {
 // distinct from a successful completion. Pre-set the gauge to a known
 // value, run a failing scan, assert no movement.
 func TestScanDirHierarchical_DoesNotStampOnError(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
 	known := time.Unix(1700000000, 0)
-	SetLastScanComplete(known)
+	fresh.SetLastScanComplete(known)
 	before := testutil.ToFloat64(fresh.lastScanComplete)
 
-	if _, _, _, _, _, err := scanDirHierarchical("/nonexistent/path/that/does/not/exist", nil); err == nil {
+	if _, _, _, _, _, err := scanDirHierarchicalWithMetrics("/nonexistent/path/that/does/not/exist", nil, fresh); err == nil {
 		t.Fatal("expected error for nonexistent path")
 	}
 
@@ -455,11 +478,13 @@ func TestScanDirHierarchical_DoesNotStampOnError(t *testing.T) {
 // TestDiffAndReload_StampsLastReloadCompleteOnSuccess verifies the reload
 // gauge advances after a real diffAndReload (delta-based).
 func TestDiffAndReload_StampsLastReloadCompleteOnSuccess(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 	dir := t.TempDir()
 	writeHierarchicalFixture(t, dir, "90")
 
 	m := NewConfigManagerWithDebounce(dir, 0)
+	m.SetMetrics(fresh)
 	defer m.Close()
 	if err := m.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
@@ -489,11 +514,13 @@ func TestDiffAndReload_StampsLastReloadCompleteOnSuccess(t *testing.T) {
 // gauge advanced while the swap was still in progress — exactly what
 // we want to forbid.
 func TestDiffAndReload_StampsAfterAtomicSwap(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 	dir := t.TempDir()
 	writeHierarchicalFixture(t, dir, "90")
 
 	m := NewConfigManagerWithDebounce(dir, 0)
+	m.SetMetrics(fresh)
 	defer m.Close()
 	if err := m.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
@@ -516,12 +543,14 @@ func TestDiffAndReload_StampsAfterAtomicSwap(t *testing.T) {
 // TestDiffAndReload_EmitsMetricsForSourceChange ensures the full pipeline
 // (scan → diff → counter increment) hooks up end-to-end.
 func TestDiffAndReload_EmitsMetricsForSourceChange(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 
 	dir := t.TempDir()
 	writeHierarchicalFixture(t, dir, "90")
 
 	m := NewConfigManagerWithDebounce(dir, 0)
+	m.SetMetrics(fresh)
 	defer m.Close()
 	if err := m.Load(); err != nil {
 		t.Fatalf("Load: %v", err)

--- a/components/threshold-exporter/app/config_mixed_mode_test.go
+++ b/components/threshold-exporter/app/config_mixed_mode_test.go
@@ -338,11 +338,13 @@ tenants:
 // ─────────────────────────────────────────────────────────────────
 
 func TestMixedMode_MidLevelDefaultsBlastRadiusScope(t *testing.T) {
-	fresh, _ := withIsolatedMetrics(t)
+	t.Parallel()
+	fresh, _ := freshMetrics(t)
 	root := t.TempDir()
 	writeMixedModeFixture(t, root)
 
 	mgr := NewConfigManager(root)
+	mgr.SetMetrics(fresh)
 	if err := mgr.Load(); err != nil {
 		t.Fatalf("Load: %v", err)
 	}

--- a/components/threshold-exporter/app/config_slow_write_stress_test.go
+++ b/components/threshold-exporter/app/config_slow_write_stress_test.go
@@ -123,10 +123,14 @@ func TestSlowWriteTornStateStress_FinalConvergence(t *testing.T) {
 		seed         = int64(0xB7_5_0_5_0)
 	)
 
-	fresh, _ := withIsolatedMetrics(t)
+	// Deliberately NOT t.Parallel — this stress test has timing-based
+	// assertions (debounceWin, stableWindow, settleTimeout) that sibling
+	// scheduler pressure can perturb. Run serially.
+	fresh, _ := freshMetrics(t)
 	dir := buildSlowWriteFixture(t, numFiles)
 
 	m := NewConfigManagerWithDebounce(dir, debounceWin)
+	m.SetMetrics(fresh)
 	defer m.Close()
 	if err := m.Load(); err != nil {
 		t.Fatalf("initial Load: %v", err)

--- a/scripts/ops/add_t_parallel.py
+++ b/scripts/ops/add_t_parallel.py
@@ -48,12 +48,14 @@ RISKY = (
     # RISKY case (codified by PR #357).
     "slog.SetDefault",
     # `withIsolatedMetrics(t)` in components/threshold-exporter/app/
-    # implements the global-swap pattern — saves+sets+restores a
-    # package-level `configMetrics` singleton via setConfigMetrics().
-    # Two parallel tests both calling it would race on the global, with
-    # whichever test ran second's `fresh` registry receiving observations
-    # from the first test's reload. Caught by PR #356 (config_* sweep)
-    # before landing.
+    # used to implement a global-swap pattern (saves+sets+restores a
+    # package-level `configMetrics` singleton via setConfigMetrics()).
+    # Two parallel tests calling it would race on the global, with the
+    # second test's `fresh` registry receiving observations from the
+    # first test's reload. Caught by PR #356 (config_* sweep) before
+    # landing. The helper itself was removed in PR #4a (replaced by
+    # freshMetrics + ConfigManager.SetMetrics field injection); kept
+    # in RISKY as a tripwire so a future re-introduction surfaces here.
     "withIsolatedMetrics",
     "setConfigMetrics",
     # log.SetOutput / log.SetFlags swap the package-level stdlib logger.


### PR DESCRIPTION
## Summary

Final landing of the **#4a metrics-injection seam** campaign (PRs #363
foundation → #364 production rewiring → **#365 this PR** test rewrites).

Removes the `withIsolatedMetrics(t)` global-swap test helper and the
underlying `setConfigMetrics()` writer; replaces with `freshMetrics(t)`
which builds a per-test `*configMetrics` + Registry without touching the
package singleton. Caller routes the fresh instance to the code under
test via one of the three injection seams added in #363/#364:

- `m.SetMetrics(fresh)` — ConfigManager-driven tests
- `scanDirHierarchicalWithMetrics(dir, nil, fresh)` — direct scanner tests
- `fresh.IncReloadTrigger(...)` — direct method-form helper tests

Per-test ownership unblocks `t.Parallel`. **31 tests across 8 files**
converted; all parallel-eligible tests now opt in (4 left serial: 1
stress test for timing isolation, 3 still using `log.SetOutput` —
those will move when #4b lands).

## Files

| File | Tests | Pattern | t.Parallel |
|---|---|---|---|
| `config_metrics_test.go` | 20 | A/B/C mix | ✅ all |
| `config_blast_radius_test.go` | 7 | C | ✅ all |
| `config_debounce_test.go` | 2 | C | ✅ all |
| `config_mixed_mode_test.go` | 1 | C | ✅ |
| `config_slow_write_stress_test.go` | 1 | C | ⛔ (timing) |
| `config_hierarchy_test.go` | 2 | B + C | 1/2 (other = log.SetOutput) |
| `config_loaddir_test.go` | 1 | C | ⛔ (log.SetOutput, #4b) |

## Cleanups bundled

- `config_metrics.go`: `setConfigMetrics()` removed (no callers); doc
  comment on globals updated to point at `SetMetrics` seam.
- `scripts/ops/add_t_parallel.py`: kept `withIsolatedMetrics` /
  `setConfigMetrics` in RISKY tuple as a tripwire — the helpers are
  gone, but a future re-introduction by these names will surface in
  the lint pairing.

## Test plan

- [x] `go build -buildvcs=false ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -count=10 -race` on the 31 converted tests: **PASS** (17.4s)
- [x] `go test -count=5 -race` on full app pkg: **PASS** (23.1s)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)