### PR TITLE
ci: fix Nightly Mutation Pilot Python deps install

### DIFF
--- a/.github/workflows/nightly-mutation-pilot.yaml
+++ b/.github/workflows/nightly-mutation-pilot.yaml
@@ -56,9 +56,13 @@ jobs:
           cache: "pip"
 
       - name: Install dependencies
+        # No requirements.txt at repo root — this project uses pyproject.toml +
+        # inline workflow deps. Mirror the canonical Python test dep set from
+        # ci.yml (the python-tests job) since the pilot re-runs the same
+        # hypothesis-backed property tests under pytest.
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install pyyaml croniter pytest pytest-cov pytest-timeout pytest-xdist promql-parser hypothesis
 
       - name: Run Python mutation pilot
         id: pilot


### PR DESCRIPTION
## Summary

- Nightly Mutation Pilot's Python job has been failing every night with `Could not open requirements file: 'requirements.txt'` ([2026-05-09 run](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/25607811631), [2026-05-10 run](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/25635637716)) — this repo has no `requirements.txt`; the project standardizes on `pyproject.toml` + per-workflow inline dep lists.
- Replace `pip install -r requirements.txt` with the canonical Python test dep set already used by `ci.yml`'s `python-tests` job (`pyyaml croniter pytest pytest-cov pytest-timeout pytest-xdist promql-parser hypothesis`). `_mutation_pilot.py` re-runs the same hypothesis-backed property tests under pytest, so deps match by definition.
- Go pilot job is unaffected (was already green on every nightly run).

## Test plan

- [ ] After merge, trigger `Nightly Mutation Pilot` via `workflow_dispatch` and confirm the Python job reaches the `Run Python mutation pilot` step and produces a SUMMARY block.
- [ ] Verify pip cache still works under `setup-python@v6 cache: "pip"` (it falls back to `pyproject.toml` hashing when no `requirements.txt` is present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)