### PR TITLE
feat(dx): PreToolUse hook to block sed -i on mount + ad-hoc _*.bat writes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": "python \"$CLAUDE_PROJECT_DIR/scripts/session-guards/session-init.py\""
           }
         ]
+      },
+      {
+        "matcher": "Bash|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$CLAUDE_PROJECT_DIR/scripts/session-guards/preflight_bash.py\""
+          }
+        ]
       }
     ]
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ lang: zh
 
 Session 起手式 codified 為 **PreToolUse hook** (v2.8.0) — 第一次 `Bash`/`Write`/`Edit`/`MultiEdit` 自動跑 `scripts/session-guards/session-init.py`（關 VS Code Git + 寫 session marker），後續 O(1) no-op。手動觸發 / telemetry / dev-container 啟動 / session 結束清理 → 觸發 `vibe-workflow` skill 或 `make dc-*` / `make session-cleanup`。
 
+第二支 PreToolUse hook：`scripts/session-guards/preflight_bash.py`（audit-2026-04 §H1+H2）— 攔 `sed -i` + 掛載路徑（dev-rules #11，免 token 浪費 fix file hygiene）+ 攔 `_*.bat`/`_*.ps1`/`_*.cmd` 寫到 whitelist 之外（Trap #54 防再造輪子）。被擋時 stderr 直接告訴 Claude 該用什麼替代（Read+Edit / `win_git_escape.bat raw <args>`）。
+
 ### 設計原則：主路徑 / 逃生門
 
 > **主路徑**：Dev Container 層做所有事（code / test / commit / push）；優先 `make dc-*` 統一入口。

--- a/docs/internal/dev-rules.md
+++ b/docs/internal/dev-rules.md
@@ -151,9 +151,9 @@ lang: zh
 
 ### 11. 檔案衛生：禁用 `sed -i` 在掛載路徑
 
-**規則**：禁止對掛載路徑（`/sessions/*/mnt/**`）用 `sed -i`——FUSE 下對缺 EOF newline 的檔案會截斷最後一行。改用 Read + Edit（首選）或 `git show HEAD:file | sed '...' | tr -d '\0' > file`（批次 pipe）。
+**規則**：禁止對掛載路徑（`/sessions/*/mnt/**`、`/workspaces/vibe-k8s-lab/**`、`C:\Users\<user>\vibe-k8s-lab\**`）用 `sed -i`——FUSE 下截斷缺 EOF newline 的檔案 + 可能注入 NUL bytes。**改檔決策樹**：單檔小改→Read+Edit；整檔重寫→Read+Write；批次跨檔→Python + `scripts/tools/dx/_atomic_write.py`；真的要 pipe →`git show HEAD:<f> | sed '...' | tr -d '\0' > <f>`（非 in-place，HEAD 讀避 FUSE stale）。
 
-✅ **Codified**：`file-hygiene` pre-commit hook 偵測並修復 null bytes + 缺 EOF newline。**Symlink 例外（v2.7.1 LL）**：symlink proxy md 已在 `.pre-commit-config.yaml` `exclude` 正則內排除（避免 EOF fixer 把 `../target.md` 變成 `../target.md\n` 讓 Linux CI `readlink()` 解不了）；事件記錄見 [windows-mcp-playbook §v2.7.1 LL](windows-mcp-playbook.md#v271-llend-of-file-fixer-會把-symlink-blob-弄壞)。
+✅ **四層防護**：(1) Prevent (harness) — `preflight_bash.py` PreToolUse hook 攔 `sed -i`+掛載路徑（audit-2026-04 §H1）；(2) Detect — `detect_sed_damage.py` (commit-time NUL+截斷)；(3) Repair — `fix_file_hygiene.py` (auto-補 EOF + 移 NUL)；(4) Shell — `vibe-sed-guard.sh` (docker exec / 人類 dev)。**Symlink 例外**：symlink proxy md 在 `.pre-commit-config.yaml` `exclude` 排除（詳 [windows-mcp-playbook §v2.7.1 LL](windows-mcp-playbook.md#v271-llend-of-file-fixer-會把-symlink-blob-弄壞)）。
 
 ### 12. Branch + PR 流程：禁止直推 main
 

--- a/scripts/session-guards/preflight_bash.py
+++ b/scripts/session-guards/preflight_bash.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block patterns we already know cause damage in this repo.
+
+Currently enforced (audit playbook-audit-2026-04 §H1, §H2):
+
+  1. Bash tool — `sed -i` (or `sed --in-place`) targeting mounted paths.
+     Reason: dev-rules #11. FUSE mount truncates files lacking EOF newline
+     and may inject NUL bytes. The repair layer (`fix_file_hygiene.py`)
+     and detection layer (`detect_sed_damage.py`) already exist; this is
+     the prevention layer at the harness. The shell-function override
+     `vibe-sed-guard.sh` does not fire from Claude Code's Bash tool
+     (no .bashrc sourcing), so we attach here instead.
+
+  2. Write tool — ad-hoc `_*.bat` / `_*.ps1` / `_*.cmd` outside the
+     whitelisted dirs (scripts/ops/, scripts/tools/, tools/).
+     Reason: trap #54 (session-after-session reinventing escape-hatch
+     wrappers). The pre-commit hook `check_ad_hoc_git_scripts.py` already
+     blocks these at commit time; this stops them at write time so we
+     don't burn tokens producing the file.
+
+Failure policy:
+  - Hook never blocks "normal" tool calls. Parse failures, regex bugs,
+    unhandled exceptions all exit 0 with a stderr warning.
+  - Only documented patterns trigger exit 2 with a remediation message.
+
+Exit codes:
+  0 — allow (default)
+  2 — block; stderr is fed back to the model so it can self-correct.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Repo root resolution
+# ---------------------------------------------------------------------------
+_THIS = Path(__file__).resolve()
+_REPO_ROOT = _THIS.parents[2]  # scripts/session-guards/preflight_bash.py → repo
+
+# ---------------------------------------------------------------------------
+# Patterns
+# ---------------------------------------------------------------------------
+
+# `sed -i` or `sed --in-place`. Covers:
+#   sed -i '...'
+#   sed -i.bak '...'
+#   sed -i'' '...'      (zero-length suffix)
+#   sed -i"" '...'      (double-quoted zero-length)
+#   sed -isuffix        (glued)
+#   sed --in-place
+#   gsed -i             (GNU sed alias on macOS / some Cowork images)
+# Word boundary on the left of `sed` so we don't match `pushed`, `parsed`, etc.
+_SED_INPLACE_RE = re.compile(
+    r"(?<![A-Za-z0-9_/])g?sed\s+(?:[^|;&]*\s)?(?:-[A-Za-z]*i|--in-place)",
+    re.IGNORECASE,
+)
+
+# Mount-path patterns that FUSE / Docker bind-mount paths fall under in this
+# repo. We intentionally cast a wide net — false positives only show a clear
+# remediation message; false negatives let damage through.
+_MOUNT_PATH_RE = re.compile(
+    r"(?:"
+    r"/sessions/[^\s/]+/mnt/"             # Cowork sandbox legacy
+    r"|/workspaces/vibe-k8s-lab/"         # Dev container mount
+    r"|/c/Users/[^\s/]+/vibe-k8s-lab/"    # Git Bash POSIX path
+    r"|[Cc]:[\\/]+Users[\\/]+[^\s\\/]+[\\/]+vibe-k8s-lab[\\/]+"  # Windows native
+    r")"
+)
+
+# Ad-hoc script names. Pre-commit hook already enforces this at commit; we
+# add the harness layer to stop the WRITE before tokens are spent.
+# Whitelist mirrors `scripts/tools/lint/check_ad_hoc_git_scripts.py`.
+_AD_HOC_SCRIPT_RE = re.compile(r".*[\\/]_[^\\/]+\.(bat|ps1|cmd)$", re.IGNORECASE)
+_AD_HOC_WHITELIST_DIRS = (
+    "scripts/ops/",
+    "scripts/tools/",
+    "tools/",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _normalize_path(p: str) -> str:
+    """Normalize Windows backslashes to forward slashes for matching."""
+    return p.replace("\\", "/")
+
+
+def _is_in_whitelist(file_path: str) -> bool:
+    norm = _normalize_path(file_path)
+    return any(d in norm for d in _AD_HOC_WHITELIST_DIRS)
+
+
+def _check_bash(command: str) -> tuple[int, str]:
+    """Return (exit_code, stderr_message). exit_code 0 = allow, 2 = block."""
+    if not command:
+        return 0, ""
+    sed_match = _SED_INPLACE_RE.search(command)
+    if not sed_match:
+        return 0, ""
+    if not _MOUNT_PATH_RE.search(command):
+        # `sed -i` is fine on /tmp/, on host paths, anywhere outside our
+        # mounted workspace. Don't get in the way.
+        return 0, ""
+    msg = (
+        "[preflight] BLOCKED: dev-rules #11 -- `sed -i` on mounted path.\n"
+        "FUSE truncates files lacking EOF newline + may inject NUL bytes.\n"
+        "\n"
+        "Replace this command with one of:\n"
+        "  - Read + Edit       (preferred for single-file changes)\n"
+        "  - Read + Write      (full-file rewrites)\n"
+        "  - Pipe out-of-place: git show HEAD:<f> | sed '...' > <f>\n"
+        "                      (read from HEAD avoids FUSE stale state)\n"
+        "  - Python + atomic_write: scripts/tools/dx/_atomic_write.py\n"
+        "\n"
+        "See docs/internal/dev-rules.md (rule 11). The regex only fires\n"
+        "when both `sed -i` AND a mount-path token appear on the same\n"
+        "Bash invocation -- legitimate sed -i outside the mount is fine.\n"
+        f"Detected command fragment: {sed_match.group(0)}"
+    )
+    return 2, msg
+
+
+def _check_write(file_path: str) -> tuple[int, str]:
+    if not file_path:
+        return 0, ""
+    norm = _normalize_path(file_path)
+    if not _AD_HOC_SCRIPT_RE.match(norm):
+        return 0, ""
+    if _is_in_whitelist(norm):
+        return 0, ""
+    msg = (
+        "[preflight] BLOCKED: ad-hoc `_*.bat` / `_*.ps1` / `_*.cmd` outside\n"
+        "the whitelisted dirs (scripts/ops/, scripts/tools/, tools/).\n"
+        "\n"
+        "This repo already has standard Windows escape-hatch wrappers.\n"
+        "Don't reinvent them -- extend or call them instead:\n"
+        "  - scripts/ops/win_git_escape.bat  (status / add / commit-file /\n"
+        "                                     push / tag / branch / log /\n"
+        "                                     diff / preflight / pr-preflight\n"
+        "                                     / fix-hooks)\n"
+        "  - scripts/ops/win_gh.bat          (pr-checks / pr-view / pr-create\n"
+        "                                     / run-view / run-log / raw)\n"
+        "  - scripts/ops/win_async_exec.ps1  (fire-and-forget for >60s ops)\n"
+        "  - scripts/ops/win_read_fresh.ps1  (FUSE dentry cache bypass)\n"
+        "  - make win-commit / fuse-commit / recover-index / fuse-locks\n"
+        "\n"
+        "Both wrappers expose `raw <args>` for one-off needs. If you truly\n"
+        "need a new subcommand, extend the wrapper in scripts/ops/ and\n"
+        "submit it (the `bat-ascii-purity-check` hook will validate).\n"
+        "See docs/internal/windows-mcp-playbook.md (section: 'Repair layer C',\n"
+        "trap #54). Run `make help-escape` for a quick reference.\n"
+        f"Attempted path: {file_path}"
+    )
+    return 2, msg
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    # Read JSON payload from stdin per Claude Code PreToolUse hook contract.
+    raw = sys.stdin.read()
+    if not raw.strip():
+        # Manual invocation with no payload — nothing to check.
+        return 0
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"[preflight] warning: invalid JSON ({exc}); allowing", file=sys.stderr)
+        return 0
+
+    tool_name = payload.get("tool_name") or ""
+    tool_input = payload.get("tool_input") or {}
+
+    try:
+        if tool_name == "Bash":
+            command = tool_input.get("command") or ""
+            code, msg = _check_bash(command)
+        elif tool_name in ("Write",):
+            # Edit / MultiEdit don't create new ad-hoc scripts (they require an
+            # existing file). Limit to Write.
+            file_path = tool_input.get("file_path") or ""
+            code, msg = _check_write(file_path)
+        else:
+            return 0
+    except Exception as exc:  # noqa: BLE001 — never block on hook bug
+        print(f"[preflight] warning: hook crashed ({exc}); allowing", file=sys.stderr)
+        return 0
+
+    if code == 0:
+        return 0
+    print(msg, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    # Keep PYTHONUTF8 implicit; we only print ASCII through stderr.
+    sys.exit(main())

--- a/tests/dx/test_preflight_bash.py
+++ b/tests/dx/test_preflight_bash.py
@@ -1,0 +1,207 @@
+"""Tests for scripts/session-guards/preflight_bash.py.
+
+Verifies the PreToolUse hook behavior for the sed -i mount-path guard
+(audit playbook-audit-2026-04 §H1) and ad-hoc _*.bat write blocker (§H2).
+
+Failure policy is "never block on hook bug" — verified explicitly.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "session-guards" / "preflight_bash.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("preflight_bash", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run_with_payload(payload: dict) -> tuple[int, str]:
+    """Invoke the script as subprocess with a JSON payload on stdin."""
+    proc = subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    return proc.returncode, proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# §H1 — sed -i on mounted path
+# ---------------------------------------------------------------------------
+
+class TestSedInplaceGuard:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # POSIX mount
+            "sed -i 's/foo/bar/' /workspaces/vibe-k8s-lab/x.md",
+            # Glued -i variants
+            "sed -i.bak 's/foo/bar/' /workspaces/vibe-k8s-lab/x.md",
+            "sed -i'' 's/foo/bar/' /workspaces/vibe-k8s-lab/x.md",
+            'sed -i"" \'s/foo/bar/\' /workspaces/vibe-k8s-lab/x.md',
+            # Long form
+            "sed --in-place 's/foo/bar/' /workspaces/vibe-k8s-lab/x.md",
+            # Cowork sandbox legacy path
+            "sed -i 's/.../.../' /sessions/abc/mnt/vibe-k8s-lab/y.md",
+            # Git Bash POSIX path on Windows side
+            "sed -i 's/x/y/' /c/Users/vencs/vibe-k8s-lab/scripts/foo.sh",
+            # Windows native path
+            r"sed -i s/x/y/ C:\Users\vencs\vibe-k8s-lab\scripts\foo.sh",
+            # Compound: && chain still trips on the second leg
+            "echo ok && sed -i 's/x/y/' /workspaces/vibe-k8s-lab/x.md",
+            # GNU sed alias
+            "gsed -i 's/x/y/' /workspaces/vibe-k8s-lab/x.md",
+        ],
+    )
+    def test_blocks_inplace_on_mount(self, command: str) -> None:
+        code, stderr = _run_with_payload(
+            {"tool_name": "Bash", "tool_input": {"command": command}}
+        )
+        assert code == 2, f"expected block for {command!r}, stderr={stderr!r}"
+        assert "dev-rules #11" in stderr
+        assert "Read + Edit" in stderr
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # `sed -i` outside mount — allowed
+            "sed -i 's/x/y/' /tmp/foo.txt",
+            "sed -i.bak 's/x/y/' ~/notes.md",
+            # `sed` without -i — allowed (read-only)
+            "sed 's/x/y/' /workspaces/vibe-k8s-lab/x.md",
+            # Pipe form (no -i) on mount — allowed
+            "git show HEAD:x.md | sed 's/x/y/' > /workspaces/vibe-k8s-lab/x.md",
+            # Words containing 'sed' — must not match
+            "echo passed && pushed origin main",
+            "ls /workspaces/vibe-k8s-lab/parsed/",
+            # Comment lines should not trip a real subprocess. We allow them
+            # because the harness only sees the literal command anyway.
+            "echo 'we used sed -i in /workspaces/vibe-k8s-lab/ in 2024'",
+        ],
+    )
+    def test_allows_safe_patterns(self, command: str) -> None:
+        # The last case (echo 'we used sed -i ...') is intentionally generous:
+        # detecting "literal command containing the pattern in a quoted echo"
+        # would require a full shell parser. We accept the false-positive risk
+        # there — same trade-off `vibe-sed-guard.sh` makes.
+        code, stderr = _run_with_payload(
+            {"tool_name": "Bash", "tool_input": {"command": command}}
+        )
+        if code != 0:
+            # echo-quoted case is permitted to false-positive; assert only on
+            # truly safe cases.
+            assert "echo " in command, f"unexpected block for {command!r}: {stderr}"
+
+
+# ---------------------------------------------------------------------------
+# §H2 — Ad-hoc _*.bat write
+# ---------------------------------------------------------------------------
+
+class TestAdHocScriptWriteGuard:
+    @pytest.mark.parametrize(
+        "file_path",
+        [
+            r"C:\Users\vencs\vibe-k8s-lab\_my_commit.bat",
+            "/workspaces/vibe-k8s-lab/_p99_push.ps1",
+            "/c/Users/vencs/vibe-k8s-lab/_quick_fix.cmd",
+            r"some\nested\dir\_helper.bat",
+        ],
+    )
+    def test_blocks_ad_hoc_outside_whitelist(self, file_path: str) -> None:
+        code, stderr = _run_with_payload(
+            {"tool_name": "Write", "tool_input": {"file_path": file_path}}
+        )
+        assert code == 2, f"expected block for {file_path!r}"
+        assert "win_git_escape.bat" in stderr or "win_gh.bat" in stderr
+
+    @pytest.mark.parametrize(
+        "file_path",
+        [
+            # Whitelisted dirs
+            "scripts/ops/win_new_subcommand.bat",
+            "/workspaces/vibe-k8s-lab/scripts/ops/_local_helper.bat",
+            "scripts/tools/lint/_my_helper.ps1",
+            "tools/portal/_internal.cmd",
+            # Non-script files (no _ prefix)
+            "scripts/ops/win_gh.bat",
+            "scripts/ops/win_git_escape.bat",
+            # Wrong extension (not bat/ps1/cmd)
+            "/workspaces/vibe-k8s-lab/_some_doc.md",
+            "/workspaces/vibe-k8s-lab/_msg.txt",
+        ],
+    )
+    def test_allows_legit_writes(self, file_path: str) -> None:
+        code, _ = _run_with_payload(
+            {"tool_name": "Write", "tool_input": {"file_path": file_path}}
+        )
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Failure policy — never block on hook bugs
+# ---------------------------------------------------------------------------
+
+class TestNeverBlocksOnHookFailure:
+    def test_invalid_json_allows(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPT)],
+            input="not json {{{",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert proc.returncode == 0
+        assert "warning" in proc.stderr.lower()
+
+    def test_empty_stdin_allows(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPT)],
+            input="",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert proc.returncode == 0
+
+    def test_unknown_tool_allows(self) -> None:
+        code, _ = _run_with_payload(
+            {"tool_name": "ReadAndPonder", "tool_input": {"x": 1}}
+        )
+        assert code == 0
+
+    def test_edit_tool_not_intercepted(self) -> None:
+        # Edit changes existing files — the ad-hoc whitelist is enforced at
+        # commit time by the existing pre-commit hook; we only intercept
+        # Write to avoid breaking legitimate Edit on whitelisted scripts.
+        code, _ = _run_with_payload(
+            {"tool_name": "Edit", "tool_input": {"file_path": r"C:\x\_foo.bat"}}
+        )
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Direct module-level smoke (covers the matchers when imported as a lib)
+# ---------------------------------------------------------------------------
+
+def test_module_loads_cleanly() -> None:
+    mod = _load_module()
+    assert hasattr(mod, "_check_bash")
+    assert hasattr(mod, "_check_write")
+    code, _ = mod._check_bash("ls /tmp")
+    assert code == 0
+    code, _ = mod._check_bash("sed -i s/x/y/ /workspaces/vibe-k8s-lab/x.md")
+    assert code == 2


### PR DESCRIPTION
## Summary

audit-2026-04 §H1+H2 — codify the **prevention layer** that was missing for dev-rules #11 and Trap #54. Both rules already have detect/repair layers running at commit time, but tokens are already burned producing the damage by then. This puts a Claude Code PreToolUse hook in front, so the model sees `exit 2` + a remediation message and self-corrects before any work is wasted.

- 1 of 3 PRs from the playbook-audit-2026-04 work (independent, any merge order)
- Companion PRs:
  - [docs/playbook-audit-cleanup-2026-04](https://github.com/vencil/Dynamic-Alerting-Integrations/tree/docs/playbook-audit-cleanup-2026-04) — playbook dedupe + SSOT archive + audit doc itself
  - [feat/help-escape-and-cleanup-scratch](https://github.com/vencil/Dynamic-Alerting-Integrations/tree/feat/help-escape-and-cleanup-scratch) — `make help-escape` + scratch sweeper

## Changes

- **`scripts/session-guards/preflight_bash.py`** (NEW, 206 LOC)
  - **Bash tool**: blocks `sed -i` (or `--in-place`) when the same command references a known mount-path token (covers `/sessions/*/mnt`, `/workspaces/vibe-k8s-lab`, `/c/Users/.../vibe-k8s-lab`, Windows native `C:\...`). Wide enough to catch real drift, narrow enough that legitimate `sed -i` on `/tmp` or host paths is fine.
  - **Write tool**: blocks `_*.bat` / `_*.ps1` / `_*.cmd` outside the `scripts/ops/` / `scripts/tools/` / `tools/` whitelist (mirrors the existing pre-commit `check_ad_hoc_git_scripts.py`).
  - **Failure policy**: parse errors / unhandled exceptions exit 0 with a stderr warning. Hook **NEVER** blocks a tool call on its own bug.

- **`tests/dx/test_preflight_bash.py`** (NEW, 207 LOC, 34 tests) — parametrised coverage of: 10 mount-path sed patterns blocked, 7 safe sed allowed, 4 ad-hoc bat blocked, 8 legit Write allowed, 4 failure modes, 1 module-load smoke.

- **`.claude/settings.json`** — append a second PreToolUse entry; preserves the existing session-init hook untouched.

- **`docs/internal/dev-rules.md` §11** — add a 4-way decision tree and the 4-layer defense table. Stays under the 500-line cap (499 lines).

- **`CLAUDE.md`** — mention the new hook in §Agent 起手式.

## Why prevention matters here

| Layer | Tool | Triggers when | Token cost when triggered |
|---|---|---|---|
| **Prevent (harness)** ← **NEW** | `preflight_bash.py` | tool call about to run | ~0 (block before anything happens) |
| Detect (commit) | `detect_sed_damage.py` | git commit | files already modified, fix needed |
| Repair (commit) | `fix_file_hygiene.py` | git commit | files modified, hook auto-fixes |
| Shell wrapper | `vibe-sed-guard.sh` | docker exec / human dev | shell session aware, doesn't fire from Claude Code Bash tool |

Before this PR: `sed -i /workspaces/...` would burn tokens producing damaged files, then get caught at commit. After: blocked at the source.

## Test plan

- [ ] `python -m pytest tests/dx/test_preflight_bash.py -v` → 34/34 green
- [ ] `pre-commit run --files .claude/settings.json CLAUDE.md docs/internal/dev-rules.md scripts/session-guards/preflight_bash.py tests/dx/test_preflight_bash.py` → no failures
- [ ] Spot test live: `echo '{"tool_name":"Bash","tool_input":{"command":"sed -i s/foo/bar/ /workspaces/vibe-k8s-lab/x.md"}}' | python scripts/session-guards/preflight_bash.py` → exit 2 + remediation message
- [ ] Spot test allow: `echo '{"tool_name":"Bash","tool_input":{"command":"sed -i s/x/y/ /tmp/foo.txt"}}' | python scripts/session-guards/preflight_bash.py` → exit 0
- [ ] dev-rules.md still under 500-line cap

## Dogfood evidence

This very PR was authored under the new hook. The hook fired exactly once during the audit work — when an end-to-end test command triggered it from Bash. exit 2 + clear remediation, model self-corrected. Hook is live and demonstrably effective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)