### PR TITLE
test(exporter): deflake slow-write stress _count assertion

### DIFF
--- a/components/threshold-exporter/app/config_slow_write_stress_test.go
+++ b/components/threshold-exporter/app/config_slow_write_stress_test.go
@@ -213,14 +213,32 @@ func TestSlowWriteTornStateStress_FinalConvergence(t *testing.T) {
 			mismatches, len(baseline))
 	}
 
-	// (1) Batch histogram: every trigger coalesced into SOME fire.
-	//     `_sum` MUST equal numFiles regardless of how many windows
-	//     fired (contract-stable assertion). `_count` is intentionally
-	//     NOT asserted exact — it can legitimately be 1 or 2 under
-	//     loaded CI; both states are compliant per the rewrite rationale
-	//     (see file header for issue #157 history). If `_count > 2` we
-	//     do flag — that's outside the realistic CI-jitter envelope and
-	//     suggests debounce is genuinely misbehaving.
+	// (1) Batch histogram contract — two assertions, both deterministic:
+	//
+	//   `_sum == numFiles`: every triggerDebouncedReload appended exactly
+	//   one reason, and post-quiescence every reason has been consumed by
+	//   some fired window. This is the load-bearing, contract-stable
+	//   assertion — it catches the lost-trigger bug class and holds
+	//   regardless of how the burst split across windows.
+	//
+	//   `_count <= numFiles`: a window only fires after a trigger armed
+	//   its timer, so fired windows can never outnumber triggers.
+	//   Exceeding numFiles means a window fired with no reasons behind it
+	//   — a spurious/duplicate fire, a genuine debounce bug.
+	//
+	// What is deliberately NOT asserted: any *small* upper bound on
+	// `_count`. `_count` (fired-window count) is wall-clock-dependent —
+	// exactly the claim the issue #157 rewrite removed (see file header,
+	// and assertion (3) which logs the same quantity as "informational,
+	// NOT asserted exact"). An earlier revision asserted `_count <= 2` as
+	// a "runner-jitter envelope"; that flaked on PR #526 and PR #530 when
+	// a healthy debounce under loaded `-race` CI legitimately split the
+	// 50-write burst into 19 windows (sleeps overran the 100ms window).
+	// There is no scheduler-independent threshold between "broken
+	// debounce" and "slow runner", so no small bound can be both
+	// meaningful and deterministic. The "window never coalesces" bug
+	// class (`_count == numFiles`) is covered deterministically by
+	// config_debounce_test.go's back-to-back-trigger tests, not here.
 	reg := prometheus.NewRegistry()
 	if err := reg.Register(fresh.debounceBatch); err != nil {
 		t.Fatalf("register debounceBatch: %v", err)
@@ -241,10 +259,10 @@ func TestSlowWriteTornStateStress_FinalConvergence(t *testing.T) {
 				t.Errorf("debounceBatch: expected at least 1 fired window, got %d",
 					h.GetSampleCount())
 			}
-			if h.GetSampleCount() > 2 {
-				t.Errorf("debounceBatch: _count=%d exceeds runner-jitter envelope (≤2); "+
-					"debounce may be misbehaving (sliding window not coalescing)",
-					h.GetSampleCount())
+			if h.GetSampleCount() > numFiles {
+				t.Errorf("debounceBatch: _count=%d exceeds numFiles=%d — a window "+
+					"fired without a trigger arming it (spurious/duplicate fire)",
+					h.GetSampleCount(), numFiles)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

`TestSlowWriteTornStateStress_FinalConvergence` (threshold-exporter) flaked the first CI `-race` run on [#526](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/526) and [#530](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/530), passing on re-run both times. The flaky check was assertion (1)'s `debounceBatch _count <= 2` "runner-jitter envelope" — a wall-clock claim about how many debounce windows fired.

- `_count` (fired-window count) is irreducibly scheduler-dependent. Under loaded `-race` CI a healthy debounce legitimately splits the 50-write burst into many windows (observed `_count=19`); it only coalesces into `<=2` windows when sleeps stay within the 100ms window. There is no scheduler-independent threshold between "broken debounce" and "slow runner" — this is the exact bug class the issue #157 rewrite removed, and the same quantity assertion (3) of this test already logs as "informational, NOT asserted exact".
- Replaced `_count <= 2` with the one deterministic upper bound that exists: `_count <= numFiles`. A window only fires after a trigger arms its timer, so fired windows can never outnumber triggers; exceeding `numFiles` is a genuine spurious/duplicate-fire bug.
- The lost-trigger contract stays covered by the unchanged deterministic `_sum == numFiles` assertion; lost-write by the per-tenant hash-advance check; the "window never coalesces" class by `config_debounce_test.go`'s back-to-back-trigger tests.

Test-code-only; no production behaviour changed. No flaky-test registry entry — the fix makes the test deterministic rather than papering over genuine product flakiness with a retry policy.

## Test plan

- [x] `go test -run TestSlowWriteTornStateStress_FinalConvergence -race -count=3` in the dev container — passes 3x (`_count=1` each)
- [ ] CI "Go Tests (1.26)" race job green

## Follow-up (out of scope)

`docs/internal/testing-playbook.md` §2 worked example (the "Why `_count <= 2`" paragraph, ~L1105-1109) codified the now-falsified `_count <= 2` envelope and should be corrected so future tests aren't copied from stale guidance — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)