### PR TITLE
docs: fix stale _count<=2 guidance in testing-playbook §2

### DIFF
--- a/docs/internal/testing-playbook.md
+++ b/docs/internal/testing-playbook.md
@@ -1102,11 +1102,13 @@ t.Logf("debounce fires: %d (informational, not asserted)", fireCount)
 assert h.GetSampleSum() == numFiles
 // (b) every mutated tenant advanced
 assert mergedHash[tid] != baseline[tid] for all tid
-// (c) fire count not absurd (catches genuinely-broken debounce)
-assert h.GetSampleCount() <= 2  // CI-jitter envelope
+// (c) fired windows can never outnumber triggers — the ONLY
+//     deterministic _count bound (see below for why no
+//     smaller bound is safe).
+assert h.GetSampleCount() <= numFiles
 ```
 
-**Why `_count <= 2` not `_count == 1`**: a 50-write burst with 5-25ms gaps under a 100ms window legitimately splits into 1 OR 2 fired windows depending on scheduler jitter. Both are contract-compliant. `_count <= 2` is the **CI-jitter envelope** — outside this means debounce is genuinely broken (e.g. window not coalescing). The test FAILS bench injection of "skip every-other trigger" via `_sum=25 != 50` (verified during PR #159 implementation).
+**Why no *small* `_count` bound**: an earlier revision of this test asserted `_count <= 2` as a "CI-jitter envelope", reasoning that a 50-write burst with 5-25ms gaps under a 100ms window "legitimately splits into 1 OR 2 fired windows". That reasoning is wrong, and the assertion flaked on PR #526 and PR #530 — under a loaded `-race` runner a *healthy* debounce split the burst into **19** windows (sleeps overran the 100ms window). `_count` (fired-window count) is irreducibly wall-clock-dependent: there is **no scheduler-independent threshold** between "broken debounce" and "slow runner", so no small bound is both deterministic and meaningful. Asserting one re-introduces the exact lesson-§2 anti-pattern this worked example exists to demonstrate the fix for. The only deterministic upper bound is `_count <= numFiles` — a window only fires after a trigger armed its timer, so fired windows can never outnumber triggers; exceeding `numFiles` is a genuine spurious/duplicate-fire bug. The "window never coalesces" bug class (`_count == numFiles`) is *not* catchable here — it is covered deterministically by `config_debounce_test.go`'s back-to-back-trigger tests (no inter-trigger sleep → no wall-clock dependence). The lost-trigger bug class is still caught here directly: bench injection of "skip every-other trigger" fails via the deterministic, unchanged `_sum == numFiles` assertion (`_sum=25 != 50`, verified during PR #159 implementation).
 
 **Reusable helper** (`config_slow_write_stress_test.go`):
 


### PR DESCRIPTION
## Summary

Follow-up to [#532](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/532). That PR deflaked `TestSlowWriteTornStateStress_FinalConvergence` by replacing its `debounceBatch _count <= 2` assertion with the deterministic `_count <= numFiles`. But `docs/internal/testing-playbook.md` §2 ("Race-flake battles") still carried the *worked example* that codified the now-falsified `_count <= 2` "CI-jitter envelope" — so a future test built from the playbook would copy the stale bound straight back in.

§2's own thesis is "don't make wall-clock claims about fire count", yet its worked example recommended exactly such a claim. This change makes the doc consistent with both the lesson and the fixed test:

- Code block assertion (c): `h.GetSampleCount() <= 2` → `h.GetSampleCount() <= numFiles`, with a comment noting it is the only deterministic `_count` bound.
- The "Why `_count <= 2`" paragraph is rewritten to explain why no *small* `_count` bound is both deterministic and meaningful — there is no scheduler-independent threshold between "broken debounce" and "slow runner" — citing the PR #526 / #530 flake (`_count` reached 19 on a loaded `-race` runner). It notes the "window never coalesces" bug class is instead covered deterministically by `config_debounce_test.go`'s back-to-back-trigger tests.

Doc-only change in `docs/internal/`; no API/schema/CLI/count impact, no CHANGELOG entry warranted.

## Test plan

- [x] `mkdocs_strict_check.sh` run — this edit adds zero warnings (it introduces no links; only prose + a code comment changed). The 32 warnings the local run reports are pre-existing `rule-packs/` generated-doc absences, built by CI before its mkdocs job and unrelated to this change.
- [x] `make pr-preflight` — READY, all checks pass.
- [ ] CI "MkDocs Build Verification" green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)