### PR TITLE
fix(k8s): federation rejection alert skips offboarded tenants (#550)

### DIFF
--- a/docs/adr/020-tenant-federation.md
+++ b/docs/adr/020-tenant-federation.md
@@ -281,7 +281,7 @@ audit log（issue [#511](https://github.com/vencil/Dynamic-Alerting-Integrations
 | `bad_request` | 其他 4xx（含 422）| 錯誤請求；422 = storage `--query.max-samples` 超標（blast-radius 觸發訊號） |
 | `backend_error` | 5xx | 平台故障 |
 
-配 alert `FederationRejectionRateAnomaly`（per-tenant rejection ratio 異常 → `severity: warning`，notify platform ops；非 `severity: none` inhibit sentinel）。
+配 alert `FederationRejectionRateAnomaly`（per-tenant rejection ratio 異常 → `severity: warning`，notify platform ops；非 `severity: none` inhibit sentinel）。該規則 join `tenant_metadata_info`，只評估仍在 conf.d 的活躍租戶 —— 已退租租戶的殭屍 token 持續被 `403` 拒絕（撤銷後、4h TTL 未到期前計入 `auth_failed`，見下「Metric 邊界」）不會誤報（[#550](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/550)）。
 
 > **Metric 邊界**：mtail 以 `tenant_id` 為必要分桶欄位，故**純 JWT 驗證失敗**的請求（偽造 / 過期 token —— `jwt_authn` 在 claim 注入前就 401，access log 無 `tenant_id`）**不計入** `tenant_federation_requests_total`：它們無有效租戶、不屬 per-tenant 用量，屬攻擊噪音，由 Envoy `jwt_authn` 自身的 stats 觀測。被撤銷的 token 不同 —— 那是合法 JWT（claim 已注入）、由 revoked set 擋下的 403，正常計入 `auth_failed`。
 

--- a/docs/internal/tenant-offboarding-runbook.md
+++ b/docs/internal/tenant-offboarding-runbook.md
@@ -97,6 +97,27 @@ tenant-api 內建一個**被動偵測器**：週期性掃描，若發現 federat
 
 > 為什麼不做「自動撤銷的 reconciler」：自動依「租戶不在 conf.d」推論去撤銷，在 conf.d 暫態異常（GitOps sync 中、設定壞檔）時會誤殺活租戶的憑證。低風險問題不值得用一個有誤殺風險的常駐自動化去解 —— 偵測（warn）給了安全網卻零誤殺風險。詳 [#521](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/521) 的決策討論。
 
+## 已退租租戶持續打 gateway —— 告警與殘留流量
+
+退租後，**租戶端的 Grafana data source / CronJob 不知道自己被退租**，會繼續每 ~30s 帶舊 token 打 gateway。兩個階段：
+
+| 階段 | 時間 | gateway 回應 | 計入 `tenant_federation_requests_total`？ |
+|---|---|---|---|
+| 撤銷後、token 未到期 | 撤銷後 ≤ 4h（至 token 原 TTL 到期）| `403` —— 撤銷 token 仍是合法 JWT，claim 已注入 | **計入** `{status="auth_failed"}` |
+| token 到期後 | > 4h | `401` —— `jwt_authn` 在 claim 注入前就擋下 | **不計入** —— access log 無 `tenant_id`（ADR-020 §Audit log「Metric 邊界」）|
+
+### `FederationRejectionRateAnomaly` 不會對已退租租戶誤報
+
+`FederationRejectionRateAnomaly`（`k8s/03-monitoring/configmap-rules-platform.yaml`）自 [#550](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/550) 起在規則尾端 join `and on (tenant) tenant_metadata_info` —— 只評估**仍在 conf.d** 的租戶。完成步驟 3（`git rm conf.d/<tenant>.yaml`）後，threshold-exporter 重載、該租戶的 `tenant_metadata_info` 序列消失，告警的 join 隨之把它排除：殭屍 token 在上表階段一造成的 100% `auth_failed` **不會**再讓平台 ops 被一個已不存在的租戶 call 醒。
+
+> 若你**仍**看到此告警對某已退租租戶觸發 —— 代表步驟 3 沒做完（`conf.d/<tenant>.yaml` 還在 repo），threshold-exporter 仍在發該租戶的 `tenant_metadata_info`。回到 §步驟 補完。
+
+### 殘留流量本身（選用清理）
+
+即使告警已不誤報，已退租租戶那條注定失敗的輪詢仍是**無謂的 gateway 負載**（階段一還會在 audit log 留 403 噪音）。真正的修法在對方手上 —— **通知已退租客戶關掉他們的 Grafana data source / CronJob**。
+
+對方不配合、殘留流量造成困擾時，可在 ingress / WAF 層（或 gateway per-IP）block 對方來源 IP。這是**選用**清理、非必要步驟：gateway 的 per-IP 限流本就壓得住洪流，階段二的 `401` 也很便宜（`jwt_authn` 直接擋、不進 audit log、不進 metric）。
+
 ## 反面 —— 不要這樣做
 
 - **不要**用 `git push --force` 或繞過 PR review 來「快速」offboard —— offboarding 是低頻操作，沒有快的需求，走正常 PR。

--- a/k8s/03-monitoring/configmap-rules-platform.yaml
+++ b/k8s/03-monitoring/configmap-rules-platform.yaml
@@ -146,7 +146,18 @@ data:
           # Tenant-side rejection surge: >50% of a tenant's federation
           # requests rejected (rate-limited / auth-failed / bad-request)
           # for 15m. The second clause floors it at ~1 rejection/min so a
-          # single fluke on a near-idle tenant cannot trip it.
+          # single fluke on a near-idle tenant cannot trip it. The third
+          # clause — `and on(tenant) tenant_metadata_info` — scopes the
+          # alert to tenants still in conf.d (#550): an offboarded tenant
+          # whose client keeps polling with a revoked-but-unexpired token
+          # bills 100% auth_failed until the 4h TTL runs out, and without
+          # this clause the alert pages platform ops about a tenant that
+          # no longer exists. tenant_metadata_info is emitted (=1) by
+          # threshold-exporter for every conf.d tenant, so a removed
+          # tenant drops out of the join. Trade-off: if threshold-exporter
+          # is down the join empties and this alert is silenced —
+          # acceptable for a warning, and that outage is separately
+          # alerted.
           - alert: FederationRejectionRateAnomaly
             expr: |
               (
@@ -160,6 +171,8 @@ data:
               sum by (tenant) (
                 rate(tenant_federation_requests_total{status=~"rate_limited|auth_failed|bad_request"}[10m])
               ) > 0.0167
+              and on (tenant)
+              tenant_metadata_info
             for: 15m
             labels:
               severity: warning


### PR DESCRIPTION
## Summary

`FederationRejectionRateAnomaly` misfired for **offboarded** tenants. After offboarding, the ex-tenant's Grafana / CronJob keeps polling the gateway with its revoked token — while that token is still within its 4h TTL the gateway 403s it and (ADR-020 §Audit log "Metric 邊界") it counts as `auth_failed`. The ex-tenant's rejection ratio hits 100% and the alert pages platform ops about a tenant that no longer exists.

- **Rule fix** (`configmap-rules-platform.yaml`) — add `and on (tenant) tenant_metadata_info` to the alert expr. `tenant_metadata_info` is emitted (=1) by threshold-exporter for every tenant in conf.d, so once the offboarding PR removes `conf.d/<tenant>.yaml` the tenant drops out of the join and the alert stops evaluating it.
- **No new metric / Go code** — the issue suggested adding a new tenant-api active-tenant metric, but `tenant_metadata_info` (v1.11.0, *"unconditional output for group_left joins"*) already **is** that catalogue. Verifying against the codebase made the suggested new metric unnecessary.
- **Runbook** (`tenant-offboarding-runbook.md`) — a troubleshooting section: the two phases of post-offboarding traffic, why the alert no longer misfires, and an optional WAF / per-IP block for residual noise.
- **ADR-020** — a one-line note on the alert in §Audit log.

Trade-off (documented in the rule comment): if threshold-exporter is down the join empties and this alert is silenced — acceptable for a warning, and that outage is separately alerted.

## Scope note (honest framing)

The misfire is **self-limiting to ≤4h per offboarding** — once the revoked token expires it `401`s at `jwt_authn` and stops being counted (uncounted, no `tenant_id`). The fix is still correct (an alert must not evaluate dead tenants) but this is benign-noise cleanup, not an indefinite pager storm.

Doc/config-only, no API/schema/CLI/count change → no CHANGELOG entry (consistent with the other later ADR-020 sub-issues).

## Test plan

- [x] `promtool check rules` — passes (9 rules)
- [x] ad-hoc `promtool test rules` — an offboarded tenant (no `tenant_metadata_info`) with an identical 100% rejection ratio is **excluded**; the active tenant still fires
- [x] `pr-preflight` — READY
- [ ] CI green

Closes #550