### PR TITLE
fix(portal): Dockerfile wizard.jsx path post #279 restructure (E-5.c blocker)

### DIFF
--- a/components/da-portal/Dockerfile
+++ b/components/da-portal/Dockerfile
@@ -49,7 +49,9 @@ COPY --chown=nginx:nginx components/da-portal/nginx.conf /etc/nginx/conf.d/defau
 COPY --chown=nginx:nginx docs/interactive/ /usr/share/nginx/html/interactive/
 
 # ── Getting Started Wizard ────────────────────────────────────
-COPY --chown=nginx:nginx docs/getting-started/wizard.jsx /usr/share/nginx/html/getting-started/wizard.jsx
+# Path follows the portal monorepo restructure (PR #279, TD-042, 2026-05-07):
+# wizard.jsx moved from docs/getting-started/ to tools/portal/src/getting-started/.
+COPY --chown=nginx:nginx tools/portal/src/getting-started/wizard.jsx /usr/share/nginx/html/getting-started/wizard.jsx
 
 # ── Shared assets (loader, data, registry, flows) ─────────────
 COPY --chown=nginx:nginx docs/assets/jsx-loader.html     /usr/share/nginx/html/assets/jsx-loader.html


### PR DESCRIPTION
## Release-time blocker

E-5.c smoke test pushed `portal/v2.8.0` → `release.yaml` workflow fired (confirming the earlier auth-scope theory was correct) but the **build failed**:

```
ERROR: failed to compute cache key:
"/docs/getting-started/wizard.jsx": not found
```

[Failed run](https://github.com/vencil/Dynamic-Alerting-Integrations/actions/runs/25749225089)

## Root cause

[PR #279](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/279) (TD-042 portal monorepo restructure, 2026-05-07) moved `docs/getting-started/wizard.jsx` → `tools/portal/src/getting-started/wizard.jsx`. The portal Dockerfile's `COPY` line was missed in that PR.

The bug sat dormant for ~5 days because no PR between #279 and today touched anything that would trigger `release.yaml` (which only fires on tag pushes matching `exporter/v*` / `tools/v*` / `portal/v*` / `tenant-api/v*`). v2.8.0 release-tag push is the first event that re-exercised the portal image build since the restructure.

## Fix

Single-line `COPY` source-path update in `components/da-portal/Dockerfile`. Other 3 component Dockerfiles (`threshold-exporter`, `da-tools`, `tenant-api`) don't reference `docs/` paths so they're unaffected — verified with `git cat-file -p 77362897:components/<c>/Dockerfile | grep -nE "^COPY.*docs/"` returning nothing for each.

## Test plan

- [x] Confirmed `tools/portal/src/getting-started/wizard.jsx` exists at current `main` HEAD
- [ ] After merge: delete stale `portal/v2.8.0` tag (pointing at `77362897`, pre-fix) and re-create pointing at the new main HEAD via `gh api`
- [ ] Verify `release.yaml` build succeeds (image push to `ghcr.io/vencil/da-portal:v2.8.0`)
- [ ] Proceed with the other 3 component tags + platform `v2.8.0` tag + 5 `gh release create`

## Why this isn't caught at PR time

`release.yaml` only fires on tag pushes. Regular PR CI builds run `Portal Tests` (Vitest) but not the actual Docker image build. The Dockerfile is exercised only at release time — exactly the dormant-bug class that:
- Better test-coverage discipline ([test-coverage-matrix.md](docs/internal/test-coverage-matrix.md)) would catch via a "PR-time Dockerfile smoke build" gate
- v2.9.0 issue candidate: add `docker-build` job to PR CI matrix for component Dockerfiles, gated on changes touching the relevant file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
