### PR TITLE
fix(lint): trim leading whitespace in .trufflehogignore pattern parsing

### DIFF
--- a/.trufflehogignore
+++ b/.trufflehogignore
@@ -1,8 +1,12 @@
 # .trufflehogignore — false-positive escape list for the secret-scan hooks
 #
 # Read by `scripts/tools/lint/check_secrets_staged.sh` (#445 AC i, L1).
-# The L2 server-side workflow `.github/workflows/secret-scan.yml`
-# (#445 AC ii, Chunk 4 — not yet landed) will consume the same file.
+# This is an L1-only path-exclusion file: the L2 server-side workflow
+# `.github/workflows/secret-scan.yml` (#445 AC ii) scans with
+# `trufflehog git` mode and does NOT consume this file. L2 is the
+# unbypassable gate by design — sharing a silencing list with it would
+# weaken that. For an L2 false positive use the per-line
+# `# trufflehog:ignore` escape (documented near the bottom of this file).
 #
 # IMPORTANT — who interprets this file:
 #   trufflehog's `filesystem` subcommand has no stable native

--- a/scripts/tools/lint/check_secrets_staged.sh
+++ b/scripts/tools/lint/check_secrets_staged.sh
@@ -94,12 +94,19 @@ declare -a SCAN_PATHS=()
 declare -a IGNORE_PATTERNS=()
 if [ -f "${IGNORE_FILE}" ]; then
   while IFS= read -r line; do
+    # Trim leading + trailing whitespace before any interpretation. ERE
+    # patterns never carry significant edge whitespace, and leaving
+    # leading whitespace in (a) breaks the comment/blank skip below for
+    # indented lines and (b) bakes literal spaces into the regex, which
+    # silently fails-open (the pattern then matches no path → the file
+    # gets scanned anyway). Trim-first makes both correct.
+    line="${line#"${line%%[![:space:]]*}"}"   # strip leading whitespace
+    line="${line%"${line##*[![:space:]]}"}"   # strip trailing whitespace
     # Skip blank lines and comments (leading # after optional whitespace).
     case "${line}" in
       ''|'#'*) continue ;;
     esac
-    # Trim trailing whitespace.
-    IGNORE_PATTERNS+=("${line%"${line##*[![:space:]]}"}")
+    IGNORE_PATTERNS+=("${line}")
   done < "${IGNORE_FILE}"
 fi
 


### PR DESCRIPTION
## Summary

Carryover follow-up from **#445 AC i** (L1 secret-scan hook, PR #495) — the
`.trufflehogignore` leading-whitespace trim flagged by Gemini's PR #495 review.

`scripts/tools/lint/check_secrets_staged.sh` parses `.trufflehogignore` itself
(trufflehog's `filesystem` mode has no stable `--exclude-paths`). It trimmed
only **trailing** whitespace from each line. Two consequences:

- A **leading-indented pattern** baked literal spaces into the ERE regex →
  the pattern matches no path → the file is scanned anyway. This **fails
  open** (safe direction — a false positive isn't silenced), but it silently
  defeats the author's intent.
- An **indented `# comment`** was parsed as a pattern, not skipped — the
  existing code comment already claimed "leading # after optional whitespace"
  but the `case '#'*` check only matched a column-0 `#`.

Fix: trim leading **and** trailing whitespace *before* the comment/blank
skip — one change corrects both. Verified with a standalone test (7 inputs →
4 patterns; indented comment, tab-indented comment and all-whitespace line
all correctly dropped).

Also corrects the `.trufflehogignore` header comment: it claimed the L2
workflow "(#445 AC ii, Chunk 4 — not yet landed) will consume the same file."
Both halves are stale — Chunk 4 landed in #496, and `secret-scan.yml` scans
with `trufflehog git` mode and does **not** consume this file (L1-only by
design; L2 is the unbypassable gate). Header now states this accurately and
points L2 false positives at the per-line `# trufflehog:ignore` escape.

## Test plan

- [x] Standalone bash test of the trim logic (leading/trailing/all-WS/indented-comment cases)
- [x] `check_secrets_staged.sh` self-skips cleanly when trufflehog is absent (unchanged path)
- [ ] CI: pre-commit + lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)