### PR TITLE
docs: I-1 multi-system migration playbook outline (#377)

### DIFF
--- a/docs/internal/doc-map.en.md
+++ b/docs/internal/doc-map.en.md
@@ -74,10 +74,12 @@ lang: en
 | `docs/scenarios/manage-at-scale.md` (.en.md) | Platform Engineers, operator, DevOps | Scenario: Managing at Scale — Thousand-Tenant Operations |
 | `docs/scenarios/multi-cluster-federation.md` (.en.md) | Platform Engineers | Scenario: Multi-Cluster Federation — Central Threshold + Edge Metrics |
 | `docs/scenarios/multi-domain-conf-layout.md` (.en.md) | Platform Engineers, operator, DevOps | Scenario: Multi-Domain Hierarchical Configuration — conf.d/ Directory Restructuring (v2.7.0) |
+| `docs/scenarios/multi-system-migration-playbook.md` | Platform Engineers, SREs, architects | Multi-System Migration Playbook (Outline) |
 | `docs/scenarios/README.md` | All | 場景指南導覽 |
 | `docs/scenarios/shadow-audit.md` (.en.md) | Platform Engineers, Tenants | Scenario: Shadow Audit — Evaluate Alert Health Without Migration |
 | `docs/scenarios/shadow-monitoring-cutover.md` (.en.md) | Platform Engineers, SREs, DevOps, Tenants | Scenario: Shadow Monitoring — From Alert Health Assessment to Automated Cutover |
 | `docs/scenarios/tenant-lifecycle.md` (.en.md) | All | Scenario: Complete Tenant Lifecycle Management |
+| `docs/schemas/migration-state.md` | Platform Engineers, SREs, automation | Migration State Schema (.da/migration-state.json) |
 | `docs/schemas/README.md` | Platform Engineers, Tenants | JSON Schema Reference |
 | `docs/shadow-monitoring-sop.md` (.en.md) | SREs, Platform Engineers | Shadow Monitoring SRE SOP |
 | `docs/troubleshooting.md` (.en.md) | Platform Engineers, SREs, Tenants | Troubleshooting and Edge Cases |

--- a/docs/internal/doc-map.md
+++ b/docs/internal/doc-map.md
@@ -74,10 +74,12 @@ lang: zh
 | `docs/scenarios/manage-at-scale.md` (.en.md) | Platform Engineers, operator, DevOps | 場景：千租戶規模管理 |
 | `docs/scenarios/multi-cluster-federation.md` (.en.md) | Platform Engineers | 場景：多叢集聯邦架構 — 中央閾值 + 邊緣指標 |
 | `docs/scenarios/multi-domain-conf-layout.md` (.en.md) | Platform Engineers, operator, DevOps | 場景：多域名階層式配置 — conf.d/ 目錄結構重構（v2.7.0） |
+| `docs/scenarios/multi-system-migration-playbook.md` | Platform Engineers, SREs, architects | Multi-System Migration Playbook (Outline) |
 | `docs/scenarios/README.md` | All | 場景指南導覽 |
 | `docs/scenarios/shadow-audit.md` (.en.md) | Platform Engineers, Tenants | 場景：Shadow Audit — 告警品質評估 |
 | `docs/scenarios/shadow-monitoring-cutover.md` (.en.md) | Platform Engineers, SREs, DevOps, Tenants | 場景：Shadow Monitoring — 從告警健康評估到全自動切換 |
 | `docs/scenarios/tenant-lifecycle.md` (.en.md) | All | 場景：租戶完整生命週期管理 |
+| `docs/schemas/migration-state.md` | Platform Engineers, SREs, automation | Migration State Schema (.da/migration-state.json) |
 | `docs/schemas/README.md` | Platform Engineers, Tenants | JSON Schema Reference |
 | `docs/shadow-monitoring-sop.md` (.en.md) | SREs, Platform Engineers | Shadow Monitoring SRE SOP |
 | `docs/troubleshooting.md` (.en.md) | Platform Engineers, SREs, Tenants | 故障排查與邊界情況 |

--- a/docs/scenarios/multi-system-migration-playbook.md
+++ b/docs/scenarios/multi-system-migration-playbook.md
@@ -1,0 +1,383 @@
+---
+title: "Multi-System Migration Playbook (Outline)"
+tags: [migration, playbook, scenarios, multi-system, hybrid-format]
+audience: [platform-engineers, sre, architects]
+version: v2.7.0
+lang: zh
+---
+
+# Multi-System Migration Playbook
+
+> **Status**: 🟡 Outline（v0.1，2026-05-10）— 5-Phase 結構、決策樹、Gate 模型、Schema 都已 locked from PR #375-#388 strategic discussion；本檔提供 ToC + 每段 design intent + checklist 骨架。Phase-by-phase 內文在後續 PR 補完。
+>
+> **適用情境**：客戶同時換 storage backend (Prom→VM)、規則層、AM routing，並追加平台的 `_defaults.yaml` metric-split feature。**不適合**：greenfield / 1-system / 2-system → 走決策樹下方對應 redirect。
+>
+> **語氣假設**：本 playbook 假設客戶已有成熟 Prometheus + Alertmanager 運維。**不教 Prometheus 基礎**；映射客戶既有概念到本平台。
+
+---
+
+## 0. 三層 reading speed（怎麼讀本文）
+
+每個 Phase 同樣結構，依角色挑層次：
+
+| 你是誰 | 讀哪段 | 預估 |
+|---|---|---|
+| **Manager / 跨團隊溝通**（broadcast 用）| 每 Phase 開頭的 「30 秒 TL;DR」（3 bullets） | 整 playbook < 5 分鐘 |
+| **Architect / SRE Lead**（決策用）| 30 秒 TL;DR + Architect Narrative + Gates + Decision Trees | 整 playbook ~30 分鐘 |
+| **On-call / Executor**（凌晨 cutover 用）| 跳到「Cutover Checklist」`<details>` + bash code blocks | 單 Phase < 5 分鐘 |
+
+設計動機：**讀者不該抽自己的 TL;DR**。我們先抽好；不該跑命令的人不會看到命令（折疊預設關）；該執行的人 copy-paste 即可。
+
+---
+
+## 1. 我是哪一型客戶？（Routing Decision Tree）
+
+```mermaid
+flowchart TD
+    Q1{現況描述哪一類？}
+    Q1 -->|沒既有 rules、剛裝 Prom| GS["[for-tenants.md](../getting-started/for-tenants.md)<br/>Greenfield onboarding"]
+    Q1 -->|有 rules、留 Prom infra、不換 AM| MG1["[migration-guide.md](../migration-guide.md)<br/>Rule import (1-system)"]
+    Q1 -->|完整 Prom+AM+rules、留 infra| MG2["[migration-guide.md](../migration-guide.md) §rule+AM<br/>Rule + AM migration (2-system)"]
+    Q1 -->|<b>Prom→VM + rules + AM 同時換</b>| THIS["✅ <b>本 playbook</b><br/>3-system migration"]
+
+    style THIS fill:#dff,stroke:#066
+```
+
+如果你不確定該走哪一條，問自己：「**底層 storage 換不換？**」 換 → 本 playbook；不換 → migration-guide.md。
+
+---
+
+## 2. 5-Phase 全景
+
+```mermaid
+sequenceDiagram
+    participant D as Discovery
+    participant P as Pre-flight
+    participant S as Shadow
+    participant C as Cutover
+    participant K as Decommission
+    Note over D: Tier A 靜態 audit (hard)<br/>Tier B/C bonus
+    D->>P: Gate 1
+    Note over P: VM 起、雙寫、舊 Prom 留
+    P->>S: Gate 2
+    Note over S: 規則上 git，AM 帶 shadow label
+    S->>C: Gate 3
+    Note over C: Canary → 全量、git revert 保底
+    C->>K: Gate 4 + 5
+    Note over K: 關舊 Prom、清理、_defaults 漸進
+```
+
+5 個 Gate 全部用 **invariants**（不是「告警量一致」）—— 詳見 §10。
+
+---
+
+## 3. Phase 0 — Discovery & Inventory
+
+### 30 秒 TL;DR
+- 三層 tier audit：A 靜態（hard gate）/ B live snapshot（soft）/ C 歷史 telemetry（bonus）
+- 產出 dual：**`.da/migration-state.json`**（機器讀，後續 phase 自動化用）+ Markdown summary（給 PR description / 給人類）
+- Schema 詳見 [migration-state.md](../schemas/migration-state.md)
+
+### Architect Narrative（待寫，目標 1.5 頁）
+
+**這 Phase 在解什麼問題**：客戶通常不知道自己 inventory 全貌——孤兒規則、死掉的 receiver、一年沒 fire 的 alert 都常見。Phase 0 強制盤點。
+
+**三層 tier 設計理由**：客戶 telemetry 成熟度差異大。Tier A 完全靜態分析（任何客戶都能跑）；Tier B 需要當下 Prom 在線；Tier C 需要 long-retention 或 ELK。**Tier C 不可得不該擋住**——讓 Shadow phase 替代做 dynamic noise filtering。
+
+**Output 用途**：JSON 給後續 phase 的自動化讀（Phase 3 自動產生 cutover candidate list）；Markdown 給 PR review + 客戶 stakeholders 看。
+
+### Cutover Checklist
+
+<details>
+<summary>📋 Phase 0 Checklist（給 executor）</summary>
+
+- [ ] 跑 Tier A 靜態 audit
+  ```bash
+  da-tools onboard --analyze \
+      --output .da/migration-state.json \
+      --markdown-summary > migration-summary.md
+  ```
+- [ ] 把 Markdown summary 貼進 PR description（給 reviewer）
+- [ ] 確認 Tier A hard gates 通過：
+  - [ ] 沒 syntax error 的孤兒 rule
+  - [ ] 每個 receiver 都有對應 routing entry
+  - [ ] tenant id 命名與我們的 schema 相容（dev-rule #2）
+- [ ] **可選** Tier B：對活的 Prom 跑 `ALERTS{}` snapshot
+- [ ] **可選** Tier C：對 Thanos / VM-long-retention 跑歷史查詢
+- [ ] commit `.da/migration-state.json` 進 customer GitOps repo
+</details>
+
+### Failure modes
+- 「Tier A 卡在 syntax error」：常見於手寫 PromQL 用 VM-only 函數 → `da-parser --strict-promql` 標出
+- 「Tier B 拉不到 ALERTS{}」：Prom 太久沒 alert 評估 / 或 query timeout → 接受 Tier A 即可推進
+
+### Gate 1 → Phase 1
+**通過條件**：Tier A 全 hard checks pass + `.da/migration-state.json` 已 commit。
+
+---
+
+## 4. Phase 1 — Pre-flight & Dual-Write Infrastructure
+
+### 30 秒 TL;DR
+- VM cluster 起來（vmagent / vmselect / vmstorage 或 vmsingle）
+- 客戶舊 Prom + 新 VM **同時 scrape** 相同 targets（dual-write）
+- exporter 在我們的 cluster 起、發 `user_threshold` metric
+
+### Architect Narrative（待寫）
+- VM topology 選擇（vmsingle vs vmcluster）依規模 + HA 需求
+- Dual-write 策略：vmagent remote_write fan-out 或客戶在 Prom 端 federate
+- 我們的 exporter 此階段已上線但 AM 沒接（metric 純 collect）
+
+### Cutover Checklist
+
+<details>
+<summary>📋 Phase 1 Checklist</summary>
+
+- [ ] 部署 VM 至 staging cluster
+- [ ] 配 vmagent fan-out（舊 Prom + 新 VM 雙端）
+- [ ] 跑 Gate 1 invariant：VM 與 Prom 同 metric 數量 ±5%
+- [ ] 部署我們 exporter 到 staging
+- [ ] 驗證 `user_threshold` metric 在 VM 可查
+</details>
+
+### Gate 2 → Phase 2
+**通過條件**：dual-write ≥ 7 天無掉點 + Tier B live snapshot 比對 staging vs prod-Prom 無 cardinality drift。
+
+---
+
+## 5. Phase 2 — Shadow Deployment
+
+### 30 秒 TL;DR
+- 規則 commit 到 git（單一 SOT 或 base + overlay，依 [Plan A vs B](#8-plan-a-vs-plan-bgit-layout-選擇)）
+- AM routing 全部帶 `migration_status: shadow` label，告警導 /dev/null 或 debug channel
+- 既有舊 Prom + AM 仍在線、仍是 production source-of-truth
+
+### Architect Narrative（待寫）
+- 為什麼 shadow 不直接接 production AM：信心不足 / 客戶 ops 還沒培訓
+- Plan A vs B 此 phase 落地差異
+- Gate 2 invariants 由來：**subset overlap = 100%**（既有等價規則必觸發）+ **新增 alert 顯式 sign-off**（避免 noise 被當回歸）
+
+### Cutover Checklist
+
+<details>
+<summary>📋 Phase 2 Checklist</summary>
+
+- [ ] 規則 commit 進 git（用 [migrate-conf-d](../cli-reference.md) 從舊規則轉換）
+- [ ] AM routing 加 shadow matcher：
+  ```yaml
+  route:
+    routes:
+      - matchers: [migration_status="shadow"]
+        receiver: "null"
+        continue: false
+  ```
+- [ ] `da-tools shadow-verify preflight` 通過
+- [ ] Shadow 期 ≥ 2 週（Gate 3 前置）
+- [ ] 任一週內 invariants 都 hold
+</details>
+
+### Gate 3 → Phase 3
+**通過條件**：
+1. **Subset overlap = 100%**：舊系統有觸發的條件，新系統必觸發（catastrophic 假陰性 0）
+2. **新增 alert 顯式 sign-off**：客戶 ops 對每條額外 alert 點頭（確認不是 bug 雜訊）
+3. CI / CD 對 `_metric_federation_policy.yaml` 等變動 sticky 報告無 unexpected delta
+
+---
+
+## 6. Phase 3 — Incremental Cutover
+
+### 30 秒 TL;DR
+- Canary tenant（5-10%）先切：移 `migration_status: shadow` label → AM 自然激活新規則路徑
+- 24h-1 ops cycle 觀察 → 推全量
+- Rollback path：**git revert** config commit 即恢復（< 5 分鐘）
+
+### Architect Narrative（待寫）
+- 為什麼 AM cutover 不是獨立 stage（而是 Phase 3 副作用）：去掉 shadow label 後 AM route 自然失效；不需第二個 cutover step
+- Canary 比例 + 觀察窗：5% × 24h 是 minimum；推薦 **跨 1 個 ops cycle (typically 1 week)** 抓 weekly / monthly alerts
+- Connect：**staged adoption** （custom_ → golden）由獨立 **Staged Adoption Guide** (`docs/scenarios/staged-adoption-guide.md`，I-2 待 ship) 處理；**本 Phase 不重複那段內容**，只做 cutover 的 routing flip
+
+### Cutover Checklist
+
+<details>
+<summary>📋 Phase 3 Checklist</summary>
+
+**Canary 階段**
+- [ ] 選擇 canary tenants（典型 5-10%）
+- [ ] git commit：移除 canary tenants 的 `migration_status: shadow` label
+- [ ] AM reload（自動）
+- [ ] 24h 觀察期：alert 觸發率、receiver 響應、人為 incidents
+- [ ] Gate 4 通過 → 推全量
+
+**全量階段**
+- [ ] git commit：移除剩餘 tenants 的 shadow label
+- [ ] 觀察 ≥ 1 ops cycle（推薦 1 week）
+- [ ] Gate 5 通過 → Phase 4
+
+**Rollback**
+- [ ] git revert 對應 commit → AM reload → shadow label 恢復 → 新規則自動失效
+- [ ] **可逆性界線**：見 §11（config 全可逆 / 監控狀態半可逆 / 資料層不可逆）
+</details>
+
+### Gate 4（canary）→ 全量
+**通過條件**：Canary tenants 跨 24h 無 unexpected alert + 客戶 ops sign-off。
+
+### Gate 5（全量）→ Phase 4
+**通過條件**：全量切換 ≥ 1 ops cycle 無 incident。
+
+---
+
+## 7. Phase 4 — Decommission
+
+### 30 秒 TL;DR
+- 舊 Prom 進入 read-only（停 alerting evaluation）
+- N 天 grace period 後關 Prom
+- 漸進啟用 `_defaults.yaml` metric-split feature（連 **Staged Adoption Guide** (`docs/scenarios/staged-adoption-guide.md`，I-2 待 ship)）
+
+### Architect Narrative（待寫）
+- 為什麼分 read-only → off 兩步：歷史 query 需求（compliance / SRE 回顧）
+- Decommission 後才能啟用 metric-split：避免 Phase 3 期 noise 被歸因到新功能
+
+### Cutover Checklist
+
+<details>
+<summary>📋 Phase 4 Checklist</summary>
+
+- [ ] 舊 Prom 移除 alert.rules.yml（純 read-only，仍可 query）
+- [ ] Grace period（建議 30 天）
+- [ ] Prom shutdown
+- [ ] 按 **Staged Adoption Guide** (`docs/scenarios/staged-adoption-guide.md`，I-2 待 ship) 漸進啟用 `_defaults.yaml`
+- [ ] 更新客戶 internal docs / runbooks
+</details>
+
+---
+
+## 8. Plan A vs Plan B（Git layout 選擇）
+
+### Plan A — Single SOT + Per-cluster Exporter Version Skew（**預設**）
+
+`conf.d/` 是單一 Git 樹，所有 cluster 共用。差異透過該 cluster 部署的 threshold-exporter 版本決定該 cluster 在哪個 phase。
+
+```
+conf.d/
+├─ _defaults.yaml          # v2.8+ exporter 讀；v2.7 silently ignore
+├─ <domain>/
+│  └─ <region>/
+│     └─ <tenant>.yaml
+```
+
+**Forward-compat 已驗證**（PR #375 P0 check）：v2.7.0 exporter 對 v2.8.0 新欄位 graceful ignore（`yaml.Unmarshal` lenient + `_*` 底線檔案跳過慣例）。
+
+**何時用 Plan A**：cluster 間版本差距 ≤ 1 minor、無 per-cluster selective feature 需求。Cover ~80% 客戶情境。
+
+### Plan B — Base + Overlay（escape hatch）
+
+```
+conf.d/
+├─ base/                  # 所有 cluster 共用
+└─ overlays/
+   ├─ staging/            # 進階 feature
+   │  └─ _defaults.yaml
+   └─ prod/               # 還在 Shadow
+      └─ migration_status_routing.yaml
+```
+
+**何時用 Plan B**：客戶要 per-cluster selective feature adoption（staging 啟用 _defaults、prod 暫不啟用）。
+
+**Plan B platform investment**：exporter 需要 multi-mount-point overlay merge 邏輯——**目前未 ship**，是 v2.9 backlog 項。客戶觸發 Plan B 時請先確認 platform team 排期。
+
+---
+
+## 9. Partial Migration（X-Y matrix）
+
+5-Phase 是 **Y 軸**；scope wave 是 **X 軸**——兩者正交。
+
+```
+                 Phase 0  Phase 1  Phase 2  Phase 3  Phase 4
+staging cluster   ✅       ✅       ✅       ✅       ✅
+prod canary       ✅       ✅       🔄 (in)   —        —
+prod-rest         ✅       ✅       —        —        —
+```
+
+合法狀態：**staging 在 Phase 4 + prod 在 Phase 2 同時發生**。playbook 不要假設「全 cluster 同步」。
+
+---
+
+## 10. Gate Reference Table
+
+| Gate | Phase 出 | Phase 入 | 通過條件 |
+|---|---|---|---|
+| Gate 1 | Phase 0 Discovery | Phase 1 Pre-flight | Tier A 靜態 audit hard checks pass + migration-state.json committed |
+| Gate 2 | Phase 1 Pre-flight | Phase 2 Shadow | Dual-write ≥ 7 天無掉點 + Tier B 比對 staging vs prod 無 cardinality drift |
+| Gate 3 | Phase 2 Shadow | Phase 3 Cutover | **Subset overlap = 100%** + 新增 alert 顯式 sign-off + ≥ 2 週 shadow 期 |
+| Gate 4 | Phase 3 Canary | Phase 3 全量 | Canary tenants 跨 24h 無 unexpected alert + ops sign-off |
+| Gate 5 | Phase 3 全量 | Phase 4 Decommission | 全量切換 ≥ 1 ops cycle 無 incident |
+
+**所有 Gate 用 invariants**（subset overlap、cardinality drift bound 等），**不是**「告警量一致」這類 timing-sensitive 命題。
+
+---
+
+## 11. Rollback 三層可逆界線
+
+| Layer | 可逆性 | Rollback 機制 | 預估時間 |
+|---|---|---|---|
+| **Config**（rules.yaml / AM routing / `_defaults.yaml`）| ✅ | `git revert <commit>` → AM/exporter reload | < 5 分鐘 |
+| **監控狀態**（已 silenced alert / maintenance window） | ⚠️ 半可逆 | git revert + manual cleanup script（待 ship） | ~30 分鐘 |
+| **資料層**（VM 已 ingest 的 metric / Prom 已 GC 的 chunk） | ❌ 不可逆 | 接受 | — |
+
+**playbook 必須讓客戶建立 mental model**：rollback ≠ undo all.
+
+---
+
+## 12. Failure Mode Catalog（cross-phase summary）
+
+[待寫，預計 1 頁；深入排查連 **Troubleshooting Checklist** (`docs/integration/troubleshooting-checklist.md`，I-4 待 ship)]
+
+| 階段 | 症狀 | 第一手排查 | 深入文件 |
+|---|---|---|---|
+| Phase 1 dual-write | VM 比 Prom 少 metric | vmagent error log | troubleshooting-checklist §1 |
+| Phase 2 shadow | shadow alerts 漏到 production receiver | AM route 順序 + matcher | shadow-monitoring-sop.md |
+| ... | ... | ... | ... |
+
+---
+
+## 13. Appendices
+
+### A. Customer-anon scenario walkthrough（待寫，~1.5 頁）
+
+**Setting**：1000 tenant 製造業客戶，原本自管 Prom + AM 5 年，無 telemetry pipeline。Stage 4 maturity（mature multi-system）。要換 VM + 加 metric-split。
+
+[walkthrough 帶讀者過完 Phase 0-4，每 phase 1 段]
+
+### B. Cross-references
+
+- **Schema**：[`docs/schemas/migration-state.md`](../schemas/migration-state.md) — `.da/migration-state.json` 欄位 spec
+- **Shadow 機制深入**：[`docs/shadow-monitoring-sop.md`](../shadow-monitoring-sop.md)
+- **Rule-only migration**（1/2-system）：[`docs/migration-guide.md`](../migration-guide.md)
+- **Staged adoption**（custom_ → golden 漸進）：`docs/scenarios/staged-adoption-guide.md` — I-2，待 ship
+- **Troubleshooting**：`docs/integration/troubleshooting-checklist.md` — I-4，待 ship
+- **VM integration entry**：`docs/integration/victoriametrics-integration.md` — I-3，待 ship
+
+### C. ADR / Design references
+
+- 設計 commitments lock from PR #375 strategic discussion + 3 輪 Gemini adversarial review
+- 5-Phase / Gate invariants / Plan A vs B / Rollback 邊界 / X-Y matrix 全 locked
+- 內文寫作會在後續 PR 補進每 Phase 的 narrative + checklist 詳細
+
+---
+
+## Outline Status
+
+| 段 | 狀態 |
+|---|---|
+| §0-2 frame + decision tree + 5-Phase overview | ✅ outline ready |
+| §3-7 各 Phase 30-sec TL;DR + checklist 骨架 | ✅ outline ready |
+| §3-7 各 Phase Architect Narrative | 🟡 待補（內文 PR）|
+| §8 Plan A vs B Git layout | ✅ outline ready |
+| §9 X-Y matrix | ✅ outline ready |
+| §10 Gate Reference Table | ✅ outline ready |
+| §11 Rollback 三層 | ✅ outline ready |
+| §12 Failure Mode Catalog | 🟡 待補 |
+| §13 Customer-anon walkthrough | 🟡 待補 |
+| §13 Cross-refs | ✅ outline ready |
+
+**下一步**：本 outline 進 PR review（owner + Gemini）→ 通過後動內文 PR（補 Architect Narrative 段 + Failure Mode Catalog + Walkthrough）。預計內文 ~8-12h，分 1-2 PR ship。

--- a/docs/schemas/migration-state.md
+++ b/docs/schemas/migration-state.md
@@ -1,0 +1,170 @@
+---
+title: "Migration State Schema (.da/migration-state.json)"
+tags: [schema, migration, multi-system, automation]
+audience: [platform-engineers, sre, automation]
+version: v2.7.0
+lang: zh
+---
+
+# Migration State Schema (`.da/migration-state.json`)
+
+> **Status**: 🟡 Outline（v0.1，2026-05-10）— schema fields locked from
+> [multi-system-migration-playbook](../scenarios/multi-system-migration-playbook.md)
+> Phase 0 design. **未來會由 da-tools 程式碼 auto-generate 覆蓋本文件**——
+> 第一版手寫於此，後續切換 SSOT 為程式碼。
+>
+> **Future SSOT**（v2.9）：`components/da-tools/app/migration_state.py` Pydantic model；
+> CI hook 自動從 model dump schema → 對比本 .md → drift fails.
+> 在那之前 manually maintained，CI cross-check 不可用。
+
+---
+
+## 用途
+
+`da-tools onboard --analyze` 的 Phase 0 discovery 輸出。**Dual output**:
+
+| 形式 | 路徑 | 給誰 |
+|---|---|---|
+| JSON | `.da/migration-state.json`（commit 進客戶 GitOps repo）| 機器讀（後續 phase 自動化、cutover candidate selector、CI gate）|
+| Markdown summary | stdout / `migration-summary.md` | 人類讀（PR description、ops review、stakeholder broadcast）|
+
+兩個輸出**從同一個 internal state 派生**——保證一致。
+
+---
+
+## 為什麼 dual output（Gemini 對抗 reviewer 觀點）
+
+如果只產 Markdown，後續 Phase 3 的 cutover candidate selector / 自動清理腳本就**沒法讀**孤兒規則清單，automation 閉環斷掉。JSON 給機器、Markdown 給人類，是 SRE 工具鏈正確姿勢。
+
+---
+
+## Schema v1（outline）
+
+```json
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-05-10T14:00:00Z",
+  "generated_by": "da-tools onboard --analyze v2.8.0",
+
+  "discovery": {
+    "tier_a_static": {
+      "rule_files_scanned": 42,
+      "rules_total": 380,
+      "syntax_errors": [],
+      "orphan_rules": [
+        {"name": "MyAlert", "file": "rules.yaml", "reason": "no matching receiver"}
+      ],
+      "rules_with_no_route": [],
+      "receivers_unused": [],
+      "tenant_id_violations": []
+    },
+    "tier_b_live_snapshot": {
+      "available": true,
+      "captured_at": "2026-05-10T13:55:00Z",
+      "currently_firing_count": 7,
+      "active_routes_hit": 12,
+      "alerts_by_severity": {"critical": 2, "warning": 5}
+    },
+    "tier_c_historical": {
+      "available": false,
+      "reason": "Customer has no Thanos / VM-long-retention / ELK"
+    }
+  },
+
+  "current_state": {
+    "phase": "0_discovery",
+    "plan_choice": null,
+    "started_at": "2026-05-10T14:00:00Z",
+    "completed_phases": []
+  },
+
+  "scope": {
+    "clusters": [
+      {"name": "staging-us-east", "stage": "0_discovery"},
+      {"name": "prod-us-east", "stage": "0_discovery"},
+      {"name": "prod-us-west", "stage": "0_discovery"}
+    ],
+    "tenants_total": 145,
+    "rule_packs_targeted": ["mysql", "postgres", "redis"],
+    "metric_split_planned": true
+  },
+
+  "gate_log": []
+}
+```
+
+---
+
+## 欄位語意（outline）
+
+### Top-level
+- **schema_version** — semver `"<major>.<minor>"`. v0.1 outline = `"1.0"`. Major bump = breaking field changes.
+- **generated_at** — ISO 8601 UTC.
+- **generated_by** — tool + version stamp.
+
+### `discovery.tier_a_static`
+- **rule_files_scanned** / **rules_total** — counts; sanity for client.
+- **syntax_errors** — list of `{file, line, message}`. Hard gate: must be 0.
+- **orphan_rules** — rule with no matching AM receiver (will silent-drop alerts).
+- **rules_with_no_route** — opposite: rule fires, no route configured.
+- **receivers_unused** — receiver defined but no rule routes to it.
+- **tenant_id_violations** — hardcoded tenant id (dev-rule #2 violation).
+
+### `discovery.tier_b_live_snapshot`
+- **available** — false if Prom unreachable / no permission. Don't block.
+- **currently_firing_count** — sanity for "what's actively noisy".
+- **active_routes_hit** — distinct AM routes that resolved at snapshot time.
+
+### `discovery.tier_c_historical`
+- **available** — typically false (most customers).
+- 若 available 則 `lookback_days` + 各 alert 的 fire/resolve histogram.
+
+### `current_state`
+- **phase** — enum `0_discovery | 1_preflight | 2_shadow | 3_cutover_canary | 3_cutover_full | 4_decommission`.
+- **plan_choice** — `A | B | null`. Null until Phase 1 starts.
+- **completed_phases** — append-only list（後續 Phase 自動 advance）.
+
+### `scope`
+- **clusters** — list with per-cluster X-Y matrix position（`stage` 對應該 cluster 的當前 phase；正交於整體 `current_state.phase`）.
+- **rule_packs_targeted** — which Rule Packs (Mysql / Postgres / Redis...) the customer plans to import.
+- **metric_split_planned** — boolean. True triggers `_defaults.yaml` adoption in Phase 4.
+
+### `gate_log`
+- 列已通過的 Gate：`{gate_id, passed_at, criteria_met}`. 後續 phase 機械讀此 log 決定能否 advance.
+
+---
+
+## 演進路線
+
+### v1 (本 outline)
+- 手寫 schema definition
+- da-tools 寫 Python dict → JSON dump
+- CI 不檢查 drift（風險 acceptable，schema 早期）
+
+### v2（v2.9 backlog）
+- Pydantic model 在 `components/da-tools/app/migration_state.py`
+- `da-tools onboard --analyze` import model + dump
+- CI hook：model schema → JSON Schema → 對比本 .md → drift fails
+- **本 .md 變成 generated artifact**（標 `<!-- AUTO-GENERATED, DO NOT EDIT -->`）
+
+---
+
+## 關聯
+
+- **使用者**：[multi-system-migration-playbook §3](../scenarios/multi-system-migration-playbook.md#3-phase-0-discovery-inventory) Phase 0
+- **schema 系列**：[docs/schemas/](README.md)（其他 schema 文件）
+- **Future SSOT**：v2.9 backlog（待開 issue）
+
+---
+
+## Outline status
+
+| 段 | 狀態 |
+|---|---|
+| 用途 + dual output 設計 | ✅ outline ready |
+| Schema v1 JSON 範本 | ✅ outline ready |
+| 欄位語意（top-level / discovery / current_state / scope / gate_log） | ✅ outline ready |
+| 演進路線（v1 → v2 auto-gen） | ✅ outline ready |
+| Concrete examples per field（含 edge cases） | 🟡 待補（內文 PR） |
+
+**下一步**：本 outline 進 PR review；通過後 da-tools onboard --analyze 實作（v2.9 epic 的一部分）會引用本 schema 為合約。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -254,6 +254,7 @@ nav:
     - Shadow Monitoring 切換: scenarios/shadow-monitoring-cutover.md
     - 多叢集 Federation: scenarios/multi-cluster-federation.md
     - Tenant 生命週期: scenarios/tenant-lifecycle.md
+    - Multi-System Migration Playbook: scenarios/multi-system-migration-playbook.md
   - 參考:
     - da-tools CLI: cli-reference.md
     - CLI 速查表: cheat-sheet.md


### PR DESCRIPTION
## Summary

Closes the **outline phase** of [issue #377](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/377) I-1. After 4 rounds of strategic discussion + 3 rounds of Gemini adversarial review + Q1/Q2/Q3 owner sign-off, ToC + Phase frame + Gates + Plan A/B + X-Y matrix + Rollback boundaries are all locked. Per-Phase narrative content lands in follow-up PRs.

## Two new docs

### [`docs/scenarios/multi-system-migration-playbook.md`](docs/scenarios/multi-system-migration-playbook.md) (~480 lines, outline)

**Structure**: 3-tier reading speed (per Gemini hybrid format) — same shape every Phase:

| Tier | For | What |
|---|---|---|
| **30-sec TL;DR** | Manager / cross-team broadcast | 3 bullets per Phase |
| **Architect Narrative** | SRE Lead / decision-maker | Decision points + risk discussion |
| **Cutover Checklist** | On-call / executor | `<details>`-folded markdown checkboxes + bash code blocks |

**Sections**:
- Routing decision tree (Mermaid) — greenfield / 1-system / 2-system redirect to existing migration-guide; 3-system stays on this doc
- 5-Phase overview (Mermaid sequence)
- Phase 0 Discovery (3-tier audit: A static / B live / C historical; Tier A is hard gate, B/C bonus)
- Phase 1 Pre-flight & Dual-Write (VM up + dual scrape)
- Phase 2 Shadow Deployment (`subset overlap=100%` gate, **NOT** alert-count match)
- Phase 3 Incremental Cutover (canary → full; git revert rollback path)
- Phase 4 Decommission (Prom read-only grace → off → metric-split adoption)
- Plan A vs Plan B Git layout (single SOT + version skew vs base+overlay; Plan A default per PR #375 forward-compat verification)
- X-Y matrix (cluster scope orthogonal to Phase axis — `staging Phase 4 + prod Phase 2` legitimate)
- Gate Reference Table (5 gates, all invariants-based)
- Rollback 3-tier reversibility (config ✅ / monitoring state ⚠️ / data ❌)

**Out-of-scope** (per Q-new-1 owner decision):
- Greenfield onboarding (YAGNI; existing [`for-tenants.md`](docs/getting-started/for-tenants.md) sufficient)
- 1-system / 2-system migration (existing [`migration-guide.md`](docs/migration-guide.md))

### [`docs/schemas/migration-state.md`](docs/schemas/migration-state.md) (~190 lines, outline)

Phase 0 dual-output schema for `.da/migration-state.json`:
- **JSON** for machine consumption (downstream phase automation, cutover candidate selection)
- **Markdown summary** for human PR review

Per Gemini Q7 critique: machine-readable artifact unblocks automated cutover candidate selection in Phase 3. Future SSOT path (v2.9 backlog): Pydantic model auto-generates this schema doc; CI hook detects drift.

## Cognitive load reductions (per Q1 owner emphasis)

- **3-tier reading speed**: nobody scrolls past commands they shouldn't run; managers don't extract their own TL;DR
- **Decision tree at top**: routes early-out 3 of 4 customer types to existing docs; this playbook stays focused on multi-system
- **Tone-locked intro**: assumes mature ops, doesn't teach Prometheus, maps existing concepts

## Forward-references

I-2 staged-adoption-guide / I-3 victoriametrics-integration / I-4 troubleshooting-checklist mentioned as backticked filenames + `(待 ship)` rather than markdown links — actual files don't exist yet, links would fail doc-links-check.

## Test plan

- [x] All 47 pre-commit hooks pass (anchor mismatches fixed in 2 retries)
- [x] mkdocs nav adds new playbook under 場景 section
- [x] doc-map regenerated (78 entries, was 76)
- [ ] Owner + Gemini review on outline structure
- [ ] Verify Mermaid renders correctly on GitHub + MkDocs

## Next steps after merge

- Internal content PR(s): Architect Narrative + Failure Mode Catalog + customer-anon walkthrough (~8-12h, 1-2 PRs)
- I-2 staged adoption guide (separate doc, lifecycle pattern not migration step)
- I-3 VictoriaMetrics integration entry (owner confirmed strong customer demand)
- I-4 troubleshooting checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)