### PR TITLE
feat(lint): codename-leak diff-aware refactor + CI wiring (#381 V-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
         run: pip install pre-commit pyyaml
 
       - name: Run pre-commit hooks
+        # PR_BODY exposes the PR description body to bypass-aware lints.
+        # check_codename_leak.py reads it for `bypass-lint: codename-leak`
+        # tags per docs/internal/lint-policy.md §4. Empty string on push
+        # events (not a PR) — bypass simply not applicable in that mode.
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           pre-commit run tool-map-check --all-files
           pre-commit run doc-map-check --all-files
@@ -53,6 +59,10 @@ jobs:
           pre-commit run includes-sync --all-files
           pre-commit run platform-data-check --all-files
           pre-commit run repo-name-check --all-files
+          # Codename-leak guard runs in diff-only mode by default (lint-policy
+          # §3 (b) class). resolve_diff_base() auto-picks origin/$GITHUB_BASE_REF
+          # so the fetch-depth: 0 above is sufficient — no extra env wiring.
+          pre-commit run codename-leak-check --all-files
           pre-commit run tool-consistency-check --all-files
           pre-commit run structure-check --all-files
           pre-commit run routing-profiles-check --all-files

--- a/scripts/tools/lint/_lint_helpers.py
+++ b/scripts/tools/lint/_lint_helpers.py
@@ -4,12 +4,17 @@
 v2.4.0: Extracted from duplicated code in check_build_completeness.py,
 check_cli_coverage.py, and tests/test_entrypoint.py.
 
+v2.8.0: Added diff-aware helpers for class (b)/(c) lints (per
+docs/internal/lint-policy.md): get_diff_added_lines, resolve_diff_base,
+parse_bypass_tag.
+
 Provides common parsers for entrypoint.py COMMAND_MAP and build.sh TOOL_FILES.
 """
 from __future__ import annotations
 
 import os
 import re
+import subprocess
 from pathlib import Path
 from typing import Dict, Set
 
@@ -102,3 +107,135 @@ def parse_build_sh_tools(path: Path | None = None) -> Set[str]:
                 if name:
                     tools.add(os.path.basename(name))
     return tools
+
+
+# ---------------------------------------------------------------------------
+# Diff-aware lint helpers (lint-policy.md compliance for class b/c lints)
+# ---------------------------------------------------------------------------
+
+
+class DiffBaseMissingError(RuntimeError):
+    """Raised when the diff base ref (e.g. origin/main) cannot be resolved.
+
+    Most common cause: GitHub Actions ``actions/checkout@v4`` defaults to
+    ``fetch-depth: 1`` (shallow clone), which leaves no ``origin/main`` in
+    the CI worker's ``.git`` directory. See ``docs/internal/lint-policy.md``
+    §"GitHub Actions 淺拷貝陷阱" — workflows running diff-aware lints must
+    set ``fetch-depth: 0`` (full history) or explicitly ``git fetch origin
+    <base-ref>`` before invoking the lint.
+    """
+
+
+def resolve_diff_base(env_var: str = "LINT_DIFF_BASE", default: str = "origin/main") -> str:
+    """Return the diff base ref, validating it actually exists locally.
+
+    Resolution order:
+
+    1. ``$LINT_DIFF_BASE`` env var (explicit override; useful for testing
+       a different branch base locally).
+    2. ``origin/$GITHUB_BASE_REF`` (auto-set by GitHub Actions on
+       ``pull_request`` events; means "the branch this PR targets").
+    3. ``origin/main`` default for local dev not on a PR branch.
+
+    Calls ``git rev-parse --verify`` to confirm the ref resolves; raises
+    ``DiffBaseMissingError`` with a fetch-depth hint if not — never
+    silently falls through to "scan everything", which would defeat the
+    diff-aware purpose per lint-policy.md.
+    """
+    base = os.environ.get(env_var)
+    if not base:
+        gh_base = os.environ.get("GITHUB_BASE_REF")
+        if gh_base:
+            base = f"origin/{gh_base}"
+        else:
+            base = default
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{base}^{{commit}}"],
+        capture_output=True, text=True, cwd=str(REPO_ROOT), timeout=10,
+    )
+    if result.returncode != 0:
+        hint_branch = base.removeprefix("origin/")
+        raise DiffBaseMissingError(
+            f"git diff base ref '{base}' does not resolve in this repo.\n"
+            f"  - In CI: ensure actions/checkout@v4 uses fetch-depth: 0\n"
+            f"    (or `git fetch origin {hint_branch}` before lint)\n"
+            f"  - Locally: ensure you have an up-to-date `origin/main`\n"
+            f"    (run `git fetch origin main`)\n"
+            f"  - Override with $LINT_DIFF_BASE if your base branch differs\n"
+            f"  See docs/internal/lint-policy.md §\"GitHub Actions 淺拷貝陷阱\""
+        )
+    return base
+
+
+_HUNK_HEADER_RE = re.compile(r"^@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,(\d+))?\s+@@")
+
+
+def _parse_unified_zero_diff(diff_text: str) -> list:
+    """Parse `git diff --unified=0` output and return added lines with line numbers."""
+    added = []
+    current_lineno = None
+    for line in diff_text.splitlines():
+        if line.startswith("@@"):
+            m = _HUNK_HEADER_RE.match(line)
+            current_lineno = int(m.group(1)) if m else None
+            continue
+        if current_lineno is None:
+            continue
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            added.append((current_lineno, line[1:]))
+            current_lineno += 1
+        elif line.startswith("-"):
+            pass  # deleted lines don't advance new-file line counter
+        else:
+            current_lineno += 1  # context line — guard for non-unified=0
+    return added
+
+
+def get_diff_added_lines(file_path: Path, base: str) -> list:
+    """Return ``[(line_no, content), ...]`` for lines ADDED in current diff vs ``base``.
+
+    Parses ``git diff --unified=0`` hunks. Existing (unchanged) lines and
+    removed (``-``) lines are not returned. ``line_no`` is the line number
+    in the *current* (post-diff) file, suitable for citing in lint errors.
+
+    Returns ``[]`` if the file is identical to base. Returns all file lines
+    if the file is newly added in this diff (no base version).
+    """
+    if file_path.is_absolute():
+        try:
+            rel = file_path.relative_to(REPO_ROOT)
+        except ValueError:
+            rel = file_path
+    else:
+        rel = file_path
+    result = subprocess.run(
+        ["git", "diff", "--unified=0", "--no-color", base, "--", str(rel)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        cwd=str(REPO_ROOT), check=True, timeout=30,
+    )
+    return _parse_unified_zero_diff(result.stdout)
+
+
+# PR-body bypass tag matcher per lint-policy.md §4. CI workflows pass
+# ${{ github.event.pull_request.body }} via env var or file flag.
+_BYPASS_TAG_RE = re.compile(
+    r"bypass-lint:\s*(?P<lint_name>[\w-]+)\s*\n\s*reason:\s*(?P<reason>.+?)(?=\n\s*issue:|\n\s*\n|\Z)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def parse_bypass_tag(pr_body, lint_name: str):
+    """Return the bypass reason if ``pr_body`` contains a valid ``bypass-lint:
+    <lint_name>`` block, else None.
+
+    Spec from lint-policy.md §4: tag must be on its own line, followed by
+    ``reason:`` line. Optional ``issue: #NN`` after. Matched case-insensitively.
+    """
+    if not pr_body:
+        return None
+    for m in _BYPASS_TAG_RE.finditer(pr_body):
+        if m.group("lint_name").lower() == lint_name.lower():
+            return m.group("reason").strip()
+    return None

--- a/scripts/tools/lint/check_codename_leak.py
+++ b/scripts/tools/lint/check_codename_leak.py
@@ -9,17 +9,39 @@ confuse external readers who have no access to the planning context.
 Scoped to T0 (public README) and T3 (component README + CLI --help) by
 default. CHANGELOG.md and docs/internal/** are intentionally allowed.
 
+Lint class: (b) per docs/internal/lint-policy.md (negative pattern + false-
+positive escape allowlist). Default scan scope: **diff-only** — only lines
+ADDED in the current PR's diff are checked, so engineer A's prior legitimate
+use doesn't get re-flagged when engineer B touches the same file. Override
+with --full-scan for occasional manual full-file audit.
+
 Usage:
-    python3 scripts/tools/lint/check_codename_leak.py [--ci] [--scope full]
+    # Diff-only (default; CI sets LINT_DIFF_BASE)
+    python3 scripts/tools/lint/check_codename_leak.py [--ci]
+
+    # Manual full-file scan (e.g., for periodic audit)
+    python3 scripts/tools/lint/check_codename_leak.py --full-scan [--ci]
+
+    # Wider exploratory scope (T1 + T2 docs)
+    python3 scripts/tools/lint/check_codename_leak.py --scope full
+
+Bypass (per lint-policy.md §4): if a finding is intentional, add to PR body:
+    bypass-lint: codename-leak
+    reason: <≥30 words explaining why this is legitimate>
+CI passes ${{ github.event.pull_request.body }} via $PR_BODY env var or
+--pr-body-file <path>; matched bypass turns hard-fail into warning + exit 0.
 
 Exit codes:
-    0  no leaks found
+    0  no leaks (or bypass matched with audit-trail warning)
     1  leaks found (with --ci)
+    2  diff base ref missing — fix CI workflow's fetch-depth or base ref
 """
 from __future__ import annotations
 
 import argparse
+import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -29,6 +51,15 @@ if hasattr(sys.stdout, "reconfigure"):
         sys.stdout.reconfigure(encoding="utf-8", errors="replace")
     except (AttributeError, OSError):
         pass
+
+# Helpers from this lint family
+sys.path.insert(0, str(Path(__file__).parent))
+from _lint_helpers import (  # noqa: E402
+    DiffBaseMissingError,
+    get_diff_added_lines,
+    parse_bypass_tag,
+    resolve_diff_base,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -93,8 +124,7 @@ PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 ]
 
 # Substrings that look like a hit but are legitimate. Lines containing any of
-# these are skipped entirely (cheap-and-cheerful — refine if false negatives
-# show up).
+# these are skipped entirely.
 ALLOW_LINE_SUBSTRINGS = (
     "SHA-256",
     "SHA-1",
@@ -111,9 +141,32 @@ ALLOW_LINE_SUBSTRINGS = (
     "GHSA-",
 )
 
-# Files inside scanned dirs to skip (binary or generated).
 SKIP_FILE_NAMES = {".DS_Store"}
 SKIP_EXT = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".pdf", ".zip"}
+
+# Pure code-comment lines (not user-visible). These are skipped because
+# codenames in source-level comments are legitimate dev annotations — only
+# strings rendered to users (docstrings, --help output, README body) need
+# to be clean. Markdown HTML comments are NOT skipped: they show up in the
+# raw .md view that contributors browse on GitHub.
+_CODE_COMMENT_PREFIXES = {
+    ".py": ("#",),
+    ".sh": ("#",),
+    ".bash": ("#",),
+    ".go": ("//",),
+    ".js": ("//",),
+    ".ts": ("//",),
+    ".jsx": ("//",),
+    ".tsx": ("//",),
+}
+
+
+def _is_code_comment(line: str, suffix: str) -> bool:
+    prefixes = _CODE_COMMENT_PREFIXES.get(suffix)
+    if not prefixes:
+        return False
+    stripped = line.lstrip()
+    return any(stripped.startswith(p) for p in prefixes)
 
 
 def iter_files(scan_paths: list[str]) -> list[Path]:
@@ -147,32 +200,8 @@ def scan_line(line: str) -> list[tuple[str, str]]:
     return hits
 
 
-# Pure code-comment lines (not user-visible). These are skipped because
-# codenames in source-level comments are legitimate dev annotations — only
-# strings rendered to users (docstrings, --help output, README body) need
-# to be clean. Markdown HTML comments are NOT skipped: they show up in the
-# raw .md view that contributors browse on GitHub.
-_CODE_COMMENT_PREFIXES = {
-    ".py": ("#",),
-    ".sh": ("#",),
-    ".bash": ("#",),
-    ".go": ("//",),
-    ".js": ("//",),
-    ".ts": ("//",),
-    ".jsx": ("//",),
-    ".tsx": ("//",),
-}
-
-
-def _is_code_comment(line: str, suffix: str) -> bool:
-    prefixes = _CODE_COMMENT_PREFIXES.get(suffix)
-    if not prefixes:
-        return False
-    stripped = line.lstrip()
-    return any(stripped.startswith(p) for p in prefixes)
-
-
-def scan_file(path: Path) -> list[tuple[int, str, str, str]]:
+def scan_file_full(path: Path) -> list[tuple[int, str, str, str]]:
+    """Full-file scan (used by --full-scan and as fallback for newly-added files)."""
     try:
         text = path.read_text(encoding="utf-8")
     except (UnicodeDecodeError, PermissionError):
@@ -187,8 +216,45 @@ def scan_file(path: Path) -> list[tuple[int, str, str, str]]:
     return out
 
 
+def scan_file_diff(path: Path, base: str) -> list[tuple[int, str, str, str]]:
+    """Diff-only scan: only check lines ADDED in current diff vs ``base``.
+
+    For files that are newly added (no base version), git diff still emits
+    every line as added, so this returns the full content scanned. For files
+    not present in current diff, returns empty list.
+    """
+    try:
+        added_lines = get_diff_added_lines(path, base)
+    except subprocess.CalledProcessError:
+        # Unexpected git failure — fall back to full scan to err on safe side
+        # (better to flag too much than miss). resolve_diff_base() should have
+        # caught the common "base ref missing" case earlier.
+        return scan_file_full(path)
+    suffix = path.suffix.lower()
+    out: list[tuple[int, str, str, str]] = []
+    for line_no, line in added_lines:
+        if _is_code_comment(line, suffix):
+            continue
+        for label, match in scan_line(line):
+            out.append((line_no, label, match, line.rstrip()))
+    return out
+
+
+def _read_pr_body(pr_body_file: str | None) -> str | None:
+    """Read PR body from --pr-body-file or $PR_BODY env var."""
+    if pr_body_file:
+        try:
+            return Path(pr_body_file).read_text(encoding="utf-8")
+        except (FileNotFoundError, PermissionError) as e:
+            print(f"WARN: cannot read --pr-body-file {pr_body_file}: {e}", file=sys.stderr)
+    return os.environ.get("PR_BODY") or None
+
+
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__.strip().splitlines()[0])
+    parser = argparse.ArgumentParser(
+        description=__doc__.strip().splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument(
         "--ci", action="store_true", help="Exit non-zero on any violation"
     )
@@ -198,28 +264,81 @@ def main() -> int:
         default="default",
         help="default: T0 + core component READMEs. full: also T1 + remaining T3.",
     )
+    parser.add_argument(
+        "--full-scan",
+        action="store_true",
+        help="Scan full file content (default is diff-only — recommended for CI).",
+    )
+    parser.add_argument(
+        "--diff-base",
+        default=None,
+        help="Override diff base (default: $LINT_DIFF_BASE env or origin/main).",
+    )
+    parser.add_argument(
+        "--pr-body-file",
+        default=None,
+        help="Path to file containing PR body for bypass tag check.",
+    )
     args = parser.parse_args()
 
     scan_paths = FULL_SCAN_PATHS if args.scope == "full" else DEFAULT_SCAN_PATHS
     files = iter_files(scan_paths)
 
-    total = 0
+    # Resolve scan mode
+    if args.full_scan:
+        scan_mode = "full-file"
+        scanner = lambda fp: scan_file_full(fp)  # noqa: E731
+    else:
+        try:
+            base = args.diff_base or resolve_diff_base()
+        except DiffBaseMissingError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 2
+        scan_mode = f"diff vs {base}"
+        scanner = lambda fp: scan_file_diff(fp, base)  # noqa: E731
+
+    # Collect findings
+    findings: list[tuple[str, int, str, str, str]] = []
     for fp in files:
         rel = fp.relative_to(REPO_ROOT).as_posix()
-        for line_no, label, match, snippet in scan_file(fp):
-            print(f"  {rel}:{line_no}: [{label}] '{match}' — {snippet[:120]}")
-            total += 1
+        for line_no, label, match, snippet in scanner(fp):
+            findings.append((rel, line_no, label, match, snippet))
 
+    # Bypass check (lint-policy.md §4)
+    pr_body = _read_pr_body(args.pr_body_file)
+    bypass_reason = parse_bypass_tag(pr_body, "codename-leak")
+
+    # Emit
+    for rel, line_no, label, match, snippet in findings:
+        print(f"  {rel}:{line_no}: [{label}] '{match}' — {snippet[:120]}")
+
+    total = len(findings)
     if total == 0:
-        print(f"OK no codename leaks in {len(files)} file(s) (scope={args.scope}).")
+        print(
+            f"OK no codename leaks in {len(files)} file(s) "
+            f"(mode={scan_mode}, scope={args.scope})."
+        )
+        return 0
+
+    if bypass_reason:
+        print(
+            f"\n⚠️  BYPASSED via PR body: {bypass_reason}\n"
+            f"   {total} finding(s) above are author-acknowledged intentional.\n"
+            f"   This PR retains audit trail; reviewer must confirm bypass is justified."
+        )
         return 0
 
     print(
-        f"\nFAIL {total} codename leak(s) found in scope={args.scope}.\n"
+        f"\nFAIL {total} codename leak(s) (mode={scan_mode}, scope={args.scope}).\n"
         f"  Codenames (Phase .c / Track A / TD-NNN / PR-N / S#NN / HA-NN /\n"
         f"  letter-id like C-12) belong in CHANGELOG.md or docs/internal/**\n"
         f"  only — never in user-facing surfaces. Replace with feature names\n"
-        f"  or version labels."
+        f"  or version labels.\n"
+        f"\n"
+        f"  If a finding is intentional, add to PR description:\n"
+        f"    bypass-lint: codename-leak\n"
+        f"    reason: <≥30 words explaining why this is legitimate>\n"
+        f"  See docs/internal/lint-policy.md §4 for bypass spec."
     )
     return 1 if args.ci else 0
 

--- a/tests/lint/test_check_codename_leak.py
+++ b/tests/lint/test_check_codename_leak.py
@@ -1,0 +1,242 @@
+"""Tests for check_codename_leak.py — diff-aware refactor (lint-policy.md compliance).
+
+Pinned contracts
+----------------
+1. **Pattern detection** (negative regex):
+   - "Phase .a/.b/.c" lowercase dot-prefixed → flagged
+   - "Phase A/B/C" plain (no dot) → NOT flagged (legitimate user-facing playbook structure)
+   - "Track [A-E]" → flagged
+   - "TD-NN" / "S#NN" / "HA-NN" / "REG-NN" / "PR-N" / "Wave N" / "[A-E]-NNN" → flagged
+
+2. **False-positive escape** (ALLOW_LINE_SUBSTRINGS):
+   - Lines containing SHA-256 / RFC-XXX / ISO-XXXX / CVE-XXXX → entire line skipped
+
+3. **Code-comment skip**:
+   - Python `#` line / shell `#` line / Go|JS|TS `//` line → skipped (not user-visible)
+   - Markdown HTML comments NOT skipped (visible in raw .md view)
+
+4. **Diff parsing** (_parse_unified_zero_diff in _lint_helpers):
+   - `@@ -X,Y +A,B @@` headers parse correctly
+   - Only `+` lines returned with correct line numbers
+   - `-` lines do NOT advance counter; `+` lines do
+
+5. **Bypass tag** (parse_bypass_tag in _lint_helpers):
+   - `bypass-lint: codename-leak` + `reason: ...` matched
+   - Wrong lint name in tag → no match
+   - Case-insensitive matching
+   - Multiple bypass tags → only matching one returned
+
+These tests exercise the lint's individual stages without invoking subprocess
+git commands (covered in integration tests when CI runs the full lint).
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "scripts", "tools", "lint"
+)
+sys.path.insert(0, _TOOLS_DIR)
+
+import check_codename_leak as ccl  # noqa: E402
+from _lint_helpers import (  # noqa: E402
+    _parse_unified_zero_diff,
+    parse_bypass_tag,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pattern detection
+# ---------------------------------------------------------------------------
+class TestPatternDetection:
+    @pytest.mark.parametrize(
+        "line,expected_label_substr",
+        [
+            ("Some text mentioning Phase .a feature", "Phase .a/.b/.c letter"),
+            ("Working in Phase .b track", "Phase .a/.b/.c letter"),
+            ("Plan involves Phase .c work", "Phase .a/.b/.c letter"),
+            ("Track A items only", "Track A/B/C letter"),
+            ("See Wave 3 backlog", "Wave N"),
+            ("Issue TD-030 follow-up", "TD-NNN ticket"),
+            ("S#74 closure", "S#NN sprint id"),
+            ("HA-11 hardening", "HA-NN sprint id"),
+            ("Done in PR-2d", "PR-N internal id"),
+            ("Item C-12 done", "Letter-prefix planning id"),
+            ("Item B-4 status", "Letter-prefix planning id"),
+        ],
+    )
+    def test_codename_patterns_flagged(self, line, expected_label_substr):
+        hits = ccl.scan_line(line)
+        assert hits, f"expected match for: {line!r}"
+        assert any(expected_label_substr in label for label, _ in hits)
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # User-facing playbook style — must NOT flag
+            "Phase A: Triage",
+            "Phase B: Convert + Shadow",
+            "Phase C: Cutover",
+            # Plain text, no codename signature
+            "This is normal text without internal markers.",
+            "Use the v2.8.0 release notes for details.",
+            # Code identifier with letter-digit but not in 1-3 digit range
+            "version 2-1-0 release",
+        ],
+    )
+    def test_clean_lines_not_flagged(self, line):
+        hits = ccl.scan_line(line)
+        assert hits == [], f"unexpected match in: {line!r}"
+
+
+class TestAllowlistEscape:
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "computed via SHA-256 hash",
+            "described in RFC-7234",
+            "compliant with ISO-8601 timestamps",
+            "tracking CVE-2024-12345",
+            "GHSA-abcd-1234 advisory",
+            "encoded UTF-8 / UTF-16 strings",
+            "uses HTTP/2 multiplexing",
+        ],
+    )
+    def test_known_technical_acronyms_skip_line(self, line):
+        # Even if the line contains a codename-pattern hit, ALLOW_LINE_SUBSTRINGS
+        # should suppress the entire line.
+        assert ccl.scan_line(line) == []
+
+    def test_allowlist_does_not_swallow_genuine_leak(self):
+        # Allowlist applies per-line; another line with a real codename still flagged.
+        line = "TD-030 still pending"  # no allowed substring
+        assert ccl.scan_line(line) != []
+
+
+class TestCodeCommentSkip:
+    @pytest.mark.parametrize(
+        "line,suffix,should_skip",
+        [
+            ("# TD-030 comment", ".py", True),
+            ("    # nested # TD-030", ".py", True),
+            ("// TD-030 in JS", ".js", True),
+            ("// TD-030 in Go", ".go", True),
+            ("# shell comment HA-11", ".sh", True),
+            # Not a comment — just contains # in middle
+            ("var = 'TD-030'  # noqa", ".py", False),
+            # Markdown — HTML comments visible to GitHub raw viewer, NOT skipped
+            ("<!-- TD-030 hidden in markdown -->", ".md", False),
+            # Plain text — not a recognized comment syntax
+            ("TD-030 in plain text", ".md", False),
+        ],
+    )
+    def test_code_comment_detection(self, line, suffix, should_skip):
+        assert ccl._is_code_comment(line, suffix) is should_skip
+
+
+# ---------------------------------------------------------------------------
+# Diff parsing (in _lint_helpers)
+# ---------------------------------------------------------------------------
+class TestDiffParsing:
+    def test_simple_added_line(self):
+        diff = (
+            "diff --git a/foo.md b/foo.md\n"
+            "--- a/foo.md\n"
+            "+++ b/foo.md\n"
+            "@@ -10,0 +11 @@\n"
+            "+New line content\n"
+        )
+        added = _parse_unified_zero_diff(diff)
+        assert added == [(11, "New line content")]
+
+    def test_multiple_added_lines_in_one_hunk(self):
+        diff = (
+            "@@ -5,0 +6,3 @@\n"
+            "+line a\n"
+            "+line b\n"
+            "+line c\n"
+        )
+        added = _parse_unified_zero_diff(diff)
+        assert added == [(6, "line a"), (7, "line b"), (8, "line c")]
+
+    def test_deletion_only_no_added(self):
+        diff = (
+            "@@ -10,2 +9,0 @@\n"
+            "-removed a\n"
+            "-removed b\n"
+        )
+        assert _parse_unified_zero_diff(diff) == []
+
+    def test_mixed_hunks_distinct_line_numbers(self):
+        diff = (
+            "@@ -1,1 +1,1 @@\n"
+            "-old line 1\n"
+            "+new line 1\n"
+            "@@ -10,0 +11 @@\n"
+            "+later addition\n"
+        )
+        added = _parse_unified_zero_diff(diff)
+        assert added == [(1, "new line 1"), (11, "later addition")]
+
+    def test_empty_diff_returns_empty(self):
+        assert _parse_unified_zero_diff("") == []
+
+
+# ---------------------------------------------------------------------------
+# Bypass tag parsing (in _lint_helpers)
+# ---------------------------------------------------------------------------
+class TestBypassTag:
+    def test_basic_bypass_matched(self):
+        body = (
+            "## Summary\n\n"
+            "bypass-lint: codename-leak\n"
+            "reason: This citation requires the historical codename for accuracy in the audit-trail discussion.\n"
+        )
+        result = parse_bypass_tag(body, "codename-leak")
+        assert result is not None
+        assert "historical codename" in result
+
+    def test_bypass_with_optional_issue(self):
+        body = (
+            "bypass-lint: codename-leak\n"
+            "reason: Legitimate use of internal id for design history reference.\n"
+            "issue: #999\n"
+        )
+        result = parse_bypass_tag(body, "codename-leak")
+        assert result == "Legitimate use of internal id for design history reference."
+
+    def test_wrong_lint_name_not_matched(self):
+        body = (
+            "bypass-lint: some-other-lint\n"
+            "reason: Not for codename-leak.\n"
+        )
+        assert parse_bypass_tag(body, "codename-leak") is None
+
+    def test_case_insensitive_match(self):
+        body = (
+            "BYPASS-LINT: Codename-Leak\n"
+            "Reason: Mixed case should match.\n"
+        )
+        assert parse_bypass_tag(body, "codename-leak") is not None
+
+    def test_no_bypass_in_body(self):
+        body = "This PR is straightforward, no bypass needed."
+        assert parse_bypass_tag(body, "codename-leak") is None
+
+    def test_empty_body(self):
+        assert parse_bypass_tag("", "codename-leak") is None
+        assert parse_bypass_tag(None, "codename-leak") is None
+
+    def test_multiple_bypasses_correct_one_returned(self):
+        body = (
+            "bypass-lint: other-lint\n"
+            "reason: For some other lint.\n\n"
+            "bypass-lint: codename-leak\n"
+            "reason: For codename leak.\n"
+        )
+        result = parse_bypass_tag(body, "codename-leak")
+        assert result == "For codename leak."

--- a/tests/shared/property-coverage.yaml
+++ b/tests/shared/property-coverage.yaml
@@ -173,6 +173,10 @@ modules:
       - parse_build_sh_tools
     excluded:
       parse_command_map_keys: "Trivial wrapper around parse_command_map; covered transitively"
+      resolve_diff_base: "Env-var lookup + git rev-parse subprocess wrapper; integration-tested via check_codename_leak --ci runs (smoke verified missing-base error path)"
+      get_diff_added_lines: "Subprocess wrapper around git diff --unified=0; parsing logic split into _parse_unified_zero_diff which has dedicated unit tests in test_check_codename_leak.py::TestDiffParsing"
+      _parse_unified_zero_diff: "Pure parser tested via 5 parametrized cases in test_check_codename_leak.py::TestDiffParsing covering simple add, multi-add hunk, deletion-only, mixed hunks with distinct line numbers, empty input"
+      parse_bypass_tag: "Regex matcher tested via 7 parametrized cases in test_check_codename_leak.py::TestBypassTag covering basic match, optional issue, wrong lint name, case-insensitive, empty body, multi-bypass disambiguation"
 
   scripts/tools/lint/check_flaky_registry.py:
     covered:


### PR DESCRIPTION
## Summary

Implements [issue #381](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/381) V-2 — refactor `check_codename_leak.py` to comply with the lint-policy.md class (b) spec shipped in PR #376.

### Why
PR #375 introduced the codename-leak lint as full-file scan + path-allowlisted. Gemini's adversarial review on PR #376 flagged the **collateral damage** scenario: engineer A adds a legitimate codename use, gets approved; engineer B touches a different line in same file → CI re-scans full file → flags A's prior code → blocks B. Lint-policy.md §3 mandated **diff-only** for class (b); this PR implements it.

Also closes a gap from PR #375: codename-leak hook was registered in `.pre-commit-config.yaml` but never wired into CI's Lint job — only ran on contributors who had pre-commit installed locally.

## Changes

### Functional
- **`scripts/tools/lint/_lint_helpers.py`** (+~110 lines): four new helpers
  - `DiffBaseMissingError` — fail-loud exception with fetch-depth hint
  - `resolve_diff_base()` — resolves `$LINT_DIFF_BASE` → `$GITHUB_BASE_REF` → `origin/main`; verifies ref exists
  - `get_diff_added_lines()` + `_parse_unified_zero_diff()` — parse `git diff --unified=0` hunks
  - `parse_bypass_tag()` — match `bypass-lint: <name>\nreason: ...` per lint-policy §4
- **`scripts/tools/lint/check_codename_leak.py`**: refactor to default diff-only mode + bypass support
  - New flags: `--full-scan`, `--diff-base`, `--pr-body-file`
  - `$PR_BODY` env var consumed for CI bypass tag parsing
  - Output includes scan mode (e.g., `mode=diff vs origin/main, scope=default`)
- **`.github/workflows/ci.yml`** (Lint job): adds `pre-commit run codename-leak-check --all-files` + `PR_BODY` env wiring

### Tests
- **`tests/lint/test_check_codename_leak.py`** (new, 45 tests, all pass): pattern detection, allowlist escape, code-comment skip, diff-parsing, bypass tag parsing — including the **「Phase A: Triage」 must NOT flag** counter-test that was the root cause of my earlier mis-classification of this lint as class (c)

### Governance
- **`tests/shared/property-coverage.yaml`**: register four new `_lint_helpers` functions under `excluded:` with rationale pointing to dedicated unit tests

## Bypass mechanism contract

PR description body containing:
```
bypass-lint: codename-leak
reason: <≥30 words explaining why this case is legitimate>
issue: #<NN>  (optional)
```
→ Matched bypass downgrades hard-fail to audit-trail warning; exit 0 with `⚠️  BYPASSED via PR body: <reason>`. Reviewer must confirm bypass is justified during code review.

## V-3 status (portal i18n soft-warn)

**NO-OP**. Verified `check_portal_i18n.py` and `check_i18n_coverage.py` are already at `stages: [manual]` in `.pre-commit-config.yaml`, matching lint-policy.md §3 (c) class spec. No change needed.

## Test plan
- [x] `python3 scripts/tools/lint/check_codename_leak.py --ci` → `OK no codename leaks (mode=diff vs origin/main)`
- [x] `python3 scripts/tools/lint/check_codename_leak.py --full-scan --ci` → also passes
- [x] `LINT_DIFF_BASE=origin/nonexistent` → exits 2 with fetch-depth: 0 hint message
- [x] `pytest tests/lint/test_check_codename_leak.py -v` → 45 passed
- [x] all 47 pre-commit hooks pass
- [ ] CI Lint job re-runs codename-leak via new wiring (verify on this PR's checks)
- [ ] Reviewer to verify bypass mechanism by injecting test bypass tag + intentional codename in a separate test branch

## Closes

[issue #381](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/381) V-2 + V-3 (V-3 is no-op, already compliant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)