### PR TITLE
refactor(tenant-api): split internal/federation; methods → free functions (#537)

### DIFF
--- a/components/tenant-api/cmd/server/main.go
+++ b/components/tenant-api/cmd/server/main.go
@@ -310,99 +310,99 @@ func main() {
 
 	// Health / readiness / metrics (no auth)
 	r.Get("/health", handler.Health)
-	r.Get("/ready", deps.Ready())
+	r.Get("/ready", handler.Ready(deps))
 	r.Get("/metrics", handler.MetricsHandler)
 
 	// API v1 — all routes require identity headers (injected by oauth2-proxy)
 	r.Route("/api/v1", func(r chi.Router) {
 		// Identity endpoint (no specific permission required, just authenticated)
 		r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-			Get("/me", deps.Me())
+			Get("/me", handler.Me(deps))
 
 		// Tenant list (read permission, no specific tenant ID)
 		// v2.5.0: RBAC-filtered — only returns tenants the user can access
 		r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-			Get("/tenants", deps.ListTenants())
+			Get("/tenants", handler.ListTenants(deps))
 
 		// v2.8.0 Phase .c C-1: server-side search / filter / pagination.
 		// Snapshot cache (30s TTL) shared across requests via Deps.SearchCache.
 		r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-			Get("/tenants/search", deps.SearchTenants())
+			Get("/tenants/search", handler.SearchTenants(deps))
 
 		// Per-tenant routes
 		r.Route("/tenants/{id}", func(r chi.Router) {
 			r.With(rbacMgr.Middleware(rbac.PermRead, handler.TenantIDFromPath)).
-				Get("/", deps.GetTenant())
+				Get("/", handler.GetTenant(deps))
 
 			r.With(rbacMgr.Middleware(rbac.PermRead, handler.TenantIDFromPath)).
-				Post("/diff", deps.DiffTenant())
+				Post("/diff", handler.DiffTenant(deps))
 
 			r.With(rbacMgr.Middleware(rbac.PermWrite, handler.TenantIDFromPath)).
-				Put("/", deps.PutTenant())
+				Put("/", handler.PutTenant(deps))
 
 			r.With(rbacMgr.Middleware(rbac.PermRead, handler.TenantIDFromPath)).
-				Post("/validate", deps.ValidateTenant())
+				Post("/validate", handler.ValidateTenant(deps))
 
 			// v2.7.0 B-3 (ADR-016/017): merged effective config + dual hashes.
 			r.With(rbacMgr.Middleware(rbac.PermRead, handler.TenantIDFromPath)).
-				Get("/effective", deps.GetTenantEffective())
+				Get("/effective", handler.GetTenantEffective(deps))
 
 			// Federation metric subset (v2.9.0 — ADR-020 IV-2e). PUT's
 			// tenant-admin check is inside the handler (route middleware
 			// only confirms authentication + read on the tenant).
 			r.With(rbacMgr.Middleware(rbac.PermRead, handler.TenantIDFromPath)).
-				Get("/federation", deps.GetTenantFederation())
+				Get("/federation", handler.GetTenantFederation(deps))
 			r.With(rbacMgr.Middleware(rbac.PermRead, handler.TenantIDFromPath)).
-				Put("/federation", deps.PutTenantFederation())
+				Put("/federation", handler.PutTenantFederation(deps))
 		})
 
 		// Batch operations — route-level middleware checks read (authenticated),
 		// per-tenant write permission is enforced inside the handler.
 		r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-			Post("/tenants/batch", deps.BatchTenants())
+			Post("/tenants/batch", handler.BatchTenants(deps))
 
 		// Group management (v2.5.0) — RBAC-filtered list.
 		r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-			Get("/groups", deps.ListGroups())
+			Get("/groups", handler.ListGroups(deps))
 
 		r.Route("/groups/{id}", func(r chi.Router) {
 			r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-				Get("/", deps.GetGroup())
+				Get("/", handler.GetGroup(deps))
 
 			r.With(rbacMgr.Middleware(rbac.PermWrite, nil)).
-				Put("/", deps.PutGroup())
+				Put("/", handler.PutGroup(deps))
 
 			r.With(rbacMgr.Middleware(rbac.PermWrite, nil)).
-				Delete("/", deps.DeleteGroup())
+				Delete("/", handler.DeleteGroup(deps))
 
 			r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-				Post("/batch", deps.GroupBatch())
+				Post("/batch", handler.GroupBatch(deps))
 		})
 
 		// Saved Views (v2.5.0 Phase C)
 		r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-			Get("/views", deps.ListViews())
+			Get("/views", handler.ListViews(deps))
 
 		r.Route("/views/{id}", func(r chi.Router) {
 			r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-				Get("/", deps.GetView())
+				Get("/", handler.GetView(deps))
 
 			r.With(rbacMgr.Middleware(rbac.PermWrite, nil)).
-				Put("/", deps.PutView())
+				Put("/", handler.PutView(deps))
 
 			r.With(rbacMgr.Middleware(rbac.PermWrite, nil)).
-				Delete("/", deps.DeleteView())
+				Delete("/", handler.DeleteView(deps))
 		})
 
 		// Task polling (v2.6.0 — async batch operations)
 		r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-			Get("/tasks/{id}", deps.GetTask())
+			Get("/tasks/{id}", handler.GetTask(deps))
 
 		// PR/MR tracking (v2.6.0 Phase C — ADR-011 PR-based write-back)
 		// Works for both GitHub PRs and GitLab MRs via platform.Tracker
 		if prTracker != nil {
 			r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-				Get("/prs", deps.ListPRs())
+				Get("/prs", handler.ListPRs(deps))
 		}
 
 		// Real-time event stream (v2.6.0 — SSE for config change notifications)
@@ -415,9 +415,9 @@ func main() {
 		// handler; route-level middleware only confirms authentication.
 		r.Route("/federation/policy", func(r chi.Router) {
 			r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-				Get("/", deps.GetFederationPolicy())
+				Get("/", handler.GetFederationPolicy(deps))
 			r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-				Put("/", deps.PutFederationPolicy())
+				Put("/", handler.PutFederationPolicy(deps))
 		})
 
 		// Federation token endpoint (v2.9.0 — ADR-020 IV-2d).
@@ -428,11 +428,11 @@ func main() {
 		if federationMgr != nil {
 			r.Route("/federation/tokens", func(r chi.Router) {
 				r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-					Post("/", deps.CreateFederationToken())
+					Post("/", handler.CreateFederationToken(deps))
 				r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-					Get("/", deps.ListFederationTokens())
+					Get("/", handler.ListFederationTokens(deps))
 				r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-					Delete("/{id}", deps.DeleteFederationToken())
+					Delete("/{id}", handler.DeleteFederationToken(deps))
 			})
 		}
 	})

--- a/components/tenant-api/cmd/server/main.go
+++ b/components/tenant-api/cmd/server/main.go
@@ -29,7 +29,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/vencil/tenant-api/internal/async"
-	"github.com/vencil/tenant-api/internal/federation"
+	"github.com/vencil/tenant-api/internal/federation/fedpolicy"
+	"github.com/vencil/tenant-api/internal/federation/orphan"
+	"github.com/vencil/tenant-api/internal/federation/token"
 	"github.com/vencil/tenant-api/internal/gitops"
 	"github.com/vencil/tenant-api/internal/groups"
 	"github.com/vencil/tenant-api/internal/handler"
@@ -140,7 +142,7 @@ func main() {
 	federationNamespace := flag.String("federation-namespace", envOrDefault("TA_FEDERATION_NAMESPACE", ""),
 		"Namespace of the federation store ConfigMap. Empty uses the pod's own namespace.")
 	federationTTL := flag.Duration("federation-token-ttl",
-		parseDurationOrDefault(os.Getenv("TA_FEDERATION_TOKEN_TTL"), federation.DefaultTTL),
+		parseDurationOrDefault(os.Getenv("TA_FEDERATION_TOKEN_TTL"), token.DefaultTTL),
 		"Federation token lifetime (default 4h; ADR-020 §Token model)")
 	// v2.9.0 ADR-020 IV-2e: federation admission validator backend.
 	federationPrometheusURL := flag.String("federation-prometheus-url",
@@ -187,12 +189,12 @@ func main() {
 	// v2.9.0 ADR-020 IV-2e: federation 2-tier policy — the platform
 	// metric whitelist (`_federation_policy.yaml`). Per-tenant subsets
 	// live in separate files, read on demand by the handler.
-	federationPolicyMgr := federation.NewPolicyManager(*configDir)
+	federationPolicyMgr := fedpolicy.NewManager(*configDir)
 
 	// v2.9.0 ADR-020 IV-2e: federation admission validator. nil when
 	// --federation-prometheus-url is unset — admission is then disabled
 	// and whitelist edits are schema-checked only.
-	federationValidator := federation.NewAdmissionValidator(*federationPrometheusURL)
+	federationValidator := fedpolicy.NewAdmissionValidator(*federationPrometheusURL)
 	if federationValidator == nil {
 		slog.Info("federation admission validator disabled — set --federation-prometheus-url to enable")
 	}
@@ -269,7 +271,7 @@ func main() {
 	// offboarding runbook; never auto-revokes (a transient conf.d
 	// glitch must not nuke live tenants' tokens).
 	if federationMgr != nil {
-		go federation.NewOrphanDetector(*configDir, federationMgr.ListAllRecords).
+		go orphan.NewDetector(*configDir, federationMgr.ListAllRecords).
 			Run(*reloadInterval, stopCh)
 	}
 

--- a/components/tenant-api/cmd/server/wire.go
+++ b/components/tenant-api/cmd/server/wire.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/vencil/tenant-api/internal/federation"
+	"github.com/vencil/tenant-api/internal/federation/token"
 	gh "github.com/vencil/tenant-api/internal/github"
 	gl "github.com/vencil/tenant-api/internal/gitlab"
 	"github.com/vencil/tenant-api/internal/handler"
@@ -127,7 +127,7 @@ type federationFlags struct {
 // it (sub-issue IV-2m) so tenant-api's RBAC can be get+update on one
 // resourceName with no namespace-wide create. NewConfigMapStore fails
 // loud on NotFound.
-func wireFederation(f federationFlags) (*federation.Manager, string, error) {
+func wireFederation(f federationFlags) (*token.Manager, string, error) {
 	if f.KeyPath == "" {
 		return nil, "", nil
 	}
@@ -146,11 +146,11 @@ func wireFederation(f federationFlags) (*federation.Manager, string, error) {
 			return nil, "", fmt.Errorf("federation: resolve namespace: %w", err)
 		}
 	}
-	store, err := federation.NewConfigMapStore(client, ns, f.ConfigMapName)
+	store, err := token.NewConfigMapStore(client, ns, f.ConfigMapName)
 	if err != nil {
 		return nil, "", err
 	}
-	mgr, err := federation.NewManager(f.KeyPath, store, f.TTL)
+	mgr, err := token.NewManager(f.KeyPath, store, f.TTL)
 	if err != nil {
 		return nil, "", err
 	}

--- a/components/tenant-api/docs/docs.go
+++ b/components/tenant-api/docs/docs.go
@@ -31,7 +31,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_fedpolicy.Config"
+                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.Config"
                         }
                     }
                 }
@@ -959,7 +959,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_fedpolicy.Subset"
+                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.Subset"
                         }
                     },
                     "400": {
@@ -998,7 +998,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_fedpolicy.Subset"
+                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.Subset"
                         }
                     }
                 ],
@@ -1344,18 +1344,18 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_vencil_tenant-api_internal_fedpolicy.Config": {
+        "github_com_vencil_tenant-api_internal_federation_fedpolicy.Config": {
             "type": "object",
             "properties": {
                 "whitelist": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_fedpolicy.WhitelistEntry"
+                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry"
                     }
                 }
             }
         },
-        "github_com_vencil_tenant-api_internal_fedpolicy.Subset": {
+        "github_com_vencil_tenant-api_internal_federation_fedpolicy.Subset": {
             "type": "object",
             "properties": {
                 "metrics": {
@@ -1366,7 +1366,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_vencil_tenant-api_internal_fedpolicy.WhitelistEntry": {
+        "github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry": {
             "type": "object",
             "properties": {
                 "metric": {
@@ -1701,7 +1701,7 @@ const docTemplate = `{
                 "whitelist": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_fedpolicy.WhitelistEntry"
+                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry"
                     }
                 }
             }

--- a/components/tenant-api/docs/docs.go
+++ b/components/tenant-api/docs/docs.go
@@ -31,7 +31,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation.FederationPolicyConfig"
+                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_fedpolicy.Config"
                         }
                     }
                 }
@@ -959,7 +959,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation.FederationSubset"
+                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_fedpolicy.Subset"
                         }
                     },
                     "400": {
@@ -998,7 +998,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation.FederationSubset"
+                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_fedpolicy.Subset"
                         }
                     }
                 ],
@@ -1344,18 +1344,18 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_vencil_tenant-api_internal_federation.FederationPolicyConfig": {
+        "github_com_vencil_tenant-api_internal_fedpolicy.Config": {
             "type": "object",
             "properties": {
                 "whitelist": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation.WhitelistEntry"
+                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_fedpolicy.WhitelistEntry"
                     }
                 }
             }
         },
-        "github_com_vencil_tenant-api_internal_federation.FederationSubset": {
+        "github_com_vencil_tenant-api_internal_fedpolicy.Subset": {
             "type": "object",
             "properties": {
                 "metrics": {
@@ -1366,7 +1366,7 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_vencil_tenant-api_internal_federation.WhitelistEntry": {
+        "github_com_vencil_tenant-api_internal_fedpolicy.WhitelistEntry": {
             "type": "object",
             "properties": {
                 "metric": {
@@ -1701,7 +1701,7 @@ const docTemplate = `{
                 "whitelist": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation.WhitelistEntry"
+                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_fedpolicy.WhitelistEntry"
                     }
                 }
             }

--- a/components/tenant-api/docs/swagger.json
+++ b/components/tenant-api/docs/swagger.json
@@ -24,7 +24,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation.FederationPolicyConfig"
+                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.Config"
                         }
                     }
                 }
@@ -952,7 +952,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation.FederationSubset"
+                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.Subset"
                         }
                     },
                     "400": {
@@ -991,7 +991,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation.FederationSubset"
+                            "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.Subset"
                         }
                     }
                 ],
@@ -1337,18 +1337,18 @@
                 }
             }
         },
-        "github_com_vencil_tenant-api_internal_federation.FederationPolicyConfig": {
+        "github_com_vencil_tenant-api_internal_federation_fedpolicy.Config": {
             "type": "object",
             "properties": {
                 "whitelist": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation.WhitelistEntry"
+                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry"
                     }
                 }
             }
         },
-        "github_com_vencil_tenant-api_internal_federation.FederationSubset": {
+        "github_com_vencil_tenant-api_internal_federation_fedpolicy.Subset": {
             "type": "object",
             "properties": {
                 "metrics": {
@@ -1359,7 +1359,7 @@
                 }
             }
         },
-        "github_com_vencil_tenant-api_internal_federation.WhitelistEntry": {
+        "github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry": {
             "type": "object",
             "properties": {
                 "metric": {
@@ -1694,7 +1694,7 @@
                 "whitelist": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation.WhitelistEntry"
+                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry"
                     }
                 }
             }

--- a/components/tenant-api/docs/swagger.yaml
+++ b/components/tenant-api/docs/swagger.yaml
@@ -46,21 +46,21 @@ definitions:
         format: float64
         type: number
     type: object
-  github_com_vencil_tenant-api_internal_federation.FederationPolicyConfig:
+  github_com_vencil_tenant-api_internal_federation_fedpolicy.Config:
     properties:
       whitelist:
         items:
-          $ref: '#/definitions/github_com_vencil_tenant-api_internal_federation.WhitelistEntry'
+          $ref: '#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry'
         type: array
     type: object
-  github_com_vencil_tenant-api_internal_federation.FederationSubset:
+  github_com_vencil_tenant-api_internal_federation_fedpolicy.Subset:
     properties:
       metrics:
         items:
           type: string
         type: array
     type: object
-  github_com_vencil_tenant-api_internal_federation.WhitelistEntry:
+  github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry:
     properties:
       metric:
         type: string
@@ -287,7 +287,7 @@ definitions:
         type: string
       whitelist:
         items:
-          $ref: '#/definitions/github_com_vencil_tenant-api_internal_federation.WhitelistEntry'
+          $ref: '#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry'
         type: array
     type: object
   internal_handler.PutGroupRequest:
@@ -434,7 +434,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github_com_vencil_tenant-api_internal_federation.FederationPolicyConfig'
+            $ref: '#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.Config'
       summary: Get the platform federation whitelist
       tags:
       - federation
@@ -1027,7 +1027,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github_com_vencil_tenant-api_internal_federation.FederationSubset'
+            $ref: '#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.Subset'
         "400":
           description: Bad Request
           schema:
@@ -1051,7 +1051,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/github_com_vencil_tenant-api_internal_federation.FederationSubset'
+          $ref: '#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.Subset'
       produces:
       - application/json
       responses:

--- a/components/tenant-api/internal/federation/fedpolicy/admission.go
+++ b/components/tenant-api/internal/federation/fedpolicy/admission.go
@@ -1,4 +1,4 @@
-package federation
+package fedpolicy
 
 // Admission validator (ADR-020 IV-2e) — the data-layer label-enrichment
 // gate for the federation whitelist.

--- a/components/tenant-api/internal/federation/fedpolicy/admission_test.go
+++ b/components/tenant-api/internal/federation/fedpolicy/admission_test.go
@@ -1,4 +1,4 @@
-package federation
+package fedpolicy
 
 import (
 	"context"

--- a/components/tenant-api/internal/federation/fedpolicy/policy.go
+++ b/components/tenant-api/internal/federation/fedpolicy/policy.go
@@ -1,4 +1,4 @@
-package federation
+package fedpolicy
 
 // Federation policy — the 2-tier metric allowlist (ADR-020 IV-2e).
 //
@@ -48,16 +48,16 @@ type WhitelistEntry struct {
 	Metric string `yaml:"metric" json:"metric"`
 }
 
-// FederationPolicyConfig is the parsed _federation_policy.yaml: the
+// Config is the parsed _federation_policy.yaml: the
 // platform-wide federation whitelist.
-type FederationPolicyConfig struct {
+type Config struct {
 	Whitelist []WhitelistEntry `yaml:"whitelist" json:"whitelist"`
 }
 
-// FederationSubset is the parsed conf.d/_federation/<tenant>.yaml: the
+// Subset is the parsed conf.d/_federation/<tenant>.yaml: the
 // metric subset one tenant selected for federation. Every metric must
 // be present in the platform whitelist (the 2-tier containment rule).
-type FederationSubset struct {
+type Subset struct {
 	Metrics []string `yaml:"metrics" json:"metrics"`
 }
 
@@ -73,38 +73,38 @@ type PolicyViolation struct {
 // legitimate federation targets.
 var metricNameRE = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
 
-// PolicyManager holds the hot-reloadable platform whitelist. The
+// Manager holds the hot-reloadable platform whitelist. The
 // reload machinery lives in the embedded configwatcher.Watcher; this
 // type only adds the whitelist-specific lookup.
-type PolicyManager struct {
-	*configwatcher.Watcher[FederationPolicyConfig]
+type Manager struct {
+	*configwatcher.Watcher[Config]
 }
 
-// NewPolicyManager creates a PolicyManager reading _federation_policy.yaml
+// NewManager creates a Manager reading _federation_policy.yaml
 // from configDir. A missing file is not an error — configwatcher stores
 // an empty whitelist, and an empty whitelist simply means no metric is
 // federatable yet.
-func NewPolicyManager(configDir string) *PolicyManager {
+func NewManager(configDir string) *Manager {
 	path := filepath.Join(configDir, "_federation_policy.yaml")
 	w, err := configwatcher.New(path, "federation-policy", parsePolicyConfig, emptyPolicyConfig)
 	if err != nil {
 		slog.Warn("federation policy: initial load failed", "error", err)
 	}
-	return &PolicyManager{Watcher: w}
+	return &Manager{Watcher: w}
 }
 
-// NewPolicyManagerForTest returns a PolicyManager pre-populated with cfg
+// NewManagerForTest returns a Manager pre-populated with cfg
 // and no file path. WatchLoop / Reload become no-ops. For unit tests.
-func NewPolicyManagerForTest(cfg *FederationPolicyConfig) *PolicyManager {
-	return &PolicyManager{Watcher: configwatcher.NewForTest("federation-policy", cfg)}
+func NewManagerForTest(cfg *Config) *Manager {
+	return &Manager{Watcher: configwatcher.NewForTest("federation-policy", cfg)}
 }
 
-func emptyPolicyConfig() *FederationPolicyConfig {
-	return &FederationPolicyConfig{Whitelist: []WhitelistEntry{}}
+func emptyPolicyConfig() *Config {
+	return &Config{Whitelist: []WhitelistEntry{}}
 }
 
-func parsePolicyConfig(data []byte) (*FederationPolicyConfig, error) {
-	var cfg FederationPolicyConfig
+func parsePolicyConfig(data []byte) (*Config, error) {
+	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func parsePolicyConfig(data []byte) (*FederationPolicyConfig, error) {
 
 // IsWhitelisted reports whether metric is in the current platform
 // whitelist snapshot.
-func (m *PolicyManager) IsWhitelisted(metric string) bool {
+func (m *Manager) IsWhitelisted(metric string) bool {
 	for _, e := range m.Get().Whitelist {
 		if e.Metric == metric {
 			return true
@@ -127,8 +127,8 @@ func (m *PolicyManager) IsWhitelisted(metric string) bool {
 
 // ParseSubset decodes a per-tenant subset file. An empty document
 // yields an empty (non-nil) subset.
-func ParseSubset(data []byte) (*FederationSubset, error) {
-	var s FederationSubset
+func ParseSubset(data []byte) (*Subset, error) {
+	var s Subset
 	if err := yaml.Unmarshal(data, &s); err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func ParseSubset(data []byte) (*FederationSubset, error) {
 // must carry a non-empty, syntactically valid metric name, and no
 // metric may appear twice. Returns an empty slice when the whitelist
 // is well-formed.
-func ValidateWhitelist(cfg *FederationPolicyConfig) []PolicyViolation {
+func ValidateWhitelist(cfg *Config) []PolicyViolation {
 	var v []PolicyViolation
 	seen := make(map[string]bool, len(cfg.Whitelist))
 	for i, e := range cfg.Whitelist {
@@ -176,12 +176,12 @@ func ValidateWhitelist(cfg *FederationPolicyConfig) []PolicyViolation {
 // boundary (see ADR-020 §MVP 範圍 — cross-tenant isolation is enforced
 // solely by the proxy's `tenant` label injection), so an over-broad
 // stored subset is a consistency wart, not a breach.
-func EffectiveSubset(subset *FederationSubset, whitelist *FederationPolicyConfig) *FederationSubset {
+func EffectiveSubset(subset *Subset, whitelist *Config) *Subset {
 	allowed := make(map[string]bool, len(whitelist.Whitelist))
 	for _, e := range whitelist.Whitelist {
 		allowed[e.Metric] = true
 	}
-	out := &FederationSubset{Metrics: []string{}}
+	out := &Subset{Metrics: []string{}}
 	for _, m := range subset.Metrics {
 		if allowed[m] {
 			out.Metrics = append(out.Metrics, m)
@@ -195,7 +195,7 @@ func EffectiveSubset(subset *FederationSubset, whitelist *FederationPolicyConfig
 // the subset, and present in the whitelist — the 2-tier containment
 // rule: a tenant subset can never exceed the platform whitelist.
 // Returns an empty slice when the subset is valid.
-func ValidateSubset(subset *FederationSubset, whitelist *FederationPolicyConfig) []PolicyViolation {
+func ValidateSubset(subset *Subset, whitelist *Config) []PolicyViolation {
 	allowed := make(map[string]bool, len(whitelist.Whitelist))
 	for _, e := range whitelist.Whitelist {
 		allowed[e.Metric] = true

--- a/components/tenant-api/internal/federation/fedpolicy/policy_test.go
+++ b/components/tenant-api/internal/federation/fedpolicy/policy_test.go
@@ -1,4 +1,4 @@
-package federation
+package fedpolicy
 
 import (
 	"strings"
@@ -47,7 +47,7 @@ func TestValidateWhitelist(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ValidateWhitelist(&FederationPolicyConfig{Whitelist: tt.whitelist})
+			got := ValidateWhitelist(&Config{Whitelist: tt.whitelist})
 			if len(got) != tt.wantCount {
 				t.Fatalf("ValidateWhitelist() = %d violations %+v, want %d", len(got), got, tt.wantCount)
 			}
@@ -64,7 +64,7 @@ func TestValidateWhitelist(t *testing.T) {
 }
 
 func TestValidateSubset(t *testing.T) {
-	whitelist := &FederationPolicyConfig{Whitelist: []WhitelistEntry{
+	whitelist := &Config{Whitelist: []WhitelistEntry{
 		{Metric: "mysql_up"},
 		{Metric: "pg_up"},
 		{Metric: "tenant:cpu:rate5m"},
@@ -118,7 +118,7 @@ func TestValidateSubset(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ValidateSubset(&FederationSubset{Metrics: tt.metrics}, whitelist)
+			got := ValidateSubset(&Subset{Metrics: tt.metrics}, whitelist)
 			if len(got) != tt.wantCount {
 				t.Fatalf("ValidateSubset() = %d violations %+v, want %d", len(got), got, tt.wantCount)
 			}
@@ -134,8 +134,8 @@ func TestValidateSubsetEmptyWhitelistRejectsEverything(t *testing.T) {
 	// failure — a tenant cannot federate metrics the platform has not
 	// allowed.
 	got := ValidateSubset(
-		&FederationSubset{Metrics: []string{"mysql_up"}},
-		&FederationPolicyConfig{Whitelist: []WhitelistEntry{}},
+		&Subset{Metrics: []string{"mysql_up"}},
+		&Config{Whitelist: []WhitelistEntry{}},
 	)
 	if len(got) != 1 {
 		t.Fatalf("ValidateSubset() against empty whitelist = %d violations, want 1", len(got))
@@ -143,7 +143,7 @@ func TestValidateSubsetEmptyWhitelistRejectsEverything(t *testing.T) {
 }
 
 func TestEffectiveSubset(t *testing.T) {
-	whitelist := &FederationPolicyConfig{Whitelist: []WhitelistEntry{
+	whitelist := &Config{Whitelist: []WhitelistEntry{
 		{Metric: "mysql_up"},
 		{Metric: "pg_up"},
 	}}
@@ -175,7 +175,7 @@ func TestEffectiveSubset(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := EffectiveSubset(&FederationSubset{Metrics: tt.stored}, whitelist)
+			got := EffectiveSubset(&Subset{Metrics: tt.stored}, whitelist)
 			if len(got.Metrics) != len(tt.want) {
 				t.Fatalf("EffectiveSubset() = %v, want %v", got.Metrics, tt.want)
 			}
@@ -227,7 +227,7 @@ func TestParseSubset(t *testing.T) {
 }
 
 func TestIsWhitelisted(t *testing.T) {
-	m := NewPolicyManagerForTest(&FederationPolicyConfig{Whitelist: []WhitelistEntry{
+	m := NewManagerForTest(&Config{Whitelist: []WhitelistEntry{
 		{Metric: "mysql_up"},
 	}})
 	if !m.IsWhitelisted("mysql_up") {

--- a/components/tenant-api/internal/federation/orphan/detector.go
+++ b/components/tenant-api/internal/federation/orphan/detector.go
@@ -1,4 +1,4 @@
-package federation
+package orphan
 
 import (
 	"log/slog"
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/vencil/tenant-api/internal/federation/token"
 )
 
 // federationSubsetDir is the conf.d subdirectory holding per-tenant
@@ -15,7 +17,7 @@ import (
 // X lives at conf.d/_federation/X.yaml.
 const federationSubsetDir = "_federation"
 
-// orphanedTokens / orphanedSubsets hold the most recent OrphanDetector
+// orphanedTokens / orphanedSubsets hold the most recent Detector
 // scan result, exposed to the /metrics handler via OrphanCounts. They
 // are gauges — each scan overwrites them; both are 0 before the first
 // scan and when no detector runs.
@@ -25,7 +27,7 @@ var (
 )
 
 // OrphanCounts returns the federation-artifact orphan counts from the
-// most recent OrphanDetector scan: live token Records, and subset
+// most recent Detector scan: live token Records, and subset
 // files, whose owning tenant is no longer present in conf.d. Consumed
 // by the tenant-api /metrics endpoint (handler.MetricsHandler).
 func OrphanCounts() (tokens, subsetFiles int64) {
@@ -46,7 +48,7 @@ func (r OrphanReport) empty() bool {
 // scanOrphans diffs federation artifacts against the set of tenants
 // currently present in conf.d. Pure function — no I/O — so the diff
 // logic is unit-testable without a filesystem or a ConfigMap.
-func scanOrphans(known map[string]struct{}, records []Record, subsetTenants []string) OrphanReport {
+func scanOrphans(known map[string]struct{}, records []token.Record, subsetTenants []string) OrphanReport {
 	var rep OrphanReport
 	for _, r := range records {
 		if _, ok := known[r.TenantID]; !ok {
@@ -125,7 +127,7 @@ func tenantIDFromFile(name string) (string, bool) {
 	}
 }
 
-// OrphanDetector periodically reports federation artifacts left behind
+// Detector periodically reports federation artifacts left behind
 // by an incomplete tenant offboarding — live token Records and
 // conf.d/_federation/<tenant>.yaml subset files whose owning tenant is
 // no longer in conf.d (ADR-020 #521).
@@ -136,22 +138,22 @@ func tenantIDFromFile(name string) (string, bool) {
 // risk misfiring on a transient conf.d glitch (a GitOps sync in flight,
 // a broken file); a warn-only detector gives the same safety net with
 // zero misfire risk. See docs/internal/tenant-offboarding-runbook.md.
-type OrphanDetector struct {
+type Detector struct {
 	configDir string
-	records   func() ([]Record, error)
+	records   func() ([]token.Record, error)
 }
 
-// NewOrphanDetector builds a detector. records lists every live token
+// NewDetector builds a detector. records lists every live token
 // Record across all tenants (Manager.ListAllRecords).
-func NewOrphanDetector(configDir string, records func() ([]Record, error)) *OrphanDetector {
-	return &OrphanDetector{configDir: configDir, records: records}
+func NewDetector(configDir string, records func() ([]token.Record, error)) *Detector {
+	return &Detector{configDir: configDir, records: records}
 }
 
 // scanOnce runs one detection pass: it updates the orphan gauges and
 // emits a WARN log if anything is orphaned. A read error on conf.d or
 // on the token store aborts the pass WITHOUT touching the gauges — a
 // transient failure must never be read as "everything is orphaned".
-func (d *OrphanDetector) scanOnce() {
+func (d *Detector) scanOnce() {
 	known, err := scanKnownTenants(d.configDir)
 	if err != nil {
 		slog.Warn("federation orphan detector: cannot scan conf.d, skipping pass", "error", err)
@@ -178,7 +180,7 @@ func (d *OrphanDetector) scanOnce() {
 }
 
 // Run scans once immediately, then every interval, until stopCh closes.
-func (d *OrphanDetector) Run(interval time.Duration, stopCh <-chan struct{}) {
+func (d *Detector) Run(interval time.Duration, stopCh <-chan struct{}) {
 	d.scanOnce()
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()

--- a/components/tenant-api/internal/federation/orphan/detector_test.go
+++ b/components/tenant-api/internal/federation/orphan/detector_test.go
@@ -1,4 +1,4 @@
-package federation
+package orphan
 
 import (
 	"os"
@@ -6,11 +6,13 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/vencil/tenant-api/internal/federation/token"
 )
 
 func TestScanOrphans(t *testing.T) {
 	known := map[string]struct{}{"db-a": {}, "db-b": {}}
-	records := []Record{
+	records := []token.Record{
 		{TokenID: "ftk_live_a", TenantID: "db-a"},
 		{TokenID: "ftk_zombie", TenantID: "db-gone"},
 		{TokenID: "ftk_live_b", TenantID: "db-b"},
@@ -30,7 +32,7 @@ func TestScanOrphans(t *testing.T) {
 func TestScanOrphans_AllKnown(t *testing.T) {
 	known := map[string]struct{}{"db-a": {}}
 	rep := scanOrphans(known,
-		[]Record{{TokenID: "t1", TenantID: "db-a"}},
+		[]token.Record{{TokenID: "t1", TenantID: "db-a"}},
 		[]string{"db-a"})
 	if !rep.empty() {
 		t.Errorf("expected no orphans, got %+v", rep)
@@ -49,7 +51,7 @@ func TestScanOrphans_Empty(t *testing.T) {
 // observes and never revokes, so there is no misfire to guard against.
 func TestScanOrphans_AllOrphaned(t *testing.T) {
 	rep := scanOrphans(map[string]struct{}{},
-		[]Record{{TokenID: "t1", TenantID: "db-a"}, {TokenID: "t2", TenantID: "db-b"}},
+		[]token.Record{{TokenID: "t1", TenantID: "db-a"}, {TokenID: "t2", TenantID: "db-b"}},
 		[]string{"db-a"})
 	if len(rep.Tokens) != 2 || len(rep.Subsets) != 1 {
 		t.Errorf("expected 2 tokens + 1 subset orphaned, got %+v", rep)

--- a/components/tenant-api/internal/federation/token/configmap_store.go
+++ b/components/tenant-api/internal/federation/token/configmap_store.go
@@ -1,4 +1,4 @@
-package federation
+package token
 
 import (
 	"context"

--- a/components/tenant-api/internal/federation/token/configmap_store_test.go
+++ b/components/tenant-api/internal/federation/token/configmap_store_test.go
@@ -1,4 +1,4 @@
-package federation
+package token
 
 import (
 	"context"

--- a/components/tenant-api/internal/federation/token/manager.go
+++ b/components/tenant-api/internal/federation/token/manager.go
@@ -18,7 +18,7 @@
 //     set that the API gateway consults (sub-issue IV-2b). A revoked
 //     token is rejected within the ConfigMap projected-volume sync
 //     window (~1-2 min).
-package federation
+package token
 
 import (
 	"crypto/rand"

--- a/components/tenant-api/internal/federation/token/manager_test.go
+++ b/components/tenant-api/internal/federation/token/manager_test.go
@@ -1,4 +1,4 @@
-package federation
+package token
 
 import (
 	"crypto/rand"

--- a/components/tenant-api/internal/federation/token/mint_limiter.go
+++ b/components/tenant-api/internal/federation/token/mint_limiter.go
@@ -1,4 +1,4 @@
-package federation
+package token
 
 import (
 	"sync"

--- a/components/tenant-api/internal/federation/token/mint_limiter_test.go
+++ b/components/tenant-api/internal/federation/token/mint_limiter_test.go
@@ -1,4 +1,4 @@
-package federation
+package token
 
 import (
 	"testing"

--- a/components/tenant-api/internal/federation/token/store.go
+++ b/components/tenant-api/internal/federation/token/store.go
@@ -1,4 +1,4 @@
-package federation
+package token
 
 import (
 	"encoding/json"

--- a/components/tenant-api/internal/handler/async_test.go
+++ b/components/tenant-api/internal/handler/async_test.go
@@ -85,7 +85,7 @@ func TestBatchTenants_Async_ReturnsTaskID(t *testing.T) {
 	req.Header.Set("X-Forwarded-Email", "test@example.com")
 
 	w := httptest.NewRecorder()
-	deps.BatchTenants()(w, req)
+	BatchTenants(deps)(w, req)
 
 	if w.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want %d (Accepted), body: %s", w.Code, http.StatusAccepted, w.Body.String())
@@ -142,7 +142,7 @@ func TestBatchTenants_Async_TaskCompletes(t *testing.T) {
 	req.Header.Set("X-Forwarded-Email", "test@example.com")
 
 	w := httptest.NewRecorder()
-	deps.BatchTenants()(w, req)
+	BatchTenants(deps)(w, req)
 
 	if w.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want %d (Accepted), body: %s", w.Code, http.StatusAccepted, w.Body.String())
@@ -196,7 +196,7 @@ func TestGroupBatch_Async_ReturnsTaskID(t *testing.T) {
 	req.Header.Set("X-Forwarded-Email", "test@example.com")
 
 	w := httptest.NewRecorder()
-	deps.GroupBatch()(w, req)
+	GroupBatch(deps)(w, req)
 
 	if w.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want %d (Accepted), body: %s", w.Code, http.StatusAccepted, w.Body.String())

--- a/components/tenant-api/internal/handler/authz_test.go
+++ b/components/tenant-api/internal/handler/authz_test.go
@@ -163,7 +163,7 @@ func TestPutGroup_ForbiddenMember_Returns403(t *testing.T) {
 	req := newRequestWithChiParam("PUT", "/api/v1/groups/mixed", "id", "mixed",
 		bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
-	w := servePopulatingRBAC(t, (&Deps{Groups: mgr, Writer: writer, RBAC: rbacMgr}).PutGroup(), req,
+	w := servePopulatingRBAC(t, PutGroup(&Deps{Groups: mgr, Writer: writer, RBAC: rbacMgr}), req,
 		"alice@example.com", []string{"dba-team-a"})
 
 	if w.Code != http.StatusForbidden {
@@ -197,7 +197,7 @@ func TestPutGroup_AllMembersForbidden_ListsAllInError(t *testing.T) {
 	req := newRequestWithChiParam("PUT", "/api/v1/groups/forbidden", "id", "forbidden",
 		bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
-	w := servePopulatingRBAC(t, (&Deps{Groups: mgr, Writer: writer, RBAC: rbacMgr}).PutGroup(), req,
+	w := servePopulatingRBAC(t, PutGroup(&Deps{Groups: mgr, Writer: writer, RBAC: rbacMgr}), req,
 		"alice@example.com", []string{"unprivileged"})
 
 	if w.Code != http.StatusForbidden {
@@ -239,7 +239,7 @@ func TestDeleteGroup_ForbiddenMember_Returns403(t *testing.T) {
 `)
 
 	req := newRequestWithChiParam("DELETE", "/api/v1/groups/cross-team", "id", "cross-team", nil)
-	w := servePopulatingRBAC(t, (&Deps{Groups: mgr, Writer: writer, RBAC: rbacMgr}).DeleteGroup(), req,
+	w := servePopulatingRBAC(t, DeleteGroup(&Deps{Groups: mgr, Writer: writer, RBAC: rbacMgr}), req,
 		"alice@example.com", []string{"dba-team-a"})
 
 	if w.Code != http.StatusForbidden {
@@ -277,7 +277,7 @@ func TestGetTask_FiltersResultsByTenantAccess(t *testing.T) {
 	taskID := task.ID
 
 	req := newRequestWithChiParam("GET", "/api/v1/tasks/"+taskID, "id", taskID, nil)
-	w := servePopulatingRBAC(t, (&Deps{Tasks: taskMgr, RBAC: rbacMgr}).GetTask(), req,
+	w := servePopulatingRBAC(t, GetTask(&Deps{Tasks: taskMgr, RBAC: rbacMgr}), req,
 		"alice@example.com", []string{"viewers"})
 
 	if w.Code != http.StatusOK {
@@ -318,7 +318,7 @@ func TestGetTask_NoAccessibleResults_Returns403(t *testing.T) {
 	taskID := task.ID
 
 	req := newRequestWithChiParam("GET", "/api/v1/tasks/"+taskID, "id", taskID, nil)
-	w := servePopulatingRBAC(t, (&Deps{Tasks: taskMgr, RBAC: rbacMgr}).GetTask(), req,
+	w := servePopulatingRBAC(t, GetTask(&Deps{Tasks: taskMgr, RBAC: rbacMgr}), req,
 		"alice@example.com", []string{"viewers"})
 
 	if w.Code != http.StatusForbidden {
@@ -370,7 +370,7 @@ func TestListPRs_FiltersBulkListByTenantAccess(t *testing.T) {
 `)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/prs", nil)
-	w := servePopulatingRBAC(t, (&Deps{PRTracker: tracker, RBAC: rbacMgr}).ListPRs(), req,
+	w := servePopulatingRBAC(t, ListPRs(&Deps{PRTracker: tracker, RBAC: rbacMgr}), req,
 		"alice@example.com", []string{"viewers"})
 
 	if w.Code != http.StatusOK {
@@ -405,7 +405,7 @@ func TestListPRs_TenantQueryReturnsEmptyWhenForbidden(t *testing.T) {
 `)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/prs?tenant=db-secret", nil)
-	w := servePopulatingRBAC(t, (&Deps{PRTracker: tracker, RBAC: rbacMgr}).ListPRs(), req,
+	w := servePopulatingRBAC(t, ListPRs(&Deps{PRTracker: tracker, RBAC: rbacMgr}), req,
 		"alice@example.com", []string{"viewers"})
 
 	if w.Code != http.StatusOK {

--- a/components/tenant-api/internal/handler/body_validator_test.go
+++ b/components/tenant-api/internal/handler/body_validator_test.go
@@ -446,7 +446,7 @@ func TestBatchTenants_BodyValidation_RejectsBadValue(t *testing.T) {
 	gw := newTestWriter(configDir)
 	rbacMgr := newRBACManager(t, "")
 
-	h := (&Deps{Writer: gw, ConfigDir: configDir, RBAC: rbacMgr, WriteMode: WriteModeDirect}).BatchTenants()
+	h := BatchTenants(&Deps{Writer: gw, ConfigDir: configDir, RBAC: rbacMgr, WriteMode: WriteModeDirect})
 	req := httptest.NewRequest("POST", "/api/v1/tenants/batch", body)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -487,7 +487,7 @@ func TestBatchTenants_BodyValidation_ReportsAllViolations(t *testing.T) {
 	gw := newTestWriter(configDir)
 	rbacMgr := newRBACManager(t, "")
 
-	h := (&Deps{Writer: gw, ConfigDir: configDir, RBAC: rbacMgr, WriteMode: WriteModeDirect}).BatchTenants()
+	h := BatchTenants(&Deps{Writer: gw, ConfigDir: configDir, RBAC: rbacMgr, WriteMode: WriteModeDirect})
 	req := httptest.NewRequest("POST", "/api/v1/tenants/batch", body)
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()

--- a/components/tenant-api/internal/handler/deps.go
+++ b/components/tenant-api/internal/handler/deps.go
@@ -21,7 +21,8 @@ package handler
 
 import (
 	"github.com/vencil/tenant-api/internal/async"
-	"github.com/vencil/tenant-api/internal/federation"
+	"github.com/vencil/tenant-api/internal/federation/fedpolicy"
+	"github.com/vencil/tenant-api/internal/federation/token"
 	"github.com/vencil/tenant-api/internal/gitops"
 	"github.com/vencil/tenant-api/internal/groups"
 	"github.com/vencil/tenant-api/internal/platform"
@@ -80,19 +81,19 @@ type Deps struct {
 	// Optional — nil when no signing key is configured, in which case
 	// main.go leaves the /federation/tokens routes unregistered, so
 	// handlers reading it are never reached with a nil value.
-	Federation *federation.Manager
+	Federation *token.Manager
 
 	// FederationPolicy holds the platform federation whitelist
 	// (ADR-020 IV-2e, `_federation_policy.yaml`). Always wired — the
 	// 2-tier policy is independent of token signing.
-	FederationPolicy *federation.PolicyManager
+	FederationPolicy *fedpolicy.Manager
 
 	// AdmissionValidator runs the data-layer label-enrichment check
 	// when a metric is added to the federation whitelist (ADR-020
 	// IV-2e). Optional — nil when --federation-prometheus-url is unset,
 	// in which case PutFederationPolicy skips admission and the
 	// whitelist edit is schema-checked only.
-	AdmissionValidator *federation.AdmissionValidator
+	AdmissionValidator *fedpolicy.AdmissionValidator
 
 	// Tasks runs async batch operations behind a goroutine pool.
 	Tasks *async.Manager

--- a/components/tenant-api/internal/handler/federation.go
+++ b/components/tenant-api/internal/handler/federation.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/vencil/tenant-api/internal/federation"
+	"github.com/vencil/tenant-api/internal/federation/token"
 	"github.com/vencil/tenant-api/internal/rbac"
 )
 
@@ -38,7 +38,7 @@ type CreateFederationTokenResponse struct {
 	Record FederationTokenRecord `json:"record"`
 }
 
-func toFederationTokenRecord(r federation.Record) FederationTokenRecord {
+func toFederationTokenRecord(r token.Record) FederationTokenRecord {
 	return FederationTokenRecord{
 		TokenID:     r.TokenID,
 		TenantID:    r.TenantID,
@@ -104,12 +104,12 @@ func (d *Deps) CreateFederationToken() http.HandlerFunc {
 			return
 		}
 
-		token, rec, err := d.Federation.Issue(req.TenantID, rbac.RequestEmail(r), req.Description)
+		jwt, rec, err := d.Federation.Issue(req.TenantID, rbac.RequestEmail(r), req.Description)
 		if err != nil {
 			switch {
-			case errors.Is(err, federation.ErrTokenLimitReached):
+			case errors.Is(err, token.ErrTokenLimitReached):
 				writeJSONErrorWithCode(w, r, http.StatusConflict, CodeConflict, err.Error())
-			case errors.Is(err, federation.ErrMintRateLimited):
+			case errors.Is(err, token.ErrMintRateLimited):
 				writeJSONErrorWithCode(w, r, http.StatusTooManyRequests, CodeRateLimited, err.Error())
 			default:
 				writeJSONError(w, r, http.StatusInternalServerError, "issue federation token: "+err.Error())
@@ -120,7 +120,7 @@ func (d *Deps) CreateFederationToken() http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(CreateFederationTokenResponse{
-			Token:  token,
+			Token:  jwt,
 			Record: toFederationTokenRecord(rec),
 		})
 	}

--- a/components/tenant-api/internal/handler/federation.go
+++ b/components/tenant-api/internal/handler/federation.go
@@ -70,7 +70,7 @@ func toFederationTokenRecord(r token.Record) FederationTokenRecord {
 // @Failure     429  {object} map[string]string
 // @Failure     500  {object} map[string]string
 // @Router      /api/v1/federation/tokens [post]
-func (d *Deps) CreateFederationToken() http.HandlerFunc {
+func CreateFederationToken(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 		if err != nil {
@@ -138,7 +138,7 @@ func (d *Deps) CreateFederationToken() http.HandlerFunc {
 // @Failure     403 {object} map[string]string
 // @Failure     500 {object} map[string]string
 // @Router      /api/v1/federation/tokens [get]
-func (d *Deps) ListFederationTokens() http.HandlerFunc {
+func ListFederationTokens(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tenantID := r.URL.Query().Get("tenant_id")
 		if tenantID == "" {
@@ -188,7 +188,7 @@ func (d *Deps) ListFederationTokens() http.HandlerFunc {
 // @Failure     404 {object} map[string]string
 // @Failure     500 {object} map[string]string
 // @Router      /api/v1/federation/tokens/{id} [delete]
-func (d *Deps) DeleteFederationToken() http.HandlerFunc {
+func DeleteFederationToken(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tokenID := chi.URLParam(r, "id")
 

--- a/components/tenant-api/internal/handler/federation_policy.go
+++ b/components/tenant-api/internal/handler/federation_policy.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/vencil/tenant-api/internal/federation"
+	"github.com/vencil/tenant-api/internal/federation/fedpolicy"
 	"github.com/vencil/tenant-api/internal/gitops"
 	"github.com/vencil/tenant-api/internal/rbac"
 	"gopkg.in/yaml.v3"
@@ -31,7 +31,7 @@ import (
 
 // toViolations adapts federation schema failures to the handler's
 // validation-error shape (both are {field, reason} — a plain copy).
-func toViolations(pv []federation.PolicyViolation) []Violation {
+func toViolations(pv []fedpolicy.PolicyViolation) []Violation {
 	out := make([]Violation, len(pv))
 	for i, v := range pv {
 		out[i] = Violation{Field: v.Field, Reason: v.Reason}
@@ -45,7 +45,7 @@ func toViolations(pv []federation.PolicyViolation) []Violation {
 // @Summary     Get the platform federation whitelist
 // @Tags        federation
 // @Produce     json
-// @Success     200 {object} federation.FederationPolicyConfig
+// @Success     200 {object} fedpolicy.Config
 // @Router      /api/v1/federation/policy [get]
 func (d *Deps) GetFederationPolicy() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +60,7 @@ func (d *Deps) GetFederationPolicy() http.HandlerFunc {
 // PII-looking label name); a hard block — a metric whose series lack
 // the tenant label — is never bypassable.
 type PutFederationPolicyRequest struct {
-	Whitelist []federation.WhitelistEntry `json:"whitelist"`
+	Whitelist []fedpolicy.WhitelistEntry `json:"whitelist"`
 	Force     bool                        `json:"force"`
 	Reason    string                      `json:"reason"`
 }
@@ -108,11 +108,11 @@ func (d *Deps) PutFederationPolicy() http.HandlerFunc {
 			writeJSONError(w, r, http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return
 		}
-		cfg := federation.FederationPolicyConfig{Whitelist: req.Whitelist}
+		cfg := fedpolicy.Config{Whitelist: req.Whitelist}
 		if cfg.Whitelist == nil {
-			cfg.Whitelist = []federation.WhitelistEntry{}
+			cfg.Whitelist = []fedpolicy.WhitelistEntry{}
 		}
-		if pv := federation.ValidateWhitelist(&cfg); len(pv) > 0 {
+		if pv := fedpolicy.ValidateWhitelist(&cfg); len(pv) > 0 {
 			writeValidationErrors(w, r, toViolations(pv))
 			return
 		}
@@ -206,7 +206,7 @@ const admissionConcurrency = 8
 
 // addedFederationMetrics returns the metric names in proposed that are
 // not already in current — the set a whitelist PUT newly introduces.
-func addedFederationMetrics(current, proposed *federation.FederationPolicyConfig) []string {
+func addedFederationMetrics(current, proposed *fedpolicy.Config) []string {
 	have := make(map[string]bool, len(current.Whitelist))
 	for _, e := range current.Whitelist {
 		have[e.Metric] = true
@@ -225,14 +225,14 @@ func addedFederationMetrics(current, proposed *federation.FederationPolicyConfig
 // take up to the validator's per-check timeout, so a batch must not run
 // strictly sequentially. Returns nil when the validator is disabled or
 // metrics is empty.
-func (d *Deps) runAdmissionChecks(ctx context.Context, metrics []string) []federation.AdmissionResult {
+func (d *Deps) runAdmissionChecks(ctx context.Context, metrics []string) []fedpolicy.AdmissionResult {
 	if d.AdmissionValidator == nil || len(metrics) == 0 {
 		return nil
 	}
 
 	// Each goroutine writes its own distinct index of `results`, so the
 	// slice needs no lock and the output order matches `metrics`.
-	results := make([]federation.AdmissionResult, len(metrics))
+	results := make([]fedpolicy.AdmissionResult, len(metrics))
 	sem := make(chan struct{}, admissionConcurrency)
 	var wg sync.WaitGroup
 	for i, metric := range metrics {
@@ -247,9 +247,9 @@ func (d *Deps) runAdmissionChecks(ctx context.Context, metrics []string) []feder
 				// unreachable) maps to the soft gate: a metric that
 				// cannot be queried cannot be proven bad, so it warns
 				// rather than hard-blocks.
-				res = federation.AdmissionResult{
+				res = fedpolicy.AdmissionResult{
 					Metric: metric,
-					State:  federation.AdmissionWarn,
+					State:  fedpolicy.AdmissionWarn,
 					Reason: "admission check could not be completed: " + err.Error(),
 				}
 			}
@@ -263,12 +263,12 @@ func (d *Deps) runAdmissionChecks(ctx context.Context, metrics []string) []feder
 // partitionAdmission splits admission results into hard blocks and soft
 // warnings. A Pass carrying PII-looking label names is a soft warning
 // (it wants reviewer judgement), not a clean pass.
-func partitionAdmission(results []federation.AdmissionResult) (hard, soft []federation.AdmissionResult) {
+func partitionAdmission(results []fedpolicy.AdmissionResult) (hard, soft []fedpolicy.AdmissionResult) {
 	for _, res := range results {
 		switch {
-		case res.State == federation.AdmissionHardBlock:
+		case res.State == fedpolicy.AdmissionHardBlock:
 			hard = append(hard, res)
-		case res.State == federation.AdmissionWarn || len(res.PIILabels) > 0:
+		case res.State == fedpolicy.AdmissionWarn || len(res.PIILabels) > 0:
 			soft = append(soft, res)
 		}
 	}
@@ -282,7 +282,7 @@ func partitionAdmission(results []federation.AdmissionResult) (hard, soft []fede
 // user and reason are sanitised first: a caller-supplied CR/LF in the
 // reason would otherwise forge extra trailer lines (e.g. a fake
 // `Approved-By:`) and break the integrity of the audit record.
-func bypassTrailer(user, reason string, soft []federation.AdmissionResult) string {
+func bypassTrailer(user, reason string, soft []fedpolicy.AdmissionResult) string {
 	return fmt.Sprintf("[Bypass-Validator] Federation admission bypassed by %s.\nReason: %s\nMetrics: %s",
 		sanitizeTrailerField(user), sanitizeTrailerField(reason),
 		strings.Join(admissionMetrics(soft), ", "))
@@ -295,7 +295,7 @@ func sanitizeTrailerField(s string) string {
 }
 
 // admissionMetrics extracts the metric names from a result slice.
-func admissionMetrics(results []federation.AdmissionResult) []string {
+func admissionMetrics(results []fedpolicy.AdmissionResult) []string {
 	out := make([]string, len(results))
 	for i, res := range results {
 		out[i] = res.Metric
@@ -317,7 +317,7 @@ func admissionMetrics(results []federation.AdmissionResult) []string {
 // @Tags        federation
 // @Produce     json
 // @Param       id path string true "Tenant ID"
-// @Success     200 {object} federation.FederationSubset
+// @Success     200 {object} fedpolicy.Subset
 // @Failure     400 {object} map[string]string
 // @Router      /api/v1/tenants/{id}/federation [get]
 func (d *Deps) GetTenantFederation() http.HandlerFunc {
@@ -333,7 +333,7 @@ func (d *Deps) GetTenantFederation() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(federation.EffectiveSubset(subset, d.FederationPolicy.Get()))
+		_ = json.NewEncoder(w).Encode(fedpolicy.EffectiveSubset(subset, d.FederationPolicy.Get()))
 	}
 }
 
@@ -350,7 +350,7 @@ func (d *Deps) GetTenantFederation() http.HandlerFunc {
 // @Accept      json
 // @Produce     json
 // @Param       id   path string true "Tenant ID"
-// @Param       body body federation.FederationSubset true "Metric subset"
+// @Param       body body fedpolicy.Subset true "Metric subset"
 // @Success     200  {object} map[string]any
 // @Failure     400  {object} map[string]string
 // @Failure     403  {object} map[string]string
@@ -375,7 +375,7 @@ func (d *Deps) PutTenantFederation() http.HandlerFunc {
 			writeJSONError(w, r, http.StatusBadRequest, "failed to read request body: "+err.Error())
 			return
 		}
-		var subset federation.FederationSubset
+		var subset fedpolicy.Subset
 		if err := json.Unmarshal(body, &subset); err != nil {
 			writeJSONError(w, r, http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return
@@ -384,7 +384,7 @@ func (d *Deps) PutTenantFederation() http.HandlerFunc {
 			subset.Metrics = []string{}
 		}
 		// 2-tier containment: the subset must not exceed the whitelist.
-		if pv := federation.ValidateSubset(&subset, d.FederationPolicy.Get()); len(pv) > 0 {
+		if pv := fedpolicy.ValidateSubset(&subset, d.FederationPolicy.Get()); len(pv) > 0 {
 			writeValidationErrors(w, r, toViolations(pv))
 			return
 		}
@@ -415,14 +415,14 @@ func (d *Deps) PutTenantFederation() http.HandlerFunc {
 // readFederationSubset loads conf.d/_federation/<tenantID>.yaml. A
 // missing file is not an error — it means the tenant has selected no
 // federation metrics yet, which yields an empty subset.
-func (d *Deps) readFederationSubset(tenantID string) (*federation.FederationSubset, error) {
+func (d *Deps) readFederationSubset(tenantID string) (*fedpolicy.Subset, error) {
 	path := filepath.Join(d.ConfigDir, "_federation", tenantID+".yaml")
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
-		return &federation.FederationSubset{Metrics: []string{}}, nil
+		return &fedpolicy.Subset{Metrics: []string{}}, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	return federation.ParseSubset(data)
+	return fedpolicy.ParseSubset(data)
 }

--- a/components/tenant-api/internal/handler/federation_policy.go
+++ b/components/tenant-api/internal/handler/federation_policy.go
@@ -47,7 +47,7 @@ func toViolations(pv []fedpolicy.PolicyViolation) []Violation {
 // @Produce     json
 // @Success     200 {object} fedpolicy.Config
 // @Router      /api/v1/federation/policy [get]
-func (d *Deps) GetFederationPolicy() http.HandlerFunc {
+func GetFederationPolicy(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(d.FederationPolicy.Get())
@@ -89,7 +89,7 @@ type PutFederationPolicyRequest struct {
 // @Failure     403  {object} map[string]string
 // @Failure     409  {object} map[string]string
 // @Router      /api/v1/federation/policy [put]
-func (d *Deps) PutFederationPolicy() http.HandlerFunc {
+func PutFederationPolicy(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !d.RBAC.HasPermission(rbac.RequestGroups(r), "*", rbac.PermAdmin) {
 			writeJSONErrorWithCode(w, r, http.StatusForbidden, CodeForbidden,
@@ -129,7 +129,7 @@ func (d *Deps) PutFederationPolicy() http.HandlerFunc {
 					len(added), maxNewMetricsPerRequest))
 				return
 			}
-			hard, soft := partitionAdmission(d.runAdmissionChecks(r.Context(), added))
+			hard, soft := partitionAdmission(runAdmissionChecks(d, r.Context(), added))
 			if len(hard) > 0 {
 				writeErrorEnvelope(w, r, http.StatusBadRequest, ErrorResponse{
 					Error: "federation admission: hard block — metric(s) have data but no series carries the tenant label and cannot be whitelisted",
@@ -225,7 +225,7 @@ func addedFederationMetrics(current, proposed *fedpolicy.Config) []string {
 // take up to the validator's per-check timeout, so a batch must not run
 // strictly sequentially. Returns nil when the validator is disabled or
 // metrics is empty.
-func (d *Deps) runAdmissionChecks(ctx context.Context, metrics []string) []fedpolicy.AdmissionResult {
+func runAdmissionChecks(d *Deps, ctx context.Context, metrics []string) []fedpolicy.AdmissionResult {
 	if d.AdmissionValidator == nil || len(metrics) == 0 {
 		return nil
 	}
@@ -320,14 +320,14 @@ func admissionMetrics(results []fedpolicy.AdmissionResult) []string {
 // @Success     200 {object} fedpolicy.Subset
 // @Failure     400 {object} map[string]string
 // @Router      /api/v1/tenants/{id}/federation [get]
-func (d *Deps) GetTenantFederation() http.HandlerFunc {
+func GetTenantFederation(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
 		if err := ValidateTenantID(tenantID); err != nil {
 			writeJSONError(w, r, http.StatusBadRequest, err.Error())
 			return
 		}
-		subset, err := d.readFederationSubset(tenantID)
+		subset, err := readFederationSubset(d, tenantID)
 		if err != nil {
 			writeJSONError(w, r, http.StatusInternalServerError, "read federation subset: "+err.Error())
 			return
@@ -356,7 +356,7 @@ func (d *Deps) GetTenantFederation() http.HandlerFunc {
 // @Failure     403  {object} map[string]string
 // @Failure     409  {object} map[string]string
 // @Router      /api/v1/tenants/{id}/federation [put]
-func (d *Deps) PutTenantFederation() http.HandlerFunc {
+func PutTenantFederation(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
 		if err := ValidateTenantID(tenantID); err != nil {
@@ -415,7 +415,7 @@ func (d *Deps) PutTenantFederation() http.HandlerFunc {
 // readFederationSubset loads conf.d/_federation/<tenantID>.yaml. A
 // missing file is not an error — it means the tenant has selected no
 // federation metrics yet, which yields an empty subset.
-func (d *Deps) readFederationSubset(tenantID string) (*fedpolicy.Subset, error) {
+func readFederationSubset(d *Deps, tenantID string) (*fedpolicy.Subset, error) {
 	path := filepath.Join(d.ConfigDir, "_federation", tenantID+".yaml")
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {

--- a/components/tenant-api/internal/handler/federation_policy_test.go
+++ b/components/tenant-api/internal/handler/federation_policy_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/vencil/tenant-api/internal/federation"
+	"github.com/vencil/tenant-api/internal/federation/fedpolicy"
 )
 
 // fakePrometheus mocks the Prometheus Series API for handler-level
@@ -113,14 +113,14 @@ func TestGetFederationPolicy_Empty(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
 	d := &Deps{
-		FederationPolicy: federation.NewPolicyManager(configDir),
+		FederationPolicy: fedpolicy.NewManager(configDir),
 		RBAC:             newRBACManager(t, ""),
 	}
 	w := executeWithRBAC(t, d.GetFederationPolicy(), fedReq(t, "GET", "/api/v1/federation/policy", "", "", ""))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
 	}
-	var got federation.FederationPolicyConfig
+	var got fedpolicy.Config
 	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestPutFederationPolicy_ForbiddenForNonPlatformAdmin(t *testing.T) {
 	d := &Deps{
 		ConfigDir:        configDir,
 		Writer:           newTestWriter(configDir),
-		FederationPolicy: federation.NewPolicyManager(configDir),
+		FederationPolicy: fedpolicy.NewManager(configDir),
 		// Caller is admin on db-a only — not a "*"-scoped platform admin.
 		RBAC: newRBACManager(t, scopedAdminRBAC),
 	}
@@ -154,7 +154,7 @@ func TestPutFederationPolicy_Success(t *testing.T) {
 	d := &Deps{
 		ConfigDir:        configDir,
 		Writer:           newTestWriter(configDir),
-		FederationPolicy: federation.NewPolicyManager(configDir),
+		FederationPolicy: fedpolicy.NewManager(configDir),
 		RBAC:             newRBACManager(t, platformAdminRBAC),
 	}
 	body := `{"whitelist":[{"metric":"mysql_up"},{"metric":"tenant:cpu:rate5m"}]}`
@@ -181,8 +181,8 @@ func TestPutFederationPolicy_AdmissionHardBlock(t *testing.T) {
 	d := &Deps{
 		ConfigDir:          configDir,
 		Writer:             newTestWriter(configDir),
-		FederationPolicy:   federation.NewPolicyManager(configDir),
-		AdmissionValidator: federation.NewAdmissionValidator(promURL),
+		FederationPolicy:   fedpolicy.NewManager(configDir),
+		AdmissionValidator: fedpolicy.NewAdmissionValidator(promURL),
 		RBAC:               newRBACManager(t, platformAdminRBAC),
 	}
 	w := executeWithRBAC(t, d.PutFederationPolicy(),
@@ -204,8 +204,8 @@ func TestPutFederationPolicy_AdmissionWarnNeedsForce(t *testing.T) {
 	d := &Deps{
 		ConfigDir:          configDir,
 		Writer:             newTestWriter(configDir),
-		FederationPolicy:   federation.NewPolicyManager(configDir),
-		AdmissionValidator: federation.NewAdmissionValidator(promURL),
+		FederationPolicy:   fedpolicy.NewManager(configDir),
+		AdmissionValidator: fedpolicy.NewAdmissionValidator(promURL),
 		RBAC:               newRBACManager(t, platformAdminRBAC),
 	}
 	// No force → rejected.
@@ -241,8 +241,8 @@ func TestPutFederationPolicy_AdmissionPass(t *testing.T) {
 	d := &Deps{
 		ConfigDir:          configDir,
 		Writer:             newTestWriter(configDir),
-		FederationPolicy:   federation.NewPolicyManager(configDir),
-		AdmissionValidator: federation.NewAdmissionValidator(promURL),
+		FederationPolicy:   fedpolicy.NewManager(configDir),
+		AdmissionValidator: fedpolicy.NewAdmissionValidator(promURL),
 		RBAC:               newRBACManager(t, platformAdminRBAC),
 	}
 	w := executeWithRBAC(t, d.PutFederationPolicy(),
@@ -263,8 +263,8 @@ func TestPutFederationPolicy_AdmissionMultipleMetricsConcurrent(t *testing.T) {
 	d := &Deps{
 		ConfigDir:          configDir,
 		Writer:             newTestWriter(configDir),
-		FederationPolicy:   federation.NewPolicyManager(configDir),
-		AdmissionValidator: federation.NewAdmissionValidator(promURL),
+		FederationPolicy:   fedpolicy.NewManager(configDir),
+		AdmissionValidator: fedpolicy.NewAdmissionValidator(promURL),
 		RBAC:               newRBACManager(t, platformAdminRBAC),
 	}
 	body := `{"whitelist":[{"metric":"m1"},{"metric":"m2"},{"metric":"m3"},{"metric":"m4"},{"metric":"m5"}]}`
@@ -284,8 +284,8 @@ func TestPutFederationPolicy_RejectsTooManyNewMetrics(t *testing.T) {
 	d := &Deps{
 		ConfigDir:          configDir,
 		Writer:             newTestWriter(configDir),
-		FederationPolicy:   federation.NewPolicyManager(configDir),
-		AdmissionValidator: federation.NewAdmissionValidator(fakePrometheus(t, nil, nil)),
+		FederationPolicy:   fedpolicy.NewManager(configDir),
+		AdmissionValidator: fedpolicy.NewAdmissionValidator(fakePrometheus(t, nil, nil)),
 		RBAC:               newRBACManager(t, platformAdminRBAC),
 	}
 	// One more than the cap — rejected before any admission call.
@@ -316,7 +316,7 @@ func TestPutFederationPolicy_CancelledContextSkipsGitWrite(t *testing.T) {
 	d := &Deps{
 		ConfigDir:        configDir,
 		Writer:           newTestWriter(configDir),
-		FederationPolicy: federation.NewPolicyManager(configDir),
+		FederationPolicy: fedpolicy.NewManager(configDir),
 		RBAC:             newRBACManager(t, platformAdminRBAC),
 	}
 	req := fedReq(t, "PUT", "/api/v1/federation/policy", "", "", `{"whitelist":[{"metric":"m"}]}`)
@@ -335,7 +335,7 @@ func TestPutFederationPolicy_RejectsInvalidMetricName(t *testing.T) {
 	d := &Deps{
 		ConfigDir:        configDir,
 		Writer:           newTestWriter(configDir),
-		FederationPolicy: federation.NewPolicyManager(configDir),
+		FederationPolicy: fedpolicy.NewManager(configDir),
 		RBAC:             newRBACManager(t, platformAdminRBAC),
 	}
 	body := `{"whitelist":[{"metric":"bad-name"}]}`
@@ -352,7 +352,7 @@ func TestPutTenantFederation_ForbiddenWithoutTenantAdmin(t *testing.T) {
 	d := &Deps{
 		ConfigDir:        configDir,
 		Writer:           newTestWriter(configDir),
-		FederationPolicy: federation.NewPolicyManager(configDir),
+		FederationPolicy: fedpolicy.NewManager(configDir),
 		// Caller has admin on db-a only — editing db-b's subset is denied.
 		RBAC: newRBACManager(t, scopedAdminRBAC),
 	}
@@ -368,8 +368,8 @@ func TestPutTenantFederation_RejectsMetricOutsideWhitelist(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	initGitRepo(t, configDir)
 	// Whitelist allows mysql_up only.
-	mgr := federation.NewPolicyManagerForTest(&federation.FederationPolicyConfig{
-		Whitelist: []federation.WhitelistEntry{{Metric: "mysql_up"}},
+	mgr := fedpolicy.NewManagerForTest(&fedpolicy.Config{
+		Whitelist: []fedpolicy.WhitelistEntry{{Metric: "mysql_up"}},
 	})
 	d := &Deps{
 		ConfigDir:        configDir,
@@ -392,8 +392,8 @@ func TestPutTenantFederation_Success(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
 	initGitRepo(t, configDir)
-	mgr := federation.NewPolicyManagerForTest(&federation.FederationPolicyConfig{
-		Whitelist: []federation.WhitelistEntry{{Metric: "mysql_up"}, {Metric: "pg_up"}},
+	mgr := fedpolicy.NewManagerForTest(&fedpolicy.Config{
+		Whitelist: []fedpolicy.WhitelistEntry{{Metric: "mysql_up"}, {Metric: "pg_up"}},
 	})
 	d := &Deps{
 		ConfigDir:        configDir,
@@ -428,8 +428,8 @@ func TestGetTenantFederation_ReadRepairDropsStaleMetric(t *testing.T) {
 		[]byte("metrics:\n  - mysql_up\n  - redis_up\n"), 0644); err != nil {
 		t.Fatalf("write stale subset: %v", err)
 	}
-	mgr := federation.NewPolicyManagerForTest(&federation.FederationPolicyConfig{
-		Whitelist: []federation.WhitelistEntry{{Metric: "mysql_up"}},
+	mgr := fedpolicy.NewManagerForTest(&fedpolicy.Config{
+		Whitelist: []fedpolicy.WhitelistEntry{{Metric: "mysql_up"}},
 	})
 	d := &Deps{ConfigDir: configDir, FederationPolicy: mgr, RBAC: newRBACManager(t, "")}
 
@@ -437,7 +437,7 @@ func TestGetTenantFederation_ReadRepairDropsStaleMetric(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
 	}
-	var got federation.FederationSubset
+	var got fedpolicy.Subset
 	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -452,14 +452,14 @@ func TestGetTenantFederation_NoFileYieldsEmptySubset(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	d := &Deps{
 		ConfigDir:        configDir,
-		FederationPolicy: federation.NewPolicyManager(configDir),
+		FederationPolicy: fedpolicy.NewManager(configDir),
 		RBAC:             newRBACManager(t, ""),
 	}
 	w := executeWithRBAC(t, d.GetTenantFederation(), fedReq(t, "GET", "/api/v1/tenants/db-a/federation", "id", "db-a", ""))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
 	}
-	var got federation.FederationSubset
+	var got fedpolicy.Subset
 	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}

--- a/components/tenant-api/internal/handler/federation_policy_test.go
+++ b/components/tenant-api/internal/handler/federation_policy_test.go
@@ -116,7 +116,7 @@ func TestGetFederationPolicy_Empty(t *testing.T) {
 		FederationPolicy: fedpolicy.NewManager(configDir),
 		RBAC:             newRBACManager(t, ""),
 	}
-	w := executeWithRBAC(t, d.GetFederationPolicy(), fedReq(t, "GET", "/api/v1/federation/policy", "", "", ""))
+	w := executeWithRBAC(t, GetFederationPolicy(d), fedReq(t, "GET", "/api/v1/federation/policy", "", "", ""))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
 	}
@@ -141,7 +141,7 @@ func TestPutFederationPolicy_ForbiddenForNonPlatformAdmin(t *testing.T) {
 		RBAC: newRBACManager(t, scopedAdminRBAC),
 	}
 	body := `{"whitelist":[{"metric":"mysql_up"}]}`
-	w := executeWithRBAC(t, d.PutFederationPolicy(), fedReq(t, "PUT", "/api/v1/federation/policy", "", "", body))
+	w := executeWithRBAC(t, PutFederationPolicy(d), fedReq(t, "PUT", "/api/v1/federation/policy", "", "", body))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
 	}
@@ -158,7 +158,7 @@ func TestPutFederationPolicy_Success(t *testing.T) {
 		RBAC:             newRBACManager(t, platformAdminRBAC),
 	}
 	body := `{"whitelist":[{"metric":"mysql_up"},{"metric":"tenant:cpu:rate5m"}]}`
-	w := executeWithRBAC(t, d.PutFederationPolicy(), fedReq(t, "PUT", "/api/v1/federation/policy", "", "", body))
+	w := executeWithRBAC(t, PutFederationPolicy(d), fedReq(t, "PUT", "/api/v1/federation/policy", "", "", body))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
 	}
@@ -185,7 +185,7 @@ func TestPutFederationPolicy_AdmissionHardBlock(t *testing.T) {
 		AdmissionValidator: fedpolicy.NewAdmissionValidator(promURL),
 		RBAC:               newRBACManager(t, platformAdminRBAC),
 	}
-	w := executeWithRBAC(t, d.PutFederationPolicy(),
+	w := executeWithRBAC(t, PutFederationPolicy(d),
 		fedReq(t, "PUT", "/api/v1/federation/policy", "", "", `{"whitelist":[{"metric":"m"}]}`))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400 (hard block), body: %s", w.Code, w.Body.String())
@@ -209,19 +209,19 @@ func TestPutFederationPolicy_AdmissionWarnNeedsForce(t *testing.T) {
 		RBAC:               newRBACManager(t, platformAdminRBAC),
 	}
 	// No force → rejected.
-	w := executeWithRBAC(t, d.PutFederationPolicy(),
+	w := executeWithRBAC(t, PutFederationPolicy(d),
 		fedReq(t, "PUT", "/api/v1/federation/policy", "", "", `{"whitelist":[{"metric":"m"}]}`))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400 (warn, no force)", w.Code)
 	}
 	// force without a reason → rejected.
-	w = executeWithRBAC(t, d.PutFederationPolicy(),
+	w = executeWithRBAC(t, PutFederationPolicy(d),
 		fedReq(t, "PUT", "/api/v1/federation/policy", "", "", `{"whitelist":[{"metric":"m"}],"force":true}`))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400 (force without reason)", w.Code)
 	}
 	// force + reason → accepted, and the bypass is recorded in git.
-	w = executeWithRBAC(t, d.PutFederationPolicy(),
+	w = executeWithRBAC(t, PutFederationPolicy(d),
 		fedReq(t, "PUT", "/api/v1/federation/policy", "", "", `{"whitelist":[{"metric":"m"}],"force":true,"reason":"cold-start: new cluster"}`))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (force + reason), body: %s", w.Code, w.Body.String())
@@ -245,7 +245,7 @@ func TestPutFederationPolicy_AdmissionPass(t *testing.T) {
 		AdmissionValidator: fedpolicy.NewAdmissionValidator(promURL),
 		RBAC:               newRBACManager(t, platformAdminRBAC),
 	}
-	w := executeWithRBAC(t, d.PutFederationPolicy(),
+	w := executeWithRBAC(t, PutFederationPolicy(d),
 		fedReq(t, "PUT", "/api/v1/federation/policy", "", "", `{"whitelist":[{"metric":"m"}]}`))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (admission pass), body: %s", w.Code, w.Body.String())
@@ -268,7 +268,7 @@ func TestPutFederationPolicy_AdmissionMultipleMetricsConcurrent(t *testing.T) {
 		RBAC:               newRBACManager(t, platformAdminRBAC),
 	}
 	body := `{"whitelist":[{"metric":"m1"},{"metric":"m2"},{"metric":"m3"},{"metric":"m4"},{"metric":"m5"}]}`
-	w := executeWithRBAC(t, d.PutFederationPolicy(), fedReq(t, "PUT", "/api/v1/federation/policy", "", "", body))
+	w := executeWithRBAC(t, PutFederationPolicy(d), fedReq(t, "PUT", "/api/v1/federation/policy", "", "", body))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400 (m3 hard block), body: %s", w.Code, w.Body.String())
 	}
@@ -298,7 +298,7 @@ func TestPutFederationPolicy_RejectsTooManyNewMetrics(t *testing.T) {
 		fmt.Fprintf(&sb, `{"metric":"m%d"}`, i)
 	}
 	sb.WriteString(`]}`)
-	w := executeWithRBAC(t, d.PutFederationPolicy(), fedReq(t, "PUT", "/api/v1/federation/policy", "", "", sb.String()))
+	w := executeWithRBAC(t, PutFederationPolicy(d), fedReq(t, "PUT", "/api/v1/federation/policy", "", "", sb.String()))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400 (too many new metrics)", w.Code)
 	}
@@ -322,7 +322,7 @@ func TestPutFederationPolicy_CancelledContextSkipsGitWrite(t *testing.T) {
 	req := fedReq(t, "PUT", "/api/v1/federation/policy", "", "", `{"whitelist":[{"metric":"m"}]}`)
 	ctx, cancel := context.WithCancel(req.Context())
 	cancel() // the request is already aborted (server timeout / client gone)
-	_ = executeWithRBAC(t, d.PutFederationPolicy(), req.WithContext(ctx))
+	_ = executeWithRBAC(t, PutFederationPolicy(d), req.WithContext(ctx))
 	if _, err := os.Stat(filepath.Join(configDir, "_federation_policy.yaml")); !os.IsNotExist(err) {
 		t.Error("a cancelled request must not write the whitelist file (zombie write)")
 	}
@@ -339,7 +339,7 @@ func TestPutFederationPolicy_RejectsInvalidMetricName(t *testing.T) {
 		RBAC:             newRBACManager(t, platformAdminRBAC),
 	}
 	body := `{"whitelist":[{"metric":"bad-name"}]}`
-	w := executeWithRBAC(t, d.PutFederationPolicy(), fedReq(t, "PUT", "/api/v1/federation/policy", "", "", body))
+	w := executeWithRBAC(t, PutFederationPolicy(d), fedReq(t, "PUT", "/api/v1/federation/policy", "", "", body))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
 	}
@@ -357,7 +357,7 @@ func TestPutTenantFederation_ForbiddenWithoutTenantAdmin(t *testing.T) {
 		RBAC: newRBACManager(t, scopedAdminRBAC),
 	}
 	body := `{"metrics":["mysql_up"]}`
-	w := executeWithRBAC(t, d.PutTenantFederation(), fedReq(t, "PUT", "/api/v1/tenants/db-b/federation", "id", "db-b", body))
+	w := executeWithRBAC(t, PutTenantFederation(d), fedReq(t, "PUT", "/api/v1/tenants/db-b/federation", "id", "db-b", body))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
 	}
@@ -379,7 +379,7 @@ func TestPutTenantFederation_RejectsMetricOutsideWhitelist(t *testing.T) {
 	}
 	// redis_up is not in the whitelist — the 2-tier containment rule rejects it.
 	body := `{"metrics":["mysql_up","redis_up"]}`
-	w := executeWithRBAC(t, d.PutTenantFederation(), fedReq(t, "PUT", "/api/v1/tenants/db-a/federation", "id", "db-a", body))
+	w := executeWithRBAC(t, PutTenantFederation(d), fedReq(t, "PUT", "/api/v1/tenants/db-a/federation", "id", "db-a", body))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400, body: %s", w.Code, w.Body.String())
 	}
@@ -402,11 +402,11 @@ func TestPutTenantFederation_Success(t *testing.T) {
 		RBAC:             newRBACManager(t, scopedAdminRBAC), // admin on db-a
 	}
 	body := `{"metrics":["mysql_up"]}`
-	w := executeWithRBAC(t, d.PutTenantFederation(), fedReq(t, "PUT", "/api/v1/tenants/db-a/federation", "id", "db-a", body))
+	w := executeWithRBAC(t, PutTenantFederation(d), fedReq(t, "PUT", "/api/v1/tenants/db-a/federation", "id", "db-a", body))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
 	}
-	subset, err := d.readFederationSubset("db-a")
+	subset, err := readFederationSubset(d, "db-a")
 	if err != nil {
 		t.Fatalf("readFederationSubset: %v", err)
 	}
@@ -433,7 +433,7 @@ func TestGetTenantFederation_ReadRepairDropsStaleMetric(t *testing.T) {
 	})
 	d := &Deps{ConfigDir: configDir, FederationPolicy: mgr, RBAC: newRBACManager(t, "")}
 
-	w := executeWithRBAC(t, d.GetTenantFederation(), fedReq(t, "GET", "/api/v1/tenants/db-a/federation", "id", "db-a", ""))
+	w := executeWithRBAC(t, GetTenantFederation(d), fedReq(t, "GET", "/api/v1/tenants/db-a/federation", "id", "db-a", ""))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
 	}
@@ -455,7 +455,7 @@ func TestGetTenantFederation_NoFileYieldsEmptySubset(t *testing.T) {
 		FederationPolicy: fedpolicy.NewManager(configDir),
 		RBAC:             newRBACManager(t, ""),
 	}
-	w := executeWithRBAC(t, d.GetTenantFederation(), fedReq(t, "GET", "/api/v1/tenants/db-a/federation", "id", "db-a", ""))
+	w := executeWithRBAC(t, GetTenantFederation(d), fedReq(t, "GET", "/api/v1/tenants/db-a/federation", "id", "db-a", ""))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
 	}

--- a/components/tenant-api/internal/handler/federation_test.go
+++ b/components/tenant-api/internal/handler/federation_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vencil/tenant-api/internal/federation"
+	"github.com/vencil/tenant-api/internal/federation/token"
 	"github.com/vencil/tenant-api/internal/rbac"
 )
 
@@ -28,15 +28,15 @@ const fedViewerRBAC = `groups:
     permissions: [read]
 `
 
-// newTestFederation builds a federation.Manager backed by a freshly
+// newTestFederation builds a token.Manager backed by a freshly
 // generated in-memory RSA key and a store under t.TempDir().
-func newTestFederation(t *testing.T) *federation.Manager {
+func newTestFederation(t *testing.T) *token.Manager {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatalf("generate key: %v", err)
 	}
-	m, err := federation.NewManagerForTest(key, filepath.Join(t.TempDir(), "fed-store.json"), time.Hour)
+	m, err := token.NewManagerForTest(key, filepath.Join(t.TempDir(), "fed-store.json"), time.Hour)
 	if err != nil {
 		t.Fatalf("NewManagerForTest: %v", err)
 	}

--- a/components/tenant-api/internal/handler/federation_test.go
+++ b/components/tenant-api/internal/handler/federation_test.go
@@ -57,7 +57,7 @@ func TestCreateFederationToken_Success(t *testing.T) {
 	req.Header.Set("X-Forwarded-Groups", "fed-admins")
 
 	w := httptest.NewRecorder()
-	wrapWithRBACMiddleware(d.CreateFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+	wrapWithRBACMiddleware(CreateFederationToken(d), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
 
 	if w.Code != http.StatusCreated {
 		t.Fatalf("status = %d, want 201, body: %s", w.Code, w.Body.String())
@@ -95,7 +95,7 @@ func TestCreateFederationToken_ForbiddenWithoutAdmin(t *testing.T) {
 	req.Header.Set("X-Forwarded-Groups", "fed-viewers")
 
 	w := httptest.NewRecorder()
-	wrapWithRBACMiddleware(d.CreateFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+	wrapWithRBACMiddleware(CreateFederationToken(d), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
 
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403, body: %s", w.Code, w.Body.String())
@@ -114,7 +114,7 @@ func TestCreateFederationToken_MissingTenantID(t *testing.T) {
 	req.Header.Set("X-Forwarded-Groups", "fed-admins")
 
 	w := httptest.NewRecorder()
-	wrapWithRBACMiddleware(d.CreateFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+	wrapWithRBACMiddleware(CreateFederationToken(d), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
@@ -133,7 +133,7 @@ func TestCreateFederationToken_InvalidJSON(t *testing.T) {
 	req.Header.Set("X-Forwarded-Groups", "fed-admins")
 
 	w := httptest.NewRecorder()
-	wrapWithRBACMiddleware(d.CreateFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+	wrapWithRBACMiddleware(CreateFederationToken(d), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
@@ -162,7 +162,7 @@ func TestListFederationTokens_Success(t *testing.T) {
 	req.Header.Set("X-Forwarded-Groups", "fed-admins")
 
 	w := httptest.NewRecorder()
-	wrapWithRBACMiddleware(d.ListFederationTokens(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+	wrapWithRBACMiddleware(ListFederationTokens(d), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
@@ -191,7 +191,7 @@ func TestListFederationTokens_MissingTenantID(t *testing.T) {
 	req.Header.Set("X-Forwarded-Groups", "fed-admins")
 
 	w := httptest.NewRecorder()
-	wrapWithRBACMiddleware(d.ListFederationTokens(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+	wrapWithRBACMiddleware(ListFederationTokens(d), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
@@ -208,7 +208,7 @@ func TestListFederationTokens_ForbiddenWithoutAdmin(t *testing.T) {
 	req.Header.Set("X-Forwarded-Groups", "fed-viewers")
 
 	w := httptest.NewRecorder()
-	wrapWithRBACMiddleware(d.ListFederationTokens(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+	wrapWithRBACMiddleware(ListFederationTokens(d), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
 
 	if w.Code != http.StatusForbidden {
 		t.Errorf("status = %d, want 403", w.Code)
@@ -232,7 +232,7 @@ func TestDeleteFederationToken_Success(t *testing.T) {
 	req.Header.Set("X-Forwarded-Groups", "fed-admins")
 
 	w := httptest.NewRecorder()
-	wrapWithRBACMiddleware(d.DeleteFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+	wrapWithRBACMiddleware(DeleteFederationToken(d), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200, body: %s", w.Code, w.Body.String())
@@ -252,7 +252,7 @@ func TestDeleteFederationToken_NotFound(t *testing.T) {
 	req.Header.Set("X-Forwarded-Groups", "fed-admins")
 
 	w := httptest.NewRecorder()
-	wrapWithRBACMiddleware(d.DeleteFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+	wrapWithRBACMiddleware(DeleteFederationToken(d), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
@@ -274,7 +274,7 @@ func TestDeleteFederationToken_ForbiddenWithoutAdmin(t *testing.T) {
 	req.Header.Set("X-Forwarded-Groups", "fed-viewers")
 
 	w := httptest.NewRecorder()
-	wrapWithRBACMiddleware(d.DeleteFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+	wrapWithRBACMiddleware(DeleteFederationToken(d), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
 
 	if w.Code != http.StatusForbidden {
 		t.Errorf("status = %d, want 403", w.Code)
@@ -298,7 +298,7 @@ func TestCreateFederationToken_RejectsInvalidTenantID(t *testing.T) {
 	req.Header.Set("X-Forwarded-Groups", "fed-admins")
 
 	w := httptest.NewRecorder()
-	wrapWithRBACMiddleware(d.CreateFederationToken(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+	wrapWithRBACMiddleware(CreateFederationToken(d), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
@@ -315,7 +315,7 @@ func TestListFederationTokens_RejectsInvalidTenantID(t *testing.T) {
 	req.Header.Set("X-Forwarded-Groups", "fed-admins")
 
 	w := httptest.NewRecorder()
-	wrapWithRBACMiddleware(d.ListFederationTokens(), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
+	wrapWithRBACMiddleware(ListFederationTokens(d), rbacMgr, rbac.PermRead, nil).ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
@@ -328,7 +328,7 @@ func TestCreateFederationToken_RateLimited(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, fedAdminRBAC)
 	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
-	h := wrapWithRBACMiddleware(d.CreateFederationToken(), rbacMgr, rbac.PermRead, nil)
+	h := wrapWithRBACMiddleware(CreateFederationToken(d), rbacMgr, rbac.PermRead, nil)
 
 	post := func() int {
 		req := httptest.NewRequest("POST", "/api/v1/federation/tokens",

--- a/components/tenant-api/internal/handler/group.go
+++ b/components/tenant-api/internal/handler/group.go
@@ -33,7 +33,7 @@ type GroupResponse struct {
 // @Produce     json
 // @Success     200 {array}  GroupResponse
 // @Router      /api/v1/groups [get]
-func (d *Deps) ListGroups() http.HandlerFunc {
+func ListGroups(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idpGroups := rbac.RequestGroups(r)
 		rbacCfg := d.RBAC.Get()
@@ -92,7 +92,7 @@ func tenantIDFromString(s string) string { return s }
 // @Failure     400  {object} map[string]string
 // @Failure     404  {object} map[string]string
 // @Router      /api/v1/groups/{id} [get]
-func (d *Deps) GetGroup() http.HandlerFunc {
+func GetGroup(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		groupID := chi.URLParam(r, "id")
 		if err := groups.ValidateGroupID(groupID); err != nil {
@@ -154,7 +154,7 @@ type PutGroupRequest struct {
 // @Failure     403  {object} map[string]string
 // @Failure     409  {object} map[string]string
 // @Router      /api/v1/groups/{id} [put]
-func (d *Deps) PutGroup() http.HandlerFunc {
+func PutGroup(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		groupID := chi.URLParam(r, "id")
 		if err := groups.ValidateGroupID(groupID); err != nil {
@@ -254,7 +254,7 @@ func (d *Deps) PutGroup() http.HandlerFunc {
 // @Failure     404 {object} map[string]string
 // @Failure     409 {object} map[string]string
 // @Router      /api/v1/groups/{id} [delete]
-func (d *Deps) DeleteGroup() http.HandlerFunc {
+func DeleteGroup(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		groupID := chi.URLParam(r, "id")
 		if err := groups.ValidateGroupID(groupID); err != nil {

--- a/components/tenant-api/internal/handler/group_batch.go
+++ b/components/tenant-api/internal/handler/group_batch.go
@@ -52,7 +52,7 @@ type GroupBatchResponse struct {
 // @Failure     400   {object} map[string]string
 // @Failure     404   {object} map[string]string
 // @Router      /api/v1/groups/{id}/batch [post]
-func (d *Deps) GroupBatch() http.HandlerFunc {
+func GroupBatch(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		groupID := chi.URLParam(r, "id")
 		if err := groups.ValidateGroupID(groupID); err != nil {

--- a/components/tenant-api/internal/handler/group_test.go
+++ b/components/tenant-api/internal/handler/group_test.go
@@ -95,7 +95,7 @@ func TestListGroups_Empty(t *testing.T) {
 	mgr := groups.NewManager(configDir)
 
 	rbacMgr := newRBACManager(t, "")
-	h := (&Deps{Groups: mgr, RBAC: rbacMgr}).ListGroups()
+	h := ListGroups(&Deps{Groups: mgr, RBAC: rbacMgr})
 	req := httptest.NewRequest("GET", "/api/v1/groups", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -120,7 +120,7 @@ func TestListGroups_WithData(t *testing.T) {
 	mgr := groups.NewManager(configDir)
 
 	rbacMgr := newRBACManager(t, "")
-	h := (&Deps{Groups: mgr, RBAC: rbacMgr}).ListGroups()
+	h := ListGroups(&Deps{Groups: mgr, RBAC: rbacMgr})
 	req := httptest.NewRequest("GET", "/api/v1/groups", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -160,7 +160,7 @@ func TestGetGroup_Success(t *testing.T) {
 	setupGroupsFile(t, configDir, testGroupsYAML)
 	mgr := groups.NewManager(configDir)
 
-	h := (&Deps{Groups: mgr}).GetGroup()
+	h := GetGroup(&Deps{Groups: mgr})
 	req := newRequestWithChiParam("GET", "/api/v1/groups/production-dba", "id", "production-dba", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -192,7 +192,7 @@ func TestGetGroup_NotFound(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	mgr := groups.NewManager(configDir)
 
-	h := (&Deps{Groups: mgr}).GetGroup()
+	h := GetGroup(&Deps{Groups: mgr})
 	req := newRequestWithChiParam("GET", "/api/v1/groups/nonexistent", "id", "nonexistent", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -207,7 +207,7 @@ func TestGetGroup_InvalidID(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	mgr := groups.NewManager(configDir)
 
-	h := (&Deps{Groups: mgr}).GetGroup()
+	h := GetGroup(&Deps{Groups: mgr})
 	req := newRequestWithChiParam("GET", "/api/v1/groups/INVALID!", "id", "INVALID!", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -235,7 +235,7 @@ func TestPutGroup_Create(t *testing.T) {
 	// permissiveRBACManager: v2.8.0 B-6 PR-2 hardening requires
 	// PermWrite on every member tenant. Open-mode RBAC only grants
 	// PermRead, so the test caller needs an explicit admin grant.
-	h := (&Deps{Groups: mgr, Writer: writer, RBAC: permissiveRBACManager(t)}).PutGroup()
+	h := PutGroup(&Deps{Groups: mgr, Writer: writer, RBAC: permissiveRBACManager(t)})
 	w := executeWithRBAC(t, h, req)
 
 	if w.Code != http.StatusOK {
@@ -278,7 +278,7 @@ func TestPutGroup_Update(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	setRequestIdentity(req, "test@example.com")
 
-	h := (&Deps{Groups: mgr, Writer: writer, RBAC: permissiveRBACManager(t)}).PutGroup()
+	h := PutGroup(&Deps{Groups: mgr, Writer: writer, RBAC: permissiveRBACManager(t)})
 	w := executeWithRBAC(t, h, req)
 
 	if w.Code != http.StatusOK {
@@ -306,7 +306,7 @@ func TestPutGroup_MissingLabel(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
-	h := (&Deps{Groups: mgr, Writer: writer, RBAC: newRBACManager(t, "")}).PutGroup()
+	h := PutGroup(&Deps{Groups: mgr, Writer: writer, RBAC: newRBACManager(t, "")})
 	h(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -325,7 +325,7 @@ func TestPutGroup_InvalidJSON(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
-	h := (&Deps{Groups: mgr, Writer: writer, RBAC: newRBACManager(t, "")}).PutGroup()
+	h := PutGroup(&Deps{Groups: mgr, Writer: writer, RBAC: newRBACManager(t, "")})
 	h(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -346,7 +346,7 @@ func TestDeleteGroup_Success(t *testing.T) {
 	req := newRequestWithChiParam("DELETE", "/api/v1/groups/staging-all", "id", "staging-all", nil)
 	setRequestIdentity(req, "test@example.com")
 
-	h := (&Deps{Groups: mgr, Writer: writer, RBAC: permissiveRBACManager(t)}).DeleteGroup()
+	h := DeleteGroup(&Deps{Groups: mgr, Writer: writer, RBAC: permissiveRBACManager(t)})
 	w := executeWithRBAC(t, h, req)
 
 	if w.Code != http.StatusOK {
@@ -375,7 +375,7 @@ func TestDeleteGroup_NotFound(t *testing.T) {
 	req.Header.Set("X-Forwarded-Email", "test@example.com")
 
 	w := httptest.NewRecorder()
-	h := (&Deps{Groups: mgr, Writer: writer, RBAC: newRBACManager(t, "")}).DeleteGroup()
+	h := DeleteGroup(&Deps{Groups: mgr, Writer: writer, RBAC: newRBACManager(t, "")})
 	h(w, req)
 
 	if w.Code != http.StatusNotFound {
@@ -404,7 +404,7 @@ func TestGroupBatch_Success(t *testing.T) {
 	req.Header.Set("X-Forwarded-Email", "test@example.com")
 
 	w := httptest.NewRecorder()
-	h := (&Deps{Groups: groupMgr, Writer: writer, ConfigDir: configDir, RBAC: rbacMgr}).GroupBatch()
+	h := GroupBatch(&Deps{Groups: groupMgr, Writer: writer, ConfigDir: configDir, RBAC: rbacMgr})
 	h(w, req)
 
 	if w.Code != http.StatusOK {
@@ -439,7 +439,7 @@ func TestGroupBatch_GroupNotFound(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
-	h := (&Deps{Groups: groupMgr, Writer: writer, ConfigDir: configDir, RBAC: rbacMgr}).GroupBatch()
+	h := GroupBatch(&Deps{Groups: groupMgr, Writer: writer, ConfigDir: configDir, RBAC: rbacMgr})
 	h(w, req)
 
 	if w.Code != http.StatusNotFound {
@@ -461,7 +461,7 @@ func TestGroupBatch_EmptyPatch(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
-	h := (&Deps{Groups: groupMgr, Writer: writer, ConfigDir: configDir, RBAC: rbacMgr}).GroupBatch()
+	h := GroupBatch(&Deps{Groups: groupMgr, Writer: writer, ConfigDir: configDir, RBAC: rbacMgr})
 	h(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -492,7 +492,7 @@ func TestListTenants_WithMetadata(t *testing.T) {
 	})
 
 	rbacMgr := newRBACManager(t, "")
-	h := (&Deps{ConfigDir: configDir, RBAC: rbacMgr}).ListTenants()
+	h := ListTenants(&Deps{ConfigDir: configDir, RBAC: rbacMgr})
 	req := httptest.NewRequest("GET", "/api/v1/tenants", nil)
 	w := httptest.NewRecorder()
 	h(w, req)

--- a/components/tenant-api/internal/handler/handler_test.go
+++ b/components/tenant-api/internal/handler/handler_test.go
@@ -92,7 +92,7 @@ func TestHealth(t *testing.T) {
 func TestReady(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	handler := (&Deps{ConfigDir: dir}).Ready()
+	handler := Ready(&Deps{ConfigDir: dir})
 
 	req := httptest.NewRequest("GET", "/ready", nil)
 	w := httptest.NewRecorder()
@@ -119,7 +119,7 @@ func TestReady(t *testing.T) {
 func TestReady_MissingDir(t *testing.T) {
 	t.Parallel()
 	missing := filepath.Join(t.TempDir(), "does-not-exist")
-	handler := (&Deps{ConfigDir: missing}).Ready()
+	handler := Ready(&Deps{ConfigDir: missing})
 
 	req := httptest.NewRequest("GET", "/ready", nil)
 	w := httptest.NewRecorder()
@@ -146,7 +146,7 @@ func TestReady_NotADirectory(t *testing.T) {
 	if err := os.WriteFile(filePath, []byte("not a dir"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	handler := (&Deps{ConfigDir: filePath}).Ready()
+	handler := Ready(&Deps{ConfigDir: filePath})
 
 	req := httptest.NewRequest("GET", "/ready", nil)
 	w := httptest.NewRecorder()
@@ -165,7 +165,7 @@ func TestGetTenant_Success(t *testing.T) {
 		"db-a.yaml": "tenants:\n  db-a:\n    _silent_mode: \"warning\"\n",
 	})
 
-	h := (&Deps{ConfigDir: configDir}).GetTenant()
+	h := GetTenant(&Deps{ConfigDir: configDir})
 	req := newRequestWithChiParam("GET", "/api/v1/tenants/db-a", "id", "db-a", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -189,7 +189,7 @@ func TestGetTenant_NotFound(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
 
-	h := (&Deps{ConfigDir: configDir}).GetTenant()
+	h := GetTenant(&Deps{ConfigDir: configDir})
 	req := newRequestWithChiParam("GET", "/api/v1/tenants/nonexistent", "id", "nonexistent", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -203,7 +203,7 @@ func TestGetTenant_InvalidID(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
 
-	h := (&Deps{ConfigDir: configDir}).GetTenant()
+	h := GetTenant(&Deps{ConfigDir: configDir})
 	req := newRequestWithChiParam("GET", "/api/v1/tenants/../etc", "id", "../etc", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -220,7 +220,7 @@ func TestGetTenant_WithDefaults(t *testing.T) {
 		"db-a.yaml":      "tenants:\n  db-a:\n    mysql_connections: \"70\"\n",
 	})
 
-	h := (&Deps{ConfigDir: configDir}).GetTenant()
+	h := GetTenant(&Deps{ConfigDir: configDir})
 	req := newRequestWithChiParam("GET", "/api/v1/tenants/db-a", "id", "db-a", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -244,7 +244,7 @@ func TestGetTenant_EmptyID(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
 
-	h := (&Deps{ConfigDir: configDir}).GetTenant()
+	h := GetTenant(&Deps{ConfigDir: configDir})
 	req := newRequestWithChiParam("GET", "/api/v1/tenants/", "id", "", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -260,7 +260,7 @@ func TestListTenants_Empty(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
 
-	h := (&Deps{ConfigDir: configDir, RBAC: newRBACManager(t, "")}).ListTenants()
+	h := ListTenants(&Deps{ConfigDir: configDir, RBAC: newRBACManager(t, "")})
 	req := httptest.NewRequest("GET", "/api/v1/tenants", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -284,7 +284,7 @@ func TestListTenants_MultipleTenants(t *testing.T) {
 		"db-b.yaml": "tenants:\n  db-b:\n    _state_maintenance: \"enable\"\n",
 	})
 
-	h := (&Deps{ConfigDir: configDir, RBAC: newRBACManager(t, "")}).ListTenants()
+	h := ListTenants(&Deps{ConfigDir: configDir, RBAC: newRBACManager(t, "")})
 	req := httptest.NewRequest("GET", "/api/v1/tenants", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -326,7 +326,7 @@ func TestListTenants_SkipsHiddenAndDefaults(t *testing.T) {
 		"not-yaml.txt":   "not yaml",
 	})
 
-	h := (&Deps{ConfigDir: configDir, RBAC: newRBACManager(t, "")}).ListTenants()
+	h := ListTenants(&Deps{ConfigDir: configDir, RBAC: newRBACManager(t, "")})
 	req := httptest.NewRequest("GET", "/api/v1/tenants", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -346,7 +346,7 @@ func TestListTenants_WithYmlExtension(t *testing.T) {
 		"db-c.yml": "tenants:\n  db-c:\n    mysql_cpu: \"75\"\n",
 	})
 
-	h := (&Deps{ConfigDir: configDir, RBAC: newRBACManager(t, "")}).ListTenants()
+	h := ListTenants(&Deps{ConfigDir: configDir, RBAC: newRBACManager(t, "")})
 	req := httptest.NewRequest("GET", "/api/v1/tenants", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -370,7 +370,7 @@ func TestListTenants_MalformedYAML(t *testing.T) {
 		"db-a.yaml": "tenants:\n  db-a:\n    mysql_cpu: \"80\"\n",
 	})
 
-	h := (&Deps{ConfigDir: configDir, RBAC: newRBACManager(t, "")}).ListTenants()
+	h := ListTenants(&Deps{ConfigDir: configDir, RBAC: newRBACManager(t, "")})
 	req := httptest.NewRequest("GET", "/api/v1/tenants", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -396,7 +396,7 @@ func TestValidateTenant_Valid(t *testing.T) {
 		"_defaults.yaml": "defaults:\n  mysql_connections: 80\n",
 	})
 
-	h := (&Deps{ConfigDir: configDir}).ValidateTenant()
+	h := ValidateTenant(&Deps{ConfigDir: configDir})
 	body := bytes.NewBufferString("tenants:\n  db-a:\n    mysql_connections: \"70\"\n")
 	req := newRequestWithChiParam("POST", "/api/v1/tenants/db-a/validate", "id", "db-a", body)
 	w := httptest.NewRecorder()
@@ -418,7 +418,7 @@ func TestValidateTenant_InvalidID(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
 
-	h := (&Deps{ConfigDir: configDir}).ValidateTenant()
+	h := ValidateTenant(&Deps{ConfigDir: configDir})
 	body := bytes.NewBufferString("tenants:\n  bad:\n    x: \"1\"\n")
 	req := newRequestWithChiParam("POST", "/api/v1/tenants/../bad/validate", "id", "../bad", body)
 	w := httptest.NewRecorder()
@@ -433,7 +433,7 @@ func TestValidateTenant_WithWarnings(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil) // no defaults
 
-	h := (&Deps{ConfigDir: configDir}).ValidateTenant()
+	h := ValidateTenant(&Deps{ConfigDir: configDir})
 	// unknown_key is not in defaults and not a reserved key -> warning
 	body := bytes.NewBufferString("tenants:\n  db-a:\n    unknown_key_xyz: \"70\"\n")
 	req := newRequestWithChiParam("POST", "/api/v1/tenants/db-a/validate", "id", "db-a", body)
@@ -459,7 +459,7 @@ func TestDiffTenant_NewTenant_JSON(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	gw := newTestWriter(configDir)
 
-	h := (&Deps{Writer: gw}).DiffTenant()
+	h := DiffTenant(&Deps{Writer: gw})
 	reqBody, _ := json.Marshal(DiffRequest{Proposed: "tenants:\n  new-db:\n    cpu: \"80\"\n"})
 	body := bytes.NewBuffer(reqBody)
 	req := newRequestWithChiParam("POST", "/api/v1/tenants/new-db/diff", "id", "new-db", body)
@@ -493,7 +493,7 @@ func TestDiffTenant_NoDiff(t *testing.T) {
 	})
 	gw := newTestWriter(configDir)
 
-	h := (&Deps{Writer: gw}).DiffTenant()
+	h := DiffTenant(&Deps{Writer: gw})
 	reqBody, _ := json.Marshal(DiffRequest{Proposed: content})
 	body := bytes.NewBuffer(reqBody)
 	req := newRequestWithChiParam("POST", "/api/v1/tenants/db-a/diff", "id", "db-a", body)
@@ -520,7 +520,7 @@ func TestDiffTenant_RawYAML(t *testing.T) {
 	})
 	gw := newTestWriter(configDir)
 
-	h := (&Deps{Writer: gw}).DiffTenant()
+	h := DiffTenant(&Deps{Writer: gw})
 	body := bytes.NewBufferString("tenants:\n  db-a:\n    cpu: \"90\"\n")
 	req := newRequestWithChiParam("POST", "/api/v1/tenants/db-a/diff", "id", "db-a", body)
 	req.Header.Set("Content-Type", "application/yaml")
@@ -544,7 +544,7 @@ func TestDiffTenant_InvalidID(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	gw := newTestWriter(configDir)
 
-	h := (&Deps{Writer: gw}).DiffTenant()
+	h := DiffTenant(&Deps{Writer: gw})
 	req := newRequestWithChiParam("POST", "/api/v1/tenants/../bad/diff", "id", "../bad", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -560,7 +560,7 @@ func TestDiffTenant_JSONAutoDetect(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	gw := newTestWriter(configDir)
 
-	h := (&Deps{Writer: gw}).DiffTenant()
+	h := DiffTenant(&Deps{Writer: gw})
 	reqBody, _ := json.Marshal(DiffRequest{Proposed: "tenants:\n  db-x:\n    cpu: \"80\"\n"})
 	body := bytes.NewBuffer(reqBody)
 	req := newRequestWithChiParam("POST", "/api/v1/tenants/db-x/diff", "id", "db-x", body)
@@ -681,7 +681,7 @@ func TestPutTenant_InvalidID(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	gw := newTestWriter(configDir)
 
-	h := (&Deps{Writer: gw, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect}).PutTenant()
+	h := PutTenant(&Deps{Writer: gw, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect})
 	body := bytes.NewBufferString("tenants:\n  bad:\n    x: \"1\"\n")
 	req := newRequestWithChiParam("PUT", "/api/v1/tenants/../bad", "id", "../bad", body)
 	w := httptest.NewRecorder()
@@ -697,7 +697,7 @@ func TestPutTenant_EmptyID(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	gw := newTestWriter(configDir)
 
-	h := (&Deps{Writer: gw, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect}).PutTenant()
+	h := PutTenant(&Deps{Writer: gw, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect})
 	body := bytes.NewBufferString("tenants:\n  test:\n    x: \"1\"\n")
 	req := newRequestWithChiParam("PUT", "/api/v1/tenants/", "id", "", body)
 	w := httptest.NewRecorder()
@@ -714,7 +714,7 @@ func TestPutTenant_ValidationFailure(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	gw := newTestWriter(configDir)
 
-	h := (&Deps{Writer: gw, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect}).PutTenant()
+	h := PutTenant(&Deps{Writer: gw, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect})
 	// Valid ID but YAML doesn't contain the matching tenant section
 	body := bytes.NewBufferString("tenants:\n  other-tenant:\n    x: \"1\"\n")
 	req := newRequestWithChiParam("PUT", "/api/v1/tenants/db-a", "id", "db-a", body)
@@ -732,7 +732,7 @@ func TestPutTenant_InvalidYAML(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	gw := newTestWriter(configDir)
 
-	h := (&Deps{Writer: gw, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect}).PutTenant()
+	h := PutTenant(&Deps{Writer: gw, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect})
 	body := bytes.NewBufferString("{{invalid yaml")
 	req := newRequestWithChiParam("PUT", "/api/v1/tenants/db-a", "id", "db-a", body)
 	w := httptest.NewRecorder()
@@ -751,7 +751,7 @@ func TestBatchTenants_EmptyOperations(t *testing.T) {
 	gw := newTestWriter(configDir)
 	rbacMgr := newRBACManager(t, "")
 
-	h := (&Deps{Writer: gw, ConfigDir: configDir, RBAC: rbacMgr, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect}).BatchTenants()
+	h := BatchTenants(&Deps{Writer: gw, ConfigDir: configDir, RBAC: rbacMgr, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect})
 	reqBody, _ := json.Marshal(BatchRequest{Operations: []BatchOperation{}})
 	body := bytes.NewBuffer(reqBody)
 	req := httptest.NewRequest("POST", "/api/v1/tenants/batch", body)
@@ -770,7 +770,7 @@ func TestBatchTenants_InvalidJSON(t *testing.T) {
 	gw := newTestWriter(configDir)
 	rbacMgr := newRBACManager(t, "")
 
-	h := (&Deps{Writer: gw, ConfigDir: configDir, RBAC: rbacMgr, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect}).BatchTenants()
+	h := BatchTenants(&Deps{Writer: gw, ConfigDir: configDir, RBAC: rbacMgr, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect})
 	body := bytes.NewBufferString("{invalid json")
 	req := httptest.NewRequest("POST", "/api/v1/tenants/batch", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -788,7 +788,7 @@ func TestBatchTenants_InvalidTenantID(t *testing.T) {
 	gw := newTestWriter(configDir)
 	rbacMgr := newRBACManager(t, "")
 
-	h := (&Deps{Writer: gw, ConfigDir: configDir, RBAC: rbacMgr, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect}).BatchTenants()
+	h := BatchTenants(&Deps{Writer: gw, ConfigDir: configDir, RBAC: rbacMgr, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect})
 	reqBody, _ := json.Marshal(BatchRequest{
 		Operations: []BatchOperation{
 			{TenantID: "../bad", Patch: map[string]string{"_silent_mode": "warning"}},
@@ -823,7 +823,7 @@ func TestBatchTenants_PermissionDenied(t *testing.T) {
     permissions: [read]
 `)
 
-	h := (&Deps{Writer: gw, ConfigDir: configDir, RBAC: rbacMgr, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect}).BatchTenants()
+	h := BatchTenants(&Deps{Writer: gw, ConfigDir: configDir, RBAC: rbacMgr, Policy: policy.NewManager(configDir), WriteMode: WriteModeDirect})
 	reqBody, _ := json.Marshal(BatchRequest{
 		Operations: []BatchOperation{
 			{TenantID: "db-a", Patch: map[string]string{"_silent_mode": "warning"}},
@@ -998,7 +998,7 @@ func TestFullRouter_GetTenant(t *testing.T) {
 
 	r := chi.NewRouter()
 	r.With(rbacMgr.Middleware(rbac.PermRead, TenantIDFromPath)).
-		Get("/api/v1/tenants/{id}", (&Deps{ConfigDir: configDir}).GetTenant())
+		Get("/api/v1/tenants/{id}", GetTenant(&Deps{ConfigDir: configDir}))
 
 	req := httptest.NewRequest("GET", "/api/v1/tenants/db-a", nil)
 	req.Header.Set("X-Forwarded-Email", "test@example.com")
@@ -1025,7 +1025,7 @@ func TestFullRouter_GetTenant_Unauthorized(t *testing.T) {
 
 	r := chi.NewRouter()
 	r.With(rbacMgr.Middleware(rbac.PermRead, TenantIDFromPath)).
-		Get("/api/v1/tenants/{id}", (&Deps{ConfigDir: configDir}).GetTenant())
+		Get("/api/v1/tenants/{id}", GetTenant(&Deps{ConfigDir: configDir}))
 
 	// No identity headers
 	req := httptest.NewRequest("GET", "/api/v1/tenants/db-a", nil)
@@ -1051,7 +1051,7 @@ func TestFullRouter_GetTenant_Forbidden(t *testing.T) {
 
 	r := chi.NewRouter()
 	r.With(rbacMgr.Middleware(rbac.PermRead, TenantIDFromPath)).
-		Get("/api/v1/tenants/{id}", (&Deps{ConfigDir: configDir}).GetTenant())
+		Get("/api/v1/tenants/{id}", GetTenant(&Deps{ConfigDir: configDir}))
 
 	req := httptest.NewRequest("GET", "/api/v1/tenants/db-a", nil)
 	req.Header.Set("X-Forwarded-Email", "test@example.com")
@@ -1078,7 +1078,7 @@ func TestFullRouter_ListTenants(t *testing.T) {
 
 	r := chi.NewRouter()
 	r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-		Get("/api/v1/tenants", (&Deps{ConfigDir: configDir, RBAC: newRBACManager(t, "")}).ListTenants())
+		Get("/api/v1/tenants", ListTenants(&Deps{ConfigDir: configDir, RBAC: newRBACManager(t, "")}))
 
 	req := httptest.NewRequest("GET", "/api/v1/tenants", nil)
 	req.Header.Set("X-Forwarded-Email", "test@example.com")
@@ -1160,7 +1160,7 @@ groups:
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := (&Deps{RBAC: rbacMgr}).Me()
+			handler := Me(&Deps{RBAC: rbacMgr})
 
 			// Create request and inject RBAC context
 			req := httptest.NewRequest("GET", "/api/v1/me", nil)
@@ -1196,7 +1196,7 @@ groups:
 func TestMe_EmptyGroupsRendersAsArray(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, "")
-	handler := (&Deps{RBAC: rbacMgr}).Me()
+	handler := Me(&Deps{RBAC: rbacMgr})
 
 	// No X-Forwarded-Groups header — caller has no group memberships.
 	req := httptest.NewRequest("GET", "/api/v1/me", nil)
@@ -1232,7 +1232,7 @@ func TestMeMissingIdentity(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, "")
 
-	handler := (&Deps{RBAC: rbacMgr}).Me()
+	handler := Me(&Deps{RBAC: rbacMgr})
 	req := httptest.NewRequest("GET", "/api/v1/me", nil)
 	// Intentionally omit X-Forwarded-Email
 
@@ -1251,7 +1251,7 @@ func TestMeEmptyEmailDirect(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, "")
 
-	handler := (&Deps{RBAC: rbacMgr}).Me()
+	handler := Me(&Deps{RBAC: rbacMgr})
 	req := httptest.NewRequest("GET", "/api/v1/me", nil)
 	// No middleware — RequestEmail(r) returns "" from empty context
 

--- a/components/tenant-api/internal/handler/health.go
+++ b/components/tenant-api/internal/handler/health.go
@@ -17,7 +17,7 @@ func Health(w http.ResponseWriter, r *http.Request) {
 // stat-able (e.g. ConfigMap mount failed, PV detached). Returns 200
 // only when the directory is readable, so K8s drains traffic away
 // from a pod whose tenant data the app cannot serve.
-func (d *Deps) Ready() http.HandlerFunc {
+func Ready(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 

--- a/components/tenant-api/internal/handler/me.go
+++ b/components/tenant-api/internal/handler/me.go
@@ -32,7 +32,7 @@ type MeResponse struct {
 // @Success     200 {object} MeResponse
 // @Failure     401 {object} map[string]string
 // @Router      /api/v1/me [get]
-func (d *Deps) Me() http.HandlerFunc {
+func Me(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		email := rbac.RequestEmail(r)
 		if email == "" {

--- a/components/tenant-api/internal/handler/metrics.go
+++ b/components/tenant-api/internal/handler/metrics.go
@@ -6,7 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/vencil/tenant-api/internal/federation"
+	"github.com/vencil/tenant-api/internal/federation/orphan"
 )
 
 // Metrics tracks basic request counters exposed at /metrics.
@@ -89,7 +89,7 @@ func MetricsHandler(w http.ResponseWriter, r *http.Request) {
 
 	// ADR-020 #521: federation artifacts left by an incomplete tenant
 	// offboarding. Non-zero ⇒ work docs/internal/tenant-offboarding-runbook.md.
-	orphanTokens, orphanSubsets := federation.OrphanCounts()
+	orphanTokens, orphanSubsets := orphan.OrphanCounts()
 	_, _ = fmt.Fprintf(w, "# HELP tenant_api_federation_orphaned_tokens Live federation token records whose tenant is no longer in conf.d.\n")
 	_, _ = fmt.Fprintf(w, "# TYPE tenant_api_federation_orphaned_tokens gauge\n")
 	_, _ = fmt.Fprintf(w, "tenant_api_federation_orphaned_tokens %d\n", orphanTokens)

--- a/components/tenant-api/internal/handler/pr.go
+++ b/components/tenant-api/internal/handler/pr.go
@@ -41,7 +41,7 @@ type PRListResponse struct {
 // @Param       tenant query  string false "Filter by tenant ID"
 // @Success     200   {object} PRListResponse
 // @Router      /api/v1/prs [get]
-func (d *Deps) ListPRs() http.HandlerFunc {
+func ListPRs(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idpGroups := rbac.RequestGroups(r)
 		tenantFilter := r.URL.Query().Get("tenant")

--- a/components/tenant-api/internal/handler/pr_test.go
+++ b/components/tenant-api/internal/handler/pr_test.go
@@ -47,7 +47,7 @@ func TestListPRs_Empty(t *testing.T) {
 	t.Parallel()
 	tracker := newTestTracker(t, []platform.PRInfo{})
 
-	h := (&Deps{PRTracker: tracker, RBAC: newRBACManager(t, "")}).ListPRs()
+	h := ListPRs(&Deps{PRTracker: tracker, RBAC: newRBACManager(t, "")})
 	req := httptest.NewRequest("GET", "/api/v1/prs", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -72,7 +72,7 @@ func TestListPRs_WithPRs(t *testing.T) {
 		{Number: 2, WebURL: "https://gh/2", State: "open", Title: "PR2", HeadRef: "tenant-api/db-b/20260406"},
 	})
 
-	h := (&Deps{PRTracker: tracker, RBAC: newRBACManager(t, "")}).ListPRs()
+	h := ListPRs(&Deps{PRTracker: tracker, RBAC: newRBACManager(t, "")})
 	req := httptest.NewRequest("GET", "/api/v1/prs", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -100,7 +100,7 @@ func TestListPRs_WithRegisteredPR(t *testing.T) {
 		HeadRef:  "tenant-api/db-a/20260406",
 	})
 
-	h := (&Deps{PRTracker: tracker, RBAC: newRBACManager(t, "")}).ListPRs()
+	h := ListPRs(&Deps{PRTracker: tracker, RBAC: newRBACManager(t, "")})
 	req := httptest.NewRequest("GET", "/api/v1/prs", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -127,7 +127,7 @@ func TestListPRs_FilterByTenant(t *testing.T) {
 		Number: 2, WebURL: "https://gh/2", State: "open", TenantID: "db-b",
 	})
 
-	h := (&Deps{PRTracker: tracker, RBAC: newRBACManager(t, "")}).ListPRs()
+	h := ListPRs(&Deps{PRTracker: tracker, RBAC: newRBACManager(t, "")})
 
 	// Filter for db-a only
 	req := httptest.NewRequest("GET", "/api/v1/prs?tenant=db-a", nil)
@@ -152,7 +152,7 @@ func TestListPRs_FilterByNonexistentTenant(t *testing.T) {
 		Number: 1, WebURL: "https://gh/1", State: "open", TenantID: "db-a",
 	})
 
-	h := (&Deps{PRTracker: tracker, RBAC: newRBACManager(t, "")}).ListPRs()
+	h := ListPRs(&Deps{PRTracker: tracker, RBAC: newRBACManager(t, "")})
 	req := httptest.NewRequest("GET", "/api/v1/prs?tenant=nonexistent", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -175,7 +175,7 @@ func TestPutTenant_DirectMode(t *testing.T) {
 	})
 	writer := newTestWriter(configDir)
 
-	h := (&Deps{Writer: writer, WriteMode: WriteModeDirect}).PutTenant()
+	h := PutTenant(&Deps{Writer: writer, WriteMode: WriteModeDirect})
 	body := bytes.NewBufferString("tenants:\n  db-a:\n    _silent_mode: \"critical\"\n")
 	req := newRequestWithChiParam("PUT", "/api/v1/tenants/db-a", "id", "db-a", body)
 	// Set identity headers for RBAC
@@ -217,7 +217,7 @@ func TestPutTenant_PRMode_PendingPRConflict(t *testing.T) {
 		HeadRef:  "tenant-api/db-a/20260406",
 	})
 
-	h := (&Deps{Writer: writer, WriteMode: WriteModePR, PRClient: ghClient, PRTracker: tracker}).PutTenant()
+	h := PutTenant(&Deps{Writer: writer, WriteMode: WriteModePR, PRClient: ghClient, PRTracker: tracker})
 	body := bytes.NewBufferString("tenants:\n  db-a:\n    _silent_mode: \"critical\"\n")
 	req := newRequestWithChiParam("PUT", "/api/v1/tenants/db-a", "id", "db-a", body)
 	req.Header.Set("X-Forwarded-Email", "test@example.com")
@@ -253,7 +253,7 @@ func TestPutTenant_PRMode_InvalidTenantID(t *testing.T) {
 	ghClient.SetBaseURL(ghSrv.URL)
 	tracker := gh.NewTracker(ghClient, 1<<30)
 
-	h := (&Deps{Writer: writer, WriteMode: WriteModePR, PRClient: ghClient, PRTracker: tracker}).PutTenant()
+	h := PutTenant(&Deps{Writer: writer, WriteMode: WriteModePR, PRClient: ghClient, PRTracker: tracker})
 	body := bytes.NewBufferString("content")
 	req := newRequestWithChiParam("PUT", "/api/v1/tenants/../etc/passwd", "id", "../etc/passwd", body)
 	w := httptest.NewRecorder()
@@ -293,7 +293,7 @@ func TestPutTenant_GitLabMode_PendingMRConflict(t *testing.T) {
 	})
 
 	// Use pr-gitlab write mode with the tracker
-	h := (&Deps{Writer: writer, WriteMode: WriteModePRGitLab, PRClient: ghClient, PRTracker: tracker}).PutTenant()
+	h := PutTenant(&Deps{Writer: writer, WriteMode: WriteModePRGitLab, PRClient: ghClient, PRTracker: tracker})
 	body := bytes.NewBufferString("tenants:\n  db-a:\n    _silent_mode: \"critical\"\n")
 	req := newRequestWithChiParam("PUT", "/api/v1/tenants/db-a", "id", "db-a", body)
 	req.Header.Set("X-Forwarded-Email", "test@example.com")
@@ -391,7 +391,7 @@ func TestPutTenant_PRMode_HappyPath(t *testing.T) {
 	}
 	mockTracker := &mockPlatformTracker{}
 
-	h := (&Deps{Writer: writer, WriteMode: WriteModePR, PRClient: mockClient, PRTracker: mockTracker}).PutTenant()
+	h := PutTenant(&Deps{Writer: writer, WriteMode: WriteModePR, PRClient: mockClient, PRTracker: mockTracker})
 	body := bytes.NewBufferString("tenants:\n  db-a:\n    _silent_mode: \"critical\"\n")
 	req := newRequestWithChiParam("PUT", "/api/v1/tenants/db-a", "id", "db-a", body)
 	req.Header.Set("X-Forwarded-Email", "alice@example.com")
@@ -437,7 +437,7 @@ func TestPutTenant_GitLabMode_HappyPath(t *testing.T) {
 	mockClient := &mockPlatformClient{providerName: "gitlab"}
 	mockTracker := &mockPlatformTracker{}
 
-	h := (&Deps{Writer: writer, WriteMode: WriteModePRGitLab, PRClient: mockClient, PRTracker: mockTracker}).PutTenant()
+	h := PutTenant(&Deps{Writer: writer, WriteMode: WriteModePRGitLab, PRClient: mockClient, PRTracker: mockTracker})
 	body := bytes.NewBufferString("tenants:\n  db-a:\n    _silent_mode: \"critical\"\n")
 	req := newRequestWithChiParam("PUT", "/api/v1/tenants/db-a", "id", "db-a", body)
 	req.Header.Set("X-Forwarded-Email", "alice@example.com")
@@ -466,7 +466,7 @@ func TestBatchTenants_PRMode_AllInvalid(t *testing.T) {
 	mockClient := &mockPlatformClient{providerName: "github"}
 	mockTracker := &mockPlatformTracker{}
 
-	h := (&Deps{Writer: writer, ConfigDir: configDir, RBAC: rbacMgr, WriteMode: WriteModePR, PRClient: mockClient, PRTracker: mockTracker}).BatchTenants()
+	h := BatchTenants(&Deps{Writer: writer, ConfigDir: configDir, RBAC: rbacMgr, WriteMode: WriteModePR, PRClient: mockClient, PRTracker: mockTracker})
 
 	batchReq := `{"operations":[{"tenant_id":"../etc/passwd","patch":{"_silent_mode":"warning"}}]}`
 	req := httptest.NewRequest("POST", "/api/v1/tenants/batch", strings.NewReader(batchReq))

--- a/components/tenant-api/internal/handler/pr_writeflow.go
+++ b/components/tenant-api/internal/handler/pr_writeflow.go
@@ -39,7 +39,7 @@ import (
 // All tenantIDs MUST be non-empty. Empty input is a caller bug
 // (would register a no-tenant PR that PendingPRForTenant cannot
 // resolve, leaving the PR un-trackable).
-func (d *Deps) createPRAndRegister(
+func createPRAndRegister(d *Deps,
 	title, body, branchName string,
 	labels []string,
 	tenantIDs []string,

--- a/components/tenant-api/internal/handler/task.go
+++ b/components/tenant-api/internal/handler/task.go
@@ -27,7 +27,7 @@ import (
 //   - all accessible → return Task as-is
 //   - empty original (Task with no Results yet — still running) →
 //     return Task as-is (no tenants disclosed yet)
-func (d *Deps) GetTask() http.HandlerFunc {
+func GetTask(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		taskID := chi.URLParam(r, "id")
 

--- a/components/tenant-api/internal/handler/task_test.go
+++ b/components/tenant-api/internal/handler/task_test.go
@@ -39,7 +39,7 @@ func TestGetTask_Found(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	// Call handler
-	handler := (&Deps{Tasks: taskMgr, RBAC: newRBACManager(t, "")}).GetTask()
+	handler := GetTask(&Deps{Tasks: taskMgr, RBAC: newRBACManager(t, "")})
 	handler(w, req)
 
 	// Verify response
@@ -87,7 +87,7 @@ func TestGetTask_NotFound(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	// Call handler
-	handler := (&Deps{Tasks: taskMgr, RBAC: newRBACManager(t, "")}).GetTask()
+	handler := GetTask(&Deps{Tasks: taskMgr, RBAC: newRBACManager(t, "")})
 	handler(w, req)
 
 	// Verify response status is 404
@@ -169,7 +169,7 @@ func TestGetTask_CompletedTask(t *testing.T) {
 				req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 				// Call handler
-				handler := (&Deps{Tasks: taskMgr, RBAC: newRBACManager(t, "")}).GetTask()
+				handler := GetTask(&Deps{Tasks: taskMgr, RBAC: newRBACManager(t, "")})
 				handler(w, req)
 
 				// Verify response
@@ -250,7 +250,7 @@ func TestGetTask_OrphanedHint(t *testing.T) {
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 	// Call handler
-	handler := (&Deps{Tasks: taskMgr2, RBAC: newRBACManager(t, "")}).GetTask()
+	handler := GetTask(&Deps{Tasks: taskMgr2, RBAC: newRBACManager(t, "")})
 	handler(w, req)
 
 	// Verify 404 response
@@ -306,7 +306,7 @@ func TestGetTask_MultiplePolls(t *testing.T) {
 		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
 		// Call handler
-		handler := (&Deps{Tasks: taskMgr, RBAC: newRBACManager(t, "")}).GetTask()
+		handler := GetTask(&Deps{Tasks: taskMgr, RBAC: newRBACManager(t, "")})
 		handler(w, req)
 
 		// Decode response

--- a/components/tenant-api/internal/handler/tenant_batch.go
+++ b/components/tenant-api/internal/handler/tenant_batch.go
@@ -72,7 +72,7 @@ type BatchResponse struct {
 // @Success     202  {object} map[string]interface{}
 // @Failure     400  {object} map[string]string
 // @Router      /api/v1/tenants/batch [post]
-func (d *Deps) BatchTenants() http.HandlerFunc {
+func BatchTenants(d *Deps) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		email := rbac.RequestEmail(r)
 		groups := rbac.RequestGroups(r)
@@ -163,7 +163,7 @@ func (d *Deps) BatchTenants() http.HandlerFunc {
 			}
 			prBody := fmt.Sprintf("**Operator:** %s\n**Source:** tenant-manager UI (batch)\n**Tenants:** %s",
 				email, strings.Join(tenantList, ", "))
-			pr, err := d.createPRAndRegister(
+			pr, err := createPRAndRegister(d, 
 				prTitle, prBody, result.BranchName,
 				[]string{"tenant-api", "auto-generated", "batch"},
 				tenantList,

--- a/components/tenant-api/internal/handler/tenant_diff.go
+++ b/components/tenant-api/internal/handler/tenant_diff.go
@@ -37,7 +37,7 @@ type DiffResponse struct {
 // @Failure     400   {object} map[string]string
 // @Failure     500   {object} map[string]string
 // @Router      /api/v1/tenants/{id}/diff [post]
-func (d *Deps) DiffTenant() http.HandlerFunc {
+func DiffTenant(d *Deps) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
 		if err := ValidateTenantID(tenantID); err != nil {

--- a/components/tenant-api/internal/handler/tenant_effective.go
+++ b/components/tenant-api/internal/handler/tenant_effective.go
@@ -44,7 +44,7 @@ import (
 // @Failure     404  {object} map[string]string
 // @Failure     500  {object} map[string]string
 // @Router      /api/v1/tenants/{id}/effective [get]
-func (d *Deps) GetTenantEffective() http.HandlerFunc {
+func GetTenantEffective(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
 		if err := ValidateTenantID(tenantID); err != nil {

--- a/components/tenant-api/internal/handler/tenant_effective_test.go
+++ b/components/tenant-api/internal/handler/tenant_effective_test.go
@@ -42,7 +42,7 @@ func TestGetTenantEffective_Success_Flat(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "db-a.yaml"),
 		"tenants:\n  db-a:\n    mysql_connections: \"70\"\n")
 
-	h := (&Deps{ConfigDir: dir}).GetTenantEffective()
+	h := GetTenantEffective(&Deps{ConfigDir: dir})
 	req := newRequestWithChiParam("GET", "/api/v1/tenants/db-a/effective", "id", "db-a", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -94,7 +94,7 @@ func TestGetTenantEffective_Success_Hierarchy(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "team-a", "tenant-a.yaml"),
 		"tenants:\n  tenant-a:\n    mysql_connections: \"70\"\n") // tenant overrides mysql_connections
 
-	h := (&Deps{ConfigDir: dir}).GetTenantEffective()
+	h := GetTenantEffective(&Deps{ConfigDir: dir})
 	req := newRequestWithChiParam("GET", "/api/v1/tenants/tenant-a/effective", "id", "tenant-a", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -142,7 +142,7 @@ func TestGetTenantEffective_NotFound(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "db-a.yaml"),
 		"tenants:\n  db-a:\n    mysql_connections: \"70\"\n")
 
-	h := (&Deps{ConfigDir: dir}).GetTenantEffective()
+	h := GetTenantEffective(&Deps{ConfigDir: dir})
 	req := newRequestWithChiParam("GET", "/api/v1/tenants/nonexistent/effective", "id", "nonexistent", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -164,7 +164,7 @@ func TestGetTenantEffective_InvalidID(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
-	h := (&Deps{ConfigDir: dir}).GetTenantEffective()
+	h := GetTenantEffective(&Deps{ConfigDir: dir})
 	req := newRequestWithChiParam("GET", "/api/v1/tenants/../etc/effective", "id", "../etc", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -178,7 +178,7 @@ func TestGetTenantEffective_EmptyID(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
-	h := (&Deps{ConfigDir: dir}).GetTenantEffective()
+	h := GetTenantEffective(&Deps{ConfigDir: dir})
 	req := newRequestWithChiParam("GET", "/api/v1/tenants//effective", "id", "", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -198,7 +198,7 @@ func TestGetTenantEffective_HashStable(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "db-a.yaml"),
 		"tenants:\n  db-a:\n    mysql_connections: \"70\"\n")
 
-	h := (&Deps{ConfigDir: dir}).GetTenantEffective()
+	h := GetTenantEffective(&Deps{ConfigDir: dir})
 
 	callOnce := func() cfg.EffectiveConfig {
 		req := newRequestWithChiParam("GET", "/api/v1/tenants/db-a/effective", "id", "db-a", nil)
@@ -233,7 +233,7 @@ func TestGetTenantEffective_HashChangesOnContentEdit(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "db-a.yaml"),
 		"tenants:\n  db-a:\n    mysql_connections: \"70\"\n")
 
-	h := (&Deps{ConfigDir: dir}).GetTenantEffective()
+	h := GetTenantEffective(&Deps{ConfigDir: dir})
 
 	callOnce := func() cfg.EffectiveConfig {
 		req := newRequestWithChiParam("GET", "/api/v1/tenants/db-a/effective", "id", "db-a", nil)
@@ -276,7 +276,7 @@ func TestGetTenantEffective_NullDeletesInheritedKey(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "db-a.yaml"),
 		"tenants:\n  db-a:\n    mysql_connections: ~\n") // YAML null
 
-	h := (&Deps{ConfigDir: dir}).GetTenantEffective()
+	h := GetTenantEffective(&Deps{ConfigDir: dir})
 	req := newRequestWithChiParam("GET", "/api/v1/tenants/db-a/effective", "id", "db-a", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -308,7 +308,7 @@ func TestGetTenantEffective_MetadataSkipped(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "db-a.yaml"),
 		"tenants:\n  db-a:\n    mysql_cpu: \"85\"\n")
 
-	h := (&Deps{ConfigDir: dir}).GetTenantEffective()
+	h := GetTenantEffective(&Deps{ConfigDir: dir})
 	req := newRequestWithChiParam("GET", "/api/v1/tenants/db-a/effective", "id", "db-a", nil)
 	w := httptest.NewRecorder()
 	h(w, req)

--- a/components/tenant-api/internal/handler/tenant_get.go
+++ b/components/tenant-api/internal/handler/tenant_get.go
@@ -32,7 +32,7 @@ type TenantDetail struct {
 // @Failure     404  {object} map[string]string
 // @Failure     500  {object} map[string]string
 // @Router      /api/v1/tenants/{id} [get]
-func (d *Deps) GetTenant() http.HandlerFunc {
+func GetTenant(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
 		if err := ValidateTenantID(tenantID); err != nil {

--- a/components/tenant-api/internal/handler/tenant_list.go
+++ b/components/tenant-api/internal/handler/tenant_list.go
@@ -41,7 +41,7 @@ type TenantSummary struct {
 // @Success     200 {array}  TenantSummary
 // @Failure     500 {object} map[string]string
 // @Router      /api/v1/tenants [get]
-func (d *Deps) ListTenants() http.HandlerFunc {
+func ListTenants(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idpGroups := rbac.RequestGroups(r)
 

--- a/components/tenant-api/internal/handler/tenant_put.go
+++ b/components/tenant-api/internal/handler/tenant_put.go
@@ -48,7 +48,7 @@ type PutTenantResponse struct {
 // @Failure     409   {object} map[string]string
 // @Failure     500   {object} map[string]string
 // @Router      /api/v1/tenants/{id} [put]
-func (d *Deps) PutTenant() http.HandlerFunc {
+func PutTenant(d *Deps) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
 		if err := ValidateTenantID(tenantID); err != nil {
@@ -100,7 +100,7 @@ func (d *Deps) PutTenant() http.HandlerFunc {
 			// PR-6/11: shared with BatchTenants via createPRAndRegister.
 			prTitle := fmt.Sprintf("[tenant-api] Update %s configuration", tenantID)
 			prBody := fmt.Sprintf("**Operator:** %s\n**Source:** tenant-manager UI\n**Tenant:** %s", email, tenantID)
-			pr, err := d.createPRAndRegister(
+			pr, err := createPRAndRegister(d, 
 				prTitle, prBody, result.BranchName,
 				[]string{"tenant-api", "auto-generated"},
 				[]string{tenantID},

--- a/components/tenant-api/internal/handler/tenant_search.go
+++ b/components/tenant-api/internal/handler/tenant_search.go
@@ -132,7 +132,7 @@ type SearchResponse struct {
 // Response: SearchResponse (see above) on 200, structured JSON error
 // otherwise. RBAC filtering is applied identically to ListTenants —
 // callers without metadata access see fewer rows.
-func (d *Deps) SearchTenants() http.HandlerFunc {
+func SearchTenants(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idpGroups := rbac.RequestGroups(r)
 

--- a/components/tenant-api/internal/handler/tenant_search_test.go
+++ b/components/tenant-api/internal/handler/tenant_search_test.go
@@ -77,7 +77,7 @@ func makeFixtureDir(t *testing.T, n int, factory func(i int) (string, string)) s
 func runSearch(t *testing.T, configDir string, mgr *rbac.Manager, idpGroups []string, query string) (*SearchResponse, int, []byte) {
 	t.Helper()
 	cache := NewTenantSnapshotCache()
-	inner := (&Deps{ConfigDir: configDir, RBAC: mgr, SearchCache: cache}).SearchTenants()
+	inner := SearchTenants(&Deps{ConfigDir: configDir, RBAC: mgr, SearchCache: cache})
 	// The list endpoint passes nil tenantIDFn (no per-tenant
 	// permission check) — same as the production route binding.
 	h := mgr.Middleware(rbac.PermRead, nil)(inner)

--- a/components/tenant-api/internal/handler/tenant_validate.go
+++ b/components/tenant-api/internal/handler/tenant_validate.go
@@ -28,7 +28,7 @@ type ValidateResponse struct {
 // @Success     200   {object} ValidateResponse
 // @Failure     400   {object} map[string]string
 // @Router      /api/v1/tenants/{id}/validate [post]
-func (d *Deps) ValidateTenant() http.HandlerFunc {
+func ValidateTenant(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
 		if err := ValidateTenantID(tenantID); err != nil {

--- a/components/tenant-api/internal/handler/view.go
+++ b/components/tenant-api/internal/handler/view.go
@@ -29,7 +29,7 @@ type ViewResponse struct {
 // @Produce     json
 // @Success     200 {array}  ViewResponse
 // @Router      /api/v1/views [get]
-func (d *Deps) ListViews() http.HandlerFunc {
+func ListViews(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		list := d.Views.ListViews()
 		resp := make([]ViewResponse, 0, len(list))
@@ -57,7 +57,7 @@ func (d *Deps) ListViews() http.HandlerFunc {
 // @Failure     400 {object} map[string]string
 // @Failure     404 {object} map[string]string
 // @Router      /api/v1/views/{id} [get]
-func (d *Deps) GetView() http.HandlerFunc {
+func GetView(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		viewID := chi.URLParam(r, "id")
 		if err := views.ValidateViewID(viewID); err != nil {
@@ -107,7 +107,7 @@ type PutViewRequest struct {
 // @Failure     400  {object} map[string]string
 // @Failure     409  {object} map[string]string
 // @Router      /api/v1/views/{id} [put]
-func (d *Deps) PutView() http.HandlerFunc {
+func PutView(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		viewID := chi.URLParam(r, "id")
 		if err := views.ValidateViewID(viewID); err != nil {
@@ -191,7 +191,7 @@ func (d *Deps) PutView() http.HandlerFunc {
 // @Failure     404 {object} map[string]string
 // @Failure     409 {object} map[string]string
 // @Router      /api/v1/views/{id} [delete]
-func (d *Deps) DeleteView() http.HandlerFunc {
+func DeleteView(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		viewID := chi.URLParam(r, "id")
 		if err := views.ValidateViewID(viewID); err != nil {

--- a/components/tenant-api/internal/handler/view_test.go
+++ b/components/tenant-api/internal/handler/view_test.go
@@ -45,7 +45,7 @@ func TestListViews_Empty(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	mgr := views.NewManager(configDir)
 
-	h := (&Deps{Views: mgr}).ListViews()
+	h := ListViews(&Deps{Views: mgr})
 	req := httptest.NewRequest("GET", "/api/v1/views", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -70,7 +70,7 @@ func TestListViews_WithData(t *testing.T) {
 	setupViewsFile(t, configDir, testViewsYAML)
 	mgr := views.NewManager(configDir)
 
-	h := (&Deps{Views: mgr}).ListViews()
+	h := ListViews(&Deps{Views: mgr})
 	req := httptest.NewRequest("GET", "/api/v1/views", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -118,7 +118,7 @@ func TestGetView_Success(t *testing.T) {
 	setupViewsFile(t, configDir, testViewsYAML)
 	mgr := views.NewManager(configDir)
 
-	h := (&Deps{Views: mgr}).GetView()
+	h := GetView(&Deps{Views: mgr})
 	req := newRequestWithChiParam("GET", "/api/v1/views/prod-finance", "id", "prod-finance", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -157,7 +157,7 @@ func TestGetView_NotFound(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	mgr := views.NewManager(configDir)
 
-	h := (&Deps{Views: mgr}).GetView()
+	h := GetView(&Deps{Views: mgr})
 	req := newRequestWithChiParam("GET", "/api/v1/views/nonexistent", "id", "nonexistent", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -173,7 +173,7 @@ func TestGetView_InvalidID(t *testing.T) {
 	configDir := setupConfigDir(t, nil)
 	mgr := views.NewManager(configDir)
 
-	h := (&Deps{Views: mgr}).GetView()
+	h := GetView(&Deps{Views: mgr})
 	req := newRequestWithChiParam("GET", "/api/v1/views/INVALID!", "id", "INVALID!", nil)
 	w := httptest.NewRecorder()
 	h(w, req)
@@ -206,7 +206,7 @@ func TestPutView_Create(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	setRequestIdentity(req, "test@example.com")
 
-	h := (&Deps{Views: mgr, Writer: writer}).PutView()
+	h := PutView(&Deps{Views: mgr, Writer: writer})
 	w := executeWithRBAC(t, h, req)
 
 	if w.Code != http.StatusOK {
@@ -274,7 +274,7 @@ func TestPutView_Update(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	setRequestIdentity(req, "test@example.com")
 
-	h := (&Deps{Views: mgr, Writer: writer}).PutView()
+	h := PutView(&Deps{Views: mgr, Writer: writer})
 	w := executeWithRBAC(t, h, req)
 
 	if w.Code != http.StatusOK {
@@ -315,7 +315,7 @@ func TestPutView_MissingLabel(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
-	h := (&Deps{Views: mgr, Writer: writer}).PutView()
+	h := PutView(&Deps{Views: mgr, Writer: writer})
 	h(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -344,7 +344,7 @@ func TestPutView_EmptyFilters(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
-	h := (&Deps{Views: mgr, Writer: writer}).PutView()
+	h := PutView(&Deps{Views: mgr, Writer: writer})
 	h(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -364,7 +364,7 @@ func TestPutView_InvalidJSON(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
-	h := (&Deps{Views: mgr, Writer: writer}).PutView()
+	h := PutView(&Deps{Views: mgr, Writer: writer})
 	h(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -388,7 +388,7 @@ func TestPutView_InvalidViewID(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	w := httptest.NewRecorder()
-	h := (&Deps{Views: mgr, Writer: writer}).PutView()
+	h := PutView(&Deps{Views: mgr, Writer: writer})
 	h(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -416,7 +416,7 @@ func TestDeleteView_Success(t *testing.T) {
 	req := newRequestWithChiParam("DELETE", "/api/v1/views/prod-finance", "id", "prod-finance", nil)
 	setRequestIdentity(req, "test@example.com")
 
-	h := (&Deps{Views: mgr, Writer: writer}).DeleteView()
+	h := DeleteView(&Deps{Views: mgr, Writer: writer})
 	w := executeWithRBAC(t, h, req)
 
 	if w.Code != http.StatusOK {
@@ -454,7 +454,7 @@ func TestDeleteView_NotFound(t *testing.T) {
 	req := newRequestWithChiParam("DELETE", "/api/v1/views/nonexistent", "id", "nonexistent", nil)
 	setRequestIdentity(req, "test@example.com")
 
-	h := (&Deps{Views: mgr, Writer: writer}).DeleteView()
+	h := DeleteView(&Deps{Views: mgr, Writer: writer})
 	w := executeWithRBAC(t, h, req)
 
 	if w.Code != http.StatusNotFound {
@@ -472,7 +472,7 @@ func TestDeleteView_InvalidID(t *testing.T) {
 	req := newRequestWithChiParam("DELETE", "/api/v1/views/INVALID!", "id", "INVALID!", nil)
 	setRequestIdentity(req, "test@example.com")
 
-	h := (&Deps{Views: mgr, Writer: writer}).DeleteView()
+	h := DeleteView(&Deps{Views: mgr, Writer: writer})
 	w := executeWithRBAC(t, h, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -506,7 +506,7 @@ func TestPutView_Conflict(t *testing.T) {
 		t.SkipNow()
 	}
 
-	h := (&Deps{Views: mgr, Writer: writer}).PutView()
+	h := PutView(&Deps{Views: mgr, Writer: writer})
 	w := executeWithRBAC(t, h, req)
 
 	// The request should succeed even if there was a pre-existing HEAD


### PR DESCRIPTION
## Summary

#537 (post-ADR-020-epic tenant-api package structure review) → execute refactor.

Two phases land here:

### Phase A — `internal/federation/` split into three sub-packages
- `token/` — `Manager`, `RecordStore`, `MintLimiter`, `configMapStore`, `Record`, `DefaultTTL`
- `fedpolicy/` — `Manager` (was `PolicyManager`), `AdmissionValidator`, `Config` (was `FederationPolicyConfig`), `Subset` (was `FederationSubset`), policy validators
- `orphan/` — `Detector` (was `OrphanDetector`)

`fedpolicy` chosen over `policy` to avoid collision with the existing `internal/policy/` (domain-level policy). Dir name == package name, no aliases anywhere.

### Phase B — all 31 `(d *Deps)` handler methods → free functions

Uniform free-function style across all 25 handler files:
```go
func (d *Deps) Foo(args...) RetType { ... }
   →
func Foo(d *Deps, args...) RetType { ... }
```

Call-site rewrites:
- handler-package internal helpers: `d.Foo(args)` → `Foo(d, args)`
- `cmd/server/main.go`: `deps.Foo(args)` → `handler.Foo(deps, args)`
- handler-package tests: `d.Foo()` / `deps.Foo()` / `(&Deps{...}).Foo()` → free-function calls.

## Scope refinements vs original Option B

- **Deps stays in `package handler`** (NOT moved to `internal/handler/deps/`). Moving `Deps` would cascade through `tenantSnapshotCache` → `TenantSummary` → `loadAllTenants` and require exporting / relocating multiple types — work disproportionate to the benefit. Uniform free-function style is achieved either way.
- **Phase C (federation handlers → `internal/handler/federation/` sub-package) deferred.** Would require exporting 8 unexported handler helpers (`writeJSONError`, `writeJSONErrorWithCode`, `validateStructTags`, `writeValidationErrors`, `toViolations`, `toFederationTokenRecord`, `addedFederationMetrics`, etc.) plus updating their callers across the handler package. Cosmetic separation; cost > benefit for this PR. Tracked as a follow-up.

## Sed gotcha (logged)

Bulk sed `d\.X\(` matched suffix `d` in identifiers like `wrapped`, `fed`, `cmd` → `wrappeServeHTTP`, `feIssue`, `cmRun`. Restored manually. Lesson: add word boundary when rewriting variable-name patterns.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass on a clean checkout; **two tests fail when run from within a worktree on the local dev container** (`TestDiffTenant_RawYAML`, `TestDiff_ModifiedContent`) because the worktree's `.git` file points to a Windows-style path the Linux container can't resolve when `git diff --no-index` is invoked. Not a refactor bug — same tests fail regardless of refactor state on the worktree path. **CI will pass** (clean ubuntu-latest checkout).
- [x] `pr-preflight` — READY
- [ ] CI green

Closes #537