### PR TITLE
docs: sync component README version refs to released v2.8.0

### DIFF
--- a/components/da-portal/README.md
+++ b/components/da-portal/README.md
@@ -1,7 +1,7 @@
-# da-portal (v2.7.0)
+# da-portal (v2.8.0)
 
-<!-- 標題版號 = 最後 released tag；v2.8.0 in-flight feature 在內文以 **v2.8.0** inline 標記。
-     Release wrap 切五線 tag 時，本標題 + 下方 helm --version 跟著批次同步 bump 為 v2.8.0。 -->
+<!-- 標題版號 = 最後 released tag（目前 v2.8.0）；下一版 in-flight feature 在內文以 inline 版號標記。
+     Release wrap 切五線 tag 時，本標題 + 下方 helm --version 跟著批次同步 bump。 -->
 
 > **核心 component** — 把 Dynamic Alerting 的 43 個互動工具（Hub + Wizard + Tenant Manager + Self-Service Portal）封進一顆 ~12 MB nginx-alpine image，**zero build step**（瀏覽器端 Babel standalone 轉譯 JSX），給內網 / air-gapped 環境離線使用。
 >
@@ -57,7 +57,7 @@ docker run -p 8080:80 ghcr.io/vencil/da-portal:v2.8.0
 
 ```bash
 helm install da-portal \
-  oci://ghcr.io/vencil/charts/da-portal --version 2.7.0 \
+  oci://ghcr.io/vencil/charts/da-portal --version 2.8.0 \
   -n monitoring --create-namespace \
   -f values-override.yaml
 ```
@@ -198,7 +198,7 @@ docker run -p 8080:80 \
 
 | 症狀 | 可能原因 | 解法 |
 |------|---------|------|
-| Hub 載入後白屏 | 某 JSX parse 失敗 + 沒 ErrorBoundary | 開 DevTools console；單檔修；v2.8.0+ 規劃加 ErrorBoundary（見 [PR roadmap](#)） |
+| Hub 載入後白屏 | 某 JSX parse 失敗 + 沒 ErrorBoundary | 開 DevTools console 找出 parse 失敗的 JSX 單檔修復；ErrorBoundary 為已知缺口，未來版本補強 |
 | 404 on `/healthz` | 舊 image（< v2.3.0） | 重 build：`make portal-image` |
 | CORS error on Tenant API | nginx proxy upstream 錯 | 改 `nginx.conf` 的 `proxy_pass`，或在 K8s 確認 `tenant-api` Service 存在於 `monitoring` namespace |
 | Tenant Manager 顯示 demo-mode toast | `/api/v1/tenants/search` 回 404 / 5xx | 確認 Tenant API 跑著且 RBAC 有 read 權限；也可能是純靜態部署（無 backend），demo mode 為 expected |

--- a/components/da-tools/README.md
+++ b/components/da-tools/README.md
@@ -1,6 +1,6 @@
-# da-tools (v2.7.0)
+# da-tools (v2.8.0)
 
-<!-- 標題版號 = 最後 released tag；v2.8.0 in-flight feature 在內文以 **v2.8.0** inline 標記。
+<!-- 標題版號 = 最後 released tag（目前 v2.8.0）；下一版 in-flight feature 在內文以 inline 版號標記。
      Release wrap 切五線 tag 時，本標題 + VERSION 檔 + 下方版號表跟著批次同步 bump。 -->
 
 > **核心 component** — 一顆 ~60 MB Alpine Python image，把 Dynamic Alerting 平台所需 45 個驗證 / 遷移 / 治理 CLI 工具裝在一起，**無需 clone repo、無需安裝 Python 依賴**，docker pull 即用。Platform Engineers / SREs / Tenants（DevOps）共用入口。
@@ -38,7 +38,7 @@
 ## 3. Quick Start
 
 ```bash
-# 抓 image（v2.8.0 釋出後改用 v2.8.0 tag）
+# 抓 image（quick-start 用 :latest 即可；production 請釘特定版號如 :v2.8.0）
 docker pull ghcr.io/vencil/da-tools:latest
 
 # Help / Version
@@ -355,13 +355,13 @@ DA_LANG=en docker run --rm ghcr.io/vencil/da-tools migrate --help
 
 | 元件 | 版號 | Git Tag | 內容 |
 |------|------|---------|------|
-| 平台文件 | v2.8.0 | `v2.7.0` | 整體釋出版本 |
+| 平台文件 | v2.8.0 | `v2.8.0` | 整體釋出版本 |
 | threshold-exporter | v2.8.0 | `exporter/v2.8.0` | Go binary（含 da-guard / da-batchpr / da-parser） |
 | **da-tools** | **v2.8.0** | **`tools/v2.8.0`** | 本 image（45 個 Python CLI + 3 個 bundled Go binary） |
-| da-portal | v2.7.0 | `portal/v2.7.0` | Interactive Tools Hub image |
-| tenant-api | v2.7.0 | `tenant-api/v2.7.0` | Go HTTP API |
+| da-portal | v2.8.0 | `portal/v2.8.0` | Interactive Tools Hub image |
+| tenant-api | v2.8.0 | `tenant-api/v2.8.0` | Go HTTP API |
 
-> v2.8.0 in-flight feature 在 §2 What's New 與命令表用 ✨v2.8.0 標註；release 收尾切五線 tag 時，本 README 標題與 [VERSION](app/VERSION) 跟著批次同步 bump。
+> §2 What's New 與命令表的 ✨v2.8.0 標記表示該命令於 v2.8.0 引入；下一版 in-flight 命令沿用同款 inline 標記。Release 收尾切五線 tag 時，本 README 標題與 [VERSION](app/VERSION) 跟著批次同步 bump。
 
 CI/CD 由 `tools/v*` tag 觸發，不受平台文件 / exporter 變更影響。
 

--- a/components/threshold-exporter/README.md
+++ b/components/threshold-exporter/README.md
@@ -1,6 +1,6 @@
 # Threshold Exporter (v2.8.0)
 
-<!-- 標題版號 = 最後 released tag；v2.8.0 in-flight feature 在內文以 **v2.8.0** inline 標記。
+<!-- 標題版號 = 最後 released tag（目前 v2.8.0）；下一版 in-flight feature 在內文以 inline 版號標記。
      Release wrap 切五線 tag 時，本標題 + 下方 helm --version 跟著批次同步 bump。 -->
 
 > **核心 component** — 把 `conf.d/` YAML 配置轉成 Prometheus `user_threshold` 系列 metrics 的 config-driven exporter。Directory Scanner + 四層繼承 + Dual-Hash 熱重載 + Cardinality Guard。


### PR DESCRIPTION
## Summary

Audit of the four `components/*/README.md` for version-correctness against
the actual repo state. **v2.8.0 shipped on 2026-05-13** — all five release
tags (`v2.8.0` / `exporter` / `tools` / `portal` / `tenant-api`) exist on
the remote, `## [v2.8.0]` is a closed CHANGELOG section, and every
`helm/*/Chart.yaml` is `version: 2.8.0`. But the release-wrap README title
bumps were only partly done.

| Component README | Title | Other version refs |
|---|---|---|
| **da-tools** | ❌ `v2.7.0` → ✅ `v2.8.0` | §7 table: `平台文件` / `da-portal` / `tenant-api` Git-Tag rows still `v2.7.0`; §3 stale parenthetical |
| **da-portal** | ❌ `v2.7.0` → ✅ `v2.8.0` | helm quick-start `--version 2.7.0` → `2.8.0`; dead `[PR roadmap](#)` link removed |
| **threshold-exporter** | ✅ `v2.8.0` (already correct) | — |
| **tenant-api** | ✅ `v2.8.0` (already correct) | — |

### Changes

- **da-tools**: title `v2.7.0`→`v2.8.0`; §7 versioning table corrected (3 rows
  showed the pre-release Git Tag); §3 `# 抓 image（v2.8.0 釋出後…）` reworded
  (v2.8.0 *is* released).
- **da-portal**: title `v2.7.0`→`v2.8.0`; helm `--version 2.7.0`→`2.8.0`
  (`Chart.yaml` is `2.8.0`); removed a dead `[PR roadmap](#)` placeholder link
  in the troubleshooting table and reworded the now-past "v2.8.0+ 規劃" note.
- **threshold-exporter**: title already correct — only the in-flight HTML
  comment refreshed.
- The README HTML title-comments are made **version-agnostic** ("目前 v2.8.0"
  + "下一版") so they don't silently re-stale at the next release — this drift
  happened precisely because the comment hard-coded "v2.8.0 in-flight".

### Verified against

- `git ls-remote --tags` → all five `*/v2.8.0` tags present
- `helm/{da-portal,threshold-exporter,tenant-api}/Chart.yaml` → all `version: 2.8.0`
- `components/da-tools/app/VERSION` → `2.8.0`

The README **content** (endpoints / metrics / CLI tables / env vars) was
reviewed and is current — v2.8.1-dx-interim was internal DX tooling and
changed no component user-facing surface, so no "What's New in v2.8.1"
section is warranted.

> ℹ️ Out of scope, flagged separately: `CLAUDE.md` still says "v2.8.0 開發中 …
> release 收尾尚未啟動", which is also stale post-release.

## Test plan

- [x] Cross-checked every `v2.x` ref in all 4 component READMEs vs git tags + Chart.yaml + VERSION
- [ ] CI: pre-commit + doc-link validation pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)