### PR TITLE
refactor(tenant-api): return limiter from RateLimit() — decouple tests from activeLimiter global

### DIFF
--- a/components/tenant-api/cmd/server/main.go
+++ b/components/tenant-api/cmd/server/main.go
@@ -233,7 +233,11 @@ func main() {
 	}
 	// PR-11/11: stopCh terminates the limiter's bucket-sweeper
 	// goroutine alongside the rbac/policy/tracker WatchLoops.
-	r.Use(handler.RateLimit(rlCfg, stopCh))
+	// The second return value (limiter handle) is for tests;
+	// /metrics finds the limiter via activeLimiter, set inside
+	// RateLimit().
+	rlMw, _ := handler.RateLimit(rlCfg, stopCh)
+	r.Use(rlMw)
 
 	// Health / readiness / metrics (no auth)
 	r.Get("/health", handler.Health)

--- a/components/tenant-api/internal/handler/errors_test.go
+++ b/components/tenant-api/internal/handler/errors_test.go
@@ -189,7 +189,7 @@ func TestCodeFromStatus(t *testing.T) {
 func TestRateLimit_EnvelopeShape(t *testing.T) {
 	t.Parallel()
 	cfg := RateLimitConfig{RequestsPerMinute: 1}
-	mw := RateLimit(cfg, make(chan struct{}))
+	mw, _ := RateLimit(cfg, make(chan struct{}))
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/components/tenant-api/internal/handler/middleware.go
+++ b/components/tenant-api/internal/handler/middleware.go
@@ -295,10 +295,15 @@ func RateLimitMetrics() (rejections int64, activeCallers int) {
 }
 
 // RateLimit returns chi middleware that throttles per-caller
-// request rate. Skipped paths are exempt; everything else is
-// counted. Over-cap responses return JSON with the same shape
-// the rest of the API uses (error key) plus a code and
-// retry_after_s field for programmatic clients.
+// request rate, plus a handle to the underlying limiter for
+// callers that need direct counter readback (tests, future
+// explicit /metrics injection). Skipped paths are exempt;
+// everything else is counted. Over-cap responses return JSON
+// with the same shape the rest of the API uses (error key) plus
+// a code and retry_after_s field for programmatic clients.
+//
+// The returned `*rateLimiter` is nil when cfg.RequestsPerMinute
+// <= 0 (limiter disabled — middleware is a no-op pass-through).
 //
 // `stopCh` controls the bucket-sweeper goroutine lifecycle. Pass
 // the same stop channel main.go uses to terminate hot-reload
@@ -306,11 +311,19 @@ func RateLimitMetrics() (rejections int64, activeCallers int) {
 // Tests that don't want a background sweeper can pass a fresh
 // channel and never close it (the sweeper sleeps until interval
 // or stopCh; idle cost is one ticker per process).
-func RateLimit(cfg RateLimitConfig, stopCh <-chan struct{}) func(http.Handler) http.Handler {
+//
+// Most production callers can discard the second return value
+// (`mw, _ := RateLimit(...)`); /metrics still finds the limiter
+// via activeLimiter. Tests that need to assert counter values
+// MUST use the returned limiter directly — activeLimiter is a
+// package-level pointer overwritten by every RateLimit() call,
+// so under t.Parallel() RateLimitMetrics() may read someone
+// else's limiter.
+func RateLimit(cfg RateLimitConfig, stopCh <-chan struct{}) (func(http.Handler) http.Handler, *rateLimiter) {
 	if cfg.RequestsPerMinute <= 0 {
 		// Limiter disabled: hand back the identity middleware so
 		// the chain composes cleanly.
-		return func(next http.Handler) http.Handler { return next }
+		return func(next http.Handler) http.Handler { return next }, nil
 	}
 	// Production limiters get the sweeper; the activeLimiter
 	// pointer is updated so /metrics finds the right one even
@@ -322,7 +335,7 @@ func RateLimit(cfg RateLimitConfig, stopCh <-chan struct{}) func(http.Handler) h
 	}()
 	limiter := newRateLimiterWithSweep(cfg, sweepStop)
 	activeLimiter.Store(limiter)
-	return func(next http.Handler) http.Handler {
+	mw := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if cfg.SkipPaths != nil && cfg.SkipPaths[r.URL.Path] {
 				next.ServeHTTP(w, r)
@@ -346,6 +359,7 @@ func RateLimit(cfg RateLimitConfig, stopCh <-chan struct{}) func(http.Handler) h
 			next.ServeHTTP(w, r)
 		})
 	}
+	return mw, limiter
 }
 
 // ─────────────────────────────────────────────────────────────────

--- a/components/tenant-api/internal/handler/middleware_test.go
+++ b/components/tenant-api/internal/handler/middleware_test.go
@@ -91,7 +91,8 @@ func TestRequestIDResponse_NoOpWhenContextEmpty(t *testing.T) {
 func TestRateLimit_AllowsUnderCap(t *testing.T) {
 	t.Parallel()
 	cfg := RateLimitConfig{RequestsPerMinute: 3}
-	handler := RateLimit(cfg, make(chan struct{}))(http.HandlerFunc(
+	mw, _ := RateLimit(cfg, make(chan struct{}))
+	handler := mw(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -110,7 +111,8 @@ func TestRateLimit_AllowsUnderCap(t *testing.T) {
 func TestRateLimit_BlocksAtCap(t *testing.T) {
 	t.Parallel()
 	cfg := RateLimitConfig{RequestsPerMinute: 2}
-	handler := RateLimit(cfg, make(chan struct{}))(http.HandlerFunc(
+	mw, _ := RateLimit(cfg, make(chan struct{}))
+	handler := mw(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -165,7 +167,8 @@ func TestRateLimit_PerCallerIsolation(t *testing.T) {
 	t.Parallel()
 	// Alice's bucket overflowing must NOT affect Bob's bucket.
 	cfg := RateLimitConfig{RequestsPerMinute: 1}
-	handler := RateLimit(cfg, make(chan struct{}))(http.HandlerFunc(
+	mw, _ := RateLimit(cfg, make(chan struct{}))
+	handler := mw(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -205,7 +208,8 @@ func TestRateLimit_SkipPathsExempt(t *testing.T) {
 	// cap=1 they should return 200 indefinitely.
 	cfg := DefaultRateLimit()
 	cfg.RequestsPerMinute = 1
-	handler := RateLimit(cfg, make(chan struct{}))(http.HandlerFunc(
+	mw, _ := RateLimit(cfg, make(chan struct{}))
+	handler := mw(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -225,7 +229,8 @@ func TestRateLimit_DisabledWhenZero(t *testing.T) {
 	// requestsPerMinute=0 → middleware degrades to a no-op pass-
 	// through. The same identity can call any number of times.
 	cfg := RateLimitConfig{RequestsPerMinute: 0}
-	handler := RateLimit(cfg, make(chan struct{}))(http.HandlerFunc(
+	mw, _ := RateLimit(cfg, make(chan struct{}))
+	handler := mw(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -245,7 +250,8 @@ func TestRateLimit_FallbackToIPWhenNoEmail(t *testing.T) {
 	t.Parallel()
 	// No X-Forwarded-Email → bucket by X-Real-IP.
 	cfg := RateLimitConfig{RequestsPerMinute: 1}
-	handler := RateLimit(cfg, make(chan struct{}))(http.HandlerFunc(
+	mw, _ := RateLimit(cfg, make(chan struct{}))
+	handler := mw(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -472,35 +478,41 @@ func TestSlogRequestLogger_5xxLogsAtWarn(t *testing.T) {
 // PR-11/11: rate-limiter polish (rejections counter, sweeper)
 // ─────────────────────────────────────────────────────────────────
 
-// TestRateLimit_RejectionsCounter verifies the rejection counter
-// increments once per blocked request.
+// TestRateLimit_RejectionsCounter verifies that every blocked request
+// through the RateLimit middleware increments the limiter's rejection
+// counter exactly once.
 //
-// Uses the lower-level limiter directly (newRateLimiter) instead of
-// the RateLimit() constructor + RateLimitMetrics() path. Reason: the
-// constructor mutates package-level `activeLimiter` (see middleware.go
-// docstring: "tests that want isolation construct their own limiters
-// via newRateLimiter"). With every RateLimit-using test in this package
-// running under t.Parallel(), the global pointer flips mid-test and
-// RateLimitMetrics() reads from someone else's limiter — observed as
-// "rejections delta = 1, want 3" CI flake.
-//
-// Format coverage of the /metrics endpoint lives in
-// TestMetricsHandler_IncludesRateLimitMetrics.
+// Uses the limiter handle returned by RateLimit (rather than reading
+// the package-level activeLimiter via RateLimitMetrics) so the test
+// is decoupled from global state — under t.Parallel, every concurrent
+// RateLimit(...) call overwrites activeLimiter, and a RateLimitMetrics
+// read can land on someone else's limiter. The middleware path + the
+// counter logic + the rateLimitCaller header extraction are still
+// exercised end-to-end via wrapped.ServeHTTP.
 func TestRateLimit_RejectionsCounter(t *testing.T) {
 	t.Parallel()
-	l := newRateLimiter(RateLimitConfig{RequestsPerMinute: 1})
-	caller := "ratelimit-counter-test@example.com"
-	now := time.Now()
+	cfg := RateLimitConfig{RequestsPerMinute: 1}
+	stop := make(chan struct{})
+	defer close(stop)
+	mw, limiter := RateLimit(cfg, stop)
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	wrapped := mw(inner)
 
 	// First request passes; next 3 are rejected.
 	for i := 0; i < 4; i++ {
-		l.allow(caller, now)
+		req := httptest.NewRequest("GET", "/x", nil)
+		req.Header.Set("X-Forwarded-Email", "ratelimit-counter-test@example.com")
+		w := httptest.NewRecorder()
+		wrapped.ServeHTTP(w, req)
 	}
 
-	if got := l.Rejections(); got != 3 {
+	if got := limiter.Rejections(); got != 3 {
 		t.Errorf("rejections = %d, want 3", got)
 	}
-	if got := l.activeCallers(); got < 1 {
+	if got := limiter.activeCallers(); got < 1 {
 		t.Errorf("active callers = %d, want >= 1", got)
 	}
 }

--- a/components/tenant-api/internal/handler/middleware_test.go
+++ b/components/tenant-api/internal/handler/middleware_test.go
@@ -472,40 +472,36 @@ func TestSlogRequestLogger_5xxLogsAtWarn(t *testing.T) {
 // PR-11/11: rate-limiter polish (rejections counter, sweeper)
 // ─────────────────────────────────────────────────────────────────
 
-// TestRateLimit_RejectionsCounter verifies the package-level
-// rejection counter increments once per blocked request and is
-// readable via RateLimitMetrics().
+// TestRateLimit_RejectionsCounter verifies the rejection counter
+// increments once per blocked request.
+//
+// Uses the lower-level limiter directly (newRateLimiter) instead of
+// the RateLimit() constructor + RateLimitMetrics() path. Reason: the
+// constructor mutates package-level `activeLimiter` (see middleware.go
+// docstring: "tests that want isolation construct their own limiters
+// via newRateLimiter"). With every RateLimit-using test in this package
+// running under t.Parallel(), the global pointer flips mid-test and
+// RateLimitMetrics() reads from someone else's limiter — observed as
+// "rejections delta = 1, want 3" CI flake.
+//
+// Format coverage of the /metrics endpoint lives in
+// TestMetricsHandler_IncludesRateLimitMetrics.
 func TestRateLimit_RejectionsCounter(t *testing.T) {
 	t.Parallel()
-	cfg := RateLimitConfig{RequestsPerMinute: 1}
-	stop := make(chan struct{})
-	defer close(stop)
-	mw := RateLimit(cfg, stop)
-
-	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-	wrapped := mw(inner)
-
-	// Snapshot baseline so the test is independent of any earlier
-	// limiter activity in the same process.
-	baselineRejections, _ := RateLimitMetrics()
+	l := newRateLimiter(RateLimitConfig{RequestsPerMinute: 1})
+	caller := "ratelimit-counter-test@example.com"
+	now := time.Now()
 
 	// First request passes; next 3 are rejected.
 	for i := 0; i < 4; i++ {
-		req := httptest.NewRequest("GET", "/x", nil)
-		req.Header.Set("X-Forwarded-Email", "ratelimit-counter-test@example.com")
-		w := httptest.NewRecorder()
-		wrapped.ServeHTTP(w, req)
+		l.allow(caller, now)
 	}
 
-	gotRejections, gotActive := RateLimitMetrics()
-	delta := gotRejections - baselineRejections
-	if delta != 3 {
-		t.Errorf("rejections delta = %d, want 3", delta)
+	if got := l.Rejections(); got != 3 {
+		t.Errorf("rejections = %d, want 3", got)
 	}
-	if gotActive < 1 {
-		t.Errorf("active callers = %d, want >= 1", gotActive)
+	if got := l.activeCallers(); got < 1 {
+		t.Errorf("active callers = %d, want >= 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the `TestRateLimit_RejectionsCounter` CI flake observed on [PR #413, run 25666010776](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/25666010776/job/75338524383?pr=413) (`rejections delta = 1, want 3`), via a structural change rather than a test-only patch.

## Root cause

`RateLimit(cfg, stopCh)` constructor at [middleware.go:324](components/tenant-api/internal/handler/middleware.go:324) does `activeLimiter.Store(limiter)` — package-level `atomic.Pointer[rateLimiter]`. `RateLimitMetrics()` ([middleware.go:290](components/tenant-api/internal/handler/middleware.go:290)) reads from that single global so the chi-route `/metrics` handler can find the limiter without explicit injection.

7 tests in `middleware_test.go` + 1 in `errors_test.go` each construct a `RateLimit(...)` under `t.Parallel()`. Every constructor call **flips the global pointer**. `TestRateLimit_RejectionsCounter` was:

1. Snapshot baseline via `RateLimitMetrics()` — reads limiter A (own)
2. Run 4 requests → A.rejections = 3
3. Snapshot final via `RateLimitMetrics()` — if a parallel test installed limiter B between steps 1 and 3, this read B, not A. delta = B.rejections − A's baseline ≠ 3.

Observed `delta = 1` exactly matches: another parallel test (e.g. `TestRateLimit_EnvelopeShape`, `TestRateLimit_BlocksAtCap`) installed its own limiter that had recorded 1 rejection, and our final read landed on it.

## Approach pivot during review

First commit (`f3ccbf25`) was a minimal test-only fix — switched `TestRateLimit_RejectionsCounter` to `newRateLimiter().allow()` directly. Race gone, but it lost end-to-end coverage of the public `RateLimit()` → `RateLimitMetrics()` wire-up. If someone refactored `RateLimit()` to drop the `activeLimiter.Store(limiter)` line, the format-only `TestMetricsHandler_IncludesRateLimitMetrics` would not catch it.

Second commit (`777a1ce6` — this PR's final state) fixes the design instead:

```go
// Before
func RateLimit(cfg, stopCh) func(http.Handler) http.Handler

// After
func RateLimit(cfg, stopCh) (func(http.Handler) http.Handler, *rateLimiter)
```

Production callers do `mw, _ := RateLimit(...)`; the global `activeLimiter` is untouched and `/metrics` still reads through it as before. Tests that need to assert counter values hold the **returned** limiter directly — under `t.Parallel()`, the global pointer can flip all it wants, the test's assertion source is local.

`TestRateLimit_RejectionsCounter` is back to its original integration shape: full `wrapped.ServeHTTP(w, req)` × 4 path including `rateLimitCaller` header extraction, with assertions against `limiter.Rejections()` / `limiter.activeCallers()`.

## Callsite changes

| File | Sites | Change |
|---|---|---|
| `cmd/server/main.go` | 1 | `r.Use(handler.RateLimit(...))` → `mw, _ := ...; r.Use(mw)` |
| `internal/handler/middleware_test.go` | 7 | `handler := RateLimit(...)(...)` → `mw, _ := RateLimit(...); handler := mw(...)` (plus the one race-fixed test uses `mw, limiter := ...`) |
| `internal/handler/errors_test.go` | 1 | `mw := RateLimit(...)` → `mw, _ := RateLimit(...)` |

## Tradeoff considered

`RateLimit` is exported; the new return type `*rateLimiter` is unexported. Returning unexported from exported is mildly non-idiomatic, but acceptable here because (a) `internal/handler` cannot be imported outside `tenant-api`, so no external callers exist; (b) all current and foreseeable consumers either ignore the value or live in the same package. If a future consumer outside the package needs counter readback, the right move is to expose an interface (`RateLimitController { Rejections() int64; ActiveCallers() int }`) — that's an additive change, not a breaking one.

## Why not just drop `t.Parallel()` from the flaky test?

That was Option B in discussion — minimal 1-line fix, race-free via Go's "Parallel signals only with other parallel tests" semantic. Rejected because the invariant lives only in a comment; a future contributor adding `t.Parallel()` back wouldn't get a compile error, and the race returns silently. Option P (this PR) makes the test structurally race-free regardless of `t.Parallel`.

## Test plan

- [x] `go build ./cmd/server ./internal/handler` — clean
- [x] `go test ./internal/handler/ -race -count=5 -run TestRateLimit` — 18 tests × 5 iterations, all pass
- [x] `go test ./internal/handler/ -race -count=3` — full handler package, all pass
- [x] `go test ./cmd/... ./internal/... -race -count=1` — full CI scope, all pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)