### PR TITLE
fix(dx): generate_adr_index uses atomic_write_text(newline=\n) (#475 follow-up)

### DIFF
--- a/scripts/dx/generate_adr_index.py
+++ b/scripts/dx/generate_adr_index.py
@@ -24,6 +24,17 @@ from typing import List
 
 import yaml
 
+# Reuse the atomic-write helper already shared by generate_doc_map.py /
+# generate_tool_map.py. It defaults to `newline="\n"` (forces LF so the same
+# regen run on Windows and Linux produces byte-identical output — without it,
+# Path.write_text translates "\n" to os.linesep and Windows local invocations
+# emit CRLF, creating noise diffs even though .gitattributes normalises on
+# commit) and writes via a sibling .tmp + os.replace, defending against FUSE
+# Trap #60 mid-flush corruption.
+_TOOLS_DX = Path(__file__).resolve().parent.parent / "tools" / "dx"
+sys.path.insert(0, str(_TOOLS_DX))
+from _atomic_write import atomic_write_text  # noqa: E402
+
 # Make stdout tolerate non-ASCII on Windows shells (cp950, cp1252).
 if hasattr(sys.stdout, "reconfigure"):
     try:
@@ -222,7 +233,7 @@ def main() -> int:
     if new == current:
         print(f"OK: no change ({len(entries)} entries)")
     else:
-        args.target.write_text(new, encoding="utf-8")
+        atomic_write_text(args.target, new)
         print(f"WROTE: {rel_target} ({len(entries)} entries)")
     return 0
 

--- a/tests/dx/test_generate_adr_index.py
+++ b/tests/dx/test_generate_adr_index.py
@@ -315,6 +315,24 @@ class TestMainCli:
         assert "no change" in proc.stdout
         assert target.read_text(encoding="utf-8") == once
 
+    def test_write_forces_lf_newlines(self, tiny_repo):
+        """Regen output must be LF on every platform — see PR #475 self-review
+        issue A. Without atomic_write_text(newline='\\n'), Path.write_text on
+        Windows translates '\\n' into '\\r\\n' and the same regen produces
+        byte-different output across hosts; `.gitattributes eol=lf` masks the
+        diff at commit time but the working-copy `--check` step still drifts.
+        """
+        adr_dir, target = tiny_repo
+        self._run("--write", "--adr-dir", str(adr_dir), "--target", str(target))
+        # Read in binary mode to bypass Python's universal-newlines translation;
+        # we want to see exactly what bytes hit disk.
+        raw = target.read_bytes()
+        assert b"\r\n" not in raw, (
+            "Regenerated file contains CRLF — atomic_write_text(newline='\\n') "
+            "is supposed to force LF on every platform."
+        )
+        assert raw.endswith(b"\n"), "File should terminate with a final LF."
+
     def test_mode_flag_required(self, tiny_repo):
         adr_dir, target = tiny_repo
         # Neither --check nor --write → argparse exit code 2.


### PR DESCRIPTION
## Summary

Follow-up to **PR #475** — addresses **Issue A** from the post-merge self-review (raised by reviewer): the new ADR-index generator used `Path.write_text(content, encoding="utf-8")` without specifying `newline=`, so Windows local invocations produced CRLF while Linux / dev-container produced LF.

## Real-world impact (low but real)

- `make adr-index` on Windows host writes CRLF; same regen on Linux writes LF.
- `.gitattributes` has `* text=auto eol=lf` → **committed** bytes stay identical (auto-normalised on `git add`).
- BUT the working-copy state drifts: after Windows regen, `git status` shows the file modified (CRLF on disk vs LF in index) until git renormalises on next add — phantom diff.
- `--check` itself stays accurate because Python text-mode translates CRLF back to `\n` for comparison; the noise is purely in the working tree.

## Fix

Route the write through the existing `scripts/tools/dx/_atomic_write.py::atomic_write_text` helper, which `generate_doc_map.py` / `generate_tool_map.py` already use. That helper:

- Defaults `newline="\n"` — explicit LF on every platform (the helper docstring literally says "prevents CRLF ping-pong drift on Windows regens").
- Writes via a sibling `<target>.tmp` + `os.replace()` → atomic, defends against FUSE Trap #60 mid-flush corruption.
- Sets explicit `0o644` mode on the `.tmp` **before** the rename → closes the umask-default race window.

Cross-dir import: the generator lives at `scripts/dx/`, the helper at `scripts/tools/dx/`. Resolved with a one-line `sys.path.insert` + a comment, mirroring how `tests/dx/test_generate_adr_index.py` already imports the script under test.

## Regression test

New `TestMainCli.test_write_forces_lf_newlines` reads the regenerated file in **binary** mode (bypassing Python's universal-newlines translation) and asserts:

1. `b"\r\n"` does not appear anywhere in the file.
2. The file terminates with a final `b"\n"` (matches helper contract).

Catches any future change that drops `newline="\n"` (e.g. someone calling `atomic_write_text(target, content, newline=None)` to "match platform default").

## Verification

- `pytest tests/dx/test_generate_adr_index.py -v` → **26 → 27 passed**
- `python3 scripts/dx/generate_adr_index.py --check` → **OK (21 entries)**
- No behaviour change for the committed target file: rendered bytes identical, only the write path changed.

## Test plan

- [ ] CI green (Python Tests 3.13, MkDocs strict, drift gates)
- [ ] (Manual, optional) Run `make adr-index` on a Windows host pre-fix → confirm CRLF; pin this PR → re-run → confirm LF
- [ ] Verify `architecture-and-design.md` unchanged on disk (only generator + test files in diff)

## Other self-review findings (NOT in this PR — tracked separately)

- **Issue B** (ADR-004 multi-state `Accepted → Extended` renders as just `Accepted v1.12.0`) — cosmetic, future enhancement.
- **Issue C** (pre-commit `files:` regex incidentally matches `.en.md`) — no-op trigger, cosmetic.
- **Issue D** (no test for future `Superseded` / `Rejected` / `Deprecated` status) — add when first such ADR lands.
- **Issue E** (defensive `isinstance(title, str)` guard) — low priority, current corpus all-string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)