### PR TITLE
docs: cleanup stale scaffolding labels missed by prior audit sweep

### DIFF
--- a/docs/adr/020-planning-ssot.md
+++ b/docs/adr/020-planning-ssot.md
@@ -11,11 +11,11 @@ lang: zh
 > 跨檔分散的計畫追蹤（tech-debt / dx-backlog / known-regression / future-roadmap / sprint planning）統一治理。
 > 對 AI agent 解決 context fragmentation；對人類 contributor 提供單一索引入口。
 >
-> **EN mirror**：本 ADR 仍在 `Proposed` 階段；待 `Accepted` 後 ship `020-planning-ssot.en.md`（與 ADR-019 對齊的雙語策略）。
+> **EN mirror**：本 ADR 已 `Accepted`；EN 翻譯 tracked under [issue #409](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/409)（與 ADR-019 對齊的雙語策略）。
 
 ## 狀態
 
-🟡 **Proposed**（PR #TBD，2026-05-10 起草）
+✅ **Accepted**（PR [#375](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/375)，v2.8.0）
 
 ## 背景
 

--- a/docs/scenarios/multi-system-migration-playbook.md
+++ b/docs/scenarios/multi-system-migration-playbook.md
@@ -419,7 +419,7 @@ Gate 3 通過條件：
 - 24h-1 ops cycle 觀察 → 推全量
 - Rollback path：**git revert** config commit → rule evaluator reload → shadow label 恢復 → 告警重新被 AM 既有 shadow matcher 路由到 /dev/null（< 5 分鐘）
 
-### Architect Narrative（待寫）
+### Architect Narrative
 
 **關鍵機制澄清**（避免常見誤解）：
 


### PR DESCRIPTION
## Summary

Maintainer flagged `Architect Narrative（待寫）` in playbook §6. Section is **fully written** (predict_linear story / Canary tenant criteria / Disablement drift / Grafana datasource switch / Staged Adoption handoff) — only the "to be written" label is stale.

Audit sweep PR #403 should have caught this but my grep patterns were `待補|待 ship|🟡|Outline status|fan-out` — didn't include `（待寫）`. Another instance of §4.2.1 self-review limitation: my "exhaustive pattern list" wasn't exhaustive.

This PR fixes the immediate item + does a broader sweep.

## Changes

| File:Line | Before | After |
|---|---|---|
| `multi-system-migration-playbook.md:422` | `### Architect Narrative（待寫）` | `### Architect Narrative` |
| `adr/020-planning-ssot.md:14` | "本 ADR 仍在 `Proposed` 階段" | "本 ADR 已 `Accepted`" + cross-link to issue #409 for EN |
| `adr/020-planning-ssot.md:18` | `🟡 **Proposed**（PR #TBD, 2026-05-10 起草）` | `✅ **Accepted**（PR #375, v2.8.0）` |

ADR-020 status was simply stale — ADR shipped via PR #375 (months ago). Brings format in line with the other ADRs' convention (cross-checked: ADR-001/002/003/etc. all use `✅ **Accepted** (vX.Y.Z)`).

## Verified clean (full sweep)

Patterns checked across `docs/scenarios/`, `docs/integration/`, `docs/schemas/`, `docs/adr/`, `docs/*.md`:
- `待寫` / `(待寫)` / `待補` / `TBD` / `TODO:` / `FIXME` / `🟡`

**Result: zero false-positive scaffolding remaining.**

False-positive hits I deliberately left alone:
- `flat-to-conf-d-cutover-decision.md` 🟡 in decision matrix cell — legitimate "可遷可不遷" indicator
- ADR-020 §32 `FIXME` — content describing code-comment conventions, not a TODO

## Pattern observation

10th independent confirmation this conversation that adversarial review catches what self-review misses. The audit-sweep's own pattern list was a blind spot for the audit itself — recursively §4.2.1.

## Future TD candidate

The audit-sweep grep pattern list is currently hardcoded in commit messages / my head. Worth parameterizing as `scripts/tools/lint/check_scaffolding_drift.py` with an extendable pattern list the maintainer can add to. **Not building speculatively**; will file as TD if pattern bites a 3rd time.

## Test plan
- [x] Pre-commit clean on both files
- [x] Full grep sweep verified zero residual scaffolding
- [x] ADR-020 status now consistent with other ADRs convention
- [x] EN-mirror clause aligned to #409 tracking (consistent with PR #410/#415/#416)

🤖 Generated with [Claude Code](https://claude.com/claude-code)