### PR TITLE
docs: scrub codenames from contributor READMEs (B1.2-II from #375)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -45,8 +45,8 @@ Go 測試**不在** `tests/`，而是與被測程式碼同目錄：
 | 看覆蓋率 | `make coverage`（HTML：`ARGS="--html"`） |
 | 跑 Playwright E2E | `make test-e2e` |
 | 跑 Playwright 單一 spec | `make test-e2e ARGS="saved-views.spec.ts"` |
-| 跑 Vitest portal 單元測試 | `make test-portal`（TD-030） |
-| Build portal ESM bundles | `make portal-build`（TD-030） |
+| 跑 Vitest portal 單元測試 | `make test-portal` |
+| Build portal ESM bundles | `make portal-build` |
 | 跑 Go 測試 | `make dc-go-test`（必須 dev container；host 端 Go 不可用） |
 | Skip 配額審計 | `make test-skip-audit`（budget=5） |
 
@@ -59,10 +59,10 @@ Go 測試**不在** `tests/`，而是與被測程式碼同目錄：
 | `Python Tests (3.13)` (ci.yml) | `pytest tests/ scripts/tools/`，跳過 3 個 `@slow` 測試（見下） |
 | `Go Tests (1.26)` (ci.yml) | `go test ./cmd/... ./internal/...`（tenant-api）+ `./...`（threshold-exporter） |
 | `Smoke Tests (Chromium)` (Playwright E2E workflow) | `tests/e2e/*.spec.ts`（排除 `@visual` tag） |
-| `Portal Tests` (ci.yml) | `tools/portal/tests/*.test.{ts,tsx}` Vitest 單元測試（TD-030 Option C；TD-042 monorepo restructure 後從 tests/portal/ 搬入） |
-| `Nightly Race Detector` (nightly-race.yaml) | Go `-race -count=10`，advisory only（TD-026） |
+| `Portal Tests` (ci.yml) | `tools/portal/tests/*.test.{ts,tsx}` Vitest 單元測試（ESM Option C；monorepo restructure 後從 tests/portal/ 搬入） |
+| `Nightly Race Detector` (nightly-race.yaml) | Go `-race -count=10`，advisory only |
 | `Lint Documentation` (ci.yml) | `make lint-docs`（含 changelog / link / structure check） |
-| `Visual Regression Baseline Update` (visual-baseline.yaml) | manual `workflow_dispatch`，重產 visual.spec.ts 基線（TD-029） |
+| `Visual Regression Baseline Update` (visual-baseline.yaml) | manual `workflow_dispatch`，重產 visual.spec.ts 基線（限 Ubuntu CI） |
 
 **CI 跳過的慢測試**（local 用 `make test` 會跑）：
 - `tests/shared/test_property.py` — Hypothesis property-based（`@slow`）
@@ -78,8 +78,8 @@ Go 測試**不在** `tests/`，而是與被測程式碼同目錄：
 測試跨檔案 / 基礎設施?                → tests/shared/test_<topic>.py
 測試 Go 程式碼?                       → 同檔案旁 *_test.go（不在 tests/）
 測試使用者操作 portal UI?              → tests/e2e/*.spec.ts
-要鎖視覺回歸（pixel-diff baseline）?  → tests/e2e/visual.spec.ts（Ubuntu CI 才能產基線，TD-029）
-要單元測試 portal JSX 元件邏輯?       → tools/portal/tests/<Component>.test.tsx（Vitest，TD-030 Option C / TD-042 restructure 後）
+要鎖視覺回歸（pixel-diff baseline）?  → tests/e2e/visual.spec.ts（Ubuntu CI 才能產基線）
+要單元測試 portal JSX 元件邏輯?       → tools/portal/tests/<Component>.test.tsx（Vitest，ESM Option C / monorepo restructure 後）
 測試前端跨工具效能 / 頁面載入?         → tests/e2e-bench/
 測試需要真實 DB / Prometheus / docker? → tests/scenarios/ + Makefile target
 ```
@@ -118,5 +118,5 @@ CI 失敗或 local flake → 查 [testing-playbook.md](../docs/internal/testing-
 
 - ⛔ **不要** hardcode tenant id（`db-a` / `db-b`）— 用 factory 產生 random id（dev-rule #2）
 - ⛔ **不要**自己寫 helper，先看 `factories.py` / `tests/e2e/fixtures/`
-- ⛔ **不要**對沒理由的 `time.Sleep`，用 ticker poll until condition（TD-019 / TD-024 模式）
-- ⛔ **不要**在 Go test 用 `assert.NoError` 在 setup 階段（fail-fast 用 `require.NoError`，TD-023）
+- ⛔ **不要**對沒理由的 `time.Sleep`，用 ticker poll until condition（見 testing-playbook §quiescence-pattern）
+- ⛔ **不要**在 Go test 用 `assert.NoError` 在 setup 階段（fail-fast 用 `require.NoError`）

--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -50,7 +50,7 @@ CONTRACT_MAX_EXAMPLES=50 make contract-test
 
 ## CI 整合
 
-**已啟用**（TD-028 修復 spec drift 後）：在 `Go Tests (1.26)` job 末段，於 swag drift check 之後跑。`CONTRACT_MAX_EXAMPLES=5` 讓單次 CI ~10-20s。
+**已啟用**（spec-drift fix 之後）：在 `Go Tests (1.26)` job 末段，於 swag drift check 之後跑。`CONTRACT_MAX_EXAMPLES=5` 讓單次 CI ~10-20s。
 
 當前 CI step:
 ```yaml

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -5,8 +5,8 @@ purpose: |
   父 README（tests/README.md）回答「我要寫什麼測試該擺哪」；本檔回答
   「進到 tests/e2e/ 後，怎麼下手」。
 
-  TD-032a 對齊現況：24 specs / 136 tests / 5 fixtures。先前版本只列
-  5 個 critical path spec、未文件化任何 fixture 或 tag 語意，已隨本次
+  最新對齊現況：24 specs / 136 tests / 5 fixtures。先前版本只列
+  5 個 critical path spec、未文件化任何 fixture 或 tag 語意，已於本次
   改寫汰換。
 audience: [contributors, ai-agent]
 lang: zh
@@ -16,7 +16,7 @@ lang: zh
 
 父 README：[`tests/README.md`](../README.md)。先看父檔的決策樹（測試擺哪、CI 對應、跑法 cheat sheet）；本檔處理進到 `tests/e2e/` 之後的細節：tag 語意、fixture 契約、新 spec 模板、REG 編號制度。
 
-## 目前規模（TD-032a snapshot）
+## 目前規模（最新 snapshot）
 
 - **24 specs / 136 tests**（chromium-only smoke + 互動）
 - **5 fixtures**（`fixtures/`）：portal-tool-smoke / axe-helper / diagnostic-matchers / mock-data / test-helpers
@@ -49,7 +49,7 @@ lang: zh
 | | `assertNoAbsoluteRootHrefs(page)` | 找出 `href="/foo"` 樣式的絕對根路徑（REG-004 風險） | 不檢查 fragment / external link |
 | `axe-helper.ts` | `checkA11y(page, opts)` | 跑 axe-core WCAG 2.1 AA scan，回傳 `violations` | 不自動 fail；caller 自己決定 budget |
 | | `waitForPageReady(page, sel?)` | 等 networkidle + 可選的 selector visible（CI Python http.server 慢需要） | 不等 React mount 完成 |
-| `diagnostic-matchers.ts` | `toBeVisibleWithDiagnostics()` Playwright matcher | element 找不到時 dump 所有 `[data-testid]` 與 `aria-label` 到失敗訊息（S#98 / LL §11） | 不取代 `toBeVisible`；只在 cold-start 風險點用 |
+| `diagnostic-matchers.ts` | `toBeVisibleWithDiagnostics()` Playwright matcher | element 找不到時 dump 所有 `[data-testid]` 與 `aria-label` 到失敗訊息（見 testing-playbook §LL §11 cold-start） | 不取代 `toBeVisible`；只在 cold-start 風險點用 |
 | `mock-data.ts` | `mockUser` / `mockTenants` / `mockGroups` / `mockAlerts` / `mockBatchOperationResponse` 等常數 | 提供共用 mock fixture | 不自動掛 `page.route` |
 | `test-helpers.ts` | `waitForPortalReady(page)` / `mockApiEndpoint(...)` 等 | portal 級操作（不專屬單一 portal 工具） | 不取代 `portal-tool-smoke` 的 navigate |
 

--- a/tools/portal/README.md
+++ b/tools/portal/README.md
@@ -1,14 +1,14 @@
 ---
-title: "Portal Build & Test (TECH-DEBT-030)"
+title: "Portal Build & Test"
 purpose: |
-  Foundation for Option C ES modules sweep — esbuild build pipeline +
-  Vitest unit-test harness. PR-A of a multi-PR series; subsequent PRs
-  migrate JSX tools from `window.__X` registration → ESM `export {}`.
+  ES modules build pipeline + Vitest unit-test harness for portal JSX tools.
+  Foundation for the multi-PR sweep that migrates tools from `window.__X`
+  registration to ESM `export {}`.
 audience: [contributors, ai-agent]
 lang: zh
 ---
 
-# Portal Build & Test (TD-030 foundation)
+# Portal Build & Test
 
 ## 怎麼用
 
@@ -26,7 +26,7 @@ make portal-build-watch
 make test-portal
 ```
 
-## 結構（TD-042 monorepo restructure 後）
+## 結構（monorepo restructure 後）
 
 ```
 tools/portal/
@@ -74,14 +74,14 @@ docs/interactive/index.html  # portal hub page — STAYS in docs/ (it's a real d
 
 ## 並存契約
 
-TD-030 sweep 期間 jsx-loader.html 與 dist bundle **同時存在**：
+ESM sweep 期間 jsx-loader.html 與 dist bundle **同時存在**：
 - 已遷移工具 → dist bundle
 - 未遷移工具 → jsx-loader.html
 - 兩條路徑都 work，瀏覽器不中斷
 
-最後 TD-030z PR 退役 jsx-loader.html。
+最終遷移完成後一次性 PR 退役 jsx-loader.html。
 
 ## 相關
-- TD-030 sub-issues: [#247-253](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/247)
+- ESM sweep tracking: [issues #247-253](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/247)
 - Project memory: `project_portal_vitest_choice.md`
-- 現役 jsx-loader doc: [`docs/internal/jsx-multi-file-pattern.md`](../../docs/internal/jsx-multi-file-pattern.md)（TD-030z 後改寫為歷史記錄）
+- 現役 jsx-loader doc: [`docs/internal/jsx-multi-file-pattern.md`](../../docs/internal/jsx-multi-file-pattern.md)（jsx-loader 退役後改寫為歷史記錄）


### PR DESCRIPTION
## Summary

Closes B1.2-II from PR #375 retrospective: scrub TD-NN / S#NN codenames from T3 contributor-facing READMEs that don't help newcomers. Targets [issue #378](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/378) II-3 deliverable.

## Files cleaned (all hits)

| File | Hits | Pattern |
|---|---|---|
| [`tools/portal/README.md`](tools/portal/README.md) | 6 | `TD-030` / `TD-030z` / `TD-042` |
| [`tests/README.md`](tests/README.md) | 8 | `TD-019` / `TD-023` / `TD-024` / `TD-026` / `TD-029` / `TD-030` / `TD-042` |
| [`tests/contract/README.md`](tests/contract/README.md) | 1 | `TD-028` |
| [`tests/e2e/README.md`](tests/e2e/README.md) | 3 | `TD-032a` / `S#98` |

Replacement strategy:
- Codenames referencing **conventions** (e.g., `TD-019/TD-024` for sleep-avoidance) → version-neutral phrasing pointing to testing-playbook
- Codenames referencing **sprint structure** (e.g., `TD-030 sweep`) → feature-name (e.g., "ESM sweep")
- Codenames referencing **tracked issues** (e.g., `TD-030 sub-issues #247-253`) → keep real GitHub issue refs, drop TD prefix
- Snapshot dates / sizes → "最新 snapshot" without TD-tag

Verification: `grep -nE "Phase|Track [A-E]|S#\d+|HA-\d+|C-\d+|PR-\d+|B-\d+|TD-\d+|Wave \d" tools/portal/README.md tests/README.md tests/contract/README.md tests/e2e/README.md` → **zero hits**.

## Out of scope

`tests/e2e-bench/README.md` and `tests/e2e-bench/fixture/customer-anon/README.md` deferred. The narrative is structurally written around "PR-2 of 3 in B-1 Phase 2 rollout" — sprint structure IS the story. Mechanical find-replace would break narrative coherence; needs full rewrite as "how this benchmark harness works today" instead of "how this sprint shipped". Will open follow-up issue.

## Test plan

- [x] All 47 pre-commit hooks pass
- [x] No build / test impact (pure documentation change)
- [ ] Reviewer: spot-check that replacement phrasing preserves the original semantic intent (e.g., "Visual Regression baseline 限 Ubuntu CI" still conveys the platform constraint that `TD-029` was tracking)

## Closes (partial)

[Issue #378](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/378) II-3. The issue's other two deliverables (II-1 migration-guide hub, II-2 architecture-and-design slim) are larger content rewrites tracked separately and depend on multi-system-migration playbook outline ([#377](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/377)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)