### PR TITLE
feat(tenant-api): federation token endpoint (ADR-020 IV-2d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to the **Dynamic Alerting Integrations** project will be doc
 
 <!-- 下一版 in-flight 工作暫存區。每筆 entry 目標 3-6 行使用者重點 + 一行指回內部 artifact；session 過程 / FUSE trap / 完整 commit list 不入此處。release 收尾時做最終 condensation 並切正式 `## [vX.Y.Z]` heading。 -->
 
+### Added
+
+- **Tenant federation token endpoint（ADR-020 IV-2d，issue [#509](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/509)）**：tenant-api 新增 `POST` / `GET` / `DELETE /api/v1/federation/tokens` — 為租戶簽發短效（預設 4h）RS256 JWT，供其向 label-injection proxy（vmauth / prom-label-proxy）拉取自己的 metrics 子集回租戶側 infra 自管（ADR-020 §Token model）。簽發需對目標租戶具 `admin` 權限（資料域外持出，門檻高於 config write）；token claim 帶 `tenant_id` / `token_id`，為 proxy 注入 label 與 gateway 取 rate-limit key 的跨組件契約。MVP 無 server-side revocation — `DELETE` 僅移除 bookkeeping record，JWT 至 `exp` 前仍有效（補償控制為 IV-2b gateway rate limit）。新增 `internal/federation` package（RS256 簽章器 + JSON 檔案 token record store，刻意不入 git conf.d）；`--federation-key` 未設時整個 endpoint 不註冊。詳 [ADR-020](docs/adr/020-tenant-federation.md)。
+
 ---
 
 ## [v2.8.1] — secret-scan 四層防線 + Planning SSOT + DX 工具鏈收斂 (2026-05-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to the **Dynamic Alerting Integrations** project will be doc
 
 ### Added
 
-- **Tenant federation token endpoint（ADR-020 IV-2d，issue [#509](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/509)）**：tenant-api 新增 `POST` / `GET` / `DELETE /api/v1/federation/tokens` — 為租戶簽發短效（預設 4h）RS256 JWT，供其向 label-injection proxy（vmauth / prom-label-proxy）拉取自己的 metrics 子集回租戶側 infra 自管（ADR-020 §Token model）。簽發需對目標租戶具 `admin` 權限（資料域外持出，門檻高於 config write）；token claim 帶 `tenant_id` / `token_id`，為 proxy 注入 label 與 gateway 取 rate-limit key 的跨組件契約。MVP 無 server-side revocation — `DELETE` 僅移除 bookkeeping record，JWT 至 `exp` 前仍有效（補償控制為 IV-2b gateway rate limit）。新增 `internal/federation` package（RS256 簽章器 + JSON 檔案 token record store，刻意不入 git conf.d）；`--federation-key` 未設時整個 endpoint 不註冊。詳 [ADR-020](docs/adr/020-tenant-federation.md)。
+- **Tenant federation token endpoint（ADR-020 IV-2d，issue [#509](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/509)）**：tenant-api 新增 `POST` / `GET` / `DELETE /api/v1/federation/tokens` — 為租戶簽發短效（預設 4h）RS256 JWT，供其向 label-injection proxy（vmauth / prom-label-proxy）拉取自己的 metrics 子集回租戶側 infra 自管（ADR-020 §Token model）。簽發需對目標租戶具 `admin` 權限（資料域外持出，門檻高於 config write）；token claim 帶 `tenant_id` / `token_id`（proxy 注入 label、gateway 取 rate-limit key 的跨組件契約）+ `aud=tenant-federation`（防 cross-service replay）。MVP 無 server-side revocation — `DELETE` 僅移除 bookkeeping record，JWT 至 `exp` 前仍有效（補償控制為 IV-2b gateway rate limit）。新增 `internal/federation` package（RS256 簽章器 + JSON 檔案 token record store，刻意不入 git conf.d）；`--federation-key` 未設時整個 endpoint 不註冊。詳 [ADR-020](docs/adr/020-tenant-federation.md)。
 
 ---
 

--- a/components/tenant-api/README.md
+++ b/components/tenant-api/README.md
@@ -79,6 +79,16 @@
 | `GET` | `/api/v1/prs` | read | Pending PR / MR 列表；caller 不可讀的 `tenant_id` 自動隱藏；`?tenant=<id>` 不可讀回空陣列（避免 existence oracle） |
 | `GET` | `/api/v1/events` | read | SSE 即時事件流（config_change） |
 
+### Federation（v2.9.0 — ADR-020）
+
+| Method | Path | 權限 | 說明 |
+|--------|------|------|------|
+| `POST` | `/api/v1/federation/tokens` | admin（對 body 的 `tenant_id`） | 簽發短效 RS256 JWT（預設 4h）供租戶向 label-injection proxy 拉取自己的 metrics 子集；signed token 只在回應中出現一次 |
+| `GET` | `/api/v1/federation/tokens?tenant_id=<id>` | admin（對 query 的 `tenant_id`） | 列出該租戶未過期的 token record（不含 JWT 本體） |
+| `DELETE` | `/api/v1/federation/tokens/{id}` | admin（對 token 的 tenant） | 移除 token bookkeeping record；MVP 無 server-side revocation，JWT 至 `exp` 前仍有效 |
+
+`--federation-key` 未設時整個 endpoint 不註冊。詳 [ADR-020](../../docs/adr/020-tenant-federation.md)。
+
 ## Operational concerns
 
 ### Limits + caps
@@ -168,6 +178,9 @@ data: {"type":"config_change","tenant_id":"db-a-prod","timestamp":"2026-05-03T10
 | `TA_GITLAB_TARGET_BRANCH` | `main` | MR target |
 | `TA_GITLAB_API_URL` | (空) | 自託管 GitLab URL |
 | `GIT_COMMITTER_NAME` / `GIT_COMMITTER_EMAIL` | (空) | service account 身份；空時 fallback 到 author |
+| `TA_FEDERATION_KEY` | (空 = 停用) | **(v2.9.0)** RS256 私鑰 PEM 路徑；簽發 federation token 用，空則 `/api/v1/federation/*` 不註冊 |
+| `TA_FEDERATION_STORE` | (空 = `os.TempDir`) | **(v2.9.0)** federation token record store（JSON）路徑；production 應指向持久卷 |
+| `TA_FEDERATION_TOKEN_TTL` | `4h` | **(v2.9.0)** federation token 效期（Go duration string） |
 
 ### RBAC YAML
 

--- a/components/tenant-api/cmd/server/main.go
+++ b/components/tenant-api/cmd/server/main.go
@@ -211,6 +211,9 @@ func main() {
 		if *federationStore == "" {
 			slog.Warn("federation token store is on os.TempDir; set TA_FEDERATION_STORE to a persistent volume for production")
 		}
+		if len(rbacMgr.Get().Groups) == 0 {
+			slog.Warn("federation endpoint enabled but RBAC is in open mode — every token issuance will be denied (admin permission required); supply --rbac")
+		}
 	}
 
 	// Wire all handler dependencies into a single struct (PR-4/11).

--- a/components/tenant-api/cmd/server/main.go
+++ b/components/tenant-api/cmd/server/main.go
@@ -23,12 +23,14 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/vencil/tenant-api/internal/async"
+	"github.com/vencil/tenant-api/internal/federation"
 	"github.com/vencil/tenant-api/internal/gitops"
 	"github.com/vencil/tenant-api/internal/groups"
 	"github.com/vencil/tenant-api/internal/handler"
@@ -129,6 +131,17 @@ func main() {
 	idleTimeout := flag.Duration("idle-timeout",
 		parseDurationOrDefault(os.Getenv("TA_IDLE_TIMEOUT"), 60*time.Second),
 		"HTTP server idle timeout (default 60s; TA_IDLE_TIMEOUT)")
+
+	// v2.9.0 ADR-020 IV-2d: tenant federation token endpoint.
+	// An empty --federation-key disables the endpoint entirely.
+	federationKey := flag.String("federation-key", envOrDefault("TA_FEDERATION_KEY", ""),
+		"Path to the RS256 private key (PEM) for signing federation tokens. Empty disables the federation endpoint.")
+	federationStore := flag.String("federation-store", envOrDefault("TA_FEDERATION_STORE", ""),
+		"Path to the federation token record store (JSON). Defaults to <os.TempDir>/tenant-api-federation-tokens.json.")
+	federationTTL := flag.Duration("federation-token-ttl",
+		parseDurationOrDefault(os.Getenv("TA_FEDERATION_TOKEN_TTL"), federation.DefaultTTL),
+		"Federation token lifetime (default 4h; ADR-020 §Token model)")
+
 	flag.Parse()
 
 	// PR-10/11: structured (JSON) logging via slog. Configure before
@@ -181,6 +194,25 @@ func main() {
 		ReloadInterval: *reloadInterval,
 	})
 
+	// v2.9.0 ADR-020 IV-2d: federation token signer. Optional — when
+	// --federation-key is unset NewManager returns nil and the
+	// /federation routes below stay unregistered.
+	fedStorePath := *federationStore
+	if fedStorePath == "" {
+		fedStorePath = filepath.Join(os.TempDir(), "tenant-api-federation-tokens.json")
+	}
+	federationMgr, err := federation.NewManager(*federationKey, fedStorePath, *federationTTL)
+	if err != nil {
+		log.Fatalf("FATAL: federation init: %v", err)
+	}
+	if federationMgr != nil {
+		slog.Info("federation token endpoint enabled",
+			"token_ttl", federationMgr.TTL(), "store", fedStorePath)
+		if *federationStore == "" {
+			slog.Warn("federation token store is on os.TempDir; set TA_FEDERATION_STORE to a persistent volume for production")
+		}
+	}
+
 	// Wire all handler dependencies into a single struct (PR-4/11).
 	// Every handler is now a method on *deps; pass-through positional
 	// args are gone.
@@ -191,6 +223,7 @@ func main() {
 		Policy:      policyMgr,
 		Groups:      groupMgr,
 		Views:       viewMgr,
+		Federation:  federationMgr,
 		Tasks:       taskMgr,
 		PRClient:    prClient,
 		PRTracker:   prTracker,
@@ -331,6 +364,22 @@ func main() {
 		// Real-time event stream (v2.6.0 — SSE for config change notifications)
 		r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
 			Get("/events", eventHub.ServeHTTP)
+
+		// Federation token endpoint (v2.9.0 — ADR-020 IV-2d).
+		// Registered only when a signing key is configured. Route-level
+		// middleware checks authentication; per-tenant admin permission
+		// is enforced inside each handler because the tenant ID is in
+		// the body / query / token record, not the URL path.
+		if federationMgr != nil {
+			r.Route("/federation/tokens", func(r chi.Router) {
+				r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
+					Post("/", deps.CreateFederationToken())
+				r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
+					Get("/", deps.ListFederationTokens())
+				r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
+					Delete("/{id}", deps.DeleteFederationToken())
+			})
+		}
 	})
 
 	// ── HTTP server with graceful shutdown ────────────────────────────────────

--- a/components/tenant-api/docs/docs.go
+++ b/components/tenant-api/docs/docs.go
@@ -115,6 +115,15 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/components/tenant-api/docs/docs.go
+++ b/components/tenant-api/docs/docs.go
@@ -18,6 +18,174 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/api/v1/federation/tokens": {
+            "get": {
+                "description": "Returns the non-expired federation token records for the tenant named by the tenant_id query parameter. Requires admin permission on that tenant. The signed JWTs themselves are not returned.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "federation"
+                ],
+                "summary": "List a tenant's federation tokens",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Tenant ID",
+                        "name": "tenant_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_handler.FederationTokenRecord"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Mints a short-lived RS256 JWT for the named tenant (ADR-020). Requires admin permission on the tenant. The signed token is returned once and is not retrievable afterwards.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "federation"
+                ],
+                "summary": "Issue a tenant federation token",
+                "parameters": [
+                    {
+                        "description": "Token request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.CreateFederationTokenRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.CreateFederationTokenResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/federation/tokens/{id}": {
+            "delete": {
+                "description": "Removes a federation token's bookkeeping record. NOTE: per ADR-020 there is no server-side revocation — a still-valid JWT remains usable until it expires. Requires admin permission on the token's tenant.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "federation"
+                ],
+                "summary": "Delete a federation token record",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Token ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/groups": {
             "get": {
                 "description": "Returns tenant groups visible to the authenticated user, filtered by RBAC.",
@@ -1089,6 +1257,34 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_handler.CreateFederationTokenRequest": {
+            "type": "object",
+            "required": [
+                "tenant_id"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "maxLength": 256
+                },
+                "tenant_id": {
+                    "type": "string",
+                    "maxLength": 128,
+                    "minLength": 1
+                }
+            }
+        },
+        "internal_handler.CreateFederationTokenResponse": {
+            "type": "object",
+            "properties": {
+                "record": {
+                    "$ref": "#/definitions/internal_handler.FederationTokenRecord"
+                },
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_handler.DiffRequest": {
             "type": "object",
             "properties": {
@@ -1108,6 +1304,29 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "tenant_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.FederationTokenRecord": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "issued_at": {
+                    "type": "string"
+                },
+                "issued_by": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "token_id": {
                     "type": "string"
                 }
             }

--- a/components/tenant-api/docs/swagger.json
+++ b/components/tenant-api/docs/swagger.json
@@ -11,6 +11,174 @@
     },
     "basePath": "/api/v1",
     "paths": {
+        "/api/v1/federation/tokens": {
+            "get": {
+                "description": "Returns the non-expired federation token records for the tenant named by the tenant_id query parameter. Requires admin permission on that tenant. The signed JWTs themselves are not returned.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "federation"
+                ],
+                "summary": "List a tenant's federation tokens",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Tenant ID",
+                        "name": "tenant_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_handler.FederationTokenRecord"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Mints a short-lived RS256 JWT for the named tenant (ADR-020). Requires admin permission on the tenant. The signed token is returned once and is not retrievable afterwards.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "federation"
+                ],
+                "summary": "Issue a tenant federation token",
+                "parameters": [
+                    {
+                        "description": "Token request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.CreateFederationTokenRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.CreateFederationTokenResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/federation/tokens/{id}": {
+            "delete": {
+                "description": "Removes a federation token's bookkeeping record. NOTE: per ADR-020 there is no server-side revocation — a still-valid JWT remains usable until it expires. Requires admin permission on the token's tenant.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "federation"
+                ],
+                "summary": "Delete a federation token record",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Token ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/groups": {
             "get": {
                 "description": "Returns tenant groups visible to the authenticated user, filtered by RBAC.",
@@ -1082,6 +1250,34 @@
                 }
             }
         },
+        "internal_handler.CreateFederationTokenRequest": {
+            "type": "object",
+            "required": [
+                "tenant_id"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "maxLength": 256
+                },
+                "tenant_id": {
+                    "type": "string",
+                    "maxLength": 128,
+                    "minLength": 1
+                }
+            }
+        },
+        "internal_handler.CreateFederationTokenResponse": {
+            "type": "object",
+            "properties": {
+                "record": {
+                    "$ref": "#/definitions/internal_handler.FederationTokenRecord"
+                },
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_handler.DiffRequest": {
             "type": "object",
             "properties": {
@@ -1101,6 +1297,29 @@
                     "type": "boolean"
                 },
                 "tenant_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.FederationTokenRecord": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "issued_at": {
+                    "type": "string"
+                },
+                "issued_by": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "token_id": {
                     "type": "string"
                 }
             }

--- a/components/tenant-api/docs/swagger.json
+++ b/components/tenant-api/docs/swagger.json
@@ -108,6 +108,15 @@
                             }
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/components/tenant-api/docs/swagger.yaml
+++ b/components/tenant-api/docs/swagger.yaml
@@ -463,6 +463,12 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "500":
           description: Internal Server Error
           schema:

--- a/components/tenant-api/docs/swagger.yaml
+++ b/components/tenant-api/docs/swagger.yaml
@@ -130,6 +130,25 @@ definitions:
       tenant_id:
         type: string
     type: object
+  internal_handler.CreateFederationTokenRequest:
+    properties:
+      description:
+        maxLength: 256
+        type: string
+      tenant_id:
+        maxLength: 128
+        minLength: 1
+        type: string
+    required:
+    - tenant_id
+    type: object
+  internal_handler.CreateFederationTokenResponse:
+    properties:
+      record:
+        $ref: '#/definitions/internal_handler.FederationTokenRecord'
+      token:
+        type: string
+    type: object
   internal_handler.DiffRequest:
     properties:
       proposed:
@@ -143,6 +162,21 @@ definitions:
       has_diff:
         type: boolean
       tenant_id:
+        type: string
+    type: object
+  internal_handler.FederationTokenRecord:
+    properties:
+      description:
+        type: string
+      expires_at:
+        type: string
+      issued_at:
+        type: string
+      issued_by:
+        type: string
+      tenant_id:
+        type: string
+      token_id:
         type: string
     type: object
   internal_handler.GroupBatchRequest:
@@ -362,6 +396,123 @@ info:
   title: Tenant API
   version: v2.8.0
 paths:
+  /api/v1/federation/tokens:
+    get:
+      description: Returns the non-expired federation token records for the tenant
+        named by the tenant_id query parameter. Requires admin permission on that
+        tenant. The signed JWTs themselves are not returned.
+      parameters:
+      - description: Tenant ID
+        in: query
+        name: tenant_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/internal_handler.FederationTokenRecord'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List a tenant's federation tokens
+      tags:
+      - federation
+    post:
+      consumes:
+      - application/json
+      description: Mints a short-lived RS256 JWT for the named tenant (ADR-020). Requires
+        admin permission on the tenant. The signed token is returned once and is not
+        retrievable afterwards.
+      parameters:
+      - description: Token request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.CreateFederationTokenRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/internal_handler.CreateFederationTokenResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Issue a tenant federation token
+      tags:
+      - federation
+  /api/v1/federation/tokens/{id}:
+    delete:
+      description: 'Removes a federation token''s bookkeeping record. NOTE: per ADR-020
+        there is no server-side revocation — a still-valid JWT remains usable until
+        it expires. Requires admin permission on the token''s tenant.'
+      parameters:
+      - description: Token ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Delete a federation token record
+      tags:
+      - federation
   /api/v1/groups:
     get:
       description: Returns tenant groups visible to the authenticated user, filtered

--- a/components/tenant-api/go.mod
+++ b/components/tenant-api/go.mod
@@ -5,6 +5,7 @@ go 1.26.3
 require (
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-playground/validator/v10 v10.30.2
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/vencil/threshold-exporter v0.0.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/components/tenant-api/go.sum
+++ b/components/tenant-api/go.sum
@@ -12,6 +12,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.30.2 h1:JiFIMtSSHb2/XBUbWM4i/MpeQm9ZK2xqPNk8vgvu5JQ=
 github.com/go-playground/validator/v10 v10.30.2/go.mod h1:mAf2pIOVXjTEBrwUMGKkCWKKPs9NheYGabeB04txQSc=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=

--- a/components/tenant-api/internal/federation/federation.go
+++ b/components/tenant-api/internal/federation/federation.go
@@ -47,6 +47,12 @@ const issuer = "tenant-api"
 // prefix keeps those lines greppable.
 const tokenIDPrefix = "ftk_"
 
+// minRSAKeyBits is the smallest RSA modulus accepted for the signing
+// key. Below 2048 bits a forged signature becomes computationally
+// feasible, so a weak key is a silent vulnerability — it is rejected
+// at load time rather than allowed to sign tokens.
+const minRSAKeyBits = 2048
+
 // Claims is the JWT payload of a federation token.
 //
 // TenantID and TokenID are the cross-component contract fixed by
@@ -198,7 +204,7 @@ func newTokenID() (string, error) {
 
 // loadPrivateKey reads an RSA private key from a PEM file, accepting
 // both PKCS#8 (BEGIN PRIVATE KEY) and PKCS#1 (BEGIN RSA PRIVATE KEY)
-// encodings.
+// encodings. A key smaller than minRSAKeyBits is rejected.
 func loadPrivateKey(path string) (*rsa.PrivateKey, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -208,14 +214,27 @@ func loadPrivateKey(path string) (*rsa.PrivateKey, error) {
 	if block == nil {
 		return nil, errors.New("no PEM block found in key file")
 	}
-	if k, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+	key, err := parseRSAPrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	if bits := key.N.BitLen(); bits < minRSAKeyBits {
+		return nil, fmt.Errorf("RSA signing key is %d-bit, want at least %d-bit", bits, minRSAKeyBits)
+	}
+	return key, nil
+}
+
+// parseRSAPrivateKey decodes DER bytes as an RSA private key, trying
+// PKCS#8 first then PKCS#1.
+func parseRSAPrivateKey(der []byte) (*rsa.PrivateKey, error) {
+	if k, err := x509.ParsePKCS8PrivateKey(der); err == nil {
 		rk, ok := k.(*rsa.PrivateKey)
 		if !ok {
 			return nil, fmt.Errorf("key is %T, want an RSA private key", k)
 		}
 		return rk, nil
 	}
-	rk, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	rk, err := x509.ParsePKCS1PrivateKey(der)
 	if err != nil {
 		return nil, fmt.Errorf("parse RSA private key: %w", err)
 	}

--- a/components/tenant-api/internal/federation/federation.go
+++ b/components/tenant-api/internal/federation/federation.go
@@ -42,6 +42,12 @@ const DefaultTTL = 4 * time.Hour
 // issuer is the JWT `iss` claim — identifies tenant-api as the signer.
 const issuer = "tenant-api"
 
+// audience is the JWT `aud` claim. Binding every federation token to a
+// single audience lets a verifier reject a token replayed against any
+// other API that happens to trust the same signing key (cross-service
+// replay). ADR-020 Wave-0 decision 3.
+const audience = "tenant-federation"
+
 // tokenIDPrefix namespaces the public token handle. The audit log
 // (sub-issue IV-2f) records a token_id_prefix, so a recognisable
 // prefix keeps those lines greppable.
@@ -91,13 +97,25 @@ type Record struct {
 // expired reports whether the record is past its expiry as of now.
 func (r Record) expired(now time.Time) bool { return now.After(r.ExpiresAt) }
 
+// RecordStore is the persistence backend for token Records. The MVP
+// ships the JSON-file store (store.go); ADR-020 Wave-0 decision 4
+// targets a ConfigMap-backed implementation (sub-issue IV-2n) so
+// tenant-api can run multi-replica. The interface methods are
+// unexported — it is implemented only within this package.
+type RecordStore interface {
+	put(r Record) error
+	get(tokenID string) (Record, bool)
+	list(tenantID string, now time.Time) []Record
+	remove(tokenID string) (bool, error)
+}
+
 // Manager signs federation tokens and tracks issued-token Records.
 // It is safe for concurrent use: the signing key is immutable after
 // construction and the store guards its own state.
 type Manager struct {
 	key   *rsa.PrivateKey
 	ttl   time.Duration
-	store *store
+	store RecordStore
 }
 
 // NewManager loads the RS256 signing key from keyPath (a PEM file,
@@ -164,6 +182,7 @@ func (m *Manager) Issue(tenantID, issuedBy, description string) (string, Record,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    issuer,
 			Subject:   tenantID,
+			Audience:  jwt.ClaimStrings{audience},
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(m.ttl)),
 		},

--- a/components/tenant-api/internal/federation/federation.go
+++ b/components/tenant-api/internal/federation/federation.go
@@ -53,6 +53,17 @@ const tokenIDPrefix = "ftk_"
 // at load time rather than allowed to sign tokens.
 const minRSAKeyBits = 2048
 
+// maxTokensPerTenant caps the live federation tokens one tenant may
+// hold. It is an abuse guard, not a precise quota — concurrent
+// issuance may exceed it slightly, which is acceptable. A tenant with
+// this many live 4h tokens is almost certainly misbehaving (an
+// issuance loop, or never letting old tokens expire).
+const maxTokensPerTenant = 16
+
+// ErrTokenLimitReached is returned by Issue when the tenant already
+// holds maxTokensPerTenant live tokens.
+var ErrTokenLimitReached = errors.New("federation: tenant federation-token limit reached")
+
 // Claims is the JWT payload of a federation token.
 //
 // TenantID and TokenID are the cross-component contract fixed by
@@ -140,6 +151,9 @@ func (m *Manager) TTL() time.Duration { return m.ttl }
 // re-display it, so the caller must surface it to the operator once.
 func (m *Manager) Issue(tenantID, issuedBy, description string) (string, Record, error) {
 	now := time.Now()
+	if live := m.store.list(tenantID, now); len(live) >= maxTokensPerTenant {
+		return "", Record{}, ErrTokenLimitReached
+	}
 	tokenID, err := newTokenID()
 	if err != nil {
 		return "", Record{}, err

--- a/components/tenant-api/internal/federation/federation.go
+++ b/components/tenant-api/internal/federation/federation.go
@@ -1,0 +1,223 @@
+// Package federation implements federation-token issuance for ADR-020
+// (Tenant Federation — Label-Injection Proxy over Self-Built Endpoint).
+//
+// A federation token is a short-lived (default 4h) RS256-signed JWT a
+// tenant presents to the label-injection proxy (vmauth / prom-label-proxy)
+// to pull its own metrics subset back to tenant-side infrastructure.
+// tenant-api is the *signer only*: the proxy and API gateway verify the
+// signature with the public half of the key and never call back here, so
+// verification is fully stateless.
+//
+// MVP scope (ADR-020 §Token model):
+//   - No server-side revocation list. A leaked token stays valid until
+//     its exp claim (≤ TTL). The compensating control is the API-gateway
+//     per-token rate limit (sub-issue IV-2b). DELETE removes only the
+//     local bookkeeping Record — it does not invalidate the JWT.
+//   - Token Records are operational state (machine-written on every
+//     issuance, high churn). They persist to a dedicated JSON store,
+//     deliberately NOT to the git-backed conf.d directory, so issuance
+//     does not generate a commit per token.
+package federation
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// DefaultTTL is the federation-token lifetime when none is configured.
+// ADR-020 §Token model fixes 4h as the balance point between "short
+// enough that the absence of a revocation list is acceptable" and
+// "long enough that re-signing is not operationally painful".
+const DefaultTTL = 4 * time.Hour
+
+// issuer is the JWT `iss` claim — identifies tenant-api as the signer.
+const issuer = "tenant-api"
+
+// tokenIDPrefix namespaces the public token handle. The audit log
+// (sub-issue IV-2f) records a token_id_prefix, so a recognisable
+// prefix keeps those lines greppable.
+const tokenIDPrefix = "ftk_"
+
+// Claims is the JWT payload of a federation token.
+//
+// TenantID and TokenID are the cross-component contract fixed by
+// ADR-020 Wave-0 decision 3: the proxy reads TenantID to inject
+// {tenant_id="<X>"} into every selector, and the API gateway reads
+// TokenID as the per-token rate-limit key.
+type Claims struct {
+	TenantID string `json:"tenant_id"`
+	TokenID  string `json:"token_id"`
+	jwt.RegisteredClaims
+}
+
+// Record is the bookkeeping metadata for one issued token. The signed
+// JWT itself is never stored — only what GET needs to list issued
+// tokens and DELETE needs to identify one. TokenID is the public handle.
+type Record struct {
+	TokenID     string    `json:"token_id"`
+	TenantID    string    `json:"tenant_id"`
+	IssuedBy    string    `json:"issued_by"`
+	Description string    `json:"description,omitempty"`
+	IssuedAt    time.Time `json:"issued_at"`
+	ExpiresAt   time.Time `json:"expires_at"`
+}
+
+// expired reports whether the record is past its expiry as of now.
+func (r Record) expired(now time.Time) bool { return now.After(r.ExpiresAt) }
+
+// Manager signs federation tokens and tracks issued-token Records.
+// It is safe for concurrent use: the signing key is immutable after
+// construction and the store guards its own state.
+type Manager struct {
+	key   *rsa.PrivateKey
+	ttl   time.Duration
+	store *store
+}
+
+// NewManager loads the RS256 signing key from keyPath (a PEM file,
+// PKCS#1 or PKCS#8) and opens the Record store at storePath. A
+// non-positive ttl falls back to DefaultTTL.
+//
+// When keyPath is empty NewManager returns (nil, nil): the federation
+// feature is then disabled and the caller leaves the /federation
+// routes unregistered — the same optional-dependency pattern main.go
+// uses for the PR tracker.
+func NewManager(keyPath, storePath string, ttl time.Duration) (*Manager, error) {
+	if keyPath == "" {
+		return nil, nil
+	}
+	key, err := loadPrivateKey(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("federation: load signing key: %w", err)
+	}
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	st, err := newStore(storePath)
+	if err != nil {
+		return nil, fmt.Errorf("federation: open token store: %w", err)
+	}
+	return &Manager{key: key, ttl: ttl, store: st}, nil
+}
+
+// NewManagerForTest builds a Manager around an in-memory signing key,
+// skipping PEM file loading. The Record store is created at storePath;
+// a non-positive ttl falls back to DefaultTTL. Intended for unit tests
+// of this package and of the HTTP handlers that depend on it.
+func NewManagerForTest(key *rsa.PrivateKey, storePath string, ttl time.Duration) (*Manager, error) {
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	st, err := newStore(storePath)
+	if err != nil {
+		return nil, err
+	}
+	return &Manager{key: key, ttl: ttl, store: st}, nil
+}
+
+// TTL returns the configured token lifetime.
+func (m *Manager) TTL() time.Duration { return m.ttl }
+
+// Issue mints a signed federation JWT for tenantID and persists its
+// Record. issuedBy is the operator email (audit trail); description is
+// an optional free-text label. The returned token string is the
+// compact-serialised JWT — tenant-api does not store it and cannot
+// re-display it, so the caller must surface it to the operator once.
+func (m *Manager) Issue(tenantID, issuedBy, description string) (string, Record, error) {
+	now := time.Now()
+	tokenID, err := newTokenID()
+	if err != nil {
+		return "", Record{}, err
+	}
+	claims := Claims{
+		TenantID: tenantID,
+		TokenID:  tokenID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    issuer,
+			Subject:   tenantID,
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(m.ttl)),
+		},
+	}
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(m.key)
+	if err != nil {
+		return "", Record{}, fmt.Errorf("federation: sign token: %w", err)
+	}
+	rec := Record{
+		TokenID:     tokenID,
+		TenantID:    tenantID,
+		IssuedBy:    issuedBy,
+		Description: description,
+		IssuedAt:    now,
+		ExpiresAt:   now.Add(m.ttl),
+	}
+	if err := m.store.put(rec); err != nil {
+		return "", Record{}, fmt.Errorf("federation: persist token record: %w", err)
+	}
+	return signed, rec, nil
+}
+
+// List returns the non-expired Records for tenantID, oldest first.
+func (m *Manager) List(tenantID string) []Record {
+	return m.store.list(tenantID, time.Now())
+}
+
+// Get returns the Record for tokenID, or false if no such record
+// exists. An expired-but-not-yet-pruned record is still returned —
+// callers that care about liveness check ExpiresAt themselves.
+func (m *Manager) Get(tokenID string) (Record, bool) {
+	return m.store.get(tokenID)
+}
+
+// Delete removes the bookkeeping Record for tokenID and reports
+// whether a record was present. Per ADR-020 there is no server-side
+// revocation: a still-valid JWT keeps working until its exp even
+// after its Record is deleted.
+func (m *Manager) Delete(tokenID string) (bool, error) {
+	return m.store.remove(tokenID)
+}
+
+// newTokenID returns a fresh public token handle: tokenIDPrefix plus
+// 16 hex characters (8 random bytes).
+func newTokenID() (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("federation: generate token id: %w", err)
+	}
+	return tokenIDPrefix + hex.EncodeToString(b), nil
+}
+
+// loadPrivateKey reads an RSA private key from a PEM file, accepting
+// both PKCS#8 (BEGIN PRIVATE KEY) and PKCS#1 (BEGIN RSA PRIVATE KEY)
+// encodings.
+func loadPrivateKey(path string) (*rsa.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("no PEM block found in key file")
+	}
+	if k, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		rk, ok := k.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("key is %T, want an RSA private key", k)
+		}
+		return rk, nil
+	}
+	rk, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse RSA private key: %w", err)
+	}
+	return rk, nil
+}

--- a/components/tenant-api/internal/federation/federation_test.go
+++ b/components/tenant-api/internal/federation/federation_test.go
@@ -274,3 +274,23 @@ func TestStore_Persistence(t *testing.T) {
 		t.Errorf("reloaded record = %+v", got)
 	}
 }
+
+func TestNewManager_RejectsWeakKey(t *testing.T) {
+	t.Parallel()
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "weak.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	if _, err := NewManager(path, filepath.Join(t.TempDir(), "s.json"), time.Hour); err == nil {
+		t.Fatal("expected an error for a sub-2048-bit RSA signing key")
+	}
+}

--- a/components/tenant-api/internal/federation/federation_test.go
+++ b/components/tenant-api/internal/federation/federation_test.go
@@ -1,0 +1,276 @@
+package federation
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// writeTestKey generates a 2048-bit RSA key, writes it as a PKCS#8 PEM
+// file under t.TempDir(), and returns the path plus the key (the key
+// is used to verify signatures in assertions).
+func writeTestKey(t *testing.T) (string, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "fed-key.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return path, key
+}
+
+func newTestManager(t *testing.T, ttl time.Duration) *Manager {
+	t.Helper()
+	keyPath, _ := writeTestKey(t)
+	m, err := NewManager(keyPath, filepath.Join(t.TempDir(), "store.json"), ttl)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if m == nil {
+		t.Fatal("NewManager returned nil with a key path set")
+	}
+	return m
+}
+
+func TestNewManager_EmptyKeyPathDisablesFeature(t *testing.T) {
+	t.Parallel()
+	m, err := NewManager("", "", 0)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if m != nil {
+		t.Fatal("expected nil Manager when key path is empty")
+	}
+}
+
+func TestNewManager_DefaultTTL(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t, 0)
+	if m.TTL() != DefaultTTL {
+		t.Errorf("TTL() = %v, want default %v", m.TTL(), DefaultTTL)
+	}
+}
+
+func TestNewManager_AcceptsPKCS1Key(t *testing.T) {
+	t.Parallel()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "pkcs1.pem")
+	der := x509.MarshalPKCS1PrivateKey(key)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	m, err := NewManager(path, filepath.Join(t.TempDir(), "s.json"), time.Hour)
+	if err != nil {
+		t.Fatalf("NewManager with PKCS#1 key: %v", err)
+	}
+	if m == nil {
+		t.Fatal("expected a Manager")
+	}
+}
+
+func TestNewManager_RejectsBadKey(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "bad.pem")
+	if err := os.WriteFile(path, []byte("not a pem file"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if _, err := NewManager(path, filepath.Join(t.TempDir(), "s.json"), time.Hour); err == nil {
+		t.Fatal("expected an error for a malformed key file")
+	}
+}
+
+func TestIssue_SignsVerifiableJWT(t *testing.T) {
+	t.Parallel()
+	keyPath, key := writeTestKey(t)
+	m, err := NewManager(keyPath, filepath.Join(t.TempDir(), "store.json"), time.Hour)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	before := time.Now()
+	signed, rec, err := m.Issue("tenant-alpha", "ops@example.com", "grafana pull")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	if rec.TenantID != "tenant-alpha" {
+		t.Errorf("Record.TenantID = %q, want tenant-alpha", rec.TenantID)
+	}
+	if rec.IssuedBy != "ops@example.com" {
+		t.Errorf("Record.IssuedBy = %q", rec.IssuedBy)
+	}
+	if rec.Description != "grafana pull" {
+		t.Errorf("Record.Description = %q", rec.Description)
+	}
+	if !strings.HasPrefix(rec.TokenID, "ftk_") {
+		t.Errorf("Record.TokenID = %q, want ftk_ prefix", rec.TokenID)
+	}
+	if d := rec.ExpiresAt.Sub(rec.IssuedAt); d != time.Hour {
+		t.Errorf("ExpiresAt-IssuedAt = %v, want 1h", d)
+	}
+
+	var claims Claims
+	tok, err := jwt.ParseWithClaims(signed, &claims, func(*jwt.Token) (interface{}, error) {
+		return &key.PublicKey, nil
+	})
+	if err != nil {
+		t.Fatalf("ParseWithClaims: %v", err)
+	}
+	if !tok.Valid {
+		t.Fatal("parsed token is not valid")
+	}
+	if claims.TenantID != "tenant-alpha" {
+		t.Errorf("claim tenant_id = %q", claims.TenantID)
+	}
+	if claims.TokenID != rec.TokenID {
+		t.Errorf("claim token_id = %q, want %q (Record.TokenID)", claims.TokenID, rec.TokenID)
+	}
+	if claims.Issuer != "tenant-api" {
+		t.Errorf("claim iss = %q, want tenant-api", claims.Issuer)
+	}
+	if claims.Subject != "tenant-alpha" {
+		t.Errorf("claim sub = %q", claims.Subject)
+	}
+	exp := claims.ExpiresAt.Time
+	if exp.Before(before.Add(time.Hour-time.Minute)) || exp.After(time.Now().Add(time.Hour+time.Minute)) {
+		t.Errorf("claim exp = %v, want ~1h from issuance", exp)
+	}
+}
+
+func TestIssue_RejectsByWrongKey(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t, time.Hour)
+	signed, _, err := m.Issue("tenant-x", "u@example.com", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	otherKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	if _, err := jwt.ParseWithClaims(signed, &Claims{}, func(*jwt.Token) (interface{}, error) {
+		return &otherKey.PublicKey, nil
+	}); err == nil {
+		t.Fatal("expected verification to fail against an unrelated public key")
+	}
+}
+
+func TestManager_ListGetDelete(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t, time.Hour)
+
+	_, recA1, err := m.Issue("tenant-a", "u@example.com", "first")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	_, recA2, err := m.Issue("tenant-a", "u@example.com", "second")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	_, recB1, err := m.Issue("tenant-b", "u@example.com", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	listA := m.List("tenant-a")
+	if len(listA) != 2 {
+		t.Fatalf("List(tenant-a) = %d records, want 2", len(listA))
+	}
+	gotIDs := map[string]bool{listA[0].TokenID: true, listA[1].TokenID: true}
+	if !gotIDs[recA1.TokenID] || !gotIDs[recA2.TokenID] {
+		t.Errorf("List(tenant-a) missing an issued token: %v", gotIDs)
+	}
+	if got := m.List("tenant-b"); len(got) != 1 || got[0].TokenID != recB1.TokenID {
+		t.Errorf("List(tenant-b) = %v, want [%s]", got, recB1.TokenID)
+	}
+	if got := m.List("tenant-unknown"); len(got) != 0 {
+		t.Errorf("List(tenant-unknown) = %d, want 0", len(got))
+	}
+
+	got, ok := m.Get(recA1.TokenID)
+	if !ok || got.TenantID != "tenant-a" {
+		t.Errorf("Get(%s) = (%+v, %v)", recA1.TokenID, got, ok)
+	}
+	if _, ok := m.Get("ftk_does_not_exist"); ok {
+		t.Error("Get of an unknown token reported present")
+	}
+
+	deleted, err := m.Delete(recA1.TokenID)
+	if err != nil || !deleted {
+		t.Fatalf("Delete(%s) = (%v, %v), want (true, nil)", recA1.TokenID, deleted, err)
+	}
+	if got := m.List("tenant-a"); len(got) != 1 {
+		t.Errorf("List(tenant-a) after delete = %d, want 1", len(got))
+	}
+	if deleted, _ := m.Delete(recA1.TokenID); deleted {
+		t.Error("second Delete of the same token reported a deletion")
+	}
+}
+
+func TestStore_ListExcludesExpiredButGetReturnsIt(t *testing.T) {
+	t.Parallel()
+	st, err := newStore(filepath.Join(t.TempDir(), "s.json"))
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+	now := time.Now()
+	live := Record{TokenID: "ftk_live", TenantID: "t", IssuedAt: now.Add(-time.Hour), ExpiresAt: now.Add(time.Hour)}
+	dead := Record{TokenID: "ftk_dead", TenantID: "t", IssuedAt: now.Add(-2 * time.Hour), ExpiresAt: now.Add(-time.Hour)}
+	if err := st.put(live); err != nil {
+		t.Fatalf("put live: %v", err)
+	}
+	if err := st.put(dead); err != nil {
+		t.Fatalf("put dead: %v", err)
+	}
+
+	got := st.list("t", now)
+	if len(got) != 1 || got[0].TokenID != "ftk_live" {
+		t.Errorf("list = %v, want only ftk_live", got)
+	}
+	if _, ok := st.get("ftk_dead"); !ok {
+		t.Error("get should still return an expired-but-unpruned record")
+	}
+}
+
+func TestStore_Persistence(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "s.json")
+	st1, err := newStore(path)
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+	now := time.Now()
+	rec := Record{TokenID: "ftk_persist", TenantID: "tenant-p", IssuedBy: "u@example.com", IssuedAt: now, ExpiresAt: now.Add(time.Hour)}
+	if err := st1.put(rec); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	st2, err := newStore(path)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	got, ok := st2.get("ftk_persist")
+	if !ok {
+		t.Fatal("record was not reloaded from disk")
+	}
+	if got.TenantID != "tenant-p" || got.IssuedBy != "u@example.com" {
+		t.Errorf("reloaded record = %+v", got)
+	}
+}

--- a/components/tenant-api/internal/federation/federation_test.go
+++ b/components/tenant-api/internal/federation/federation_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -292,5 +293,37 @@ func TestNewManager_RejectsWeakKey(t *testing.T) {
 	}
 	if _, err := NewManager(path, filepath.Join(t.TempDir(), "s.json"), time.Hour); err == nil {
 		t.Fatal("expected an error for a sub-2048-bit RSA signing key")
+	}
+}
+
+func TestIssue_EnforcesTokenLimit(t *testing.T) {
+	t.Parallel()
+	m := newTestManager(t, time.Hour)
+	for i := 0; i < maxTokensPerTenant; i++ {
+		if _, _, err := m.Issue("tenant-cap", "u@example.com", ""); err != nil {
+			t.Fatalf("Issue %d: %v", i, err)
+		}
+	}
+	if _, _, err := m.Issue("tenant-cap", "u@example.com", ""); !errors.Is(err, ErrTokenLimitReached) {
+		t.Fatalf("Issue past cap = %v, want ErrTokenLimitReached", err)
+	}
+	// A different tenant is unaffected by another tenant's cap.
+	if _, _, err := m.Issue("tenant-other", "u@example.com", ""); err != nil {
+		t.Fatalf("Issue for a different tenant: %v", err)
+	}
+}
+
+func TestNewStore_RemovesStaleTempFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "s.json")
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte("[]"), 0o600); err != nil {
+		t.Fatalf("write stale tmp: %v", err)
+	}
+	if _, err := newStore(path); err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Errorf("stale .tmp file was not removed (stat err = %v)", err)
 	}
 }

--- a/components/tenant-api/internal/federation/federation_test.go
+++ b/components/tenant-api/internal/federation/federation_test.go
@@ -149,6 +149,9 @@ func TestIssue_SignsVerifiableJWT(t *testing.T) {
 	if claims.Issuer != "tenant-api" {
 		t.Errorf("claim iss = %q, want tenant-api", claims.Issuer)
 	}
+	if len(claims.Audience) != 1 || claims.Audience[0] != "tenant-federation" {
+		t.Errorf("claim aud = %v, want [tenant-federation]", claims.Audience)
+	}
 	if claims.Subject != "tenant-alpha" {
 		t.Errorf("claim sub = %q", claims.Subject)
 	}

--- a/components/tenant-api/internal/federation/store.go
+++ b/components/tenant-api/internal/federation/store.go
@@ -20,6 +20,13 @@ import (
 // signed JWTs remain valid (verification is stateless) until they
 // expire. For production the store path should point at a mounted
 // volume; see main.go's --federation-store flag.
+//
+// MVP constraint: the store is pod-local. With tenant-api scaled past
+// one replica, GET listings become per-replica and inconsistent
+// (token signing and proxy-side verification are unaffected — both are
+// stateless). v2.9.0 ships with replicaCount=1; a multi-replica
+// deployment needs a shared store, which is also the prerequisite for
+// a future server-side revocation list.
 type store struct {
 	path string
 	mu   sync.Mutex

--- a/components/tenant-api/internal/federation/store.go
+++ b/components/tenant-api/internal/federation/store.go
@@ -1,0 +1,130 @@
+package federation
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"sort"
+	"sync"
+	"time"
+)
+
+// store is the JSON-file-backed Record store. Federation token records
+// are operational state, not GitOps configuration (ADR-020 Wave-0
+// decision 4): they are machine-written on every issuance and must not
+// generate a git commit each time. The whole file is rewritten under a
+// mutex on each mutation — one tenant holds at most a handful of live
+// 4h tokens, so the rewrite cost is negligible.
+//
+// A pod restart that loses the file costs only the GET listing: the
+// signed JWTs remain valid (verification is stateless) until they
+// expire. For production the store path should point at a mounted
+// volume; see main.go's --federation-store flag.
+type store struct {
+	path string
+	mu   sync.Mutex
+	recs map[string]Record // keyed by TokenID
+}
+
+// newStore opens the Record store at path. A missing file is not an
+// error — the store starts empty and the file is created on first
+// mutation.
+func newStore(path string) (*store, error) {
+	s := &store{path: path, recs: make(map[string]Record)}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return s, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return s, nil
+	}
+	var recs []Record
+	if err := json.Unmarshal(data, &recs); err != nil {
+		return nil, err
+	}
+	for _, r := range recs {
+		s.recs[r.TokenID] = r
+	}
+	return s, nil
+}
+
+// put inserts or replaces a Record and persists the store.
+func (s *store) put(r Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pruneLocked(time.Now())
+	s.recs[r.TokenID] = r
+	return s.flushLocked()
+}
+
+// get returns the Record for tokenID. Expired-but-unpruned records are
+// still returned; liveness is the caller's concern.
+func (s *store) get(tokenID string) (Record, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.recs[tokenID]
+	return r, ok
+}
+
+// list returns the non-expired Records for tenantID, oldest first.
+func (s *store) list(tenantID string, now time.Time) []Record {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Record, 0)
+	for _, r := range s.recs {
+		if r.TenantID == tenantID && !r.expired(now) {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].IssuedAt.Before(out[j].IssuedAt) })
+	return out
+}
+
+// remove deletes the Record for tokenID and persists the store. It
+// reports whether a record was present.
+func (s *store) remove(tokenID string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.recs[tokenID]; !ok {
+		return false, nil
+	}
+	delete(s.recs, tokenID)
+	if err := s.flushLocked(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// pruneLocked drops expired Records. The caller must hold s.mu.
+// Expired records carry no security weight — the JWT is already past
+// its exp — so pruning only keeps the file and GET listing tidy.
+func (s *store) pruneLocked(now time.Time) {
+	for id, r := range s.recs {
+		if r.expired(now) {
+			delete(s.recs, id)
+		}
+	}
+}
+
+// flushLocked writes the current Record set to disk via a temp file +
+// rename so a crash mid-write cannot truncate the store. The caller
+// must hold s.mu.
+func (s *store) flushLocked() error {
+	recs := make([]Record, 0, len(s.recs))
+	for _, r := range s.recs {
+		recs = append(recs, r)
+	}
+	sort.Slice(recs, func(i, j int) bool { return recs[i].IssuedAt.Before(recs[j].IssuedAt) })
+	data, err := json.MarshalIndent(recs, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, s.path)
+}

--- a/components/tenant-api/internal/federation/store.go
+++ b/components/tenant-api/internal/federation/store.go
@@ -38,6 +38,10 @@ type store struct {
 // mutation.
 func newStore(path string) (*store, error) {
 	s := &store{path: path, recs: make(map[string]Record)}
+	// Drop a stale temp file left by a crash mid-flush (write-temp +
+	// rename). It is at most a partial / unrenamed write; the real file
+	// is the authoritative state, so the temp is just litter.
+	_ = os.Remove(path + ".tmp")
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return s, nil

--- a/components/tenant-api/internal/handler/deps.go
+++ b/components/tenant-api/internal/handler/deps.go
@@ -21,6 +21,7 @@ package handler
 
 import (
 	"github.com/vencil/tenant-api/internal/async"
+	"github.com/vencil/tenant-api/internal/federation"
 	"github.com/vencil/tenant-api/internal/gitops"
 	"github.com/vencil/tenant-api/internal/groups"
 	"github.com/vencil/tenant-api/internal/platform"
@@ -74,6 +75,12 @@ type Deps struct {
 
 	// Views manages saved filter views (`_views.yaml`).
 	Views *views.Manager
+
+	// Federation signs tenant federation tokens (ADR-020 IV-2d).
+	// Optional — nil when no signing key is configured, in which case
+	// main.go leaves the /federation routes unregistered, so handlers
+	// reading it are never reached with a nil value.
+	Federation *federation.Manager
 
 	// Tasks runs async batch operations behind a goroutine pool.
 	Tasks *async.Manager

--- a/components/tenant-api/internal/handler/federation.go
+++ b/components/tenant-api/internal/handler/federation.go
@@ -84,6 +84,14 @@ func (d *Deps) CreateFederationToken() http.HandlerFunc {
 			writeValidationErrors(w, r, violations)
 			return
 		}
+		// Reject path-traversal / non-simple tenant IDs — the same gate
+		// the other tenant-scoped handlers use, applied here for
+		// consistency and defence-in-depth (the RBAC check below is the
+		// real bar).
+		if err := ValidateTenantID(req.TenantID); err != nil {
+			writeJSONError(w, r, http.StatusBadRequest, err.Error())
+			return
+		}
 
 		// Federation token issuance is data egress — require admin on
 		// the target tenant (ADR-020 Wave-0 decision 5).
@@ -124,6 +132,10 @@ func (d *Deps) ListFederationTokens() http.HandlerFunc {
 		tenantID := r.URL.Query().Get("tenant_id")
 		if tenantID == "" {
 			writeJSONError(w, r, http.StatusBadRequest, "query parameter tenant_id is required")
+			return
+		}
+		if err := ValidateTenantID(tenantID); err != nil {
+			writeJSONError(w, r, http.StatusBadRequest, err.Error())
 			return
 		}
 

--- a/components/tenant-api/internal/handler/federation.go
+++ b/components/tenant-api/internal/handler/federation.go
@@ -1,0 +1,196 @@
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/vencil/tenant-api/internal/federation"
+	"github.com/vencil/tenant-api/internal/rbac"
+)
+
+// CreateFederationTokenRequest is the body of POST /api/v1/federation/tokens.
+type CreateFederationTokenRequest struct {
+	TenantID    string `json:"tenant_id" validate:"required,min=1,max=128"`
+	Description string `json:"description" validate:"max=256"`
+}
+
+// FederationTokenRecord is the listable metadata for one issued token.
+// The signed JWT is never included — it is returned exactly once, by
+// CreateFederationToken, and is not stored server-side.
+type FederationTokenRecord struct {
+	TokenID     string `json:"token_id"`
+	TenantID    string `json:"tenant_id"`
+	IssuedBy    string `json:"issued_by"`
+	Description string `json:"description,omitempty"`
+	IssuedAt    string `json:"issued_at"`
+	ExpiresAt   string `json:"expires_at"`
+}
+
+// CreateFederationTokenResponse is the body of a successful POST. The
+// `token` field is the compact JWT and is shown only here — it cannot
+// be retrieved again.
+type CreateFederationTokenResponse struct {
+	Token  string                `json:"token"`
+	Record FederationTokenRecord `json:"record"`
+}
+
+func toFederationTokenRecord(r federation.Record) FederationTokenRecord {
+	return FederationTokenRecord{
+		TokenID:     r.TokenID,
+		TenantID:    r.TenantID,
+		IssuedBy:    r.IssuedBy,
+		Description: r.Description,
+		IssuedAt:    r.IssuedAt.UTC().Format(time.RFC3339),
+		ExpiresAt:   r.ExpiresAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// CreateFederationToken handles POST /api/v1/federation/tokens.
+//
+// Issues a short-lived RS256 JWT (ADR-020) that the named tenant
+// presents to the label-injection proxy to pull its own metrics. The
+// caller must hold `admin` on the target tenant — federation is data
+// egress, a higher bar than config write. The tenant ID is in the
+// body, so that check is here rather than in route middleware.
+//
+// @Summary     Issue a tenant federation token
+// @Description Mints a short-lived RS256 JWT for the named tenant (ADR-020). Requires admin permission on the tenant. The signed token is returned once and is not retrievable afterwards.
+// @Tags        federation
+// @Accept      json
+// @Produce     json
+// @Param       body body     CreateFederationTokenRequest true "Token request"
+// @Success     201  {object} CreateFederationTokenResponse
+// @Failure     400  {object} map[string]string
+// @Failure     403  {object} map[string]string
+// @Failure     500  {object} map[string]string
+// @Router      /api/v1/federation/tokens [post]
+func (d *Deps) CreateFederationToken() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			writeJSONError(w, r, http.StatusBadRequest, "failed to read request body: "+err.Error())
+			return
+		}
+
+		var req CreateFederationTokenRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			writeJSONError(w, r, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			return
+		}
+		if violations := validateStructTags(&req); len(violations) > 0 {
+			writeValidationErrors(w, r, violations)
+			return
+		}
+
+		// Federation token issuance is data egress — require admin on
+		// the target tenant (ADR-020 Wave-0 decision 5).
+		if !d.RBAC.HasPermission(rbac.RequestGroups(r), req.TenantID, rbac.PermAdmin) {
+			writeJSONErrorWithCode(w, r, http.StatusForbidden, CodeForbidden,
+				"admin permission required on tenant "+req.TenantID+" to issue a federation token")
+			return
+		}
+
+		token, rec, err := d.Federation.Issue(req.TenantID, rbac.RequestEmail(r), req.Description)
+		if err != nil {
+			writeJSONError(w, r, http.StatusInternalServerError, "issue federation token: "+err.Error())
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(CreateFederationTokenResponse{
+			Token:  token,
+			Record: toFederationTokenRecord(rec),
+		})
+	}
+}
+
+// ListFederationTokens handles GET /api/v1/federation/tokens?tenant_id=X.
+//
+// @Summary     List a tenant's federation tokens
+// @Description Returns the non-expired federation token records for the tenant named by the tenant_id query parameter. Requires admin permission on that tenant. The signed JWTs themselves are not returned.
+// @Tags        federation
+// @Produce     json
+// @Param       tenant_id query string true "Tenant ID"
+// @Success     200 {array}  FederationTokenRecord
+// @Failure     400 {object} map[string]string
+// @Failure     403 {object} map[string]string
+// @Router      /api/v1/federation/tokens [get]
+func (d *Deps) ListFederationTokens() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tenantID := r.URL.Query().Get("tenant_id")
+		if tenantID == "" {
+			writeJSONError(w, r, http.StatusBadRequest, "query parameter tenant_id is required")
+			return
+		}
+
+		if !d.RBAC.HasPermission(rbac.RequestGroups(r), tenantID, rbac.PermAdmin) {
+			writeJSONErrorWithCode(w, r, http.StatusForbidden, CodeForbidden,
+				"admin permission required on tenant "+tenantID)
+			return
+		}
+
+		recs := d.Federation.List(tenantID)
+		resp := make([]FederationTokenRecord, 0, len(recs))
+		for _, rec := range recs {
+			resp = append(resp, toFederationTokenRecord(rec))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// DeleteFederationToken handles DELETE /api/v1/federation/tokens/{id}.
+//
+// Removes the bookkeeping record for a token. Per ADR-020 there is no
+// server-side revocation list: a still-valid JWT keeps working until
+// its expiry even after this call. DELETE exists so operators can tidy
+// the listing and so a future revocation feature has a hook.
+//
+// @Summary     Delete a federation token record
+// @Description Removes a federation token's bookkeeping record. NOTE: per ADR-020 there is no server-side revocation — a still-valid JWT remains usable until it expires. Requires admin permission on the token's tenant.
+// @Tags        federation
+// @Produce     json
+// @Param       id path string true "Token ID"
+// @Success     200 {object} map[string]string
+// @Failure     403 {object} map[string]string
+// @Failure     404 {object} map[string]string
+// @Failure     500 {object} map[string]string
+// @Router      /api/v1/federation/tokens/{id} [delete]
+func (d *Deps) DeleteFederationToken() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tokenID := chi.URLParam(r, "id")
+
+		rec, ok := d.Federation.Get(tokenID)
+		if !ok {
+			writeJSONError(w, r, http.StatusNotFound, "federation token not found: "+tokenID)
+			return
+		}
+
+		if !d.RBAC.HasPermission(rbac.RequestGroups(r), rec.TenantID, rbac.PermAdmin) {
+			writeJSONErrorWithCode(w, r, http.StatusForbidden, CodeForbidden,
+				"admin permission required on tenant "+rec.TenantID)
+			return
+		}
+
+		deleted, err := d.Federation.Delete(tokenID)
+		if err != nil {
+			writeJSONError(w, r, http.StatusInternalServerError, "delete federation token: "+err.Error())
+			return
+		}
+		if !deleted {
+			writeJSONError(w, r, http.StatusNotFound, "federation token not found: "+tokenID)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"status":   "ok",
+			"token_id": tokenID,
+		})
+	}
+}

--- a/components/tenant-api/internal/handler/federation.go
+++ b/components/tenant-api/internal/handler/federation.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"time"
@@ -65,6 +66,7 @@ func toFederationTokenRecord(r federation.Record) FederationTokenRecord {
 // @Success     201  {object} CreateFederationTokenResponse
 // @Failure     400  {object} map[string]string
 // @Failure     403  {object} map[string]string
+// @Failure     409  {object} map[string]string
 // @Failure     500  {object} map[string]string
 // @Router      /api/v1/federation/tokens [post]
 func (d *Deps) CreateFederationToken() http.HandlerFunc {
@@ -103,6 +105,10 @@ func (d *Deps) CreateFederationToken() http.HandlerFunc {
 
 		token, rec, err := d.Federation.Issue(req.TenantID, rbac.RequestEmail(r), req.Description)
 		if err != nil {
+			if errors.Is(err, federation.ErrTokenLimitReached) {
+				writeJSONErrorWithCode(w, r, http.StatusConflict, CodeConflict, err.Error())
+				return
+			}
 			writeJSONError(w, r, http.StatusInternalServerError, "issue federation token: "+err.Error())
 			return
 		}

--- a/components/tenant-api/internal/handler/federation_test.go
+++ b/components/tenant-api/internal/handler/federation_test.go
@@ -1,0 +1,285 @@
+package handler
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vencil/tenant-api/internal/federation"
+	"github.com/vencil/tenant-api/internal/rbac"
+)
+
+const fedAdminRBAC = `groups:
+  - name: fed-admins
+    tenants: ["*"]
+    permissions: [read, write, admin]
+`
+
+const fedViewerRBAC = `groups:
+  - name: fed-viewers
+    tenants: ["*"]
+    permissions: [read]
+`
+
+// newTestFederation builds a federation.Manager backed by a freshly
+// generated in-memory RSA key and a store under t.TempDir().
+func newTestFederation(t *testing.T) *federation.Manager {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	m, err := federation.NewManagerForTest(key, filepath.Join(t.TempDir(), "fed-store.json"), time.Hour)
+	if err != nil {
+		t.Fatalf("NewManagerForTest: %v", err)
+	}
+	return m
+}
+
+// --- CreateFederationToken ---
+
+func TestCreateFederationToken_Success(t *testing.T) {
+	t.Parallel()
+	rbacMgr := newRBACManager(t, fedAdminRBAC)
+	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+
+	req := httptest.NewRequest("POST", "/api/v1/federation/tokens",
+		bytes.NewBufferString(`{"tenant_id":"tenant-alpha","description":"grafana pull"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-Email", "ops@example.com")
+	req.Header.Set("X-Forwarded-Groups", "fed-admins")
+
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(d.CreateFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201, body: %s", w.Code, w.Body.String())
+	}
+	var resp CreateFederationTokenResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Token == "" {
+		t.Error("expected a non-empty signed token")
+	}
+	if resp.Record.TenantID != "tenant-alpha" {
+		t.Errorf("record tenant_id = %q, want tenant-alpha", resp.Record.TenantID)
+	}
+	if resp.Record.IssuedBy != "ops@example.com" {
+		t.Errorf("record issued_by = %q, want ops@example.com", resp.Record.IssuedBy)
+	}
+	if resp.Record.Description != "grafana pull" {
+		t.Errorf("record description = %q", resp.Record.Description)
+	}
+	if !strings.HasPrefix(resp.Record.TokenID, "ftk_") {
+		t.Errorf("record token_id = %q, want ftk_ prefix", resp.Record.TokenID)
+	}
+}
+
+func TestCreateFederationToken_ForbiddenWithoutAdmin(t *testing.T) {
+	t.Parallel()
+	rbacMgr := newRBACManager(t, fedViewerRBAC)
+	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+
+	req := httptest.NewRequest("POST", "/api/v1/federation/tokens",
+		bytes.NewBufferString(`{"tenant_id":"tenant-alpha"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-Email", "viewer@example.com")
+	req.Header.Set("X-Forwarded-Groups", "fed-viewers")
+
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(d.CreateFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateFederationToken_MissingTenantID(t *testing.T) {
+	t.Parallel()
+	rbacMgr := newRBACManager(t, fedAdminRBAC)
+	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+
+	req := httptest.NewRequest("POST", "/api/v1/federation/tokens",
+		bytes.NewBufferString(`{"description":"no tenant"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-Email", "ops@example.com")
+	req.Header.Set("X-Forwarded-Groups", "fed-admins")
+
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(d.CreateFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestCreateFederationToken_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	rbacMgr := newRBACManager(t, fedAdminRBAC)
+	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+
+	req := httptest.NewRequest("POST", "/api/v1/federation/tokens",
+		bytes.NewBufferString("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-Email", "ops@example.com")
+	req.Header.Set("X-Forwarded-Groups", "fed-admins")
+
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(d.CreateFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+// --- ListFederationTokens ---
+
+func TestListFederationTokens_Success(t *testing.T) {
+	t.Parallel()
+	rbacMgr := newRBACManager(t, fedAdminRBAC)
+	fed := newTestFederation(t)
+	if _, _, err := fed.Issue("tenant-a", "ops@example.com", "one"); err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if _, _, err := fed.Issue("tenant-a", "ops@example.com", "two"); err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if _, _, err := fed.Issue("tenant-b", "ops@example.com", "other"); err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	d := &Deps{RBAC: rbacMgr, Federation: fed}
+
+	req := httptest.NewRequest("GET", "/api/v1/federation/tokens?tenant_id=tenant-a", nil)
+	req.Header.Set("X-Forwarded-Email", "ops@example.com")
+	req.Header.Set("X-Forwarded-Groups", "fed-admins")
+
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(d.ListFederationTokens(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+	}
+	var resp []FederationTokenRecord
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp) != 2 {
+		t.Fatalf("listed %d tokens for tenant-a, want 2", len(resp))
+	}
+	for _, rec := range resp {
+		if rec.TenantID != "tenant-a" {
+			t.Errorf("listing leaked a non-tenant-a record: %+v", rec)
+		}
+	}
+}
+
+func TestListFederationTokens_MissingTenantID(t *testing.T) {
+	t.Parallel()
+	rbacMgr := newRBACManager(t, fedAdminRBAC)
+	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+
+	req := httptest.NewRequest("GET", "/api/v1/federation/tokens", nil)
+	req.Header.Set("X-Forwarded-Email", "ops@example.com")
+	req.Header.Set("X-Forwarded-Groups", "fed-admins")
+
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(d.ListFederationTokens(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestListFederationTokens_ForbiddenWithoutAdmin(t *testing.T) {
+	t.Parallel()
+	rbacMgr := newRBACManager(t, fedViewerRBAC)
+	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+
+	req := httptest.NewRequest("GET", "/api/v1/federation/tokens?tenant_id=tenant-a", nil)
+	req.Header.Set("X-Forwarded-Email", "viewer@example.com")
+	req.Header.Set("X-Forwarded-Groups", "fed-viewers")
+
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(d.ListFederationTokens(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", w.Code)
+	}
+}
+
+// --- DeleteFederationToken ---
+
+func TestDeleteFederationToken_Success(t *testing.T) {
+	t.Parallel()
+	rbacMgr := newRBACManager(t, fedAdminRBAC)
+	fed := newTestFederation(t)
+	_, rec, err := fed.Issue("tenant-a", "ops@example.com", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	d := &Deps{RBAC: rbacMgr, Federation: fed}
+
+	req := newRequestWithChiParam("DELETE", "/api/v1/federation/tokens/"+rec.TokenID, "id", rec.TokenID, nil)
+	req.Header.Set("X-Forwarded-Email", "ops@example.com")
+	req.Header.Set("X-Forwarded-Groups", "fed-admins")
+
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(d.DeleteFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
+	}
+	if _, ok := fed.Get(rec.TokenID); ok {
+		t.Error("token record should be gone after delete")
+	}
+}
+
+func TestDeleteFederationToken_NotFound(t *testing.T) {
+	t.Parallel()
+	rbacMgr := newRBACManager(t, fedAdminRBAC)
+	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+
+	req := newRequestWithChiParam("DELETE", "/api/v1/federation/tokens/ftk_missing", "id", "ftk_missing", nil)
+	req.Header.Set("X-Forwarded-Email", "ops@example.com")
+	req.Header.Set("X-Forwarded-Groups", "fed-admins")
+
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(d.DeleteFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestDeleteFederationToken_ForbiddenWithoutAdmin(t *testing.T) {
+	t.Parallel()
+	rbacMgr := newRBACManager(t, fedViewerRBAC)
+	fed := newTestFederation(t)
+	_, rec, err := fed.Issue("tenant-a", "ops@example.com", "")
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	d := &Deps{RBAC: rbacMgr, Federation: fed}
+
+	req := newRequestWithChiParam("DELETE", "/api/v1/federation/tokens/"+rec.TokenID, "id", rec.TokenID, nil)
+	req.Header.Set("X-Forwarded-Email", "viewer@example.com")
+	req.Header.Set("X-Forwarded-Groups", "fed-viewers")
+
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(d.DeleteFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", w.Code)
+	}
+	if _, ok := fed.Get(rec.TokenID); !ok {
+		t.Error("token record should survive a forbidden delete")
+	}
+}

--- a/components/tenant-api/internal/handler/federation_test.go
+++ b/components/tenant-api/internal/handler/federation_test.go
@@ -283,3 +283,41 @@ func TestDeleteFederationToken_ForbiddenWithoutAdmin(t *testing.T) {
 		t.Error("token record should survive a forbidden delete")
 	}
 }
+
+// --- tenant_id validation ---
+
+func TestCreateFederationToken_RejectsInvalidTenantID(t *testing.T) {
+	t.Parallel()
+	rbacMgr := newRBACManager(t, fedAdminRBAC)
+	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+
+	req := httptest.NewRequest("POST", "/api/v1/federation/tokens",
+		bytes.NewBufferString(`{"tenant_id":"../escape"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-Email", "ops@example.com")
+	req.Header.Set("X-Forwarded-Groups", "fed-admins")
+
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(d.CreateFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestListFederationTokens_RejectsInvalidTenantID(t *testing.T) {
+	t.Parallel()
+	rbacMgr := newRBACManager(t, fedAdminRBAC)
+	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+
+	req := httptest.NewRequest("GET", "/api/v1/federation/tokens?tenant_id=../escape", nil)
+	req.Header.Set("X-Forwarded-Email", "ops@example.com")
+	req.Header.Set("X-Forwarded-Groups", "fed-admins")
+
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(d.ListFederationTokens(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary

實作 **#509（ADR-020 IV-2d）** — tenant-api federation token endpoint。為租戶簽發短效 RS256 JWT，供其向 label-injection proxy（vmauth / prom-label-proxy）拉取自己的 metrics 子集回租戶側 infra 自管。

- `POST` / `GET` / `DELETE /api/v1/federation/tokens` — 簽發 / 列舉 / 刪除
- 新 `internal/federation` package — RS256 簽章器 + JSON 檔案 token record store
- `--federation-key` 未設時整個 endpoint 不註冊（optional-dependency pattern，比照 PR tracker）
- doc-as-code：CHANGELOG `[Unreleased]` + tenant-api README + 重生成 OpenAPI spec

19 個新測試（federation package 9 + handler 10）全綠；`go build` / `go vet` clean。

## ⚠️ Wave-0 設計決策 — 需 owner 確認

實作時依 ADR-020 建議定了 #504 的決策，**其中 1 項偏離 ADR**：

| 決策 | 採用 | 備註 |
|---|---|---|
| #2 簽章 | RS256 非對稱 | 依 ADR 建議。tenant-api 只簽，proxy/gateway 無狀態驗章 |
| #3 claim schema | `tenant_id` / `token_id` / `iss` / `sub` / `iat` / `exp` | 依 ADR；proxy 注入 label、gateway 取 rate-limit key 的跨組件契約 |
| **#4 token 儲存** | **獨立 JSON 檔案 store** | ⚠️ **偏離 ADR** — ADR 原建議 conf.d `_federation_tokens.yaml`，但 token record 是高頻機器寫入的 operational state，每次簽發觸發 git commit 是錯的設計。改用 git conf.d 之外的 JSON store。**請確認此取捨。** |
| #5 RBAC | 簽發需對目標租戶具 `admin` | 依 ADR 建議（資料域外持出，門檻高於 config write） |
| #7 非互動式 auth | **未實作** | 依 #504 — 自動換發路徑 (a)/(b) 尚未拍板。本 PR 只走互動式（oauth2-proxy）路徑；#509 的非互動式 auth 待 #504 決策 |

## Scope

- 本 PR = #509 的 **token endpoint** 部分。federation 完整功能尚需 IV-2a Helm proxy（#506）等其他 sub-issue。
- MVP 無 server-side revocation（ADR §Token model）—`DELETE` 僅移除 bookkeeping record，JWT 至 `exp` 前仍有效（補償控制為 IV-2b gateway rate limit）。

## Test plan

- [x] `go build ./internal/... ./cmd/...` — clean（`docs` 套件的 swag import 缺 go.mod 條目為 pre-existing 狀態，非本 PR）
- [x] `go vet ./internal/... ./cmd/...` — clean
- [x] `go test ./internal/federation/...` — 9 tests pass
- [x] `go test ./internal/handler/...`（federation 部分）— 10 tests pass
- [x] `swag init` 重生成 OpenAPI spec — federation endpoint 已入 `swagger.json`
- [ ] owner 確認 Wave-0 決策 #4（token 儲存偏離 ADR）

## 備註

- 依賴新增 `golang-jwt/jwt/v5`（`go.mod` +1 行、`go.sum` +2 行 — 最小差異；`go mod tidy` 會連帶改寫既有非整然部分，故只做最小追加）。

Part of #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)