### PR TITLE
fix(release): v2.8.0 release-blockers — Go 1.26.3 CVE bump + exporter Dockerfile pkg/

### DIFF
--- a/components/tenant-api/Dockerfile
+++ b/components/tenant-api/Dockerfile
@@ -11,7 +11,7 @@
 #   docker run -p 8080:8080 -v $(pwd)/conf.d:/conf.d ghcr.io/vencil/tenant-api:2.4.0
 
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM golang:1.26.2-alpine3.22 AS builder
+FROM golang:1.26.3-alpine3.22 AS builder
 
 WORKDIR /src
 

--- a/components/tenant-api/go.mod
+++ b/components/tenant-api/go.mod
@@ -1,6 +1,6 @@
 module github.com/vencil/tenant-api
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/components/threshold-exporter/app/Dockerfile
+++ b/components/threshold-exporter/app/Dockerfile
@@ -1,10 +1,16 @@
-FROM golang:1.26.2-alpine3.22 AS builder
+FROM golang:1.26.3-alpine3.22 AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 
+# main package files live at app root; pkg/ holds the config library
+# that config_hierarchy.go / config_inheritance.go / config_parse.go
+# import (extracted as a proper library in PR-7/PR-8 during v2.8.0).
+# Both must be COPY'd or `go build` fails with "no required module
+# provides package github.com/vencil/threshold-exporter/pkg/config".
 COPY *.go ./
+COPY pkg ./pkg
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /threshold-exporter .
 
 FROM gcr.io/distroless/static-debian12:nonroot

--- a/components/threshold-exporter/app/go.mod
+++ b/components/threshold-exporter/app/go.mod
@@ -1,6 +1,6 @@
 module github.com/vencil/threshold-exporter
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/VictoriaMetrics/metricsql v0.87.0

--- a/tests/e2e-bench/receiver/Dockerfile
+++ b/tests/e2e-bench/receiver/Dockerfile
@@ -4,7 +4,7 @@
 # Same distroless pattern as components/threshold-exporter/app/Dockerfile
 # for consistency: nonroot UID 65532, no shell, static binary.
 
-FROM golang:1.26.2-alpine3.22 AS builder
+FROM golang:1.26.3-alpine3.22 AS builder
 WORKDIR /src
 COPY go.mod ./
 COPY *.go ./

--- a/tests/e2e-bench/receiver/go.mod
+++ b/tests/e2e-bench/receiver/go.mod
@@ -1,3 +1,3 @@
 module github.com/vencil/dynamic-alerting/tests/e2e-bench/receiver
 
-go 1.26.2
+go 1.26.3


### PR DESCRIPTION
## Three independent release-blockers surfaced during E-5.c

After [PR #472](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/472) merged and the v2.8.0 component tags were re-pushed at main HEAD `26abe535`, all 4 component build workflows ran. **Result: 1 green (portal), 3 red.**

| Tag | Result | Failure mode |
|---|---|---|
| `portal/v2.8.0` | ✅ success | Dockerfile fixed in [#472](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/472) |
| `tools/v2.8.0` | ❌ Trivy scan | 5 HIGH CVEs in Go stdlib 1.26.2 (embedded `da-parser` / `da-batchpr` / `da-guard` binaries) |
| `exporter/v2.8.0` | ❌ build | `config_hierarchy.go: no required module provides package github.com/vencil/threshold-exporter/pkg/config` |
| `tenant-api/v2.8.0` | ❌ Trivy scan | Same 5 HIGH CVEs in Go stdlib 1.26.2 |

This PR bundles all three fixes so we land a single follow-up rather than 3 separate fix-tag-cycles.

## Fix 1 — `components/threshold-exporter/app/Dockerfile`

`COPY *.go ./` only grabs top-level Go files. After PR-7/PR-8 (v2.8.0 sweep, `pkg/config` library maturation), three production files import the sibling `pkg/config` subpackage:

- `config_hierarchy.go` → `pkg/config`
- `config_inheritance.go` → `pkg/config`
- `config_parse.go` → `pkg/config`

The build never re-fired between the library extraction and today's tag push, so this dormant bug stayed invisible — same class as the portal Dockerfile bug in [#472](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/472). Added `COPY pkg ./pkg` with an inline comment explaining the dependency.

## Fix 2 — Go 1.26.2 → 1.26.3 (5 HIGH CVEs)

Trivy gates on HIGH/CRITICAL by design. Go 1.26.3 patches all 5:

| CVE | Description |
|---|---|
| [CVE-2026-33811](https://avd.aquasec.com/nvd/cve-2026-33811) | LookupCNAME with cgo DNS resolver long-CNAME overflow |
| [CVE-2026-33814](https://avd.aquasec.com/nvd/cve-2026-33814) | HTTP/2 SETTINGS frames infinite loop |
| [CVE-2026-39820](https://avd.aquasec.com/nvd/cve-2026-39820) | ParseAddress / ParseAddressList parsing DoS |
| [CVE-2026-39836](https://avd.aquasec.com/nvd/cve-2026-39836) | Panic in Dial/LookupPort with NUL byte (Windows) |
| [CVE-2026-42499](https://avd.aquasec.com/nvd/cve-2026-42499) | Pathological inputs DoS through consumePhrase |

All ✓ stable per `go.dev/dl?mode=json`. Bumped:

- `components/threshold-exporter/app/Dockerfile` — builder image
- `components/threshold-exporter/app/go.mod` — minimum-version directive
- `components/tenant-api/Dockerfile` — builder image
- `components/tenant-api/go.mod` — minimum-version directive
- `tests/e2e-bench/receiver/Dockerfile` — builder image (consistency)
- `tests/e2e-bench/receiver/go.mod` — minimum-version directive (consistency)

`da-tools` Python image is unaffected (`python:3.13.13-alpine3.22`). The embedded `da-parser` / `da-batchpr` / `da-guard` binaries inherit Go 1.26.3 from `setup-go --version-file ../threshold-exporter/app/go.mod` in `release.yaml`'s `release-da-tools` job.

CHANGELOG.md keeps its `Go 1.26.2 linux/amd64` line — that's a historical measurement record (bench baseline was run with 1.26.2), not a build pin.

## Recovery sequence (after this PR merges)

1. Delete + re-create all 4 v2.8.0 component tags at new main HEAD via `gh api` (same workflow-scoped-token technique as [#472](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/472)'s recovery)
2. Verify 4 `release.yaml` builds green
3. Push platform `v2.8.0` tag via `gh api`
4. `gh release create` × 5 (using `docs/internal/v2.8.0-release-body.md` for the platform release)

## Test plan

- [x] Local: confirmed `pkg/` exists at main HEAD and only contains code reachable from the exporter's main package
- [x] Local: confirmed Go 1.26.3 is the latest stable per `go.dev/dl`
- [ ] After merge: re-create 4 tags + verify all 4 builds green
- [ ] After all builds green: proceed with platform tag + 5 GH Releases

## Why neither this nor [#472](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/472) was caught at PR time

`release.yaml` only fires on tag pushes. Regular PR CI runs Go tests (`Go Tests`) and Vitest (`Portal Tests`) but **does not exercise the production Dockerfiles**. Both bugs (portal `COPY wizard.jsx` + exporter `COPY *.go ./`) were structurally dormant the moment they were introduced, because no PR in between touched a release tag.

**v2.9.0 candidate (will codify after release lands):** add a PR-time `docker-build` smoke gate per component, triggered when changes touch:

- `components/<name>/Dockerfile` or `components/<name>/app/Dockerfile`
- Files referenced by `COPY` in that Dockerfile (would need a lint that introspects)
- `go.mod` / `go.sum` for any component

Cost: ~30-60s × 4 components, only on relevant PRs. Catches this entire bug class structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
