### PR TITLE
fix(lint): skipif test_file_read_error when running as root (#482 follow-up)

### DIFF
--- a/tests/lint/test_validate_mermaid.py
+++ b/tests/lint/test_validate_mermaid.py
@@ -156,9 +156,17 @@ class TestValidateFile:
     # ── unique edge cases (merged from _extended) ───────────────────────
 
     @pytest.mark.skipif(
-        sys.platform == "win32",
-        reason="os.chmod(0o000) is a no-op on Windows NTFS (uses ACLs, not POSIX mode); "
-               "the file stays readable and this test's read-error path cannot be exercised.",
+        sys.platform == "win32"
+        or (hasattr(os, "geteuid") and os.geteuid() == 0),
+        reason="os.chmod(0o000) is a no-op in two environments where the read "
+               "permission bit is bypassed and the file stays readable: "
+               "(1) Windows NTFS uses ACLs, not POSIX mode bits — the chmod "
+               "call is silently dropped; "
+               "(2) Linux root (the dev-container default user, plus most CI "
+               "runners) — the kernel grants superuser access regardless of "
+               "mode bits. The test's read-error path simply cannot be exercised "
+               "in either case. Caught when PR #482's full pytest run tripped "
+               "this assertion under docker-root.",
     )
     def test_file_read_error(self, tmp_path):
         """Non-readable file returns error."""


### PR DESCRIPTION
## Summary

Pre-existing platform flake surfaced by [PR #482](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/482)'s full pytest run. Independent of #482 — fixing under separate PR per scope discipline (the chunk 1b sweep doesn't touch validate_mermaid).

`tests/lint/test_validate_mermaid.py::test_file_read_error` asserts that `chmod 0o000` renders a file unreadable. The `skipif` condition previously caught only `sys.platform == 'win32'` (NTFS ACLs bypass POSIX mode bits). But there's a **second** environment where `chmod 0o000` is a no-op: **Linux root**. The kernel grants superuser access regardless of mode bits, so the file stays readable and the assertion `len(errors) == 1` fails with `0 == 1`.

This bites under:

- docker container's default root user (Vibe dev-container)
- most pre-2025 GitHub Actions runners (also root by default)
- any non-rootless container setup

## Fix

Widen the skipif:

```python
# Before:
sys.platform == "win32"

# After:
sys.platform == "win32" or (hasattr(os, "geteuid") and os.geteuid() == 0)
```

`hasattr(os, "geteuid")` guards against Windows where `geteuid` isn't exposed. Updated `reason=` text explains both bypass paths (NTFS ACL + root-bypass-perms).

## Verification

```
$ python3 -m pytest tests/lint/test_validate_mermaid.py::TestValidateFile::test_file_read_error -v
...
tests/lint/test_validate_mermaid.py::TestValidateFile::test_file_read_error SKIPPED [100%]
============================== 1 skipped in 4.80s ==============================
```

Before fix: FAILED with `assert 0 == 1`.
After fix: SKIPPED with new reason text.

## Out of scope

- Replacing the chmod-based test with an `open()` mock that raises `PermissionError` to actually exercise the error path under root. That's a more invasive refactor; this PR just unblocks CI/local pytest runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)