### PR TITLE
refactor(exporter): #4b-E — route log calls through ConfigManager.logger seam

### DIFF
--- a/components/threshold-exporter/app/config.go
+++ b/components/threshold-exporter/app/config.go
@@ -277,7 +277,7 @@ func (m *ConfigManager) commitConfig(cfg *ThresholdConfig, hash string, flatScan
 	// reloads.
 	m.detectConfigSource()
 
-	logConfigStats(cfg, logHeader)
+	logConfigStats(m.getLogger(), cfg, logHeader)
 }
 
 // runHierarchyScanReject runs populateHierarchyState with the
@@ -296,7 +296,7 @@ func (m *ConfigManager) runHierarchyScanReject(label string) error {
 		if errors.As(err, &dupErr) {
 			return fmt.Errorf("config rejected (mixed-mode duplicate tenant): %w", err)
 		}
-		log.Printf("WARN: hierarchical scan during %s failed: %v", label, err)
+		m.getLogger().Printf("WARN: hierarchical scan during %s failed: %v", label, err)
 	}
 	return nil
 }
@@ -308,7 +308,7 @@ func (m *ConfigManager) Load() error {
 	var err error
 
 	if m.isDir {
-		cfg, hash, err = loadDirWithMetrics(m.path, m.getMetrics())
+		cfg, hash, err = loadDirWithMetrics(m.path, m.getMetrics(), m.getLogger())
 	} else {
 		cfg, hash, err = loadFile(m.path)
 	}
@@ -368,7 +368,7 @@ func (m *ConfigManager) IncrementalLoad() error {
 	prevHash := m.lastHash
 	m.mu.RUnlock()
 
-	newHashes, compositeHash, newMtimes, dataCache, err := scanDirFileHashes(m.path, oldH, oldM)
+	newHashes, compositeHash, newMtimes, dataCache, err := scanDirFileHashes(m.path, oldH, oldM, m.getLogger())
 	if err != nil {
 		return err
 	}
@@ -424,7 +424,7 @@ func (m *ConfigManager) IncrementalLoad() error {
 			var rerr error
 			data, rerr = os.ReadFile(fullPath)
 			if rerr != nil {
-				log.Printf("WARN: skip unreadable file %s: %v", fullPath, rerr)
+				m.getLogger().Printf("WARN: skip unreadable file %s: %v", fullPath, rerr)
 				delete(newConfigs, name)
 				continue
 			}
@@ -435,15 +435,15 @@ func (m *ConfigManager) IncrementalLoad() error {
 			// block; promote to ERROR + emit metric (cycle-6 RCA, archive §S#37d).
 			m.getMetrics().IncParseFailure(filepath.Base(fullPath))
 			if strings.HasPrefix(name, "_") {
-				log.Printf("ERROR: skip unparseable defaults/profiles file %s: %v (entire block dropped — fix file or remove)", fullPath, err)
+				m.getLogger().Printf("ERROR: skip unparseable defaults/profiles file %s: %v (entire block dropped — fix file or remove)", fullPath, err)
 			} else {
-				log.Printf("WARN: skip unparseable file %s: %v", fullPath, err)
+				m.getLogger().Printf("WARN: skip unparseable file %s: %v", fullPath, err)
 			}
 			delete(newConfigs, name)
 			continue
 		}
 		// Apply boundary enforcement (same rules as loadDir)
-		applyBoundaryRules(name, &partial)
+		applyBoundaryRules(name, &partial, m.getLogger())
 		newConfigs[name] = partial
 	}
 
@@ -520,7 +520,7 @@ func (m *ConfigManager) IncrementalLoad() error {
 // Used for the initial load and as fallback for IncrementalLoad.
 func (m *ConfigManager) fullDirLoad() error {
 	// Compute per-file hashes (no mtime guard on first load)
-	perFileHashes, compositeHash, perFileMtimes, dataCache, err := scanDirFileHashes(m.path, nil, nil)
+	perFileHashes, compositeHash, perFileMtimes, dataCache, err := scanDirFileHashes(m.path, nil, nil, m.getLogger())
 	if err != nil {
 		return err
 	}
@@ -545,7 +545,7 @@ func (m *ConfigManager) fullDirLoad() error {
 			var rerr error
 			data, rerr = os.ReadFile(fullPath)
 			if rerr != nil {
-				log.Printf("WARN: skip unreadable file %s: %v", fullPath, rerr)
+				m.getLogger().Printf("WARN: skip unreadable file %s: %v", fullPath, rerr)
 				continue
 			}
 		}
@@ -555,13 +555,13 @@ func (m *ConfigManager) fullDirLoad() error {
 			// block; promote to ERROR + emit metric (cycle-6 RCA, archive §S#37d).
 			m.getMetrics().IncParseFailure(filepath.Base(fullPath))
 			if strings.HasPrefix(name, "_") {
-				log.Printf("ERROR: skip unparseable defaults/profiles file %s: %v (entire block dropped — fix file or remove)", fullPath, err)
+				m.getLogger().Printf("ERROR: skip unparseable defaults/profiles file %s: %v (entire block dropped — fix file or remove)", fullPath, err)
 			} else {
-				log.Printf("WARN: skip unparseable file %s: %v", fullPath, err)
+				m.getLogger().Printf("WARN: skip unparseable file %s: %v", fullPath, err)
 			}
 			continue
 		}
-		applyBoundaryRules(name, &partial)
+		applyBoundaryRules(name, &partial, m.getLogger())
 		fileConfigs[name] = partial
 	}
 
@@ -597,7 +597,7 @@ func (m *ConfigManager) fullDirLoad() error {
 // merging in place so a failed scan doesn't leave torn state visible to
 // the /effective read path.
 func (m *ConfigManager) populateHierarchyState() error {
-	tenants, defaults, hashes, mtimes, graph, err := scanDirHierarchicalWithMetrics(m.path, nil, m.getMetrics())
+	tenants, defaults, hashes, mtimes, graph, err := scanDirHierarchicalWithMetrics(m.path, nil, m.getMetrics(), m.getLogger())
 	if err != nil {
 		return err
 	}
@@ -613,7 +613,7 @@ func (m *ConfigManager) populateHierarchyState() error {
 		chain := graph.TenantDefaults[tid]
 		mh, mergeErr := m.recomputeMergedHash(tid, srcPath, chain)
 		if mergeErr != nil {
-			logMergeSkip(tid, "initial-hierarchy-scan", mergeErr)
+			logMergeSkip(m.getLogger(), tid, "initial-hierarchy-scan", mergeErr)
 			continue
 		}
 		newMergedHashes[tid] = mh
@@ -629,12 +629,12 @@ func (m *ConfigManager) populateHierarchyState() error {
 	for dp := range defaults {
 		b, rerr := os.ReadFile(dp)
 		if rerr != nil {
-			log.Printf("WARN: parsedDefaults cache: read %s: %v", dp, rerr)
+			m.getLogger().Printf("WARN: parsedDefaults cache: read %s: %v", dp, rerr)
 			continue
 		}
 		parsed, perr := parseDefaultsBytes(b)
 		if perr != nil {
-			log.Printf("WARN: parsedDefaults cache: parse %s: %v", dp, perr)
+			m.getLogger().Printf("WARN: parsedDefaults cache: parse %s: %v", dp, perr)
 			continue
 		}
 		newParsedDefaults[dp] = parsed
@@ -662,7 +662,11 @@ func (m *ConfigManager) populateHierarchyState() error {
 // At 1000 tenants, this saves ~4ms per reload (Resolve alone costs ~2-5ms).
 // The "resolved thresholds" count is estimated from tenant override counts
 // rather than running the full resolution pipeline.
-func logConfigStats(cfg *ThresholdConfig, prefix string) {
+// logger may be nil → falls back to log.Default() (production safety).
+func logConfigStats(logger *log.Logger, cfg *ThresholdConfig, prefix string) {
+	if logger == nil {
+		logger = log.Default()
+	}
 	// Cheap estimate: count total tenant overrides (each becomes ~1 resolved threshold)
 	overrideCount := 0
 	silentCount := 0
@@ -680,13 +684,13 @@ func logConfigStats(cfg *ThresholdConfig, prefix string) {
 		}
 	}
 
-	log.Printf("%s: %d defaults, %d profiles, %d state_filters, %d tenants, ~%d threshold overrides, %d state entries, %d silent modes",
+	logger.Printf("%s: %d defaults, %d profiles, %d state_filters, %d tenants, ~%d threshold overrides, %d state entries, %d silent modes",
 		prefix, len(cfg.Defaults), len(cfg.Profiles), len(cfg.StateFilters), len(cfg.Tenants),
 		overrideCount, stateCount, silentCount)
 
 	if warnings := cfg.ValidateTenantKeys(); len(warnings) > 0 {
 		for _, w := range warnings {
-			log.Printf("%s", w)
+			logger.Printf("%s", w)
 		}
 	}
 }
@@ -705,7 +709,7 @@ func (m *ConfigManager) WatchLoop(interval time.Duration, stopCh <-chan struct{}
 	for {
 		select {
 		case <-stopCh:
-			log.Println("WatchLoop stopped")
+			m.getLogger().Println("WatchLoop stopped")
 			return
 		case <-ticker.Chan():
 		}
@@ -726,11 +730,11 @@ func (m *ConfigManager) tickOnce() {
 	if m.isDir {
 		changed, reason, err := m.detectChange()
 		if err != nil {
-			log.Printf("WARN: cannot check config %s: %v", m.path, err)
+			m.getLogger().Printf("WARN: cannot check config %s: %v", m.path, err)
 			return
 		}
 		if changed {
-			log.Printf("Config changed, scheduling debounced reload...")
+			m.getLogger().Printf("Config changed, scheduling debounced reload...")
 			// v2.7.0: route through debounce even for flat mode so an
 			// ops tool that rapidly rewrites multiple files coalesces
 			// into a single reload.
@@ -742,7 +746,7 @@ func (m *ConfigManager) tickOnce() {
 	// Single-file mode: full reload (no incremental benefit)
 	_, hash, err := loadFile(m.path)
 	if err != nil {
-		log.Printf("WARN: cannot check config %s: %v", m.path, err)
+		m.getLogger().Printf("WARN: cannot check config %s: %v", m.path, err)
 		return
 	}
 
@@ -751,9 +755,9 @@ func (m *ConfigManager) tickOnce() {
 	m.mu.RUnlock()
 
 	if changed {
-		log.Printf("Config changed, reloading...")
+		m.getLogger().Printf("Config changed, reloading...")
 		if err := m.Load(); err != nil {
-			log.Printf("ERROR: failed to reload config: %v", err)
+			m.getLogger().Printf("ERROR: failed to reload config: %v", err)
 		}
 	}
 }
@@ -793,7 +797,7 @@ func (m *ConfigManager) detectChange() (bool, string, error) {
 	m.mu.RUnlock()
 
 	if hierarchical {
-		_, _, newHashes, _, _, hErr := scanDirHierarchicalWithMetrics(m.path, priorHierMtimes, m.getMetrics())
+		_, _, newHashes, _, _, hErr := scanDirHierarchicalWithMetrics(m.path, priorHierMtimes, m.getMetrics(), m.getLogger())
 		if hErr != nil {
 			return false, "", fmt.Errorf("hierarchical scan: %w", hErr)
 		}
@@ -811,7 +815,7 @@ func (m *ConfigManager) detectChange() (bool, string, error) {
 		return changed, ReloadReasonForced, nil
 	}
 
-	_, compositeHash, _, _, err := scanDirFileHashes(m.path, oldH, oldM)
+	_, compositeHash, _, _, err := scanDirFileHashes(m.path, oldH, oldM, m.getLogger())
 	if err != nil {
 		return false, "", err
 	}

--- a/components/threshold-exporter/app/config_bench_test.go
+++ b/components/threshold-exporter/app/config_bench_test.go
@@ -286,7 +286,7 @@ func BenchmarkScanDirFileHashes_100(b *testing.B) {
 	silenceLogs(b)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		scanDirFileHashes(dir, nil, nil)
+		scanDirFileHashes(dir, nil, nil, nil)
 	}
 }
 
@@ -310,10 +310,10 @@ func BenchmarkScanDirFileHashes_100_MtimeGuard(b *testing.B) {
 	silenceLogs(b)
 	backdateFiles(b, dir)
 	// Initial scan to populate mtime cache
-	hashes, _, mtimes, _, _ := scanDirFileHashes(dir, nil, nil)
+	hashes, _, mtimes, _, _ := scanDirFileHashes(dir, nil, nil, nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		scanDirFileHashes(dir, hashes, mtimes)
+		scanDirFileHashes(dir, hashes, mtimes, nil)
 	}
 }
 
@@ -401,7 +401,7 @@ func BenchmarkScanDirFileHashes_1000(b *testing.B) {
 	silenceLogs(b)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		scanDirFileHashes(dir, nil, nil)
+		scanDirFileHashes(dir, nil, nil, nil)
 	}
 }
 
@@ -410,10 +410,10 @@ func BenchmarkScanDirFileHashes_1000_MtimeGuard(b *testing.B) {
 	dir := buildDirConfig(b, 1000)
 	silenceLogs(b)
 	backdateFiles(b, dir)
-	hashes, _, mtimes, _, _ := scanDirFileHashes(dir, nil, nil)
+	hashes, _, mtimes, _, _ := scanDirFileHashes(dir, nil, nil, nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		scanDirFileHashes(dir, hashes, mtimes)
+		scanDirFileHashes(dir, hashes, mtimes, nil)
 	}
 }
 

--- a/components/threshold-exporter/app/config_debounce.go
+++ b/components/threshold-exporter/app/config_debounce.go
@@ -162,7 +162,7 @@ func (m *ConfigManager) fireDebounced() {
 	_, _, err := m.diffAndReload()
 	m.getMetrics().ObserveReloadDuration(time.Since(t0))
 	if err != nil {
-		log.Printf("ERROR: debounced reload failed: %v", err)
+		m.getLogger().Printf("ERROR: debounced reload failed: %v", err)
 	}
 }
 
@@ -271,9 +271,9 @@ func (m *ConfigManager) snapshotPriorState() reloadPriorState {
 // we keep using the hierarchical path because computeMergedHash with an
 // empty chain is well-defined.
 func (m *ConfigManager) scanAndCheckHierarchical(prior reloadPriorState) (reloadScanState, bool, error) {
-	tenants, defaults, hashes, mtimes, graph, scanErr := scanDirHierarchicalWithMetrics(m.path, prior.mtimes, m.getMetrics())
+	tenants, defaults, hashes, mtimes, graph, scanErr := scanDirHierarchicalWithMetrics(m.path, prior.mtimes, m.getMetrics(), m.getLogger())
 	if scanErr != nil {
-		log.Printf("ERROR: hierarchical scan failed: %v", scanErr)
+		m.getLogger().Printf("ERROR: hierarchical scan failed: %v", scanErr)
 		return reloadScanState{}, true, scanErr
 	}
 
@@ -281,7 +281,7 @@ func (m *ConfigManager) scanAndCheckHierarchical(prior reloadPriorState) (reload
 	// hierarchical mode yet, stay on the flat path.
 	if !prior.hierarchicalMode && len(defaults) == 0 {
 		if ierr := m.IncrementalLoad(); ierr != nil {
-			log.Printf("ERROR: incremental load failed: %v", ierr)
+			m.getLogger().Printf("ERROR: incremental load failed: %v", ierr)
 			return reloadScanState{}, true, ierr
 		}
 		return reloadScanState{}, true, nil
@@ -335,12 +335,12 @@ func (m *ConfigManager) classifyAndCount(prior reloadPriorState, scan reloadScan
 		}
 		b, rerr := os.ReadFile(dp)
 		if rerr != nil {
-			log.Printf("WARN: parsedDefaults: read %s: %v", dp, rerr)
+			m.getLogger().Printf("WARN: parsedDefaults: read %s: %v", dp, rerr)
 			continue
 		}
 		parsed, perr := parseDefaultsBytes(b)
 		if perr != nil {
-			log.Printf("WARN: parsedDefaults: parse %s: %v", dp, perr)
+			m.getLogger().Printf("WARN: parsedDefaults: parse %s: %v", dp, perr)
 			continue
 		}
 		res.newParsedDefaults[dp] = parsed
@@ -380,7 +380,7 @@ func (m *ConfigManager) classifyAndCount(prior reloadPriorState, scan reloadScan
 
 		mh, mergeErr := m.recomputeMergedHash(tid, srcPath, defaultsChain)
 		if mergeErr != nil {
-			logMergeSkip(tid, "debounced-reload", mergeErr)
+			logMergeSkip(m.getLogger(), tid, "debounced-reload", mergeErr)
 			// Preserve any prior merged_hash we had so the /effective
 			// endpoint still serves the last-known-good value. Absent prior
 			// → mark empty (tenant will read as merge-failing).
@@ -470,7 +470,7 @@ func (m *ConfigManager) classifyAndCount(prior reloadPriorState, scan reloadScan
 // atomic-swap so the gauge cannot advance ahead of observable state.
 func (m *ConfigManager) installNewHierarchyState(scan reloadScanState, result reloadResult) error {
 	if err := m.fullDirLoad(); err != nil {
-		log.Printf("ERROR: fullDirLoad inside diffAndReload failed: %v", err)
+		m.getLogger().Printf("ERROR: fullDirLoad inside diffAndReload failed: %v", err)
 		return err
 	}
 
@@ -517,7 +517,7 @@ func (m *ConfigManager) diffAndReload() (reloaded, noOp int, err error) {
 	if !m.isDir {
 		// Single-file mode has no hierarchical concept — just reload.
 		if err := m.Load(); err != nil {
-			log.Printf("ERROR: single-file reload failed: %v", err)
+			m.getLogger().Printf("ERROR: single-file reload failed: %v", err)
 			return 0, 0, err
 		}
 		return 1, 0, nil
@@ -573,7 +573,7 @@ func (m *ConfigManager) recomputeMergedHash(tenantID, tenantFile string, default
 	}
 	h, mergeErr := computeMergedHash(tenantBytes, tenantID, chainBytes)
 	if mergeErr != nil {
-		emitParseFailureSignal(m.getMetrics(), tenantID, tenantFile, defaultsChain, mergeErr)
+		emitParseFailureSignal(m.getMetrics(), m.getLogger(), tenantID, tenantFile, defaultsChain, mergeErr)
 	}
 	return h, mergeErr
 }
@@ -589,16 +589,23 @@ func (m *ConfigManager) recomputeMergedHash(tenantID, tenantFile string, default
 // (config_inheritance.go). We string-match the prefix to map the index
 // back to defaultsChain[i] for filename attribution.
 //
-// metrics is plumbed in (not the package global) so the caller's
-// ConfigManager.metrics instance is the bumped one — foundation for
-// per-test isolation (#4a).
-func emitParseFailureSignal(metrics *configMetrics, tenantID, tenantFile string, defaultsChain []string, mergeErr error) {
+// metrics + logger are plumbed in (not the package globals) so the
+// caller's ConfigManager.metrics + ConfigManager.logger instances are
+// the routed ones — foundation for per-test isolation (#4a + #4b).
+// Either may be nil → falls back to the package singleton.
+func emitParseFailureSignal(metrics *configMetrics, logger *log.Logger, tenantID, tenantFile string, defaultsChain []string, mergeErr error) {
+	if metrics == nil {
+		metrics = getConfigMetrics()
+	}
+	if logger == nil {
+		logger = log.Default()
+	}
 	msg := mergeErr.Error()
 	for i, dp := range defaultsChain {
 		needle := fmt.Sprintf("parse defaults[%d]:", i)
 		if strings.Contains(msg, needle) {
 			metrics.IncParseFailure(filepath.Base(dp))
-			log.Printf(
+			logger.Printf(
 				"ERROR: skip unparseable defaults/profiles file %s (chain index %d) for tenant=%s: %v (entire block dropped — fix file or remove)",
 				dp, i, tenantID, mergeErr,
 			)

--- a/components/threshold-exporter/app/config_hierarchy.go
+++ b/components/threshold-exporter/app/config_hierarchy.go
@@ -97,10 +97,11 @@ func (e *DuplicateTenantError) Error() string {
 // (parity first, perf later). When non-nil it is currently ignored; tests
 // should pass nil.
 //
-// Legacy wrapper that uses the package-level metrics singleton. Production
-// code should call scanDirHierarchicalWithMetrics with their owned
-// *configMetrics so per-test isolation works (#4a). Tests that don't
-// care about metric isolation keep calling this form unchanged.
+// Legacy wrapper that uses the package-level metrics + logger singletons.
+// Production code should call scanDirHierarchicalWithMetrics with their
+// owned *configMetrics + *log.Logger so per-test isolation works (#4a +
+// #4b). Tests that don't care about isolation keep calling this form
+// unchanged.
 func scanDirHierarchical(rootPath string, priorMtimes map[string]fileStat) (
 	tenants map[string]string,
 	defaults map[string]bool,
@@ -109,18 +110,21 @@ func scanDirHierarchical(rootPath string, priorMtimes map[string]fileStat) (
 	graph *InheritanceGraph,
 	err error,
 ) {
-	return scanDirHierarchicalWithMetrics(rootPath, priorMtimes, getConfigMetrics())
+	return scanDirHierarchicalWithMetrics(rootPath, priorMtimes, getConfigMetrics(), log.Default())
 }
 
 // scanDirHierarchicalWithMetrics is the injectable variant of
-// scanDirHierarchical. Same behavior; metric observations route to the
-// caller-supplied *configMetrics instead of getConfigMetrics(). Use this
-// from production code paths that own a ConfigManager: pass m.metrics so
-// the test-side SetMetrics injection actually shows up here too.
+// scanDirHierarchical. Same behavior; metric observations + log lines
+// route to the caller-supplied *configMetrics + *log.Logger instead of
+// the package singletons. Use this from production code paths that own
+// a ConfigManager: pass m.getMetrics() / m.getLogger() so the test-side
+// SetMetrics + SetLogger injections actually show up here too. Either
+// argument may be nil → falls back to the package singleton (struct-
+// literal test shortcut).
 //
-// Foundation for #4a: production callers migrate first; the legacy
-// wrapper above keeps test files green during the transition.
-func scanDirHierarchicalWithMetrics(rootPath string, priorMtimes map[string]fileStat, metrics *configMetrics) (
+// Foundation for #4a + #4b: production callers migrate first; the
+// legacy wrapper above keeps test files green during the transition.
+func scanDirHierarchicalWithMetrics(rootPath string, priorMtimes map[string]fileStat, metrics *configMetrics, logger *log.Logger) (
 	tenants map[string]string,
 	defaults map[string]bool,
 	hashes map[string]string,
@@ -134,6 +138,9 @@ func scanDirHierarchicalWithMetrics(rootPath string, priorMtimes map[string]file
 	// wrapper. Production callers always pass a real *configMetrics.
 	if metrics == nil {
 		metrics = getConfigMetrics()
+	}
+	if logger == nil {
+		logger = log.Default()
 	}
 	_ = priorMtimes // reserved for Phase 3 (mtime-skip optimization)
 
@@ -173,7 +180,7 @@ func scanDirHierarchicalWithMetrics(rootPath string, priorMtimes map[string]file
 			// Tolerate individual unreadable entries (e.g. permissions on a
 			// junk dir). Log and continue — matches Python's rglob behavior
 			// which silently skips on OS errors.
-			log.Printf("WARN: walk error at %s: %v", path, werr)
+			logger.Printf("WARN: walk error at %s: %v", path, werr)
 			return nil
 		}
 		name := d.Name()
@@ -201,13 +208,13 @@ func scanDirHierarchicalWithMetrics(rootPath string, priorMtimes map[string]file
 
 		data, rerr := os.ReadFile(path)
 		if rerr != nil {
-			log.Printf("WARN: cannot read %s: %v", path, rerr)
+			logger.Printf("WARN: cannot read %s: %v", path, rerr)
 			return nil
 		}
 
 		entryInfo, ierr := d.Info()
 		if ierr != nil {
-			log.Printf("WARN: cannot stat %s: %v", path, ierr)
+			logger.Printf("WARN: cannot stat %s: %v", path, ierr)
 			return nil
 		}
 
@@ -235,7 +242,7 @@ func scanDirHierarchicalWithMetrics(rootPath string, priorMtimes map[string]file
 			Tenants map[string]yaml.Node `yaml:"tenants"`
 		}
 		if perr := yaml.Unmarshal(data, &doc); perr != nil {
-			log.Printf("WARN: cannot parse %s: %v", path, perr)
+			logger.Printf("WARN: cannot parse %s: %v", path, perr)
 			// v2.8.0 A-8d: expose parse failure as a Prometheus counter so
 			// ops can alert on "tenant file persistently broken". label is
 			// basename (not full path) to cap cardinality.

--- a/components/threshold-exporter/app/config_hierarchy_test.go
+++ b/components/threshold-exporter/app/config_hierarchy_test.go
@@ -456,7 +456,7 @@ func TestScanDirHierarchical_MixedValidInvalid(t *testing.T) {
       cpu: 70
 `)
 
-	tenants, _, hashes, _, _, err := scanDirHierarchicalWithMetrics(root, nil, fresh)
+	tenants, _, hashes, _, _, err := scanDirHierarchicalWithMetrics(root, nil, fresh, nil)
 	if err != nil {
 		t.Fatalf("scan should not return error on per-file parse failure: %v", err)
 	}

--- a/components/threshold-exporter/app/config_incremental_test.go
+++ b/components/threshold-exporter/app/config_incremental_test.go
@@ -32,7 +32,7 @@ tenants:
     mysql_connections: "70"
 `)
 
-	hashes, composite, _, _, err := scanDirFileHashes(dir, nil, nil)
+	hashes, composite, _, _, err := scanDirFileHashes(dir, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("scanDirFileHashes failed: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestScanDirFileHashes_SkipsHiddenAndSubdirs(t *testing.T) {
 	os.MkdirAll(filepath.Join(dir, "subdir"), 0700)
 	writeTestFile(t, filepath.Join(dir, "subdir"), "extra.yaml", `defaults: {}`)
 
-	hashes, _, _, _, err := scanDirFileHashes(dir, nil, nil)
+	hashes, _, _, _, err := scanDirFileHashes(dir, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("failed: %v", err)
 	}
@@ -73,8 +73,8 @@ func TestScanDirFileHashes_StableComposite(t *testing.T) {
 	writeTestFile(t, dir, "a.yaml", `defaults: {x: 1}`)
 	writeTestFile(t, dir, "b.yaml", `tenants: {t1: {}}`)
 
-	_, hash1, _, _, _ := scanDirFileHashes(dir, nil, nil)
-	_, hash2, _, _, _ := scanDirFileHashes(dir, nil, nil)
+	_, hash1, _, _, _ := scanDirFileHashes(dir, nil, nil, nil)
+	_, hash2, _, _, _ := scanDirFileHashes(dir, nil, nil, nil)
 	if hash1 != hash2 {
 		t.Error("composite hash should be stable across calls with same content")
 	}
@@ -395,7 +395,7 @@ func TestApplyBoundaryRules_DefaultsFile(t *testing.T) {
 		Defaults:     map[string]float64{"x": 1},
 		StateFilters: map[string]StateFilter{"f": {Severity: "warning"}},
 	}
-	applyBoundaryRules("_defaults.yaml", &partial)
+	applyBoundaryRules("_defaults.yaml", &partial, nil)
 	if len(partial.Defaults) != 1 {
 		t.Error("defaults file should keep its defaults")
 	}
@@ -411,7 +411,7 @@ func TestApplyBoundaryRules_TenantFile(t *testing.T) {
 		StateFilters: map[string]StateFilter{"f": {Severity: "warning"}},
 		Profiles:     map[string]map[string]ScheduledValue{"p": {"k": SV("v")}},
 	}
-	applyBoundaryRules("db-a.yaml", &partial)
+	applyBoundaryRules("db-a.yaml", &partial, nil)
 	if partial.Defaults != nil {
 		t.Error("tenant file defaults should be cleared")
 	}

--- a/components/threshold-exporter/app/config_inheritance.go
+++ b/components/threshold-exporter/app/config_inheritance.go
@@ -86,6 +86,13 @@ func computeSourceHash(tenantYAMLBytes []byte) string {
 // used when one tenant's merge fails while others succeed. Stays in
 // `package main` because the logging convention is exporter-specific
 // (the log.Printf format is read by ops dashboards).
-func logMergeSkip(tenantID, reason string, err error) {
-	log.Printf("WARN: skipping merged_hash for tenant=%s (%s): %v", tenantID, reason, err)
+//
+// logger may be nil → falls back to log.Default() (production safety).
+// Callers in ConfigManager methods pass m.getLogger() for #4b
+// per-test isolation.
+func logMergeSkip(logger *log.Logger, tenantID, reason string, err error) {
+	if logger == nil {
+		logger = log.Default()
+	}
+	logger.Printf("WARN: skipping merged_hash for tenant=%s (%s): %v", tenantID, reason, err)
 }

--- a/components/threshold-exporter/app/config_metrics_test.go
+++ b/components/threshold-exporter/app/config_metrics_test.go
@@ -24,7 +24,7 @@ import (
 // caller is responsible for routing the fresh instance to the code
 // under test, via one of:
 //   - m.SetMetrics(fresh)        — for ConfigManager-driven tests
-//   - scanDirHierarchicalWithMetrics(dir, nil, fresh)  — for scanner tests
+//   - scanDirHierarchicalWithMetrics(dir, nil, fresh, nil)  — for scanner tests
 //   - fresh.IncReloadTrigger(...)                       — for direct
 //                                                          method-form helper tests
 //
@@ -60,10 +60,10 @@ func TestScanDirHierarchical_IncrementsScanDuration(t *testing.T) {
 	dir := t.TempDir()
 	writeHierarchicalFixture(t, dir, "90")
 
-	if _, _, _, _, _, err := scanDirHierarchicalWithMetrics(dir, nil, fresh); err != nil {
+	if _, _, _, _, _, err := scanDirHierarchicalWithMetrics(dir, nil, fresh, nil); err != nil {
 		t.Fatalf("scan: %v", err)
 	}
-	if _, _, _, _, _, err := scanDirHierarchicalWithMetrics(dir, nil, fresh); err != nil {
+	if _, _, _, _, _, err := scanDirHierarchicalWithMetrics(dir, nil, fresh, nil); err != nil {
 		t.Fatalf("scan: %v", err)
 	}
 
@@ -443,7 +443,7 @@ func TestScanDirHierarchical_StampsLastScanCompleteOnSuccess(t *testing.T) {
 
 	scanStart := time.Now().Unix()
 
-	if _, _, _, _, _, err := scanDirHierarchicalWithMetrics(dir, nil, fresh); err != nil {
+	if _, _, _, _, _, err := scanDirHierarchicalWithMetrics(dir, nil, fresh, nil); err != nil {
 		t.Fatalf("scan: %v", err)
 	}
 
@@ -465,7 +465,7 @@ func TestScanDirHierarchical_DoesNotStampOnError(t *testing.T) {
 	fresh.SetLastScanComplete(known)
 	before := testutil.ToFloat64(fresh.lastScanComplete)
 
-	if _, _, _, _, _, err := scanDirHierarchicalWithMetrics("/nonexistent/path/that/does/not/exist", nil, fresh); err == nil {
+	if _, _, _, _, _, err := scanDirHierarchicalWithMetrics("/nonexistent/path/that/does/not/exist", nil, fresh, nil); err == nil {
 		t.Fatal("expected error for nonexistent path")
 	}
 

--- a/components/threshold-exporter/app/config_test.go
+++ b/components/threshold-exporter/app/config_test.go
@@ -113,7 +113,10 @@ func TestLogConfigStats_Format(t *testing.T) {
 	log.SetOutput(&buf)
 	defer log.SetOutput(orig)
 
-	logConfigStats(cfg, "Test prefix")
+	// PR-F will replace the log.SetOutput global swap above with a
+	// per-test logger passed here. For PR-E (signature add) we pass
+	// log.Default() so the existing global swap still captures.
+	logConfigStats(log.Default(), cfg, "Test prefix")
 
 	output := buf.String()
 

--- a/components/threshold-exporter/app/flat_scanner.go
+++ b/components/threshold-exporter/app/flat_scanner.go
@@ -72,22 +72,27 @@ func loadFile(path string) (ThresholdConfig, string, error) {
 // Boundary rule: state_filters should only be defined in _defaults.yaml.
 // Tenant files should only contain a 'tenants' block. This is enforced with warnings.
 //
-// Legacy wrapper that uses the package-level metrics singleton. Production
-// code should call loadDirWithMetrics with their owned *configMetrics so
-// per-test isolation works (#4a).
+// Legacy wrapper that uses the package-level metrics + logger singletons.
+// Production code should call loadDirWithMetrics with their owned
+// *configMetrics + *log.Logger so per-test isolation works (#4a + #4b).
 func loadDir(dir string) (ThresholdConfig, string, error) {
-	return loadDirWithMetrics(dir, getConfigMetrics())
+	return loadDirWithMetrics(dir, getConfigMetrics(), log.Default())
 }
 
 // loadDirWithMetrics is the injectable variant of loadDir. Same behavior;
-// metric observations route to the caller-supplied *configMetrics
-// instead of getConfigMetrics(). Use this from production code paths
-// that own a ConfigManager.
-func loadDirWithMetrics(dir string, metrics *configMetrics) (ThresholdConfig, string, error) {
+// metric observations + log lines route to the caller-supplied
+// *configMetrics + *log.Logger instead of the package singletons. Use
+// this from production code paths that own a ConfigManager. Either
+// argument may be nil → falls back to the package singleton (struct-
+// literal test shortcut).
+func loadDirWithMetrics(dir string, metrics *configMetrics, logger *log.Logger) (ThresholdConfig, string, error) {
 	// Defensive: see scanDirHierarchicalWithMetrics for the same
 	// nil-fallback rationale (struct-literal test shortcut).
 	if metrics == nil {
 		metrics = getConfigMetrics()
+	}
+	if logger == nil {
+		logger = log.Default()
 	}
 	merged := ThresholdConfig{
 		Defaults:     make(map[string]float64),
@@ -125,7 +130,7 @@ func loadDirWithMetrics(dir string, metrics *configMetrics) (ThresholdConfig, st
 		path := filepath.Join(dir, name)
 		data, err := os.ReadFile(path)
 		if err != nil {
-			log.Printf("WARN: skip unreadable file %s: %v", path, err)
+			logger.Printf("WARN: skip unreadable file %s: %v", path, err)
 			continue
 		}
 		hasher.Write(data)
@@ -140,9 +145,9 @@ func loadDirWithMetrics(dir string, metrics *configMetrics) (ThresholdConfig, st
 			// (v2.8.0 A-8d metric) so ops can alert.
 			metrics.IncParseFailure(filepath.Base(path))
 			if strings.HasPrefix(name, "_") {
-				log.Printf("ERROR: skip unparseable defaults/profiles file %s: %v (entire block dropped — fix file or remove)", path, err)
+				logger.Printf("ERROR: skip unparseable defaults/profiles file %s: %v (entire block dropped — fix file or remove)", path, err)
 			} else {
-				log.Printf("WARN: skip unparseable file %s: %v", path, err)
+				logger.Printf("WARN: skip unparseable file %s: %v", path, err)
 			}
 			continue
 		}
@@ -153,17 +158,17 @@ func loadDirWithMetrics(dir string, metrics *configMetrics) (ThresholdConfig, st
 		// Boundary enforcement: warn if tenant file contains state_filters, defaults, or profiles
 		if !isDefaultsFile {
 			if len(partial.StateFilters) > 0 {
-				log.Printf("WARN: state_filters found in %s — should only be in _defaults.yaml, ignoring", name)
+				logger.Printf("WARN: state_filters found in %s — should only be in _defaults.yaml, ignoring", name)
 				partial.StateFilters = nil
 			}
 			if len(partial.Defaults) > 0 {
-				log.Printf("WARN: defaults found in %s — should only be in _defaults.yaml, ignoring", name)
+				logger.Printf("WARN: defaults found in %s — should only be in _defaults.yaml, ignoring", name)
 				partial.Defaults = nil
 			}
 		}
 		if !isProfilesFile && !isDefaultsFile {
 			if len(partial.Profiles) > 0 {
-				log.Printf("WARN: profiles found in %s — should only be in _profiles.yaml, ignoring", name)
+				logger.Printf("WARN: profiles found in %s — should only be in _profiles.yaml, ignoring", name)
 				partial.Profiles = nil
 			}
 		}
@@ -215,7 +220,10 @@ func loadDirWithMetrics(dir string, metrics *configMetrics) (ThresholdConfig, st
 // files whose ModTime and Size match the previous scan reuse the cached SHA-256
 // without re-reading file contents. This reduces NoChange cost from O(N×read)
 // to O(N×stat) — typically 4-5× faster at 1000 tenants.
-func scanDirFileHashes(dir string, oldHashes map[string]string, oldMtimes map[string]fileStat) (map[string]string, string, map[string]fileStat, map[string][]byte, error) {
+func scanDirFileHashes(dir string, oldHashes map[string]string, oldMtimes map[string]fileStat, logger *log.Logger) (map[string]string, string, map[string]fileStat, map[string][]byte, error) {
+	if logger == nil {
+		logger = log.Default()
+	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, "", nil, nil, fmt.Errorf("read config dir %s: %w", dir, err)
@@ -234,7 +242,7 @@ func scanDirFileHashes(dir string, oldHashes map[string]string, oldMtimes map[st
 		if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
 			info, ierr := entry.Info()
 			if ierr != nil {
-				log.Printf("WARN: skip unreadable entry %s: %v", name, ierr)
+				logger.Printf("WARN: skip unreadable entry %s: %v", name, ierr)
 				continue
 			}
 			files = append(files, dirFile{name: name, info: info})
@@ -267,7 +275,7 @@ func scanDirFileHashes(dir string, oldHashes map[string]string, oldMtimes map[st
 
 		data, rerr := os.ReadFile(fullPath)
 		if rerr != nil {
-			log.Printf("WARN: skip unreadable file %s: %v", f.name, rerr)
+			logger.Printf("WARN: skip unreadable file %s: %v", f.name, rerr)
 			continue
 		}
 		h := fmt.Sprintf("%x", sha256.Sum256(data))
@@ -296,23 +304,27 @@ func scanDirFileHashes(dir string, oldHashes map[string]string, oldMtimes map[st
 // Falls back to full Load() for single-file mode or first-time load.
 // applyBoundaryRules enforces the boundary convention: state_filters and
 // defaults only in _defaults.yaml, profiles only in _profiles.yaml.
-func applyBoundaryRules(name string, partial *ThresholdConfig) {
+// logger may be nil → falls back to log.Default() (production safety).
+func applyBoundaryRules(name string, partial *ThresholdConfig, logger *log.Logger) {
+	if logger == nil {
+		logger = log.Default()
+	}
 	isDefaultsFile := strings.HasPrefix(name, "_")
 	isProfilesFile := name == "_profiles.yaml" || name == "_profiles.yml"
 
 	if !isDefaultsFile {
 		if len(partial.StateFilters) > 0 {
-			log.Printf("WARN: state_filters found in %s — should only be in _defaults.yaml, ignoring", name)
+			logger.Printf("WARN: state_filters found in %s — should only be in _defaults.yaml, ignoring", name)
 			partial.StateFilters = nil
 		}
 		if len(partial.Defaults) > 0 {
-			log.Printf("WARN: defaults found in %s — should only be in _defaults.yaml, ignoring", name)
+			logger.Printf("WARN: defaults found in %s — should only be in _defaults.yaml, ignoring", name)
 			partial.Defaults = nil
 		}
 	}
 	if !isProfilesFile && !isDefaultsFile {
 		if len(partial.Profiles) > 0 {
-			log.Printf("WARN: profiles found in %s — should only be in _profiles.yaml, ignoring", name)
+			logger.Printf("WARN: profiles found in %s — should only be in _profiles.yaml, ignoring", name)
 			partial.Profiles = nil
 		}
 	}


### PR DESCRIPTION
## Summary

Production rewiring follow-up to PR-D foundation (#366). Routes every
\`log.Printf\` in package main's ConfigManager-driven hot paths through
the new \`m.getLogger()\` seam so PR-F can inject per-test loggers and
drop the \`log.SetOutput\` global swap from 5 captured tests. Mirrors
PR #364's metrics rewiring.

## Free-function signature changes

logger param appended; **nil falls back to log.Default()** (struct-literal
test safety, mirrors metrics nil-fallback):

| Function | Before | After |
|---|---|---|
| \`loadDirWithMetrics\` | \`(dir, metrics)\` | \`(dir, metrics, logger)\` |
| \`scanDirHierarchicalWithMetrics\` | \`(rootPath, prior, metrics)\` | \`(rootPath, prior, metrics, logger)\` |
| \`scanDirFileHashes\` | \`(dir, oldH, oldM)\` | \`(dir, oldH, oldM, logger)\` |
| \`applyBoundaryRules\` | \`(name, partial)\` | \`(name, partial, logger)\` |
| \`emitParseFailureSignal\` | \`(metrics, ...)\` | \`(metrics, **logger**, ...)\` |
| \`logConfigStats\` | \`(cfg, prefix)\` | \`(**logger**, cfg, prefix)\` |
| \`logMergeSkip\` | \`(tenantID, reason, err)\` | \`(**logger**, tenantID, reason, err)\` |

## ConfigManager methods rewired

\`log.Printf\` → \`m.getLogger().Printf\` inside:

- **config.go**: \`runHierarchyScanReject\`, \`IncrementalLoad\`,
  \`fullDirLoad\`, \`populateHierarchyState\`, \`WatchLoop\`, \`tickOnce\`
- **config_debounce.go**: \`fireDebounced\`, \`scanAndCheckHierarchical\`,
  \`classifyAndCount\`, \`installNewHierarchyState\`, \`diffAndReload\`

Production callers updated to pass \`m.getLogger()\` to the free functions.

## Test churn

18 test callsites mechanically updated to pass \`nil\` logger (don't care
about log capture). PR-F will replace these with per-test loggers + add
\`t.Parallel\` + drop \`log.SetOutput\`. The 5 log-capture tests keep the
\`log.SetOutput\` pattern temporarily — PR-E only does the signature add.

## Out of scope (intentional)

- \`cmd/da-parser/main.go\`, \`cmd/da-guard/main.go\`, \`cmd/da-batchpr/main.go\`:
  separate binaries, not exporter package main; their \`log.SetOutput\`
  calls shape CLI output for ops use, not test capture.
- \`main.go\` (exporter entry point): startup/shutdown logs, not in any
  test path.
- \`collector.go\` (Prometheus Collect path): not reached by ConfigManager
  tests.
- \`pkg/config/*\` (different Go package): separate concern.

## Campaign sequence

| PR | Scope | Status |
|----|---|---|
| D #366 | Foundation seam (inert) | ✅ merged |
| **E #367 (this)** | Production rewiring (10 files, 141+/101-) | 🟡 here |
| F (next) | Test rewrites + drop log.SetOutput + add t.Parallel | ⏳ |

## Test plan

- [x] \`go build -buildvcs=false ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -count=1 -race ./...\` PASS (all 9 packages)
- [x] \`go test -count=5 -race ./\` (app pkg) PASS (22.7s)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)