### PR TITLE
feat(lint): complete V-4 — refactor remaining 3 (b) class lints to diff-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
           # Was registered in .pre-commit-config.yaml since v2.7.x but never
           # wired to CI Lint job — only ran on contributor's local pre-commit.
           pre-commit run changelog-no-tbd-check --all-files
+          # The next 3 (b) class lints completed V-4 in a follow-up PR.
+          # Wired here for the same reason — pre-commit path filters might
+          # not trigger on every PR, but lints should run always.
+          pre-commit run ad-hoc-git-scripts-check --all-files
+          pre-commit run bat-ascii-purity-check --all-files
+          pre-commit run design-token-usage --all-files
           pre-commit run tool-consistency-check --all-files
           pre-commit run structure-check --all-files
           pre-commit run routing-profiles-check --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,7 +146,9 @@ repos:
         language: python
         pass_filenames: false
         files: \.jsx$
-        stages: [manual]
+        # PR #387: refactored to diff-only (lint-policy.md §3 class b);
+        # promoted from [manual] to default pre-commit stage to match
+        # other class (b) lints and let CI Lint job invoke directly.
 
       # WCAG 1.4.1 / 3.3.2 / 4.1.2 floor — auto-runs on changed JSX files,
       # exit 1 if any new violation surfaces. Codifies the WCAG cleanup

--- a/docs/internal/lint-policy.md
+++ b/docs/internal/lint-policy.md
@@ -177,14 +177,14 @@ PR 加入新 allowlist entry 時須在 PR description 答：
 
 ### (b) class — ~12 個
 
-| Lint | Allowlist 內容 | scope（須改 diff-only 的）|
+| Lint | Allowlist 內容 | diff-only 狀態 |
 |---|---|---|
-| `check_codename_leak.py` | 技術縮寫（SHA-256, RFC-, ISO-, UTF-8 等 12 條） | ⚠️ 須改 diff-only |
-| `check_repo_name.py` | `/workspaces/vibe-k8s-lab` 等 dev container 路徑 | ⚠️ 須改 diff-only |
-| `check_ad_hoc_git_scripts.py` | `scripts/ops/` 已 sanctioned scripts | ⚠️ 須改 diff-only |
-| `check_changelog_no_tbd.py` | HTML comment 內 / brackets 內的 TBD | ⚠️ 須改 diff-only |
-| `check_bat_ascii_purity.py` | 已知必要 non-ASCII | ⚠️ 須改 diff-only |
-| `check_design_token_usage.py` | hardcoded color allowlist (legacy theme) | ⚠️ 須改 diff-only |
+| `check_codename_leak.py` | 技術縮寫（SHA-256, RFC-, ISO-, UTF-8 等 12 條） | ✅ PR #382 |
+| `check_repo_name.py` | `/workspaces/vibe-k8s-lab` 等 dev container 路徑 | ✅ PR #383 |
+| `check_changelog_no_tbd.py` | HTML comment 內 / brackets 內的 TBD | ✅ PR #383 |
+| `check_ad_hoc_git_scripts.py` | `scripts/ops/` 已 sanctioned scripts | ✅ PR #387 |
+| `check_bat_ascii_purity.py` | 已知必要 non-ASCII | ✅ PR #387（pre-commit `files:` 自然 diff-aware）|
+| `check_design_token_usage.py` | hardcoded color allowlist (legacy theme) | ✅ PR #387 |
 | `check_dev_rules_enforcement.py` | dev-rules 內合法 placeholder | OK（diff-only acceptable） |
 | `check_dist_source_consistency.py` | excluded fixtures | OK |
 | `check_flaky_registry.py` | grandfathered tests | OK |

--- a/scripts/tools/lint/check_ad_hoc_git_scripts.py
+++ b/scripts/tools/lint/check_ad_hoc_git_scripts.py
@@ -19,9 +19,27 @@ This hook makes the failure mode physically impossible:
   * **What to do instead**: if `scripts/ops/win_git_escape.bat` / `win_gh.bat`
     lack a subcommand, **extend them**, don't write a sibling script.
 
+Lint class: (b) per docs/internal/lint-policy.md (negative pattern + path
+allowlist as false-positive escape). Default scope: **diff-only** — only
+shell scripts ADDED or MODIFIED in current diff are checked. Override
+with --full-scan for periodic manual audit of the whole tree.
+
+Usage:
+    # Diff-only (default; CI sets LINT_DIFF_BASE / GITHUB_BASE_REF)
+    python3 scripts/tools/lint/check_ad_hoc_git_scripts.py [--ci]
+
+    # Full repo scan (manual audit)
+    python3 scripts/tools/lint/check_ad_hoc_git_scripts.py --full-scan [--ci]
+
+Bypass (per lint-policy.md §4):
+    Add to PR description body:
+        bypass-lint: ad-hoc-git-scripts
+        reason: <≥30 words explaining why this case is legitimate>
+
 Exit:
-  0 = no unapproved scripts found
+  0 = no offenders (or bypass matched)
   1 = at least one script outside the allowlist
+  2 = diff base ref missing — fix CI workflow's fetch-depth or base ref
 
 Configuration:
   * ALLOWLIST_DIRS: path prefixes (repo-relative, POSIX-style) that may hold
@@ -32,8 +50,18 @@ Configuration:
 from __future__ import annotations
 
 import argparse
+import os
+import subprocess
 import sys
 from pathlib import Path
+
+# Helpers from this lint family
+sys.path.insert(0, str(Path(__file__).parent))
+from _lint_helpers import (  # noqa: E402
+    DiffBaseMissingError,
+    parse_bypass_tag,
+    resolve_diff_base,
+)
 
 EXTS = {".bat", ".ps1", ".cmd"}
 
@@ -67,19 +95,65 @@ SKIP_ANY = {
 }
 
 
-def scan(repo: Path) -> list[Path]:
-    """Return list of offending files (repo-relative)."""
+def scan_full(repo: Path) -> list[Path]:
+    """Full-tree scan: return list of offending files (repo-relative)."""
     offending: list[Path] = []
     for ext in EXTS:
         for candidate in repo.rglob(f"*{ext}"):
             parts = candidate.relative_to(repo).parts
-            # Skip if ANY path segment is in skip list (covers nested node_modules).
             if any(p in SKIP_ANY for p in parts):
                 continue
             rel_posix = "/".join(parts)
             if not is_allowlisted(rel_posix):
                 offending.append(candidate.relative_to(repo))
     return sorted(offending)
+
+
+def scan_diff(repo: Path, base: str) -> list[Path]:
+    """Diff-only scan: return offenders newly added/modified in current diff vs base.
+
+    Uses ``git diff --name-only --diff-filter=AM`` so deleted files don't
+    trigger the lint (deleting an offender is the right move).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=AM", base],
+            capture_output=True, text=True, cwd=str(repo),
+            check=True, timeout=10,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return []
+
+    offending: list[Path] = []
+    for rel in result.stdout.splitlines():
+        rel = rel.strip()
+        if not rel:
+            continue
+        # Only check Windows shell scripts
+        if not any(rel.endswith(ext) for ext in EXTS):
+            continue
+        # Skip sandbox / vendored dirs
+        parts = rel.replace("\\", "/").split("/")
+        if any(p in SKIP_ANY for p in parts):
+            continue
+        if is_allowlisted(rel.replace("\\", "/")):
+            continue
+        # File should still exist (filter=AM excludes deleted but be safe)
+        full_path = repo / rel
+        if not full_path.is_file():
+            continue
+        offending.append(Path(rel))
+    return sorted(offending)
+
+
+def _read_pr_body(pr_body_file: str | None) -> str | None:
+    """Read PR body from --pr-body-file or $PR_BODY env var."""
+    if pr_body_file:
+        try:
+            return Path(pr_body_file).read_text(encoding="utf-8")
+        except (FileNotFoundError, PermissionError) as e:
+            print(f"WARN: cannot read --pr-body-file {pr_body_file}: {e}", file=sys.stderr)
+    return os.environ.get("PR_BODY") or None
 
 
 def main() -> int:
@@ -90,20 +164,63 @@ def main() -> int:
             "proliferation — use scripts/ops/win_git_escape.bat instead."
         )
     )
-    parser.parse_args()
+    parser.add_argument(
+        "--full-scan", action="store_true",
+        help="Scan entire repo (default is diff-only — recommended for CI).",
+    )
+    parser.add_argument(
+        "--diff-base", default=None,
+        help="Override diff base (default: $LINT_DIFF_BASE / $GITHUB_BASE_REF / origin/main).",
+    )
+    parser.add_argument(
+        "--pr-body-file", default=None,
+        help="Path to file containing PR body for bypass tag check.",
+    )
+    args = parser.parse_args()
 
     repo = find_repo_root()
-    offenders = scan(repo)
+
+    # Resolve scan mode
+    if args.full_scan:
+        scan_mode = "full-scan"
+        offenders = scan_full(repo)
+    else:
+        try:
+            base = args.diff_base or resolve_diff_base()
+        except DiffBaseMissingError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 2
+        scan_mode = f"diff vs {base}"
+        offenders = scan_diff(repo, base)
+
     if not offenders:
+        print(
+            f"[check_ad_hoc_git_scripts] OK no ad-hoc Windows shell scripts "
+            f"(mode={scan_mode}).",
+        )
         return 0
+
+    # Bypass check (lint-policy.md §4)
+    pr_body = _read_pr_body(args.pr_body_file)
+    bypass_reason = parse_bypass_tag(pr_body, "ad-hoc-git-scripts")
 
     print(
         f"[check_ad_hoc_git_scripts] FAIL: {len(offenders)} Windows shell "
-        f"script(s) outside allowlisted dirs:",
+        f"script(s) outside allowlisted dirs (mode={scan_mode}):",
         file=sys.stderr,
     )
     for f in offenders:
         print(f"    {f}", file=sys.stderr)
+
+    if bypass_reason:
+        print(
+            f"\n⚠️  BYPASSED via PR body: {bypass_reason}\n"
+            f"   {len(offenders)} finding(s) above are author-acknowledged.\n"
+            f"   Reviewer must confirm bypass is justified.",
+            file=sys.stderr,
+        )
+        return 0
+
     allowlist = "\n".join(f"    {p}" for p in ALLOWLIST_DIRS)
     print(
         "\n  Allowlisted dirs for *.bat / *.ps1 / *.cmd:\n"
@@ -113,8 +230,10 @@ def main() -> int:
         "    2. For gh (GitHub CLI) ops   -> scripts/ops/win_gh.bat\n"
         "    3. Missing subcommand?       -> extend the existing wrapper, DO\n"
         "                                    NOT write a sibling script.\n\n"
-        "  See docs/internal/windows-mcp-playbook.md#修復層-c (Windows escape\n"
-        "  hatch) for the full playbook.\n",
+        "  See docs/internal/windows-mcp-playbook.md for the full playbook.\n"
+        "  Or add to PR description (per lint-policy.md §4):\n"
+        "    bypass-lint: ad-hoc-git-scripts\n"
+        "    reason: <≥30 words explaining why this case is legitimate>",
         file=sys.stderr,
     )
     return 1

--- a/scripts/tools/lint/check_bat_ascii_purity.py
+++ b/scripts/tools/lint/check_bat_ascii_purity.py
@@ -41,16 +41,43 @@ the same rules at pytest time. Defence-in-depth: pre-commit stops bad
 commits locally, pytest catches anything that slipped through or was
 added via the Windows-side ``--no-verify`` escape hatch.
 
+Lint class & scope (lint-policy.md §3)
+--------------------------------------
+Class **(b)** — negative pattern (forbidden bytes / line endings) +
+allowlist scope (only ``scripts/ops/*.bat``). Default invocation is
+already effectively **diff-aware** via pre-commit's ``files:`` filter
+(only staged .bat files reach this hook). For ad-hoc CLI invocation:
+
+* No paths, no flag → diff-aware (only files in current diff vs base)
+* ``--full-scan`` → scan every ``scripts/ops/*.bat``
+* Explicit paths → scan those (pre-commit pass-through)
+
+Bypass (per lint-policy.md §4):
+    Add to PR description body:
+        bypass-lint: bat-ascii-purity
+        reason: <≥30 words explaining why this case is legitimate>
+
 Exit codes
 ----------
-0 = all files OK
+0 = all files OK (or bypass matched)
 1 = one or more .bat files have violations
+2 = diff base ref missing — fix CI workflow's fetch-depth or base ref
 """
 from __future__ import annotations
 
 import argparse
+import os
+import subprocess
 import sys
 from pathlib import Path
+
+# Helpers from this lint family
+sys.path.insert(0, str(Path(__file__).parent))
+from _lint_helpers import (  # noqa: E402
+    DiffBaseMissingError,
+    parse_bypass_tag,
+    resolve_diff_base,
+)
 
 
 def find_repo_root() -> Path:
@@ -117,6 +144,37 @@ def scan_bat(path: Path) -> list[str]:
     return violations
 
 
+def _read_pr_body(pr_body_file: str | None) -> str | None:
+    """Read PR body from --pr-body-file or $PR_BODY env var."""
+    if pr_body_file:
+        try:
+            return Path(pr_body_file).read_text(encoding="utf-8")
+        except (FileNotFoundError, PermissionError) as e:
+            print(f"WARN: cannot read --pr-body-file {pr_body_file}: {e}", file=sys.stderr)
+    return os.environ.get("PR_BODY") or None
+
+
+def _diff_changed_bats(repo: Path, base: str) -> list[Path]:
+    """Return scripts/ops/*.bat changed in current diff vs base."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=AM", base, "--",
+             "scripts/ops/*.bat"],
+            capture_output=True, text=True, cwd=str(repo),
+            check=True, timeout=10,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return []
+    out: list[Path] = []
+    for rel in result.stdout.splitlines():
+        rel = rel.strip()
+        if rel and rel.endswith(".bat"):
+            full = repo / rel
+            if full.is_file():
+                out.append(full)
+    return out
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=(
@@ -130,16 +188,41 @@ def main() -> int:
         nargs="*",
         help=(
             "Explicit file paths to check (pre-commit passes the staged .bat "
-            "files here). If empty, scans all scripts/ops/*.bat."
+            "files here). If empty + no flag: diff-only. With --full-scan: "
+            "all scripts/ops/*.bat."
         ),
+    )
+    parser.add_argument(
+        "--full-scan", action="store_true",
+        help="Scan every scripts/ops/*.bat (manual audit; ignores diff).",
+    )
+    parser.add_argument(
+        "--diff-base", default=None,
+        help="Override diff base (default: $LINT_DIFF_BASE / $GITHUB_BASE_REF / origin/main).",
+    )
+    parser.add_argument(
+        "--pr-body-file", default=None,
+        help="Path to file containing PR body for bypass tag check.",
     )
     args = parser.parse_args()
 
     repo = find_repo_root()
+
+    # Determine which .bat files to scan
     if args.paths:
         bat_paths = [Path(p) for p in args.paths]
-    else:
+        scan_mode = "explicit-paths"
+    elif args.full_scan:
         bat_paths = sorted((repo / "scripts" / "ops").glob("*.bat"))
+        scan_mode = "full-scan"
+    else:
+        try:
+            base = args.diff_base or resolve_diff_base()
+        except DiffBaseMissingError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 2
+        bat_paths = _diff_changed_bats(repo, base)
+        scan_mode = f"diff vs {base}"
 
     # Only apply the rule to scripts/ops/*.bat -- other .bat (e.g. dev-
     # container bind-mount scripts) don't go through Desktop Commander
@@ -166,13 +249,27 @@ def main() -> int:
     if not all_violations:
         return 0
 
+    # Bypass check (lint-policy.md §4)
+    pr_body = _read_pr_body(args.pr_body_file)
+    bypass_reason = parse_bypass_tag(pr_body, "bat-ascii-purity")
+
     print(
         "[check_bat_ascii_purity] FAIL: pitfall #45 rule violated in "
-        f"{len(filtered)} file(s) under scripts/ops/",
+        f"{len(filtered)} file(s) under scripts/ops/ (mode={scan_mode})",
         file=sys.stderr,
     )
     for line in all_violations:
         print(line, file=sys.stderr)
+
+    if bypass_reason:
+        print(
+            f"\n⚠️  BYPASSED via PR body: {bypass_reason}\n"
+            f"   {len(all_violations)} finding(s) above are author-acknowledged.\n"
+            f"   Reviewer must confirm bypass is justified.",
+            file=sys.stderr,
+        )
+        return 0
+
     print(
         "\n  Fix:\n"
         "    * Replace CJK headings in REM comments with ASCII prose, "
@@ -187,7 +284,10 @@ def main() -> int:
         "  byte >= 0x80 corrupts parser state on downstream lines, silently\n"
         "  breaking @echo off / setlocal / goto.\n"
         "\n  See docs/internal/windows-mcp-playbook.md pitfall #45 for the\n"
-        "  full byte-level analysis + dogfood proof.\n",
+        "  full byte-level analysis + dogfood proof.\n"
+        "  Or add to PR description (per lint-policy.md §4):\n"
+        "    bypass-lint: bat-ascii-purity\n"
+        "    reason: <≥30 words explaining why this case is legitimate>\n",
         file=sys.stderr,
     )
     return 1

--- a/scripts/tools/lint/check_design_token_usage.py
+++ b/scripts/tools/lint/check_design_token_usage.py
@@ -12,17 +12,42 @@
   - 0px, 1px, 2px（邊框 / hairline）不檢查
   - design-tokens.css 本身不掃描（定義端）
 
+Lint class & scope (lint-policy.md §3)
+--------------------------------------
+Class **(b)** — negative pattern + token-exempt allowlist.
+Default scope: **diff-only** — only lines ADDED in current diff vs base
+emit findings. Override with --full-scan for periodic manual audit.
+
+Bypass (per lint-policy.md §4):
+    Add to PR description body:
+        bypass-lint: design-token-usage
+        reason: <≥30 words explaining why this case is legitimate>
+
 用法:
+    # Diff-only (default; CI sets LINT_DIFF_BASE / GITHUB_BASE_REF)
     python3 scripts/tools/lint/check_design_token_usage.py [--ci]
-    python3 scripts/tools/lint/check_design_token_usage.py --ci && echo "All clean"
+
+    # Full-scan (manual audit)
+    python3 scripts/tools/lint/check_design_token_usage.py --full-scan [--ci]
 """
 
 import argparse
+import os
 import re
+import subprocess
 import sys
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Tuple
+
+# Helpers from this lint family
+sys.path.insert(0, str(Path(__file__).parent))
+from _lint_helpers import (  # noqa: E402
+    DiffBaseMissingError,
+    get_diff_added_lines,
+    parse_bypass_tag,
+    resolve_diff_base,
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 JSX_TOOLS_DIR = REPO_ROOT / "docs" / "interactive" / "tools"
@@ -139,8 +164,12 @@ def check_hardcoded_px_values(content: str, filename: str) -> List[Dict]:
     return issues
 
 
-def scan_jsx_files() -> Tuple[Dict[str, List[Dict]], Dict[str, List[Dict]]]:
-    """Scan all JSX files for design token violations.
+def scan_jsx_files(diff_base: str | None = None) -> Tuple[Dict[str, List[Dict]], Dict[str, List[Dict]]]:
+    """Scan JSX files for design token violations.
+
+    If ``diff_base`` is None: full-scan all JSX files in JSX_TOOLS_DIR + WIZARD_DIR.
+    If ``diff_base`` is a ref: only flag findings on lines ADDED in the current
+    diff vs that base. Existing pre-existing violations are not re-emitted.
 
     Returns (hex_issues_by_file, px_issues_by_file).
     """
@@ -165,17 +194,37 @@ def scan_jsx_files() -> Tuple[Dict[str, List[Dict]], Dict[str, List[Dict]]]:
 
             rel_path = str(jsx_file.relative_to(REPO_ROOT))
 
-            # Check hex colors
+            # Run full scan to get all findings
             hex_found = check_hardcoded_hex_colors(content, jsx_file.name)
+            px_found = check_hardcoded_px_values(content, jsx_file.name)
+
+            # If diff-only, filter findings to lines actually added in current diff
+            if diff_base is not None:
+                try:
+                    added_lines = {ln for ln, _ in get_diff_added_lines(jsx_file, diff_base)}
+                except subprocess.CalledProcessError:
+                    # Git error — keep all findings (safer than silent suppress)
+                    added_lines = None
+                if added_lines is not None:
+                    hex_found = [h for h in hex_found if h["line"] in added_lines]
+                    px_found = [h for h in px_found if h["line"] in added_lines]
+
             if hex_found:
                 hex_issues[rel_path] = hex_found
-
-            # Check px values
-            px_found = check_hardcoded_px_values(content, jsx_file.name)
             if px_found:
                 px_issues[rel_path] = px_found
 
     return dict(hex_issues), dict(px_issues)
+
+
+def _read_pr_body(pr_body_file: str | None) -> str | None:
+    """Read PR body from --pr-body-file or $PR_BODY env var."""
+    if pr_body_file:
+        try:
+            return Path(pr_body_file).read_text(encoding="utf-8")
+        except (FileNotFoundError, PermissionError) as e:
+            print(f"WARN: cannot read --pr-body-file {pr_body_file}: {e}", file=sys.stderr)
+    return os.environ.get("PR_BODY") or None
 
 
 # ---------------------------------------------------------------------------
@@ -192,15 +241,39 @@ def main():
         action="store_true",
         help="CI 模式: 有違規時 exit 1"
     )
+    parser.add_argument(
+        "--full-scan", action="store_true",
+        help="Scan ALL existing violations (default: diff-only — only added lines).",
+    )
+    parser.add_argument(
+        "--diff-base", default=None,
+        help="Override diff base (default: $LINT_DIFF_BASE / $GITHUB_BASE_REF / origin/main).",
+    )
+    parser.add_argument(
+        "--pr-body-file", default=None,
+        help="Path to file containing PR body for bypass tag check.",
+    )
     args = parser.parse_args()
 
-    hex_issues, px_issues = scan_jsx_files()
+    # Resolve scan mode
+    if args.full_scan:
+        scan_mode = "full-scan"
+        diff_base = None
+    else:
+        try:
+            diff_base = args.diff_base or resolve_diff_base()
+        except DiffBaseMissingError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(2)
+        scan_mode = f"diff vs {diff_base}"
+
+    hex_issues, px_issues = scan_jsx_files(diff_base=diff_base)
 
     all_files = set(hex_issues.keys()) | set(px_issues.keys())
     total_violations = 0
 
     if not all_files:
-        print("✓ 設計 token 使用檢查通過。")
+        print(f"✓ 設計 token 使用檢查通過 (mode={scan_mode})。")
         sys.exit(0)
 
     # Print results grouped by file
@@ -224,10 +297,28 @@ def main():
         print()
 
     # Summary
-    print(f"TOTAL: {total_violations} violation(s) in {len(all_files)} file(s)")
+    print(f"TOTAL: {total_violations} violation(s) in {len(all_files)} file(s) (mode={scan_mode})")
+
+    # Bypass check (lint-policy.md §4)
+    pr_body = _read_pr_body(args.pr_body_file)
+    bypass_reason = parse_bypass_tag(pr_body, "design-token-usage")
+    if bypass_reason:
+        print(
+            f"\n⚠️  BYPASSED via PR body: {bypass_reason}\n"
+            f"   {total_violations} finding(s) above are author-acknowledged.\n"
+            f"   Reviewer must confirm bypass is justified."
+        )
+        sys.exit(0)
 
     # Exit with appropriate code
     if args.ci and total_violations > 0:
+        print(
+            "\nFix: replace hardcoded values with --da-* tokens, OR add\n"
+            "  /* token-exempt */ on the line if intentional.\n"
+            "Or add to PR description (per lint-policy.md §4):\n"
+            "  bypass-lint: design-token-usage\n"
+            "  reason: <≥30 words explaining why this is legitimate>",
+        )
         sys.exit(1)
     sys.exit(0)
 

--- a/scripts/tools/lint/check_design_token_usage.py
+++ b/scripts/tools/lint/check_design_token_usage.py
@@ -40,6 +40,14 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+# Make stdout tolerate non-ASCII on Windows shells (cp950 / cp1252) — output
+# uses ✓ + Chinese strings which crash on cp-default consoles otherwise.
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, OSError):
+        pass
+
 # Helpers from this lint family
 sys.path.insert(0, str(Path(__file__).parent))
 from _lint_helpers import (  # noqa: E402

--- a/tests/lint/test_check_design_token_usage.py
+++ b/tests/lint/test_check_design_token_usage.py
@@ -239,13 +239,20 @@ class TestScanResults:
 
 class TestCLISubprocess:
     def test_cli_subprocess_with_ci_flag(self):
-        """Test running the script via subprocess with --ci flag."""
+        """Test running the script via subprocess with --ci flag.
+
+        v2.8.0 lint-policy refactor: --full-scan needed because default is
+        now diff-only (lint-policy.md §3 (b) class), and the pytest CI
+        environment may not have a resolvable origin/main ref → exit 2.
+        """
         result = subprocess.run(  # subprocess-timeout: ignore
             [sys.executable, "-m", "scripts.tools.lint.check_design_token_usage",
-             "--ci"],
+             "--full-scan", "--ci"],
             cwd=REPO_ROOT,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
         # The script will scan real project files. If there are violations,
         # exit code should be 1; otherwise 0.
@@ -254,10 +261,13 @@ class TestCLISubprocess:
     def test_cli_subprocess_without_ci_flag(self):
         """Test running the script via subprocess without --ci flag."""
         result = subprocess.run(  # subprocess-timeout: ignore
-            [sys.executable, "-m", "scripts.tools.lint.check_design_token_usage"],
+            [sys.executable, "-m", "scripts.tools.lint.check_design_token_usage",
+             "--full-scan"],
             cwd=REPO_ROOT,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
         # Without --ci, should always exit 0 (display-only mode)
         assert result.returncode == 0
@@ -265,10 +275,13 @@ class TestCLISubprocess:
     def test_cli_output_contains_violations_info(self):
         """Verify script outputs violation information when violations exist."""
         result = subprocess.run(  # subprocess-timeout: ignore
-            [sys.executable, "-m", "scripts.tools.lint.check_design_token_usage"],
+            [sys.executable, "-m", "scripts.tools.lint.check_design_token_usage",
+             "--full-scan"],
             cwd=REPO_ROOT,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
         # Output should contain helpful message or "TOTAL" summary
         assert "✓" in result.stdout or "TOTAL:" in result.stdout or "violation" in result.stdout.lower()


### PR DESCRIPTION
## Summary

Closes [#384](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/384) — the 3 remaining (b) class lints from PR #383's V-4 partial. Pattern established in PR #382 (codename-leak) and PR #383 (repo-name + changelog-no-tbd); this PR mechanically applies it to the last 3.

## Refactored

| Lint | Approach | Notes |
|---|---|---|
| `check_ad_hoc_git_scripts.py` | Path-based diff via `git diff --name-only --diff-filter=AM` | Different from line-pattern lints — checks file paths not line content |
| `check_bat_ascii_purity.py` | Per-file binary check | Already effectively diff-aware via pre-commit `files:` filter; added explicit `--full-scan` for ad-hoc CLI |
| `check_design_token_usage.py` | Line-pattern in JSX style objects | Full scan still computes findings; output filtered to diff added lines (preserves `/* token-exempt */` context) |

All three now support:
- `--full-scan` for periodic manual audit
- `--diff-base` override
- `--pr-body-file` + `$PR_BODY` env var bypass per lint-policy.md §4
- Specific bypass tag names: `ad-hoc-git-scripts` / `bat-ascii-purity` / `design-token-usage`

## CI workflow

Lint job adds three pre-commit invocations:
```yaml
pre-commit run ad-hoc-git-scripts-check --all-files
pre-commit run bat-ascii-purity-check --all-files
pre-commit run design-token-usage --all-files
```

Same rationale as PR #382/#383 CI wiring: pre-commit `files:` filter only triggers on matching path changes, but lints should run on every PR.

## Documentation

[`docs/internal/lint-policy.md`](docs/internal/lint-policy.md) §6 table updated:
- Status column header: `scope (須改 diff-only 的)` → `diff-only 狀態`
- All 6 (b) class lints marked ✅ with PR refs

## V-4 closure

With this PR, **all 6 (b) class lints in lint-policy.md §6 are diff-aware**. Issue [#381](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/381) V-4 + [#384](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/384) follow-up both closed.

## Test plan

- [x] All 47 pre-commit hooks pass on this branch
- [x] `python3 scripts/tools/lint/check_ad_hoc_git_scripts.py` (default + `--full-scan`) → OK
- [x] `python3 scripts/tools/lint/check_bat_ascii_purity.py` (default + `--full-scan`) → silent OK
- [x] `python3 scripts/tools/lint/check_design_token_usage.py --ci` (default + `--full-scan`) → OK
- [ ] CI Lint job re-runs all 3 lints via new wiring (verify on this PR's checks)

## Closes

- [Issue #384](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/384) — V-4 follow-up
- [Issue #381](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/381) — V-4 fully (V-2/V-3/V-4 all done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)