### PR TITLE
docs: fix §4 disk budget cautionary note math (1.4TB → 260GB)

### DIFF
--- a/docs/scenarios/multi-system-migration-playbook.md
+++ b/docs/scenarios/multi-system-migration-playbook.md
@@ -180,7 +180,12 @@ bytes-per-datapoint × datapoints-per-day × series count × retention days × 1
 
 實際估算**請以 [VM 官方 Capacity Calculator](https://docs.victoriametrics.com/Single-server-VictoriaMetrics.html#capacity-planning) 為準**——它會把 churn / dedup / replication factor 一起納入，比 rule-of-thumb 公式精確。本公式只供 sanity check 與初次採購估算的數量級判斷。
 
-**反例**：早期 v0.1 outline 寫過「bytes-per-series-per-day ~8-15 bytes」是錯的——把 bytes/datapoint 與 bytes/series/day 混淆。100 萬 series × 15s scrape × 30 天若用 8 bytes/series/day 會算出 < 1GB，實際正確估算約 1.4TB 量級。Phase 1 disk 撐爆的事故多半出自這類算錯。
+**反例**：早期 v0.1 outline 寫過「bytes-per-series-per-day ~8-15 bytes」是錯的——把 bytes/datapoint 與 bytes/series/day 混淆。1M series × 15s scrape × 30 days 兩種算法的差異：
+
+- **錯**：`8 bytes/series/day × 1M × 30 × 1.5 ≈ 360 MB` ←算出 disk 需求 < 1GB，明顯有問題
+- **對**：`1 byte/dp × 5760 dp/day × 1M × 30 × 1.5 ≈ 260 GB`（5760 = 86400/15s scrape）
+
+兩者差 ~700 倍。Phase 1 disk 撐爆的事故多半出自這類算錯——把 bytes/series/day 誤當公式單位、實際數值卻在 bytes/datapoint 量級。
 
 #### Dual-write 策略
 


### PR DESCRIPTION
## Summary

1-line follow-up flagged in [PR #395 comment](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/395#issuecomment-4415503149).

PR #396 introduced the corrected disk budget formula but the cautionary example I wrote in §4 had its own arithmetic error: claimed "1M series × 15s scrape × 30 days ≈ 1.4TB" using the corrected formula, when actual math yields ~260GB.

| Algorithm | Result |
|---|---|
| Wrong (8 bytes/series/day): `8 × 1M × 30 × 1.5` | **360 MB** ← obviously wrong |
| Right (1 byte/dp × 5760 dp/day): `1 × 5760 × 1M × 30 × 1.5` | **~260 GB** |

Two algorithms differ by ~700×; original 1.4TB number was off by ~5× from the right answer.

## What changed

Restructured §4 cautionary note with side-by-side bullet pair instead of inline prose, so the reader can see exactly which factor was being mis-substituted (`bytes/series/day` vs `bytes/datapoint × datapoints/day`). Reinforces the lesson without changing message.

## Test plan
- [x] Pre-commit hooks pass
- [x] Math sanity check: `5760 × 30 × 1.5 = 259200`, × 1M series × 1 byte ≈ 259GB ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)