### PR TITLE
refactor(exporter): #4b-F — drop log.SetOutput from 5 tests + add t.Parallel

### DIFF
--- a/components/threshold-exporter/app/config_hierarchy_test.go
+++ b/components/threshold-exporter/app/config_hierarchy_test.go
@@ -527,19 +527,15 @@ func TestScanDirHierarchical_MixedValidInvalid(t *testing.T) {
 // "_defaults.yaml"}[5m])) > 0` fires identically regardless of count
 // scale, so duplication is a feature (blast-radius signal), not noise.
 func TestRecomputeMergedHash_DefaultsParseFailureEmitsErrorAndMetric(t *testing.T) {
-	// NOT t.Parallel — log.SetOutput swaps a global stdlib logger; #4b
-	// will move this off the global eventually.
+	t.Parallel()
 	root := t.TempDir()
 
-	// Per-test metrics instance — routed via mgr.SetMetrics so the
-	// scanner observations land on `fresh` instead of the package
-	// singleton (parallel-friendly when paired with #4b).
+	// Per-test metrics + logger instances — routed via mgr.SetMetrics
+	// + mgr.SetLogger so observations land on `fresh`/`logBuf` instead
+	// of the package singletons (#4a + #4b; parallel-safe).
 	fresh, _ := freshMetrics(t)
-
 	var logBuf bytes.Buffer
-	origOutput := log.Writer()
-	log.SetOutput(&logBuf)
-	t.Cleanup(func() { log.SetOutput(origOutput) })
+	testLogger := log.New(&logBuf, "", 0)
 
 	// Poison-pill root _defaults.yaml.
 	writeFile(t, filepath.Join(root, "_defaults.yaml"),
@@ -553,6 +549,7 @@ func TestRecomputeMergedHash_DefaultsParseFailureEmitsErrorAndMetric(t *testing.
 
 	mgr := NewConfigManager(root)
 	mgr.SetMetrics(fresh)
+	mgr.SetLogger(testLogger)
 	// Trigger the hierarchical recompute path. Load fails (or partially
 	// succeeds) — we don't care about the return value, only the
 	// observability side-effects (ERROR log + metric).

--- a/components/threshold-exporter/app/config_loaddir_test.go
+++ b/components/threshold-exporter/app/config_loaddir_test.go
@@ -236,20 +236,15 @@ func TestConfigManager_LoadDir_EmptyDir(t *testing.T) {
 // same invariant as TestScanDirHierarchical_MixedValidInvalid for the
 // hierarchical path).
 func TestConfigManager_LoadDir_UnparseableDefaultsErrorAndMetric(t *testing.T) {
-	// NOT t.Parallel — log.SetOutput swaps a global stdlib logger; #4b
-	// will move this off the global eventually.
+	t.Parallel()
 	dir := t.TempDir()
 
-	// Per-test metrics instance — routed via mgr.SetMetrics so the
-	// scanner observations land on `fresh` (parallel-friendly when
-	// paired with #4b).
+	// Per-test metrics + logger instances — routed via mgr.SetMetrics
+	// + mgr.SetLogger so scanner observations land on `fresh`/`logBuf`
+	// instead of the package singletons (#4a + #4b; parallel-safe).
 	fresh, _ := freshMetrics(t)
-
-	// Capture log output to verify ERROR-level promotion.
 	var logBuf bytes.Buffer
-	origOutput := log.Writer()
-	log.SetOutput(&logBuf)
-	t.Cleanup(func() { log.SetOutput(origOutput) })
+	testLogger := log.New(&logBuf, "", 0)
 
 	// Poison-pill `_defaults.yaml`. Use a structurally broken YAML
 	// (unclosed brace) so yaml.Unmarshal definitively errors regardless
@@ -270,6 +265,7 @@ tenants:
 
 	mgr := NewConfigManager(dir)
 	mgr.SetMetrics(fresh)
+	mgr.SetLogger(testLogger)
 	// Load may succeed (defaults dropped, sibling tenant parses) — what we
 	// care about is the ERROR log + the metric.
 	_ = mgr.Load()

--- a/components/threshold-exporter/app/config_mixed_mode_test.go
+++ b/components/threshold-exporter/app/config_mixed_mode_test.go
@@ -161,6 +161,7 @@ func TestMixedMode_RootDefaultsCascadeToBoth(t *testing.T) {
 // ─────────────────────────────────────────────────────────────────
 
 func TestMixedMode_DuplicateAcrossModes_RejectedAtLoad(t *testing.T) {
+	t.Parallel()
 	root := t.TempDir()
 	writeTestYAML(t, filepath.Join(root, "_defaults.yaml"), `
 defaults:
@@ -183,14 +184,15 @@ tenants:
     mysql_connections: "200"
 `)
 
-	// Capture log to confirm the WARN-only path is NOT taken (post-fix
-	// the code returns error directly; WARN line should be absent).
+	// Per-test logger so the negative assertion (WARN line MUST NOT
+	// appear) is observed against THIS test's log output, not the
+	// global stdlib logger that sibling parallel tests would race on
+	// (#4b).
 	var logBuf bytes.Buffer
-	origOutput := log.Writer()
-	log.SetOutput(&logBuf)
-	t.Cleanup(func() { log.SetOutput(origOutput) })
+	testLogger := log.New(&logBuf, "", 0)
 
 	mgr := NewConfigManager(root)
+	mgr.SetLogger(testLogger)
 	err := mgr.Load()
 
 	// v2.8.x contract: Load must return error.

--- a/components/threshold-exporter/app/config_test.go
+++ b/components/threshold-exporter/app/config_test.go
@@ -90,6 +90,7 @@ tenants:
 // ============================================================
 
 func TestLogConfigStats_Format(t *testing.T) {
+	t.Parallel()
 	cfg := &ThresholdConfig{
 		Defaults:     map[string]float64{"mysql_connections": 80, "mysql_cpu": 75},
 		Profiles:     map[string]map[string]ScheduledValue{"gold": {"mysql_connections": {Default: "100"}}},
@@ -107,16 +108,13 @@ func TestLogConfigStats_Format(t *testing.T) {
 		},
 	}
 
-	// Capture log output
+	// Per-test logger writing to a captured buffer — no global stdlib
+	// state mutation, so other parallel tests never observe our log
+	// stream and we never observe theirs (#4b).
 	var buf bytes.Buffer
-	orig := log.Writer()
-	log.SetOutput(&buf)
-	defer log.SetOutput(orig)
+	testLogger := log.New(&buf, "", 0)
 
-	// PR-F will replace the log.SetOutput global swap above with a
-	// per-test logger passed here. For PR-E (signature add) we pass
-	// log.Default() so the existing global swap still captures.
-	logConfigStats(log.Default(), cfg, "Test prefix")
+	logConfigStats(testLogger, cfg, "Test prefix")
 
 	output := buf.String()
 
@@ -381,6 +379,7 @@ func TestDetectConfigSource(t *testing.T) {
 // ============================================================
 
 func TestFailSafeReload_InvalidYAML(t *testing.T) {
+	t.Parallel()
 	// Create temp directory with valid config
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.yaml")
@@ -393,8 +392,15 @@ tenants:
 `
 	writeTestFile(t, dir, "config.yaml", validContent)
 
+	// Per-test logger so any log lines emitted during the failing
+	// reload land on our buffer (not the global stdlib logger),
+	// keeping this test parallel-safe (#4b).
+	var buf bytes.Buffer
+	testLogger := log.New(&buf, "", 0)
+
 	// Load initial valid config
 	mgr := NewConfigManager(configPath)
+	mgr.SetLogger(testLogger)
 	if err := mgr.Load(); err != nil {
 		t.Fatalf("Initial Load failed: %v", err)
 	}
@@ -404,12 +410,6 @@ tenants:
 	if cfg.Defaults["mysql_connections"] != 80 {
 		t.Errorf("initial config: expected 80, got %.0f", cfg.Defaults["mysql_connections"])
 	}
-
-	// Capture log output
-	var buf bytes.Buffer
-	oldOutput := log.Writer()
-	log.SetOutput(&buf)
-	defer log.SetOutput(oldOutput)
 
 	// Write invalid YAML
 	invalidContent := `
@@ -438,7 +438,11 @@ tenants:
 		t.Error("expected IsLoaded() = true after failed reload (fail-safe preserved)")
 	}
 
-	// Verify error was logged
+	// Informational: surface whatever (if anything) was logged during
+	// the failed reload. Single-file mode currently doesn't log on
+	// loadFile failure — the original log.SetOutput observation here
+	// has always been a no-op — but the capture stays so future log
+	// additions on the failure path are visible to the test author.
 	logOutput := buf.String()
 	if !strings.Contains(logOutput, "ERROR") && !strings.Contains(logOutput, "error") {
 		t.Logf("note: error logging may not include 'ERROR' string, log output was: %s", logOutput)

--- a/scripts/ops/add_t_parallel.py
+++ b/scripts/ops/add_t_parallel.py
@@ -67,6 +67,14 @@ RISKY = (
     # PR #356 when -race surfaced bytes.Buffer races in
     # TestMixedMode_DuplicateAcrossModes_RejectedAtLoad in the Linux
     # dev container.
+    #
+    # The exporter's package main test files no longer use log.SetOutput
+    # (#4b PR-F replaced the 4 capture sites with mgr.SetLogger(testLogger)
+    # injection through the ConfigManager.logger seam from #4b PR-D).
+    # Kept in RISKY as a tripwire so a future re-introduction surfaces here.
+    # config_bench_test.go's silenceLog(b) helper still calls log.SetOutput
+    # but it's a *testing.B benchmark scope (single-threaded by design)
+    # and would not trigger this lint anyway.
     "log.SetOutput",
     "log.SetFlags",
 )


### PR DESCRIPTION
## Summary

Final landing of the **#4b log.SetOutput drop campaign** — closes the
trio with **#4a metrics injection** (#363 → #364 → #365) and **#4c
clockwork injection** (#362 foundation). Replaces the \`log.SetOutput\`
global swap in 5 captured tests with per-test loggers injected via the
\`ConfigManager.SetLogger\` seam from #4b PR-D (#366).

Per-test ownership unblocks \`t.Parallel\`: 5 tests across 4 files now
opt in to parallel execution without racing the global stdlib logger
(or each other's \`bytes.Buffer\` captures, which was the original race
trigger caught by PR #356).

## Tests converted

| File | Test | Pattern |
|---|---|---|
| \`config_test.go\` | TestLogConfigStats_Format | \`logConfigStats(testLogger, ...)\` |
| \`config_test.go\` | TestFailSafeReload_InvalidYAML | \`mgr.SetLogger\` |
| \`config_hierarchy_test.go\` | TestRecomputeMergedHash_DefaultsParseFailureEmitsErrorAndMetric | \`mgr.SetMetrics\` + \`mgr.SetLogger\` |
| \`config_loaddir_test.go\` | TestConfigManager_LoadDir_UnparseableDefaultsErrorAndMetric | \`mgr.SetMetrics\` + \`mgr.SetLogger\` |
| \`config_mixed_mode_test.go\` | TestMixedMode_DuplicateAcrossModes_RejectedAtLoad | \`mgr.SetLogger\` |

Pattern is uniform:

\`\`\`go
var logBuf bytes.Buffer
testLogger := log.New(&logBuf, \"\", 0)
mgr := NewConfigManager(...)
mgr.SetLogger(testLogger)            // #4b PR-D seam
// ... drive code ...
if !strings.Contains(logBuf.String(), \"ERROR: ...\") { ... }
\`\`\`

## RISKY tracker

\`scripts/ops/add_t_parallel.py\` keeps \`log.SetOutput\` / \`log.SetFlags\`
in the RISKY tuple as a tripwire — the package main test files no
longer use them, but a future re-introduction surfaces in the lint
pairing. Comment updated to reflect that \`config_bench_test.go\`'s
\`silenceLog(b)\` helper still uses \`log.SetOutput\` intentionally
(benchmark scope is single-threaded by design).

## Campaign sequence

| PR | Scope | Status |
|----|---|---|
| D #366 | Foundation seam (logger field + SetLogger + getLogger) | ✅ merged |
| E #367 | Production rewiring (~88 log.Printf → m.getLogger() + 7 free fns extended) | ✅ merged |
| **F #368 (this)** | Test rewrites (5 tests → SetLogger, drop log.SetOutput, t.Parallel) | 🟡 here |

## Test plan

- [x] \`go build -buildvcs=false ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -count=10 -race\` on the 5 converted tests: PASS (1.5s)
- [x] \`go test -count=5 -race\` on full app pkg: PASS (20.7s)
- [x] All 9 packages green at \`-count=1 -race\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)