### PR TITLE
feat(dx): make help-escape + cleanup_scratch.py for stray-file sweep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,12 +211,17 @@ vscode-git-on: ## 開啟 VS Code Git（手動開發用）
 	@python3 scripts/session-guards/vscode_git_toggle.py on
 
 .PHONY: session-cleanup
-session-cleanup: ## Session 結束或異常終止後的清理
+session-cleanup: ## Session 結束或異常終止後的清理。SCRATCH=1 加掃 %TEMP% / /c/tmp scratch；DRY=1 列出不刪
 	@python3 scripts/session-guards/vscode_git_toggle.py on 2>/dev/null || true
 	@bash scripts/session-guards/git_check_lock.sh --clean 2>/dev/null || true
 	@-pkill -f "[k]ubectl.*port-forward" 2>/dev/null; true
 	@rm -f _out.txt _err.txt 2>/dev/null || true
 	@python3 scripts/tools/lint/validate_planning_session_row.py 2>/dev/null || true
+	@if [ "$(SCRATCH)" = "1" ]; then \
+		python3 scripts/session-guards/cleanup_scratch.py $(if $(filter 1,$(DRY)),--dry-run,--apply); \
+	else \
+		echo "  (use SCRATCH=1 to also sweep %TEMP% / /c/tmp scratch; DRY=1 to preview)"; \
+	fi
 	@echo "✅ Session cleanup 完成"
 
 .PHONY: check-planning-bloat
@@ -862,3 +867,34 @@ vendor-check: ## 檢查 vendor/ 資源是否完整
 .PHONY: help
 help: ## 顯示說明
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: help-escape
+help-escape: ## 列出所有 Windows / FUSE 逃生門工具（卡死時的速查）— audit-2026-04 §T1
+	@printf '\033[1m=== Vibe Escape-Hatch Tools (Windows / FUSE rescue) ===\033[0m\n'
+	@printf '\n\033[33mWhen FUSE / MCP / pre-commit blocks you, scan this first.\n'
+	@printf 'Do NOT write _*.bat / _*.ps1 yourself -- the harness will block it.\033[0m\n\n'
+	@printf '\033[1m-- Make targets --\033[0m\n'
+	@printf '  \033[36mwin-commit\033[0m         sandbox hook-gate -> Windows stage/commit/push\n'
+	@printf '                       (MSG=_msg.txt FILES="a b" [SKIP=h1,h2] [SKIP_HOOKS=1])\n'
+	@printf '  \033[36mfuse-commit\033[0m        pure-sandbox plumbing commit (bypasses .git/index.lock)\n'
+	@printf '                       (MSG=_msg.txt FILES="a b" [AMEND=1])\n'
+	@printf '  \033[36mfuse-locks\033[0m         detect phantom lock state in .git/\n'
+	@printf '  \033[36mfuse-reset\033[0m         FUSE cache rebuild (Level 1+3) for ghost files\n'
+	@printf '  \033[36mrecover-index\033[0m      atomic rebuild .git/index from HEAD (CHECK=1 to diagnose only)\n'
+	@printf '  \033[36msession-cleanup\033[0m    end-of-session cleanup\n\n'
+	@printf '\033[1m-- Windows-side wrappers (scripts/ops/, all whitelisted) --\033[0m\n'
+	@printf '  \033[36mwin_git_escape.bat\033[0m  status / add / commit-file / push / tag / branch / log /\n'
+	@printf '                       diff / preflight / pr-preflight / fix-hooks / raw <args>\n'
+	@printf '  \033[36mwin_gh.bat\033[0m          pr-checks / pr-view / pr-create / run-view / run-log /\n'
+	@printf '                       raw <args>     (8.3 short path + CRLF + ASCII enforced)\n'
+	@printf '  \033[36mwin_async_exec.ps1\033[0m  fire-and-forget for >60s ops (returns PID, polls log)\n'
+	@printf '  \033[36mwin_read_fresh.ps1\033[0m  Win32 ReadAllBytes -> bypass FUSE dentry cache\n\n'
+	@printf '\033[1m-- Sandbox-side helpers --\033[0m\n'
+	@printf '  \033[36mscripts/ops/run_hooks_sandbox.sh\033[0m   sandbox-side pre-commit gate\n'
+	@printf '                                    (covers Windows commit -no-verify gap)\n'
+	@printf '  \033[36mscripts/ops/fuse_plumbing_commit.py\033[0m phantom-lock-immune commit via plumbing\n'
+	@printf '  \033[36mscripts/ops/recover_index.sh\033[0m       atomic .git/index rebuild\n\n'
+	@printf '\033[1m-- Decision tree --\033[0m\n'
+	@printf '  See: docs/internal/windows-mcp-playbook.md "Git \xe6\x93\x8d\xe4\xbd\x9c\xe6\xb1\xba\xe7\xad\x96\xe6\xa8\xb9"\n'
+	@printf '       (#git-\xe6\x93\x8d\xe4\xbd\x9c\xe6\xb1\xba\xe7\xad\x96\xe6\xa8\xb9)\n'
+	@printf '  And:  docs/internal/dev-rules.md \xc2\xa711 (file hygiene decision tree)\n'

--- a/scripts/session-guards/cleanup_scratch.py
+++ b/scripts/session-guards/cleanup_scratch.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Sweep stale scratch artifacts left behind by past Claude Code sessions.
+
+Targets (audit playbook-audit-2026-04 §T2):
+  - %TEMP% / /tmp on the host (vibe-bat-*, vibe-git-*, pr*-msg*, pr*-body*,
+    commit-out*, _jsx_out*, _out.txt, pre-commit-final.yaml)
+  - /c/tmp ad-hoc python / scratch (audit_*.py, bulk_*.py, fix_encoding.py,
+    probe.go, _backup.*, _msg.txt, test_violations.txt)
+  - vibe-session-init.* markers older than 24 hours
+
+Default mode is --dry-run (list only). Use --apply to actually delete.
+
+Safety:
+  - Files modified within the last 60 minutes are NEVER deleted (current
+    session might still be using them).
+  - The script does NOT touch repo files, .gitconfig, .claude.json, or
+    anything outside %TEMP% / /tmp / /c/tmp.
+  - Pattern matches are anchored to filename basenames -- subdirectories
+    are not recursed into.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Iterable
+
+# Filename-basename patterns to sweep. Each pattern is a single fnmatch glob
+# applied to the basename only. Order doesn't matter -- the first match wins.
+_SCRATCH_PATTERNS: tuple[str, ...] = (
+    # Tool-runtime artifacts
+    "vibe-bat-*.txt",
+    "vibe-git-*.txt",
+    # PR-sweep scratch
+    "pr*-msg.txt",
+    "pr*-msg-*.txt",
+    "pr*-fix*-msg.txt",
+    "pr*-body.md",
+    "pr*-body-*.md",
+    "pr*-backlog-body.md",
+    # Commit / hook outputs
+    "commit-out.txt",
+    "commit-out*.txt",
+    "commit-output.txt",
+    "_jsx_out*.txt",
+    "_out.txt",
+    "pre-commit-final.yaml",
+    # /c/tmp ad-hoc analysis
+    "audit_*.py",
+    "bulk_*.py",
+    "fix_encoding.py",
+    "probe.go",
+    "_backup.*",
+    "_msg.txt",
+    "test_violations.txt",
+)
+
+# Stale session-init markers (>24 hr) are sweep targets too.
+_SESSION_MARKER_PREFIX = "vibe-session-init."
+_SESSION_MARKER_AGE_HOURS = 24
+
+# Recently-modified files are skipped in case the current session is still
+# writing to them.
+_MIN_AGE_SECONDS = 60 * 60  # 1 hour
+
+
+def _scan_dirs() -> list[Path]:
+    """Return scan target dirs that exist on this host."""
+    candidates = [
+        # %TEMP%
+        Path(os.environ.get("TEMP") or os.environ.get("TMP") or "/tmp"),
+        # /c/tmp on Windows / Git Bash sandbox
+        Path("/c/tmp"),
+        Path("C:/tmp"),
+        # /tmp on Linux / Cowork VM
+        Path("/tmp"),
+    ]
+    seen = set()
+    out: list[Path] = []
+    for c in candidates:
+        try:
+            resolved = c.resolve()
+        except OSError:
+            continue
+        key = str(resolved).replace("\\", "/").rstrip("/")
+        if key in seen:
+            continue
+        seen.add(key)
+        if resolved.is_dir():
+            out.append(resolved)
+    return out
+
+
+def _matches_scratch(name: str) -> bool:
+    import fnmatch
+    return any(fnmatch.fnmatch(name, p) for p in _SCRATCH_PATTERNS)
+
+
+def _is_stale_session_marker(name: str, mtime: float, now: float) -> bool:
+    if not name.startswith(_SESSION_MARKER_PREFIX):
+        return False
+    age_hr = (now - mtime) / 3600.0
+    return age_hr > _SESSION_MARKER_AGE_HOURS
+
+
+def _candidates_in(directory: Path, now: float) -> Iterable[tuple[Path, str, float]]:
+    """Yield (path, reason, age_seconds) for sweep candidates."""
+    try:
+        entries = list(directory.iterdir())
+    except OSError:
+        return
+    for entry in entries:
+        if not entry.is_file():
+            continue
+        try:
+            stat = entry.stat()
+        except OSError:
+            continue
+        age = now - stat.st_mtime
+        if age < _MIN_AGE_SECONDS:
+            continue
+        name = entry.name
+        if _matches_scratch(name):
+            yield entry, "scratch", age
+            continue
+        if _is_stale_session_marker(name, stat.st_mtime, now):
+            yield entry, "stale-session-marker", age
+            continue
+
+
+def _format_age(seconds: float) -> str:
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m"
+    if seconds < 86400:
+        return f"{int(seconds // 3600)}h"
+    return f"{int(seconds // 86400)}d"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--dry-run", action="store_true", default=True,
+                       help="list candidates without deleting (default)")
+    group.add_argument("--apply", action="store_true",
+                       help="actually delete the candidates")
+    args = parser.parse_args()
+
+    apply_mode = args.apply
+    now = time.time()
+
+    dirs = _scan_dirs()
+    if not dirs:
+        print("[cleanup-scratch] no scan dirs found; nothing to do")
+        return 0
+
+    total_files = 0
+    total_bytes = 0
+    deleted = 0
+    failed: list[tuple[Path, str]] = []
+
+    print(f"[cleanup-scratch] mode={'APPLY' if apply_mode else 'DRY-RUN'}  "
+          f"dirs={len(dirs)}  age-floor={_MIN_AGE_SECONDS // 60}min")
+
+    for directory in dirs:
+        items = list(_candidates_in(directory, now))
+        if not items:
+            continue
+        print(f"\n  {directory}/")
+        for path, reason, age in items:
+            try:
+                size = path.stat().st_size
+            except OSError:
+                size = 0
+            total_files += 1
+            total_bytes += size
+            label = f"    {reason:21s} {_format_age(age):>4s}  {size:>7d} B  {path.name}"
+            if apply_mode:
+                try:
+                    path.unlink()
+                    deleted += 1
+                    label = "[deleted] " + label
+                except OSError as exc:
+                    failed.append((path, str(exc)))
+                    label = "[failed]  " + label
+            print(label)
+
+    if total_files == 0:
+        print("\n[cleanup-scratch] no scratch artifacts found.")
+        return 0
+
+    print(
+        f"\n[cleanup-scratch] {total_files} candidate file(s), "
+        f"{total_bytes / 1024:.1f} KB total"
+    )
+    if apply_mode:
+        print(f"  deleted: {deleted}")
+        if failed:
+            print(f"  failed: {len(failed)}")
+            for path, err in failed:
+                print(f"    {path}: {err}")
+            return 1
+    else:
+        print("  Re-run with --apply to actually delete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/dx/test_cleanup_scratch.py
+++ b/tests/dx/test_cleanup_scratch.py
@@ -1,0 +1,166 @@
+"""Tests for scripts/session-guards/cleanup_scratch.py.
+
+Covers (audit playbook-audit-2026-04 §T2):
+  - Dry-run is default; --apply needed to delete
+  - Recent files (<1h old) are NEVER deleted
+  - Recognised scratch patterns are matched
+  - Session-init markers >24h are stale, <24h kept
+  - Non-matching files are not touched
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "session-guards" / "cleanup_scratch.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("cleanup_scratch", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_old_file(tmp_path: Path, name: str, age_hours: float = 2.0) -> Path:
+    """Create a file with mtime in the past."""
+    p = tmp_path / name
+    p.write_text("scratch")
+    past = time.time() - age_hours * 3600
+    os.utime(p, (past, past))
+    return p
+
+
+@pytest.fixture
+def isolated_dirs(monkeypatch, tmp_path):
+    """Point the scan to an isolated tmp dir."""
+    mod = _load_module()
+    fake_dir = tmp_path / "fake_temp"
+    fake_dir.mkdir()
+    monkeypatch.setattr(mod, "_scan_dirs", lambda: [fake_dir])
+    return mod, fake_dir
+
+
+class TestPatternMatching:
+    def test_matches_known_scratch(self):
+        mod = _load_module()
+        for name in [
+            "vibe-bat-out.txt", "vibe-git-err.txt",
+            "pr1-msg.txt", "pr12-backlog-body.md", "pr5-fix-msg.txt",
+            "commit-out.txt", "commit-output.txt",
+            "_jsx_out.txt", "_out.txt",
+            "pre-commit-final.yaml",
+            "audit_open.py", "bulk_annotate_tests.py",
+            "fix_encoding.py", "probe.go",
+            "_backup.css", "_backup.jsx", "_msg.txt",
+            "test_violations.txt",
+        ]:
+            assert mod._matches_scratch(name), f"should match: {name}"
+
+    def test_does_not_match_legit_files(self):
+        mod = _load_module()
+        for name in [
+            "important-notes.md", "config.yaml", "main.py",
+            "README.md", "secret.json",
+            # vibe-session-init handled separately, not matched as scratch
+            "vibe-session-init.abc123",
+        ]:
+            assert not mod._matches_scratch(name), f"should NOT match: {name}"
+
+
+class TestStaleSessionMarker:
+    def test_old_marker_is_stale(self):
+        mod = _load_module()
+        now = time.time()
+        old = now - 25 * 3600  # 25 hours ago
+        assert mod._is_stale_session_marker("vibe-session-init.abc", old, now)
+
+    def test_recent_marker_kept(self):
+        mod = _load_module()
+        now = time.time()
+        recent = now - 6 * 3600  # 6 hours ago
+        assert not mod._is_stale_session_marker(
+            "vibe-session-init.abc", recent, now
+        )
+
+    def test_non_marker_not_classified(self):
+        mod = _load_module()
+        now = time.time()
+        old = now - 25 * 3600
+        assert not mod._is_stale_session_marker("foo.txt", old, now)
+
+
+class TestSweepBehavior:
+    def test_recent_file_never_deleted(self, isolated_dirs, capsys):
+        mod, d = isolated_dirs
+        # 30 minutes old — under 60min floor
+        f = _make_old_file(d, "vibe-bat-out.txt", age_hours=0.5)
+        # Run apply mode directly via main()
+        rc = mod.main.__wrapped__() if hasattr(mod.main, "__wrapped__") else None
+        # Direct subprocess to also exercise CLI parser
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--apply"],
+            env={**os.environ, "TEMP": str(d), "TMP": str(d)},
+            capture_output=True, text=True, timeout=10,
+        )
+        # Recent file is never returned by _candidates_in -> not deleted
+        assert f.exists()
+        assert "no scratch artifacts found" in proc.stdout or "0 candidate" in proc.stdout
+
+    def test_old_scratch_listed_in_dry_run(self, isolated_dirs, monkeypatch):
+        mod, d = isolated_dirs
+        _make_old_file(d, "pr3-msg.txt", age_hours=3)
+        _make_old_file(d, "audit_thing.py", age_hours=3)
+        _make_old_file(d, "important.md", age_hours=3)
+        # Patch sys.argv for argparse, run main directly
+        monkeypatch.setattr(sys, "argv", ["cleanup_scratch.py"])
+        rc = mod.main()
+        assert rc == 0
+        # Files should still exist (dry-run)
+        assert (d / "pr3-msg.txt").exists()
+        assert (d / "audit_thing.py").exists()
+        assert (d / "important.md").exists()
+
+    def test_apply_deletes_only_matching(self, isolated_dirs, monkeypatch):
+        mod, d = isolated_dirs
+        _make_old_file(d, "pr3-msg.txt", age_hours=3)
+        _make_old_file(d, "audit_thing.py", age_hours=3)
+        _make_old_file(d, "important.md", age_hours=3)
+        monkeypatch.setattr(sys, "argv", ["cleanup_scratch.py", "--apply"])
+        rc = mod.main()
+        assert rc == 0
+        assert not (d / "pr3-msg.txt").exists()
+        assert not (d / "audit_thing.py").exists()
+        # Non-matching file untouched
+        assert (d / "important.md").exists()
+
+    def test_stale_session_marker_swept(self, isolated_dirs, monkeypatch):
+        mod, d = isolated_dirs
+        _make_old_file(d, "vibe-session-init.OLD", age_hours=25)
+        _make_old_file(d, "vibe-session-init.NEW", age_hours=6)
+        monkeypatch.setattr(sys, "argv", ["cleanup_scratch.py", "--apply"])
+        mod.main()
+        assert not (d / "vibe-session-init.OLD").exists()
+        assert (d / "vibe-session-init.NEW").exists()
+
+
+class TestCLIDefaults:
+    def test_dry_run_is_default(self, tmp_path, monkeypatch):
+        # Create a scratch file in a controlled dir
+        d = tmp_path / "fakespace"
+        d.mkdir()
+        _make_old_file(d, "pr1-msg.txt", age_hours=3)
+        # Mock _scan_dirs at the module level for the CLI invocation
+        mod = _load_module()
+        monkeypatch.setattr(mod, "_scan_dirs", lambda: [d])
+        monkeypatch.setattr(sys, "argv", ["cleanup_scratch.py"])
+        mod.main()
+        assert (d / "pr1-msg.txt").exists()  # still there, dry-run default


### PR DESCRIPTION
## Summary

audit-2026-04 §T1+T2 — discoverability and predictable cleanup for the escape-hatch tooling.

- 3 of 3 PRs from the playbook-audit-2026-04 work (independent, any merge order)
- Companion PRs:
  - [feat/preflight-hook-sed-i-and-adhoc-bat](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/372) — PreToolUse hook
  - [docs/playbook-audit-cleanup-2026-04](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/373) — playbook dedupe + audit doc

## Changes

### `make help-escape`

One-screen index of all 13 escape-hatch tools (Make targets, Windows wrappers, sandbox helpers). Sessions hitting FUSE / MCP / pre-commit obstacles can scan this instead of reading the 1000-line `windows-mcp-playbook` from the top, OR (worse) reinventing a `_*.bat` wrapper that the pre-commit hook would block anyway.

```
$ make help-escape
=== Vibe Escape-Hatch Tools (Windows / FUSE rescue) ===

When FUSE / MCP / pre-commit blocks you, scan this first.
Do NOT write _*.bat / _*.ps1 yourself -- the harness will block it.

-- Make targets --
  win-commit         sandbox hook-gate -> Windows stage/commit/push
  fuse-commit        pure-sandbox plumbing commit (bypasses .git/index.lock)
  fuse-locks         detect phantom lock state in .git/
  fuse-reset         FUSE cache rebuild (Level 1+3) for ghost files
  recover-index      atomic rebuild .git/index from HEAD (CHECK=1 to diagnose only)
  session-cleanup    end-of-session cleanup

-- Windows-side wrappers (scripts/ops/, all whitelisted) --
  win_git_escape.bat  status / add / commit-file / push / tag / branch / log /
                      diff / preflight / pr-preflight / fix-hooks / raw <args>
  win_gh.bat          pr-checks / pr-view / pr-create / run-view / run-log /
                      raw <args>     (8.3 short path + CRLF + ASCII enforced)
  win_async_exec.ps1  fire-and-forget for >60s ops (returns PID, polls log)
  win_read_fresh.ps1  Win32 ReadAllBytes -> bypass FUSE dentry cache

-- Sandbox-side helpers --
  scripts/ops/run_hooks_sandbox.sh    sandbox-side pre-commit gate
                                      (covers Windows commit -no-verify gap)
  scripts/ops/fuse_plumbing_commit.py phantom-lock-immune commit via plumbing
  scripts/ops/recover_index.sh        atomic .git/index rebuild

-- Decision tree --
  See: docs/internal/windows-mcp-playbook.md "Git 操作決策樹"
       (#git-操作決策樹)
  And:  docs/internal/dev-rules.md §11 (file hygiene decision tree)
```

### `cleanup_scratch.py` + `make session-cleanup SCRATCH=1`

Sweeps stale scratch artifacts that pile up in `%TEMP%` / `/c/tmp` over multiple sessions:

- **Tool-runtime artifacts**: `vibe-bat-*.txt`, `vibe-git-*.txt`
- **PR-sweep scratch**: `pr*-msg.txt`, `pr*-body.md`
- **Hook outputs**: `commit-out*.txt`, `_jsx_out*`, `_out.txt`
- **Ad-hoc python**: `audit_*.py`, `bulk_*.py`, `fix_encoding.py`, `probe.go`, `_backup.*`, `_msg.txt`, `test_violations.txt`
- **Stale `vibe-session-init.*` markers** (>24h)

**Safety**:

- 60-minute age floor — never touches files the current session might still be writing to
- **Dry-run is the default**; `--apply` required to actually delete
- Pattern matches anchored to filename basenames (no recursion into subdirs)
- Doesn't touch repo files, `~/.gitconfig`, or `~/.claude.json`

10 tests cover pattern matching, stale-marker logic, recent-file exclusion, dry-run-by-default, and selective deletion (only matching patterns).

## Why this exists

Maintainer audit observed `C:\Users\vencs` had accumulated ~31 stray scratch files from past PR sweeps — **not** new escape-hatch wheel reinvention (the pre-commit `check_ad_hoc_git_scripts.py` whitelist already physically blocks that), but session log + commit-message draft files that nobody cleaned up. Without periodic sweep the maintainer's home dir slowly fills with 4-5 day-old leftover files.

A1 of the audit cleaned the existing pile (one-time). This PR provides the recurring sweep so it doesn't accumulate again.

## Test plan

- [ ] `python -m pytest tests/dx/test_cleanup_scratch.py -v` → 10/10 green
- [ ] `pre-commit run --files Makefile scripts/session-guards/cleanup_scratch.py tests/dx/test_cleanup_scratch.py` clean
- [ ] `python3 scripts/session-guards/cleanup_scratch.py` (no flag) → exits 0; either "no scratch artifacts found" or shows candidates with sizes/ages without deleting
- [ ] `python3 scripts/session-guards/cleanup_scratch.py --apply` deletes only matching patterns, leaves recent files (<60min) and non-matching files untouched
- [ ] `make help-escape` lists 13 tools and renders without UTF-8 errors on Windows console (`PYTHONUTF8=1` not assumed)
- [ ] `make session-cleanup SCRATCH=1 DRY=1` integrates the sweep call

🤖 Generated with [Claude Code](https://claude.com/claude-code)