### PR TITLE
refactor(tenant-api): move federation handlers to internal/handler/federation/ (#559)

### DIFF
--- a/components/tenant-api/cmd/server/main.go
+++ b/components/tenant-api/cmd/server/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/vencil/tenant-api/internal/gitops"
 	"github.com/vencil/tenant-api/internal/groups"
 	"github.com/vencil/tenant-api/internal/handler"
+	"github.com/vencil/tenant-api/internal/handler/federation"
 	"github.com/vencil/tenant-api/internal/policy"
 	"github.com/vencil/tenant-api/internal/rbac"
 	"github.com/vencil/tenant-api/internal/views"
@@ -351,9 +352,9 @@ func main() {
 			// tenant-admin check is inside the handler (route middleware
 			// only confirms authentication + read on the tenant).
 			r.With(rbacMgr.Middleware(rbac.PermRead, handler.TenantIDFromPath)).
-				Get("/federation", handler.GetTenantFederation(deps))
+				Get("/federation", federation.GetTenantFederation(deps))
 			r.With(rbacMgr.Middleware(rbac.PermRead, handler.TenantIDFromPath)).
-				Put("/federation", handler.PutTenantFederation(deps))
+				Put("/federation", federation.PutTenantFederation(deps))
 		})
 
 		// Batch operations — route-level middleware checks read (authenticated),
@@ -415,9 +416,9 @@ func main() {
 		// handler; route-level middleware only confirms authentication.
 		r.Route("/federation/policy", func(r chi.Router) {
 			r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-				Get("/", handler.GetFederationPolicy(deps))
+				Get("/", federation.GetFederationPolicy(deps))
 			r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-				Put("/", handler.PutFederationPolicy(deps))
+				Put("/", federation.PutFederationPolicy(deps))
 		})
 
 		// Federation token endpoint (v2.9.0 — ADR-020 IV-2d).
@@ -428,11 +429,11 @@ func main() {
 		if federationMgr != nil {
 			r.Route("/federation/tokens", func(r chi.Router) {
 				r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-					Post("/", handler.CreateFederationToken(deps))
+					Post("/", federation.CreateFederationToken(deps))
 				r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-					Get("/", handler.ListFederationTokens(deps))
+					Get("/", federation.ListFederationTokens(deps))
 				r.With(rbacMgr.Middleware(rbac.PermRead, nil)).
-					Delete("/{id}", handler.DeleteFederationToken(deps))
+					Delete("/{id}", federation.DeleteFederationToken(deps))
 			})
 		}
 	})

--- a/components/tenant-api/docs/docs.go
+++ b/components/tenant-api/docs/docs.go
@@ -54,7 +54,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handler.PutFederationPolicyRequest"
+                            "$ref": "#/definitions/internal_handler_federation.PutFederationPolicyRequest"
                         }
                     }
                 ],
@@ -119,7 +119,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/internal_handler.FederationTokenRecord"
+                                "$ref": "#/definitions/internal_handler_federation.FederationTokenRecord"
                             }
                         }
                     },
@@ -171,7 +171,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handler.CreateFederationTokenRequest"
+                            "$ref": "#/definitions/internal_handler_federation.CreateFederationTokenRequest"
                         }
                     }
                 ],
@@ -179,7 +179,7 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/internal_handler.CreateFederationTokenResponse"
+                            "$ref": "#/definitions/internal_handler_federation.CreateFederationTokenResponse"
                         }
                     },
                     "400": {
@@ -1493,34 +1493,6 @@ const docTemplate = `{
                 }
             }
         },
-        "internal_handler.CreateFederationTokenRequest": {
-            "type": "object",
-            "required": [
-                "tenant_id"
-            ],
-            "properties": {
-                "description": {
-                    "type": "string",
-                    "maxLength": 256
-                },
-                "tenant_id": {
-                    "type": "string",
-                    "maxLength": 128,
-                    "minLength": 1
-                }
-            }
-        },
-        "internal_handler.CreateFederationTokenResponse": {
-            "type": "object",
-            "properties": {
-                "record": {
-                    "$ref": "#/definitions/internal_handler.FederationTokenRecord"
-                },
-                "token": {
-                    "type": "string"
-                }
-            }
-        },
         "internal_handler.DiffRequest": {
             "type": "object",
             "properties": {
@@ -1540,29 +1512,6 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "tenant_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_handler.FederationTokenRecord": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "expires_at": {
-                    "type": "string"
-                },
-                "issued_at": {
-                    "type": "string"
-                },
-                "issued_by": {
-                    "type": "string"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "token_id": {
                     "type": "string"
                 }
             }
@@ -1685,23 +1634,6 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/github_com_vencil_tenant-api_internal_platform.PRInfo"
-                    }
-                }
-            }
-        },
-        "internal_handler.PutFederationPolicyRequest": {
-            "type": "object",
-            "properties": {
-                "force": {
-                    "type": "boolean"
-                },
-                "reason": {
-                    "type": "string"
-                },
-                "whitelist": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry"
                     }
                 }
             }
@@ -1890,6 +1822,74 @@ const docTemplate = `{
                 },
                 "label": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_handler_federation.CreateFederationTokenRequest": {
+            "type": "object",
+            "required": [
+                "tenant_id"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "maxLength": 256
+                },
+                "tenant_id": {
+                    "type": "string",
+                    "maxLength": 128,
+                    "minLength": 1
+                }
+            }
+        },
+        "internal_handler_federation.CreateFederationTokenResponse": {
+            "type": "object",
+            "properties": {
+                "record": {
+                    "$ref": "#/definitions/internal_handler_federation.FederationTokenRecord"
+                },
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler_federation.FederationTokenRecord": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "issued_at": {
+                    "type": "string"
+                },
+                "issued_by": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "token_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler_federation.PutFederationPolicyRequest": {
+            "type": "object",
+            "properties": {
+                "force": {
+                    "type": "boolean"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "whitelist": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry"
+                    }
                 }
             }
         }

--- a/components/tenant-api/docs/swagger.json
+++ b/components/tenant-api/docs/swagger.json
@@ -47,7 +47,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handler.PutFederationPolicyRequest"
+                            "$ref": "#/definitions/internal_handler_federation.PutFederationPolicyRequest"
                         }
                     }
                 ],
@@ -112,7 +112,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/internal_handler.FederationTokenRecord"
+                                "$ref": "#/definitions/internal_handler_federation.FederationTokenRecord"
                             }
                         }
                     },
@@ -164,7 +164,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_handler.CreateFederationTokenRequest"
+                            "$ref": "#/definitions/internal_handler_federation.CreateFederationTokenRequest"
                         }
                     }
                 ],
@@ -172,7 +172,7 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/internal_handler.CreateFederationTokenResponse"
+                            "$ref": "#/definitions/internal_handler_federation.CreateFederationTokenResponse"
                         }
                     },
                     "400": {
@@ -1486,34 +1486,6 @@
                 }
             }
         },
-        "internal_handler.CreateFederationTokenRequest": {
-            "type": "object",
-            "required": [
-                "tenant_id"
-            ],
-            "properties": {
-                "description": {
-                    "type": "string",
-                    "maxLength": 256
-                },
-                "tenant_id": {
-                    "type": "string",
-                    "maxLength": 128,
-                    "minLength": 1
-                }
-            }
-        },
-        "internal_handler.CreateFederationTokenResponse": {
-            "type": "object",
-            "properties": {
-                "record": {
-                    "$ref": "#/definitions/internal_handler.FederationTokenRecord"
-                },
-                "token": {
-                    "type": "string"
-                }
-            }
-        },
         "internal_handler.DiffRequest": {
             "type": "object",
             "properties": {
@@ -1533,29 +1505,6 @@
                     "type": "boolean"
                 },
                 "tenant_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "internal_handler.FederationTokenRecord": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "expires_at": {
-                    "type": "string"
-                },
-                "issued_at": {
-                    "type": "string"
-                },
-                "issued_by": {
-                    "type": "string"
-                },
-                "tenant_id": {
-                    "type": "string"
-                },
-                "token_id": {
                     "type": "string"
                 }
             }
@@ -1678,23 +1627,6 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/github_com_vencil_tenant-api_internal_platform.PRInfo"
-                    }
-                }
-            }
-        },
-        "internal_handler.PutFederationPolicyRequest": {
-            "type": "object",
-            "properties": {
-                "force": {
-                    "type": "boolean"
-                },
-                "reason": {
-                    "type": "string"
-                },
-                "whitelist": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry"
                     }
                 }
             }
@@ -1883,6 +1815,74 @@
                 },
                 "label": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_handler_federation.CreateFederationTokenRequest": {
+            "type": "object",
+            "required": [
+                "tenant_id"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "maxLength": 256
+                },
+                "tenant_id": {
+                    "type": "string",
+                    "maxLength": 128,
+                    "minLength": 1
+                }
+            }
+        },
+        "internal_handler_federation.CreateFederationTokenResponse": {
+            "type": "object",
+            "properties": {
+                "record": {
+                    "$ref": "#/definitions/internal_handler_federation.FederationTokenRecord"
+                },
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler_federation.FederationTokenRecord": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "issued_at": {
+                    "type": "string"
+                },
+                "issued_by": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "token_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler_federation.PutFederationPolicyRequest": {
+            "type": "object",
+            "properties": {
+                "force": {
+                    "type": "boolean"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "whitelist": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry"
+                    }
                 }
             }
         }

--- a/components/tenant-api/docs/swagger.yaml
+++ b/components/tenant-api/docs/swagger.yaml
@@ -149,25 +149,6 @@ definitions:
       tenant_id:
         type: string
     type: object
-  internal_handler.CreateFederationTokenRequest:
-    properties:
-      description:
-        maxLength: 256
-        type: string
-      tenant_id:
-        maxLength: 128
-        minLength: 1
-        type: string
-    required:
-    - tenant_id
-    type: object
-  internal_handler.CreateFederationTokenResponse:
-    properties:
-      record:
-        $ref: '#/definitions/internal_handler.FederationTokenRecord'
-      token:
-        type: string
-    type: object
   internal_handler.DiffRequest:
     properties:
       proposed:
@@ -181,21 +162,6 @@ definitions:
       has_diff:
         type: boolean
       tenant_id:
-        type: string
-    type: object
-  internal_handler.FederationTokenRecord:
-    properties:
-      description:
-        type: string
-      expires_at:
-        type: string
-      issued_at:
-        type: string
-      issued_by:
-        type: string
-      tenant_id:
-        type: string
-      token_id:
         type: string
     type: object
   internal_handler.GroupBatchRequest:
@@ -277,17 +243,6 @@ definitions:
       pending_prs:
         items:
           $ref: '#/definitions/github_com_vencil_tenant-api_internal_platform.PRInfo'
-        type: array
-    type: object
-  internal_handler.PutFederationPolicyRequest:
-    properties:
-      force:
-        type: boolean
-      reason:
-        type: string
-      whitelist:
-        items:
-          $ref: '#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry'
         type: array
     type: object
   internal_handler.PutGroupRequest:
@@ -415,6 +370,51 @@ definitions:
       label:
         type: string
     type: object
+  internal_handler_federation.CreateFederationTokenRequest:
+    properties:
+      description:
+        maxLength: 256
+        type: string
+      tenant_id:
+        maxLength: 128
+        minLength: 1
+        type: string
+    required:
+    - tenant_id
+    type: object
+  internal_handler_federation.CreateFederationTokenResponse:
+    properties:
+      record:
+        $ref: '#/definitions/internal_handler_federation.FederationTokenRecord'
+      token:
+        type: string
+    type: object
+  internal_handler_federation.FederationTokenRecord:
+    properties:
+      description:
+        type: string
+      expires_at:
+        type: string
+      issued_at:
+        type: string
+      issued_by:
+        type: string
+      tenant_id:
+        type: string
+      token_id:
+        type: string
+    type: object
+  internal_handler_federation.PutFederationPolicyRequest:
+    properties:
+      force:
+        type: boolean
+      reason:
+        type: string
+      whitelist:
+        items:
+          $ref: '#/definitions/github_com_vencil_tenant-api_internal_federation_fedpolicy.WhitelistEntry'
+        type: array
+    type: object
 info:
   contact: {}
   description: |-
@@ -447,7 +447,7 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/internal_handler.PutFederationPolicyRequest'
+          $ref: '#/definitions/internal_handler_federation.PutFederationPolicyRequest'
       produces:
       - application/json
       responses:
@@ -494,7 +494,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/internal_handler.FederationTokenRecord'
+              $ref: '#/definitions/internal_handler_federation.FederationTokenRecord'
             type: array
         "400":
           description: Bad Request
@@ -529,14 +529,14 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/internal_handler.CreateFederationTokenRequest'
+          $ref: '#/definitions/internal_handler_federation.CreateFederationTokenRequest'
       produces:
       - application/json
       responses:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/internal_handler.CreateFederationTokenResponse'
+            $ref: '#/definitions/internal_handler_federation.CreateFederationTokenResponse'
         "400":
           description: Bad Request
           schema:

--- a/components/tenant-api/internal/handler/body_validator.go
+++ b/components/tenant-api/internal/handler/body_validator.go
@@ -70,14 +70,14 @@ func newValidatorInstance() *validator.Validate {
 	return v
 }
 
-// validateStructTags runs struct-tag validation against any request struct
+// ValidateStructTags runs struct-tag validation against any request struct
 // and converts errors into the canonical Violation slice. Empty result =
 // the struct passed all tag rules.
 //
 // Note: this only handles the fixed-shape fields. Map-shaped fields
 // like Patch / Filters need per-key validation via validatePatchMap /
 // validateFilterMap.
-func validateStructTags(req interface{}) []Violation {
+func ValidateStructTags(req interface{}) []Violation {
 	if err := validatorInstance.Struct(req); err != nil {
 		var validationErrs validator.ValidationErrors
 		if errors.As(err, &validationErrs) {
@@ -314,5 +314,5 @@ func validateFilterMap(filters map[string]string, fieldPrefix string) []Violatio
 	return violations
 }
 
-// writeValidationErrors and the canonical error envelope live in
+// WriteValidationErrors and the canonical error envelope live in
 // errors.go (PR-9/11 unification).

--- a/components/tenant-api/internal/handler/body_validator_test.go
+++ b/components/tenant-api/internal/handler/body_validator_test.go
@@ -283,7 +283,7 @@ func TestValidatePatchMap_BoundaryNumeric_ExactCapPasses(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────────
-// validateStructTags — struct-level rules
+// ValidateStructTags — struct-level rules
 // ─────────────────────────────────────────────────────────────────
 
 func TestValidateStructTags_BatchRequest_RequiredOperations(t *testing.T) {
@@ -292,7 +292,7 @@ func TestValidateStructTags_BatchRequest_RequiredOperations(t *testing.T) {
 	// Note: handler also has its own len(req.Operations)==0 check; this
 	// test exercises the validator-level rule.
 	req := BatchRequest{Operations: []BatchOperation{}}
-	v := validateStructTags(&req)
+	v := ValidateStructTags(&req)
 	if len(v) == 0 {
 		t.Fatal("expected violations on empty Operations slice")
 	}
@@ -313,7 +313,7 @@ func TestValidateStructTags_PutGroupRequest_LabelTooLong(t *testing.T) {
 		Label:       strings.Repeat("L", 257),
 		Description: "ok",
 	}
-	v := validateStructTags(&req)
+	v := ValidateStructTags(&req)
 	if len(v) == 0 {
 		t.Fatal("expected violation for label > 256 chars")
 	}
@@ -331,7 +331,7 @@ func TestValidateStructTags_PutGroupRequest_DescriptionTooLong(t *testing.T) {
 		Label:       "ok",
 		Description: strings.Repeat("d", 4097),
 	}
-	v := validateStructTags(&req)
+	v := ValidateStructTags(&req)
 	if len(v) == 0 {
 		t.Fatal("expected violation for description > 4096 chars")
 	}
@@ -343,7 +343,7 @@ func TestValidateStructTags_PutGroupRequest_DescriptionTooLong(t *testing.T) {
 func TestValidateStructTags_PutGroupRequest_EmptyLabel(t *testing.T) {
 	t.Parallel()
 	req := PutGroupRequest{Label: ""}
-	v := validateStructTags(&req)
+	v := ValidateStructTags(&req)
 	if len(v) == 0 {
 		t.Fatal("expected violation for empty label")
 	}
@@ -356,7 +356,7 @@ func TestValidateStructTags_ValidPutGroupRequest_NoViolations(t *testing.T) {
 		Description: "fine",
 		Members:     []string{"db-a", "db-b"},
 	}
-	if v := validateStructTags(&req); len(v) != 0 {
+	if v := ValidateStructTags(&req); len(v) != 0 {
 		t.Errorf("expected no violations, got: %+v", v)
 	}
 }
@@ -386,7 +386,7 @@ func TestValidateFilterMap_OversizedValue(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────────
-// writeValidationErrors — JSON shape contract
+// WriteValidationErrors — JSON shape contract
 // ─────────────────────────────────────────────────────────────────
 
 func TestWriteValidationErrors_JSONShape(t *testing.T) {
@@ -396,7 +396,7 @@ func TestWriteValidationErrors_JSONShape(t *testing.T) {
 		{Field: "operations[0].patch[\"_timeout_ms\"]", Reason: "must be ≤ 3600000"},
 		{Field: "operations[0].patch[\"_silent_mode\"]", Reason: "must be one of ..."},
 	}
-	writeValidationErrors(w, nil, violations)
+	WriteValidationErrors(w, nil, violations)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)

--- a/components/tenant-api/internal/handler/errors.go
+++ b/components/tenant-api/internal/handler/errors.go
@@ -5,7 +5,7 @@ package handler
 // Pre-PR-9 there were six different shapes for an error response
 // scattered across the handler package:
 //
-//   * writeJSONError       → {error}
+//   * WriteJSONError       → {error}
 //   * writeValidationErrors→ {error, code, violations}
 //   * writePolicyViolation → {error, violations, help, action}
 //   * RateLimit middleware → {error, code, retry_after_s}
@@ -114,12 +114,12 @@ func (e ErrorResponse) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-// writeErrorEnvelope is the canonical error response writer. All
+// WriteErrorEnvelope is the canonical error response writer. All
 // other helpers in this file funnel through here.
 //
 // `r` may be nil for test-only call sites; production handlers
 // always have r in scope so request_id population is automatic.
-func writeErrorEnvelope(w http.ResponseWriter, r *http.Request, status int, env ErrorResponse) {
+func WriteErrorEnvelope(w http.ResponseWriter, r *http.Request, status int, env ErrorResponse) {
 	if env.RequestID == "" && r != nil {
 		env.RequestID = middleware.GetReqID(r.Context())
 	}
@@ -128,33 +128,33 @@ func writeErrorEnvelope(w http.ResponseWriter, r *http.Request, status int, env 
 	_ = json.NewEncoder(w).Encode(env)
 }
 
-// writeJSONError emits a simple error envelope: {error, code,
+// WriteJSONError emits a simple error envelope: {error, code,
 // request_id}. The `code` is inferred from the HTTP status when
 // not supplied explicitly — see codeFromStatus.
 //
 // Pre-PR-9 signature was (w, status, msg); migrated to include `r`
 // so request_id is populated. Test-only call sites that don't have
 // a request can pass nil (request_id will simply be omitted).
-func writeJSONError(w http.ResponseWriter, r *http.Request, status int, msg string) {
-	writeErrorEnvelope(w, r, status, ErrorResponse{
+func WriteJSONError(w http.ResponseWriter, r *http.Request, status int, msg string) {
+	WriteErrorEnvelope(w, r, status, ErrorResponse{
 		Error: msg,
 		Code:  codeFromStatus(status),
 	})
 }
 
-// writeJSONErrorWithCode lets callers override the inferred code
+// WriteJSONErrorWithCode lets callers override the inferred code
 // with an explicit machine-readable token (e.g. RATE_LIMITED,
 // PENDING_PR_EXISTS). Use this when the error class is more
 // specific than "any 400".
-func writeJSONErrorWithCode(w http.ResponseWriter, r *http.Request, status int, code, msg string) {
-	writeErrorEnvelope(w, r, status, ErrorResponse{
+func WriteJSONErrorWithCode(w http.ResponseWriter, r *http.Request, status int, code, msg string) {
+	WriteErrorEnvelope(w, r, status, ErrorResponse{
 		Error: msg,
 		Code:  code,
 	})
 }
 
 // codeFromStatus returns a default code for HTTP statuses without
-// a more-specific one provided. Keeps simple writeJSONError calls
+// a more-specific one provided. Keeps simple WriteJSONError calls
 // emitting useful machine-readable codes without forcing every
 // call site to think about it.
 func codeFromStatus(status int) string {
@@ -175,7 +175,7 @@ func codeFromStatus(status int) string {
 	return ""
 }
 
-// writeValidationErrors emits the canonical 400 response with a
+// WriteValidationErrors emits the canonical 400 response with a
 // `violations` array. Caller has decided there's at least one
 // violation; this just renders the response.
 //
@@ -189,8 +189,8 @@ func codeFromStatus(status int) string {
 //	  "request_id": "...",
 //	  "violations": [{"field": "...", "reason": "..."}]
 //	}
-func writeValidationErrors(w http.ResponseWriter, r *http.Request, violations []Violation) {
-	writeErrorEnvelope(w, r, http.StatusBadRequest, ErrorResponse{
+func WriteValidationErrors(w http.ResponseWriter, r *http.Request, violations []Violation) {
+	WriteErrorEnvelope(w, r, http.StatusBadRequest, ErrorResponse{
 		Error:      "validation failed",
 		Code:       CodeInvalidBody,
 		Violations: violations,
@@ -201,7 +201,7 @@ func writeValidationErrors(w http.ResponseWriter, r *http.Request, violations []
 // violations. The pre-PR-9 shape included a `help` URL and an
 // actionable `action` string; both preserved.
 func writePolicyViolation(w http.ResponseWriter, r *http.Request, violations []policy.Violation) {
-	writeErrorEnvelope(w, r, http.StatusForbidden, ErrorResponse{
+	WriteErrorEnvelope(w, r, http.StatusForbidden, ErrorResponse{
 		Error:   "domain policy violation",
 		Code:    CodePolicyViolation,
 		PolicyV: violations,

--- a/components/tenant-api/internal/handler/errors_test.go
+++ b/components/tenant-api/internal/handler/errors_test.go
@@ -25,7 +25,7 @@ func TestWriteJSONError_AddsCodeAndRequestID(t *testing.T) {
 	t.Parallel()
 	w := httptest.NewRecorder()
 	r := requestWithID("GET", "/x", "req-abc-123")
-	writeJSONError(w, r, http.StatusNotFound, "thing not found")
+	WriteJSONError(w, r, http.StatusNotFound, "thing not found")
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
@@ -48,7 +48,7 @@ func TestWriteJSONError_AddsCodeAndRequestID(t *testing.T) {
 func TestWriteJSONError_NilRequestOmitsRequestID(t *testing.T) {
 	t.Parallel()
 	w := httptest.NewRecorder()
-	writeJSONError(w, nil, http.StatusBadRequest, "bad")
+	WriteJSONError(w, nil, http.StatusBadRequest, "bad")
 	var resp map[string]any
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
 	if _, has := resp["request_id"]; has {
@@ -64,7 +64,7 @@ func TestWriteValidationErrors_Shape(t *testing.T) {
 		{Field: "label", Reason: "is required"},
 		{Field: "members", Reason: "must not exceed 1000 items"},
 	}
-	writeValidationErrors(w, r, violations)
+	WriteValidationErrors(w, r, violations)
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", w.Code)
@@ -129,7 +129,7 @@ func TestErrorResponse_ExtraInlinedAtTopLevel(t *testing.T) {
 	t.Parallel()
 	w := httptest.NewRecorder()
 	r := requestWithID("POST", "/x", "req-extra")
-	writeErrorEnvelope(w, r, http.StatusConflict, ErrorResponse{
+	WriteErrorEnvelope(w, r, http.StatusConflict, ErrorResponse{
 		Error: "pending_pr_exists",
 		Code:  CodePendingPR,
 		Extra: map[string]any{

--- a/components/tenant-api/internal/handler/federation/handlers.go
+++ b/components/tenant-api/internal/handler/federation/handlers.go
@@ -1,4 +1,4 @@
-package handler
+package federation
 
 import (
 	"encoding/json"
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/vencil/tenant-api/internal/federation/token"
+	"github.com/vencil/tenant-api/internal/handler"
 	"github.com/vencil/tenant-api/internal/rbac"
 )
 
@@ -70,36 +71,36 @@ func toFederationTokenRecord(r token.Record) FederationTokenRecord {
 // @Failure     429  {object} map[string]string
 // @Failure     500  {object} map[string]string
 // @Router      /api/v1/federation/tokens [post]
-func CreateFederationToken(d *Deps) http.HandlerFunc {
+func CreateFederationToken(d *handler.Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 		if err != nil {
-			writeJSONError(w, r, http.StatusBadRequest, "failed to read request body: "+err.Error())
+			handler.WriteJSONError(w, r, http.StatusBadRequest, "failed to read request body: "+err.Error())
 			return
 		}
 
 		var req CreateFederationTokenRequest
 		if err := json.Unmarshal(body, &req); err != nil {
-			writeJSONError(w, r, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			handler.WriteJSONError(w, r, http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return
 		}
-		if violations := validateStructTags(&req); len(violations) > 0 {
-			writeValidationErrors(w, r, violations)
+		if violations := handler.ValidateStructTags(&req); len(violations) > 0 {
+			handler.WriteValidationErrors(w, r, violations)
 			return
 		}
 		// Reject path-traversal / non-simple tenant IDs — the same gate
 		// the other tenant-scoped handlers use, applied here for
 		// consistency and defence-in-depth (the RBAC check below is the
 		// real bar).
-		if err := ValidateTenantID(req.TenantID); err != nil {
-			writeJSONError(w, r, http.StatusBadRequest, err.Error())
+		if err := handler.ValidateTenantID(req.TenantID); err != nil {
+			handler.WriteJSONError(w, r, http.StatusBadRequest, err.Error())
 			return
 		}
 
 		// Federation token issuance is data egress — require admin on
 		// the target tenant (ADR-020 Wave-0 decision 5).
 		if !d.RBAC.HasPermission(rbac.RequestGroups(r), req.TenantID, rbac.PermAdmin) {
-			writeJSONErrorWithCode(w, r, http.StatusForbidden, CodeForbidden,
+			handler.WriteJSONErrorWithCode(w, r, http.StatusForbidden, handler.CodeForbidden,
 				"admin permission required on tenant "+req.TenantID+" to issue a federation token")
 			return
 		}
@@ -108,11 +109,11 @@ func CreateFederationToken(d *Deps) http.HandlerFunc {
 		if err != nil {
 			switch {
 			case errors.Is(err, token.ErrTokenLimitReached):
-				writeJSONErrorWithCode(w, r, http.StatusConflict, CodeConflict, err.Error())
+				handler.WriteJSONErrorWithCode(w, r, http.StatusConflict, handler.CodeConflict, err.Error())
 			case errors.Is(err, token.ErrMintRateLimited):
-				writeJSONErrorWithCode(w, r, http.StatusTooManyRequests, CodeRateLimited, err.Error())
+				handler.WriteJSONErrorWithCode(w, r, http.StatusTooManyRequests, handler.CodeRateLimited, err.Error())
 			default:
-				writeJSONError(w, r, http.StatusInternalServerError, "issue federation token: "+err.Error())
+				handler.WriteJSONError(w, r, http.StatusInternalServerError, "issue federation token: "+err.Error())
 			}
 			return
 		}
@@ -138,27 +139,27 @@ func CreateFederationToken(d *Deps) http.HandlerFunc {
 // @Failure     403 {object} map[string]string
 // @Failure     500 {object} map[string]string
 // @Router      /api/v1/federation/tokens [get]
-func ListFederationTokens(d *Deps) http.HandlerFunc {
+func ListFederationTokens(d *handler.Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tenantID := r.URL.Query().Get("tenant_id")
 		if tenantID == "" {
-			writeJSONError(w, r, http.StatusBadRequest, "query parameter tenant_id is required")
+			handler.WriteJSONError(w, r, http.StatusBadRequest, "query parameter tenant_id is required")
 			return
 		}
-		if err := ValidateTenantID(tenantID); err != nil {
-			writeJSONError(w, r, http.StatusBadRequest, err.Error())
+		if err := handler.ValidateTenantID(tenantID); err != nil {
+			handler.WriteJSONError(w, r, http.StatusBadRequest, err.Error())
 			return
 		}
 
 		if !d.RBAC.HasPermission(rbac.RequestGroups(r), tenantID, rbac.PermAdmin) {
-			writeJSONErrorWithCode(w, r, http.StatusForbidden, CodeForbidden,
+			handler.WriteJSONErrorWithCode(w, r, http.StatusForbidden, handler.CodeForbidden,
 				"admin permission required on tenant "+tenantID)
 			return
 		}
 
 		recs, err := d.Federation.List(tenantID)
 		if err != nil {
-			writeJSONError(w, r, http.StatusInternalServerError, "list federation tokens: "+err.Error())
+			handler.WriteJSONError(w, r, http.StatusInternalServerError, "list federation tokens: "+err.Error())
 			return
 		}
 		resp := make([]FederationTokenRecord, 0, len(recs))
@@ -188,33 +189,33 @@ func ListFederationTokens(d *Deps) http.HandlerFunc {
 // @Failure     404 {object} map[string]string
 // @Failure     500 {object} map[string]string
 // @Router      /api/v1/federation/tokens/{id} [delete]
-func DeleteFederationToken(d *Deps) http.HandlerFunc {
+func DeleteFederationToken(d *handler.Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tokenID := chi.URLParam(r, "id")
 
 		rec, ok, err := d.Federation.Get(tokenID)
 		if err != nil {
-			writeJSONError(w, r, http.StatusInternalServerError, "look up federation token: "+err.Error())
+			handler.WriteJSONError(w, r, http.StatusInternalServerError, "look up federation token: "+err.Error())
 			return
 		}
 		if !ok {
-			writeJSONError(w, r, http.StatusNotFound, "federation token not found: "+tokenID)
+			handler.WriteJSONError(w, r, http.StatusNotFound, "federation token not found: "+tokenID)
 			return
 		}
 
 		if !d.RBAC.HasPermission(rbac.RequestGroups(r), rec.TenantID, rbac.PermAdmin) {
-			writeJSONErrorWithCode(w, r, http.StatusForbidden, CodeForbidden,
+			handler.WriteJSONErrorWithCode(w, r, http.StatusForbidden, handler.CodeForbidden,
 				"admin permission required on tenant "+rec.TenantID)
 			return
 		}
 
 		deleted, err := d.Federation.Delete(tokenID, rec.ExpiresAt)
 		if err != nil {
-			writeJSONError(w, r, http.StatusInternalServerError, "revoke federation token: "+err.Error())
+			handler.WriteJSONError(w, r, http.StatusInternalServerError, "revoke federation token: "+err.Error())
 			return
 		}
 		if !deleted {
-			writeJSONError(w, r, http.StatusNotFound, "federation token not found: "+tokenID)
+			handler.WriteJSONError(w, r, http.StatusNotFound, "federation token not found: "+tokenID)
 			return
 		}
 

--- a/components/tenant-api/internal/handler/federation/handlers_test.go
+++ b/components/tenant-api/internal/handler/federation/handlers_test.go
@@ -1,4 +1,4 @@
-package handler
+package federation
 
 import (
 	"bytes"
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/vencil/tenant-api/internal/federation/token"
+	"github.com/vencil/tenant-api/internal/handler"
 	"github.com/vencil/tenant-api/internal/rbac"
 )
 
@@ -48,7 +49,7 @@ func newTestFederation(t *testing.T) *token.Manager {
 func TestCreateFederationToken_Success(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, fedAdminRBAC)
-	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+	d := &handler.Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
 
 	req := httptest.NewRequest("POST", "/api/v1/federation/tokens",
 		bytes.NewBufferString(`{"tenant_id":"tenant-alpha","description":"grafana pull"}`))
@@ -86,7 +87,7 @@ func TestCreateFederationToken_Success(t *testing.T) {
 func TestCreateFederationToken_ForbiddenWithoutAdmin(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, fedViewerRBAC)
-	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+	d := &handler.Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
 
 	req := httptest.NewRequest("POST", "/api/v1/federation/tokens",
 		bytes.NewBufferString(`{"tenant_id":"tenant-alpha"}`))
@@ -105,7 +106,7 @@ func TestCreateFederationToken_ForbiddenWithoutAdmin(t *testing.T) {
 func TestCreateFederationToken_MissingTenantID(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, fedAdminRBAC)
-	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+	d := &handler.Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
 
 	req := httptest.NewRequest("POST", "/api/v1/federation/tokens",
 		bytes.NewBufferString(`{"description":"no tenant"}`))
@@ -124,7 +125,7 @@ func TestCreateFederationToken_MissingTenantID(t *testing.T) {
 func TestCreateFederationToken_InvalidJSON(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, fedAdminRBAC)
-	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+	d := &handler.Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
 
 	req := httptest.NewRequest("POST", "/api/v1/federation/tokens",
 		bytes.NewBufferString("not json"))
@@ -155,7 +156,7 @@ func TestListFederationTokens_Success(t *testing.T) {
 	if _, _, err := fed.Issue("tenant-b", "ops@example.com", "other"); err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
-	d := &Deps{RBAC: rbacMgr, Federation: fed}
+	d := &handler.Deps{RBAC: rbacMgr, Federation: fed}
 
 	req := httptest.NewRequest("GET", "/api/v1/federation/tokens?tenant_id=tenant-a", nil)
 	req.Header.Set("X-Forwarded-Email", "ops@example.com")
@@ -184,7 +185,7 @@ func TestListFederationTokens_Success(t *testing.T) {
 func TestListFederationTokens_MissingTenantID(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, fedAdminRBAC)
-	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+	d := &handler.Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
 
 	req := httptest.NewRequest("GET", "/api/v1/federation/tokens", nil)
 	req.Header.Set("X-Forwarded-Email", "ops@example.com")
@@ -201,7 +202,7 @@ func TestListFederationTokens_MissingTenantID(t *testing.T) {
 func TestListFederationTokens_ForbiddenWithoutAdmin(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, fedViewerRBAC)
-	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+	d := &handler.Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
 
 	req := httptest.NewRequest("GET", "/api/v1/federation/tokens?tenant_id=tenant-a", nil)
 	req.Header.Set("X-Forwarded-Email", "viewer@example.com")
@@ -225,7 +226,7 @@ func TestDeleteFederationToken_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
-	d := &Deps{RBAC: rbacMgr, Federation: fed}
+	d := &handler.Deps{RBAC: rbacMgr, Federation: fed}
 
 	req := newRequestWithChiParam("DELETE", "/api/v1/federation/tokens/"+rec.TokenID, "id", rec.TokenID, nil)
 	req.Header.Set("X-Forwarded-Email", "ops@example.com")
@@ -245,7 +246,7 @@ func TestDeleteFederationToken_Success(t *testing.T) {
 func TestDeleteFederationToken_NotFound(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, fedAdminRBAC)
-	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+	d := &handler.Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
 
 	req := newRequestWithChiParam("DELETE", "/api/v1/federation/tokens/ftk_missing", "id", "ftk_missing", nil)
 	req.Header.Set("X-Forwarded-Email", "ops@example.com")
@@ -267,7 +268,7 @@ func TestDeleteFederationToken_ForbiddenWithoutAdmin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Issue: %v", err)
 	}
-	d := &Deps{RBAC: rbacMgr, Federation: fed}
+	d := &handler.Deps{RBAC: rbacMgr, Federation: fed}
 
 	req := newRequestWithChiParam("DELETE", "/api/v1/federation/tokens/"+rec.TokenID, "id", rec.TokenID, nil)
 	req.Header.Set("X-Forwarded-Email", "viewer@example.com")
@@ -289,7 +290,7 @@ func TestDeleteFederationToken_ForbiddenWithoutAdmin(t *testing.T) {
 func TestCreateFederationToken_RejectsInvalidTenantID(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, fedAdminRBAC)
-	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+	d := &handler.Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
 
 	req := httptest.NewRequest("POST", "/api/v1/federation/tokens",
 		bytes.NewBufferString(`{"tenant_id":"../escape"}`))
@@ -308,7 +309,7 @@ func TestCreateFederationToken_RejectsInvalidTenantID(t *testing.T) {
 func TestListFederationTokens_RejectsInvalidTenantID(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, fedAdminRBAC)
-	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+	d := &handler.Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
 
 	req := httptest.NewRequest("GET", "/api/v1/federation/tokens?tenant_id=../escape", nil)
 	req.Header.Set("X-Forwarded-Email", "ops@example.com")
@@ -327,7 +328,7 @@ func TestListFederationTokens_RejectsInvalidTenantID(t *testing.T) {
 func TestCreateFederationToken_RateLimited(t *testing.T) {
 	t.Parallel()
 	rbacMgr := newRBACManager(t, fedAdminRBAC)
-	d := &Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
+	d := &handler.Deps{RBAC: rbacMgr, Federation: newTestFederation(t)}
 	h := wrapWithRBACMiddleware(CreateFederationToken(d), rbacMgr, rbac.PermRead, nil)
 
 	post := func() int {

--- a/components/tenant-api/internal/handler/federation/policy.go
+++ b/components/tenant-api/internal/handler/federation/policy.go
@@ -1,4 +1,4 @@
-package handler
+package federation
 
 // Federation policy handlers (ADR-020 IV-2e) — the 2-tier metric
 // allowlist:
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/vencil/tenant-api/internal/federation/fedpolicy"
+	"github.com/vencil/tenant-api/internal/handler"
 	"github.com/vencil/tenant-api/internal/gitops"
 	"github.com/vencil/tenant-api/internal/rbac"
 	"gopkg.in/yaml.v3"
@@ -31,10 +32,10 @@ import (
 
 // toViolations adapts federation schema failures to the handler's
 // validation-error shape (both are {field, reason} — a plain copy).
-func toViolations(pv []fedpolicy.PolicyViolation) []Violation {
-	out := make([]Violation, len(pv))
+func toViolations(pv []fedpolicy.PolicyViolation) []handler.Violation {
+	out := make([]handler.Violation, len(pv))
 	for i, v := range pv {
-		out[i] = Violation{Field: v.Field, Reason: v.Reason}
+		out[i] = handler.Violation{Field: v.Field, Reason: v.Reason}
 	}
 	return out
 }
@@ -47,7 +48,7 @@ func toViolations(pv []fedpolicy.PolicyViolation) []Violation {
 // @Produce     json
 // @Success     200 {object} fedpolicy.Config
 // @Router      /api/v1/federation/policy [get]
-func GetFederationPolicy(d *Deps) http.HandlerFunc {
+func GetFederationPolicy(d *handler.Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(d.FederationPolicy.Get())
@@ -89,10 +90,10 @@ type PutFederationPolicyRequest struct {
 // @Failure     403  {object} map[string]string
 // @Failure     409  {object} map[string]string
 // @Router      /api/v1/federation/policy [put]
-func PutFederationPolicy(d *Deps) http.HandlerFunc {
+func PutFederationPolicy(d *handler.Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !d.RBAC.HasPermission(rbac.RequestGroups(r), "*", rbac.PermAdmin) {
-			writeJSONErrorWithCode(w, r, http.StatusForbidden, CodeForbidden,
+			handler.WriteJSONErrorWithCode(w, r, http.StatusForbidden, handler.CodeForbidden,
 				"platform admin permission required to edit the federation whitelist")
 			return
 		}
@@ -100,12 +101,12 @@ func PutFederationPolicy(d *Deps) http.HandlerFunc {
 
 		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 		if err != nil {
-			writeJSONError(w, r, http.StatusBadRequest, "failed to read request body: "+err.Error())
+			handler.WriteJSONError(w, r, http.StatusBadRequest, "failed to read request body: "+err.Error())
 			return
 		}
 		var req PutFederationPolicyRequest
 		if err := json.Unmarshal(body, &req); err != nil {
-			writeJSONError(w, r, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			handler.WriteJSONError(w, r, http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return
 		}
 		cfg := fedpolicy.Config{Whitelist: req.Whitelist}
@@ -113,7 +114,7 @@ func PutFederationPolicy(d *Deps) http.HandlerFunc {
 			cfg.Whitelist = []fedpolicy.WhitelistEntry{}
 		}
 		if pv := fedpolicy.ValidateWhitelist(&cfg); len(pv) > 0 {
-			writeValidationErrors(w, r, toViolations(pv))
+			handler.WriteValidationErrors(w, r, toViolations(pv))
 			return
 		}
 
@@ -124,31 +125,31 @@ func PutFederationPolicy(d *Deps) http.HandlerFunc {
 		if d.AdmissionValidator != nil {
 			added := addedFederationMetrics(d.FederationPolicy.Get(), &cfg)
 			if len(added) > maxNewMetricsPerRequest {
-				writeJSONError(w, r, http.StatusBadRequest, fmt.Sprintf(
+				handler.WriteJSONError(w, r, http.StatusBadRequest, fmt.Sprintf(
 					"too many new metrics in one request (%d; max %d) — split the change into smaller PUTs so admission validation stays within the request timeout",
 					len(added), maxNewMetricsPerRequest))
 				return
 			}
 			hard, soft := partitionAdmission(runAdmissionChecks(d, r.Context(), added))
 			if len(hard) > 0 {
-				writeErrorEnvelope(w, r, http.StatusBadRequest, ErrorResponse{
+				handler.WriteErrorEnvelope(w, r, http.StatusBadRequest, handler.ErrorResponse{
 					Error: "federation admission: hard block — metric(s) have data but no series carries the tenant label and cannot be whitelisted",
-					Code:  CodeInvalidBody,
+					Code:  handler.CodeInvalidBody,
 					Extra: map[string]any{"admission": hard},
 				})
 				return
 			}
 			if len(soft) > 0 && !req.Force {
-				writeErrorEnvelope(w, r, http.StatusBadRequest, ErrorResponse{
+				handler.WriteErrorEnvelope(w, r, http.StatusBadRequest, handler.ErrorResponse{
 					Error: "federation admission: soft warning(s) — re-submit with force=true and a reason to proceed",
-					Code:  CodeInvalidBody,
+					Code:  handler.CodeInvalidBody,
 					Extra: map[string]any{"admission": soft},
 				})
 				return
 			}
 			if len(soft) > 0 { // force is true here
 				if strings.TrimSpace(req.Reason) == "" {
-					writeJSONError(w, r, http.StatusBadRequest, "force=true requires a non-empty reason")
+					handler.WriteJSONError(w, r, http.StatusBadRequest, "force=true requires a non-empty reason")
 					return
 				}
 				trailer = bypassTrailer(email, req.Reason, soft)
@@ -168,15 +169,15 @@ func PutFederationPolicy(d *Deps) http.HandlerFunc {
 
 		yamlBytes, err := yaml.Marshal(&cfg)
 		if err != nil {
-			writeJSONError(w, r, http.StatusInternalServerError, "marshal whitelist: "+err.Error())
+			handler.WriteJSONError(w, r, http.StatusInternalServerError, "marshal whitelist: "+err.Error())
 			return
 		}
 		if err := d.Writer.WriteFederationPolicyFile(email, string(yamlBytes), trailer); err != nil {
 			if errors.Is(err, gitops.ErrConflict) {
-				writeJSONError(w, r, http.StatusConflict, err.Error())
+				handler.WriteJSONError(w, r, http.StatusConflict, err.Error())
 				return
 			}
-			writeJSONError(w, r, http.StatusInternalServerError, err.Error())
+			handler.WriteJSONError(w, r, http.StatusInternalServerError, err.Error())
 			return
 		}
 		_ = d.FederationPolicy.Reload()
@@ -225,7 +226,7 @@ func addedFederationMetrics(current, proposed *fedpolicy.Config) []string {
 // take up to the validator's per-check timeout, so a batch must not run
 // strictly sequentially. Returns nil when the validator is disabled or
 // metrics is empty.
-func runAdmissionChecks(d *Deps, ctx context.Context, metrics []string) []fedpolicy.AdmissionResult {
+func runAdmissionChecks(d *handler.Deps, ctx context.Context, metrics []string) []fedpolicy.AdmissionResult {
 	if d.AdmissionValidator == nil || len(metrics) == 0 {
 		return nil
 	}
@@ -320,16 +321,16 @@ func admissionMetrics(results []fedpolicy.AdmissionResult) []string {
 // @Success     200 {object} fedpolicy.Subset
 // @Failure     400 {object} map[string]string
 // @Router      /api/v1/tenants/{id}/federation [get]
-func GetTenantFederation(d *Deps) http.HandlerFunc {
+func GetTenantFederation(d *handler.Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
-		if err := ValidateTenantID(tenantID); err != nil {
-			writeJSONError(w, r, http.StatusBadRequest, err.Error())
+		if err := handler.ValidateTenantID(tenantID); err != nil {
+			handler.WriteJSONError(w, r, http.StatusBadRequest, err.Error())
 			return
 		}
 		subset, err := readFederationSubset(d, tenantID)
 		if err != nil {
-			writeJSONError(w, r, http.StatusInternalServerError, "read federation subset: "+err.Error())
+			handler.WriteJSONError(w, r, http.StatusInternalServerError, "read federation subset: "+err.Error())
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -356,15 +357,15 @@ func GetTenantFederation(d *Deps) http.HandlerFunc {
 // @Failure     403  {object} map[string]string
 // @Failure     409  {object} map[string]string
 // @Router      /api/v1/tenants/{id}/federation [put]
-func PutTenantFederation(d *Deps) http.HandlerFunc {
+func PutTenantFederation(d *handler.Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
-		if err := ValidateTenantID(tenantID); err != nil {
-			writeJSONError(w, r, http.StatusBadRequest, err.Error())
+		if err := handler.ValidateTenantID(tenantID); err != nil {
+			handler.WriteJSONError(w, r, http.StatusBadRequest, err.Error())
 			return
 		}
 		if !d.RBAC.HasPermission(rbac.RequestGroups(r), tenantID, rbac.PermAdmin) {
-			writeJSONErrorWithCode(w, r, http.StatusForbidden, CodeForbidden,
+			handler.WriteJSONErrorWithCode(w, r, http.StatusForbidden, handler.CodeForbidden,
 				"admin permission required on tenant "+tenantID+" to edit its federation subset")
 			return
 		}
@@ -372,12 +373,12 @@ func PutTenantFederation(d *Deps) http.HandlerFunc {
 
 		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 		if err != nil {
-			writeJSONError(w, r, http.StatusBadRequest, "failed to read request body: "+err.Error())
+			handler.WriteJSONError(w, r, http.StatusBadRequest, "failed to read request body: "+err.Error())
 			return
 		}
 		var subset fedpolicy.Subset
 		if err := json.Unmarshal(body, &subset); err != nil {
-			writeJSONError(w, r, http.StatusBadRequest, "invalid JSON: "+err.Error())
+			handler.WriteJSONError(w, r, http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return
 		}
 		if subset.Metrics == nil {
@@ -385,21 +386,21 @@ func PutTenantFederation(d *Deps) http.HandlerFunc {
 		}
 		// 2-tier containment: the subset must not exceed the whitelist.
 		if pv := fedpolicy.ValidateSubset(&subset, d.FederationPolicy.Get()); len(pv) > 0 {
-			writeValidationErrors(w, r, toViolations(pv))
+			handler.WriteValidationErrors(w, r, toViolations(pv))
 			return
 		}
 
 		yamlBytes, err := yaml.Marshal(&subset)
 		if err != nil {
-			writeJSONError(w, r, http.StatusInternalServerError, "marshal subset: "+err.Error())
+			handler.WriteJSONError(w, r, http.StatusInternalServerError, "marshal subset: "+err.Error())
 			return
 		}
 		if err := d.Writer.WriteFederationSubsetFile(tenantID, email, string(yamlBytes)); err != nil {
 			if errors.Is(err, gitops.ErrConflict) {
-				writeJSONError(w, r, http.StatusConflict, err.Error())
+				handler.WriteJSONError(w, r, http.StatusConflict, err.Error())
 				return
 			}
-			writeJSONError(w, r, http.StatusInternalServerError, err.Error())
+			handler.WriteJSONError(w, r, http.StatusInternalServerError, err.Error())
 			return
 		}
 
@@ -415,7 +416,7 @@ func PutTenantFederation(d *Deps) http.HandlerFunc {
 // readFederationSubset loads conf.d/_federation/<tenantID>.yaml. A
 // missing file is not an error — it means the tenant has selected no
 // federation metrics yet, which yields an empty subset.
-func readFederationSubset(d *Deps, tenantID string) (*fedpolicy.Subset, error) {
+func readFederationSubset(d *handler.Deps, tenantID string) (*fedpolicy.Subset, error) {
 	path := filepath.Join(d.ConfigDir, "_federation", tenantID+".yaml")
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {

--- a/components/tenant-api/internal/handler/federation/policy_test.go
+++ b/components/tenant-api/internal/handler/federation/policy_test.go
@@ -1,4 +1,4 @@
-package handler
+package federation
 
 import (
 	"bytes"
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/vencil/tenant-api/internal/federation/fedpolicy"
+	"github.com/vencil/tenant-api/internal/handler"
 )
 
 // fakePrometheus mocks the Prometheus Series API for handler-level
@@ -112,7 +113,7 @@ func fedReq(t *testing.T, method, path, paramKey, paramVal, body string) *http.R
 func TestGetFederationPolicy_Empty(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
-	d := &Deps{
+	d := &handler.Deps{
 		FederationPolicy: fedpolicy.NewManager(configDir),
 		RBAC:             newRBACManager(t, ""),
 	}
@@ -133,7 +134,7 @@ func TestPutFederationPolicy_ForbiddenForNonPlatformAdmin(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
 	initGitRepo(t, configDir)
-	d := &Deps{
+	d := &handler.Deps{
 		ConfigDir:        configDir,
 		Writer:           newTestWriter(configDir),
 		FederationPolicy: fedpolicy.NewManager(configDir),
@@ -151,7 +152,7 @@ func TestPutFederationPolicy_Success(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
 	initGitRepo(t, configDir)
-	d := &Deps{
+	d := &handler.Deps{
 		ConfigDir:        configDir,
 		Writer:           newTestWriter(configDir),
 		FederationPolicy: fedpolicy.NewManager(configDir),
@@ -178,7 +179,7 @@ func TestPutFederationPolicy_AdmissionHardBlock(t *testing.T) {
 	// No tenant-labelled series, but the metric has data — hard block:
 	// not whitelistable, not forceable.
 	promURL := fakePrometheus(t, nil, []map[string]string{{"__name__": "m", "instance": "x"}})
-	d := &Deps{
+	d := &handler.Deps{
 		ConfigDir:          configDir,
 		Writer:             newTestWriter(configDir),
 		FederationPolicy:   fedpolicy.NewManager(configDir),
@@ -201,7 +202,7 @@ func TestPutFederationPolicy_AdmissionWarnNeedsForce(t *testing.T) {
 	initGitRepo(t, configDir)
 	// Both probes empty — no samples in the window → soft Warn.
 	promURL := fakePrometheus(t, nil, nil)
-	d := &Deps{
+	d := &handler.Deps{
 		ConfigDir:          configDir,
 		Writer:             newTestWriter(configDir),
 		FederationPolicy:   fedpolicy.NewManager(configDir),
@@ -238,7 +239,7 @@ func TestPutFederationPolicy_AdmissionPass(t *testing.T) {
 	initGitRepo(t, configDir)
 	// A tenant-labelled series exists → Pass, no force needed.
 	promURL := fakePrometheus(t, []map[string]string{{"__name__": "m", "tenant": "db-a"}}, nil)
-	d := &Deps{
+	d := &handler.Deps{
 		ConfigDir:          configDir,
 		Writer:             newTestWriter(configDir),
 		FederationPolicy:   fedpolicy.NewManager(configDir),
@@ -260,7 +261,7 @@ func TestPutFederationPolicy_AdmissionMultipleMetricsConcurrent(t *testing.T) {
 	// admission checks run concurrently — this verifies the fan-out
 	// maps each verdict back to the right metric (m3, not m1/m2/...).
 	promURL := fakePromPerMetric(t, "m3")
-	d := &Deps{
+	d := &handler.Deps{
 		ConfigDir:          configDir,
 		Writer:             newTestWriter(configDir),
 		FederationPolicy:   fedpolicy.NewManager(configDir),
@@ -281,7 +282,7 @@ func TestPutFederationPolicy_RejectsTooManyNewMetrics(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
 	initGitRepo(t, configDir)
-	d := &Deps{
+	d := &handler.Deps{
 		ConfigDir:          configDir,
 		Writer:             newTestWriter(configDir),
 		FederationPolicy:   fedpolicy.NewManager(configDir),
@@ -313,7 +314,7 @@ func TestPutFederationPolicy_CancelledContextSkipsGitWrite(t *testing.T) {
 	initGitRepo(t, configDir)
 	// Validator disabled so admission is skipped — isolates the
 	// point-of-no-return context guard right before the git write.
-	d := &Deps{
+	d := &handler.Deps{
 		ConfigDir:        configDir,
 		Writer:           newTestWriter(configDir),
 		FederationPolicy: fedpolicy.NewManager(configDir),
@@ -332,7 +333,7 @@ func TestPutFederationPolicy_RejectsInvalidMetricName(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
 	initGitRepo(t, configDir)
-	d := &Deps{
+	d := &handler.Deps{
 		ConfigDir:        configDir,
 		Writer:           newTestWriter(configDir),
 		FederationPolicy: fedpolicy.NewManager(configDir),
@@ -349,7 +350,7 @@ func TestPutTenantFederation_ForbiddenWithoutTenantAdmin(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
 	initGitRepo(t, configDir)
-	d := &Deps{
+	d := &handler.Deps{
 		ConfigDir:        configDir,
 		Writer:           newTestWriter(configDir),
 		FederationPolicy: fedpolicy.NewManager(configDir),
@@ -371,7 +372,7 @@ func TestPutTenantFederation_RejectsMetricOutsideWhitelist(t *testing.T) {
 	mgr := fedpolicy.NewManagerForTest(&fedpolicy.Config{
 		Whitelist: []fedpolicy.WhitelistEntry{{Metric: "mysql_up"}},
 	})
-	d := &Deps{
+	d := &handler.Deps{
 		ConfigDir:        configDir,
 		Writer:           newTestWriter(configDir),
 		FederationPolicy: mgr,
@@ -395,7 +396,7 @@ func TestPutTenantFederation_Success(t *testing.T) {
 	mgr := fedpolicy.NewManagerForTest(&fedpolicy.Config{
 		Whitelist: []fedpolicy.WhitelistEntry{{Metric: "mysql_up"}, {Metric: "pg_up"}},
 	})
-	d := &Deps{
+	d := &handler.Deps{
 		ConfigDir:        configDir,
 		Writer:           newTestWriter(configDir),
 		FederationPolicy: mgr,
@@ -431,7 +432,7 @@ func TestGetTenantFederation_ReadRepairDropsStaleMetric(t *testing.T) {
 	mgr := fedpolicy.NewManagerForTest(&fedpolicy.Config{
 		Whitelist: []fedpolicy.WhitelistEntry{{Metric: "mysql_up"}},
 	})
-	d := &Deps{ConfigDir: configDir, FederationPolicy: mgr, RBAC: newRBACManager(t, "")}
+	d := &handler.Deps{ConfigDir: configDir, FederationPolicy: mgr, RBAC: newRBACManager(t, "")}
 
 	w := executeWithRBAC(t, GetTenantFederation(d), fedReq(t, "GET", "/api/v1/tenants/db-a/federation", "id", "db-a", ""))
 	if w.Code != http.StatusOK {
@@ -450,7 +451,7 @@ func TestGetTenantFederation_ReadRepairDropsStaleMetric(t *testing.T) {
 func TestGetTenantFederation_NoFileYieldsEmptySubset(t *testing.T) {
 	t.Parallel()
 	configDir := setupConfigDir(t, nil)
-	d := &Deps{
+	d := &handler.Deps{
 		ConfigDir:        configDir,
 		FederationPolicy: fedpolicy.NewManager(configDir),
 		RBAC:             newRBACManager(t, ""),

--- a/components/tenant-api/internal/handler/federation/testhelpers_test.go
+++ b/components/tenant-api/internal/handler/federation/testhelpers_test.go
@@ -1,0 +1,102 @@
+package federation
+
+// Test helpers duplicated from internal/handler/{handler,group}_test.go.
+// They are kept here (rather than exported from internal/handler) so the
+// handler package's production API stays unaffected by sub-package test
+// scaffolding. If a helper diverges, that is acceptable — these are test
+// fixtures, not production contracts.
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/vencil/tenant-api/internal/gitops"
+	"github.com/vencil/tenant-api/internal/rbac"
+	"github.com/vencil/tenant-api/internal/testutil"
+)
+
+// initGitRepo initializes a git repo in the given directory with an initial commit.
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	cmds := [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "add", "."},
+		{"git", "commit", "--allow-empty", "-m", "init"},
+	}
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git command %v failed: %v\n%s", args, err, out)
+		}
+	}
+}
+
+func newRequestWithChiParam(method, path, paramName, paramValue string, body *bytes.Buffer) *http.Request {
+	if body == nil {
+		body = bytes.NewBuffer(nil)
+	}
+	req := httptest.NewRequest(method, path, body)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add(paramName, paramValue)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	return req
+}
+
+func setupConfigDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		testutil.WriteYAML(t, dir, name, content)
+	}
+	return dir
+}
+
+func newTestWriter(configDir string) *gitops.Writer {
+	return gitops.NewWriter(configDir, "")
+}
+
+func newRBACManager(t *testing.T, yaml string) *rbac.Manager {
+	t.Helper()
+	if yaml == "" {
+		mgr, err := rbac.NewManager("")
+		if err != nil {
+			t.Fatalf("rbac.NewManager: %v", err)
+		}
+		return mgr
+	}
+	_, rbacFile := testutil.MkTempYAML(t, "_rbac.yaml", yaml)
+	mgr, err := rbac.NewManager(rbacFile)
+	if err != nil {
+		t.Fatalf("rbac.NewManager: %v", err)
+	}
+	return mgr
+}
+
+func wrapWithRBACMiddleware(handler http.HandlerFunc, mgr *rbac.Manager, perm rbac.Permission, tenantIDFn func(*http.Request) string) http.Handler {
+	return mgr.Middleware(perm, tenantIDFn)(handler)
+}
+
+// setRequestIdentity wraps a request through the RBAC middleware to set context identity.
+// This simulates what oauth2-proxy + RBAC middleware would do in production.
+func setRequestIdentity(req *http.Request, email string) *http.Request {
+	req.Header.Set("X-Forwarded-Email", email)
+	req.Header.Set("X-Forwarded-Groups", "platform-admins")
+	return req
+}
+
+func executeWithRBAC(t *testing.T, handler http.HandlerFunc, req *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+	mgr := newRBACManager(t, "")
+	wrapped := wrapWithRBACMiddleware(handler, mgr, rbac.PermRead, nil)
+	w := httptest.NewRecorder()
+	wrapped.ServeHTTP(w, req)
+	return w
+}

--- a/components/tenant-api/internal/handler/group.go
+++ b/components/tenant-api/internal/handler/group.go
@@ -96,13 +96,13 @@ func GetGroup(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		groupID := chi.URLParam(r, "id")
 		if err := groups.ValidateGroupID(groupID); err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, err.Error())
 			return
 		}
 
 		g, ok := d.Groups.GetGroup(groupID)
 		if !ok {
-			writeJSONError(w, r,http.StatusNotFound, "group not found: "+groupID)
+			WriteJSONError(w, r,http.StatusNotFound, "group not found: "+groupID)
 			return
 		}
 
@@ -158,7 +158,7 @@ func PutGroup(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		groupID := chi.URLParam(r, "id")
 		if err := groups.ValidateGroupID(groupID); err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -167,13 +167,13 @@ func PutGroup(d *Deps) http.HandlerFunc {
 
 		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 		if err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, "failed to read request body: "+err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, "failed to read request body: "+err.Error())
 			return
 		}
 
 		var req PutGroupRequest
 		if err := json.Unmarshal(body, &req); err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, "invalid JSON: "+err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return
 		}
 
@@ -181,10 +181,10 @@ func PutGroup(d *Deps) http.HandlerFunc {
 		// rules cover Label / Description / Members; per-pair Filters
 		// length checks need the imperative path because validator's
 		// `dive` doesn't render the offending key in the field path.
-		violations := validateStructTags(&req)
+		violations := ValidateStructTags(&req)
 		violations = append(violations, validateFilterMap(req.Filters, "filters")...)
 		if len(violations) > 0 {
-			writeValidationErrors(w, r,violations)
+			WriteValidationErrors(w, r,violations)
 			return
 		}
 
@@ -194,7 +194,7 @@ func PutGroup(d *Deps) http.HandlerFunc {
 		// error so the operator can fix in one round-trip rather
 		// than discovering them one-at-a-time.
 		if forbidden := tenantsLackingPermission(d.RBAC, idpGroups, req.Members, rbac.PermWrite); len(forbidden) > 0 {
-			writeJSONError(w, r,http.StatusForbidden,
+			WriteJSONError(w, r,http.StatusForbidden,
 				"insufficient permission to write group with forbidden member tenants: "+
 					strings.Join(forbidden, ", "))
 			return
@@ -217,16 +217,16 @@ func PutGroup(d *Deps) http.HandlerFunc {
 
 		yamlBytes, err := groups.MarshalConfig(newCfg)
 		if err != nil {
-			writeJSONError(w, r,http.StatusInternalServerError, "marshal groups: "+err.Error())
+			WriteJSONError(w, r,http.StatusInternalServerError, "marshal groups: "+err.Error())
 			return
 		}
 
 		if err := d.Writer.WriteGroupsFile(email, string(yamlBytes)); err != nil {
 			if errors.Is(err, gitops.ErrConflict) {
-				writeJSONError(w, r,http.StatusConflict, err.Error())
+				WriteJSONError(w, r,http.StatusConflict, err.Error())
 				return
 			}
-			writeJSONError(w, r,http.StatusInternalServerError, err.Error())
+			WriteJSONError(w, r,http.StatusInternalServerError, err.Error())
 			return
 		}
 
@@ -258,7 +258,7 @@ func DeleteGroup(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		groupID := chi.URLParam(r, "id")
 		if err := groups.ValidateGroupID(groupID); err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -268,7 +268,7 @@ func DeleteGroup(d *Deps) http.HandlerFunc {
 		cfg := d.Groups.Get()
 		existing, ok := cfg.Groups[groupID]
 		if !ok {
-			writeJSONError(w, r,http.StatusNotFound, "group not found: "+groupID)
+			WriteJSONError(w, r,http.StatusNotFound, "group not found: "+groupID)
 			return
 		}
 
@@ -279,7 +279,7 @@ func DeleteGroup(d *Deps) http.HandlerFunc {
 		// service surface against teams who depend on dashboards
 		// keyed off that group.
 		if forbidden := tenantsLackingPermission(d.RBAC, idpGroups, existing.Members, rbac.PermWrite); len(forbidden) > 0 {
-			writeJSONError(w, r,http.StatusForbidden,
+			WriteJSONError(w, r,http.StatusForbidden,
 				"insufficient permission to delete group with forbidden member tenants: "+
 					strings.Join(forbidden, ", "))
 			return
@@ -296,16 +296,16 @@ func DeleteGroup(d *Deps) http.HandlerFunc {
 
 		yamlBytes, err := groups.MarshalConfig(newCfg)
 		if err != nil {
-			writeJSONError(w, r,http.StatusInternalServerError, "marshal groups: "+err.Error())
+			WriteJSONError(w, r,http.StatusInternalServerError, "marshal groups: "+err.Error())
 			return
 		}
 
 		if err := d.Writer.WriteGroupsFile(email, string(yamlBytes)); err != nil {
 			if errors.Is(err, gitops.ErrConflict) {
-				writeJSONError(w, r,http.StatusConflict, err.Error())
+				WriteJSONError(w, r,http.StatusConflict, err.Error())
 				return
 			}
-			writeJSONError(w, r,http.StatusInternalServerError, err.Error())
+			WriteJSONError(w, r,http.StatusInternalServerError, err.Error())
 			return
 		}
 

--- a/components/tenant-api/internal/handler/group_batch.go
+++ b/components/tenant-api/internal/handler/group_batch.go
@@ -56,7 +56,7 @@ func GroupBatch(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		groupID := chi.URLParam(r, "id")
 		if err := groups.ValidateGroupID(groupID); err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -65,22 +65,22 @@ func GroupBatch(d *Deps) http.HandlerFunc {
 
 		g, ok := d.Groups.GetGroup(groupID)
 		if !ok {
-			writeJSONError(w, r,http.StatusNotFound, "group not found: "+groupID)
+			WriteJSONError(w, r,http.StatusNotFound, "group not found: "+groupID)
 			return
 		}
 
 		var req GroupBatchRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, "invalid JSON: "+err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return
 		}
 		if len(req.Patch) == 0 {
-			writeJSONError(w, r,http.StatusBadRequest, "patch must not be empty")
+			WriteJSONError(w, r,http.StatusBadRequest, "patch must not be empty")
 			return
 		}
 
 		if len(g.Members) == 0 {
-			writeJSONError(w, r,http.StatusBadRequest, "group has no members")
+			WriteJSONError(w, r,http.StatusBadRequest, "group has no members")
 			return
 		}
 

--- a/components/tenant-api/internal/handler/handler_test.go
+++ b/components/tenant-api/internal/handler/handler_test.go
@@ -933,12 +933,12 @@ func TestLoadMergedConfig_WithStateFilters(t *testing.T) {
 	}
 }
 
-// --- writeJSONError tests ---
+// --- WriteJSONError tests ---
 
 func TestWriteJSONError(t *testing.T) {
 	t.Parallel()
 	w := httptest.NewRecorder()
-	writeJSONError(w, nil, http.StatusNotFound, "not found")
+	WriteJSONError(w, nil, http.StatusNotFound, "not found")
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
@@ -959,7 +959,7 @@ func TestWriteJSONError(t *testing.T) {
 func TestWriteJSONError_InternalError(t *testing.T) {
 	t.Parallel()
 	w := httptest.NewRecorder()
-	writeJSONError(w, nil, http.StatusInternalServerError, "something broke")
+	WriteJSONError(w, nil, http.StatusInternalServerError, "something broke")
 
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)

--- a/components/tenant-api/internal/handler/middleware.go
+++ b/components/tenant-api/internal/handler/middleware.go
@@ -349,7 +349,7 @@ func RateLimit(cfg RateLimitConfig, stopCh <-chan struct{}) (func(http.Handler) 
 				// libs (e.g. http.Client wrappers) honor the header
 				// without parsing JSON.
 				w.Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
-				writeErrorEnvelope(w, r, http.StatusTooManyRequests, ErrorResponse{
+				WriteErrorEnvelope(w, r, http.StatusTooManyRequests, ErrorResponse{
 					Error:       fmt.Sprintf("rate limit exceeded for %s; try again in %ds", caller, retryAfter),
 					Code:        CodeRateLimited,
 					RetryAfterS: retryAfter,

--- a/components/tenant-api/internal/handler/task.go
+++ b/components/tenant-api/internal/handler/task.go
@@ -33,7 +33,7 @@ func GetTask(d *Deps) http.HandlerFunc {
 
 		task, ok := d.Tasks.Get(taskID)
 		if !ok {
-			writeErrorEnvelope(w, r, http.StatusNotFound, ErrorResponse{
+			WriteErrorEnvelope(w, r, http.StatusNotFound, ErrorResponse{
 				Error: "task_not_found",
 				Code:  CodeTaskNotFound,
 				Extra: map[string]any{
@@ -52,7 +52,7 @@ func GetTask(d *Deps) http.HandlerFunc {
 			// Caller has zero access to any of the touched tenants.
 			// 403 (not 404) — the task exists, just none of its
 			// tenants are within the caller's RBAC scope.
-			writeJSONError(w, r,http.StatusForbidden,
+			WriteJSONError(w, r,http.StatusForbidden,
 				"insufficient permission to read task results: caller has no access to any of the task's tenants")
 			return
 		}

--- a/components/tenant-api/internal/handler/tenant_batch.go
+++ b/components/tenant-api/internal/handler/tenant_batch.go
@@ -79,11 +79,11 @@ func BatchTenants(d *Deps) http.HandlerFunc {
 
 		var req BatchRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSONError(rw, r,http.StatusBadRequest, "invalid JSON: "+err.Error())
+			WriteJSONError(rw, r,http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return
 		}
 		if len(req.Operations) == 0 {
-			writeJSONError(rw, r,http.StatusBadRequest, "operations list is empty")
+			WriteJSONError(rw, r,http.StatusBadRequest, "operations list is empty")
 			return
 		}
 
@@ -91,13 +91,13 @@ func BatchTenants(d *Deps) http.HandlerFunc {
 		// Track C C4). Run BEFORE any RBAC / per-op work so a malformed
 		// body fails fast with the full violation list (one round-trip
 		// for the operator to fix everything, not retry-and-discover).
-		violations := validateStructTags(&req)
+		violations := ValidateStructTags(&req)
 		for i, op := range req.Operations {
 			fieldPrefix := fmt.Sprintf("operations[%d].patch", i)
 			violations = append(violations, validatePatchMap(op.Patch, fieldPrefix)...)
 		}
 		if len(violations) > 0 {
-			writeValidationErrors(rw, r,violations)
+			WriteValidationErrors(rw, r,violations)
 			return
 		}
 
@@ -148,7 +148,7 @@ func BatchTenants(d *Deps) http.HandlerFunc {
 
 			result, err := d.Writer.WritePRBatch(batchOps, email)
 			if err != nil {
-				writeJSONError(rw, r,http.StatusInternalServerError, "PR/MR batch write failed: "+err.Error())
+				WriteJSONError(rw, r,http.StatusInternalServerError, "PR/MR batch write failed: "+err.Error())
 				return
 			}
 
@@ -170,7 +170,7 @@ func BatchTenants(d *Deps) http.HandlerFunc {
 			)
 			if err != nil {
 				provider := d.PRClient.ProviderName()
-				writeJSONError(rw, r,http.StatusServiceUnavailable, fmt.Sprintf("%s PR/MR creation failed: %s", provider, err.Error()))
+				WriteJSONError(rw, r,http.StatusServiceUnavailable, fmt.Sprintf("%s PR/MR creation failed: %s", provider, err.Error()))
 				return
 			}
 

--- a/components/tenant-api/internal/handler/tenant_diff.go
+++ b/components/tenant-api/internal/handler/tenant_diff.go
@@ -41,13 +41,13 @@ func DiffTenant(d *Deps) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
 		if err := ValidateTenantID(tenantID); err != nil {
-			writeJSONError(rw, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(rw, r,http.StatusBadRequest, err.Error())
 			return
 		}
 
 		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 		if err != nil {
-			writeJSONError(rw, r,http.StatusBadRequest, "failed to read request body: "+err.Error())
+			WriteJSONError(rw, r,http.StatusBadRequest, "failed to read request body: "+err.Error())
 			return
 		}
 
@@ -57,7 +57,7 @@ func DiffTenant(d *Deps) http.HandlerFunc {
 		if strings.Contains(ct, "json") || (len(body) > 0 && body[0] == '{') {
 			var req DiffRequest
 			if err := json.Unmarshal(body, &req); err != nil {
-				writeJSONError(rw, r,http.StatusBadRequest, "invalid JSON: "+err.Error())
+				WriteJSONError(rw, r,http.StatusBadRequest, "invalid JSON: "+err.Error())
 				return
 			}
 			proposed = req.Proposed
@@ -65,7 +65,7 @@ func DiffTenant(d *Deps) http.HandlerFunc {
 
 		diff, err := d.Writer.Diff(tenantID, proposed)
 		if err != nil {
-			writeJSONError(rw, r,http.StatusInternalServerError, err.Error())
+			WriteJSONError(rw, r,http.StatusInternalServerError, err.Error())
 			return
 		}
 

--- a/components/tenant-api/internal/handler/tenant_effective.go
+++ b/components/tenant-api/internal/handler/tenant_effective.go
@@ -48,17 +48,17 @@ func GetTenantEffective(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
 		if err := ValidateTenantID(tenantID); err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, err.Error())
 			return
 		}
 
 		ec, err := cfg.ResolveEffective(d.ConfigDir, tenantID)
 		if err != nil {
 			if errors.Is(err, cfg.ErrTenantNotFound) {
-				writeJSONError(w, r,http.StatusNotFound, "tenant not found: "+tenantID)
+				WriteJSONError(w, r,http.StatusNotFound, "tenant not found: "+tenantID)
 				return
 			}
-			writeJSONError(w, r,http.StatusInternalServerError, err.Error())
+			WriteJSONError(w, r,http.StatusInternalServerError, err.Error())
 			return
 		}
 

--- a/components/tenant-api/internal/handler/tenant_get.go
+++ b/components/tenant-api/internal/handler/tenant_get.go
@@ -36,18 +36,18 @@ func GetTenant(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
 		if err := ValidateTenantID(tenantID); err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, err.Error())
 			return
 		}
 
 		filePath := filepath.Join(d.ConfigDir, tenantID+".yaml")
 		data, err := os.ReadFile(filePath)
 		if os.IsNotExist(err) {
-			writeJSONError(w, r,http.StatusNotFound, "tenant not found: "+tenantID)
+			WriteJSONError(w, r,http.StatusNotFound, "tenant not found: "+tenantID)
 			return
 		}
 		if err != nil {
-			writeJSONError(w, r,http.StatusInternalServerError, err.Error())
+			WriteJSONError(w, r,http.StatusInternalServerError, err.Error())
 			return
 		}
 

--- a/components/tenant-api/internal/handler/tenant_list.go
+++ b/components/tenant-api/internal/handler/tenant_list.go
@@ -47,7 +47,7 @@ func ListTenants(d *Deps) http.HandlerFunc {
 
 		tenants, err := loadAllTenants(d.ConfigDir)
 		if err != nil {
-			writeJSONError(w, r,http.StatusInternalServerError, err.Error())
+			WriteJSONError(w, r,http.StatusInternalServerError, err.Error())
 			return
 		}
 

--- a/components/tenant-api/internal/handler/tenant_put.go
+++ b/components/tenant-api/internal/handler/tenant_put.go
@@ -52,14 +52,14 @@ func PutTenant(d *Deps) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
 		if err := ValidateTenantID(tenantID); err != nil {
-			writeJSONError(rw, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(rw, r,http.StatusBadRequest, err.Error())
 			return
 		}
 		email := rbac.RequestEmail(r)
 
 		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MB limit
 		if err != nil {
-			writeJSONError(rw, r,http.StatusBadRequest, "failed to read request body: "+err.Error())
+			WriteJSONError(rw, r,http.StatusBadRequest, "failed to read request body: "+err.Error())
 			return
 		}
 
@@ -77,7 +77,7 @@ func PutTenant(d *Deps) http.HandlerFunc {
 			// Check for existing pending PR/MR
 			if d.PRTracker.HasPendingPR(tenantID) {
 				existingPR, _ := d.PRTracker.PendingPRForTenant(tenantID)
-				writeErrorEnvelope(rw, r, http.StatusConflict, ErrorResponse{
+				WriteErrorEnvelope(rw, r, http.StatusConflict, ErrorResponse{
 					Error: "pending_pr_exists",
 					Code:  CodePendingPR,
 					Extra: map[string]any{
@@ -92,7 +92,7 @@ func PutTenant(d *Deps) http.HandlerFunc {
 			// Create feature branch + commit
 			result, err := d.Writer.WritePR(tenantID, email, string(body))
 			if err != nil {
-				writeJSONError(rw, r,http.StatusInternalServerError, "PR write failed: "+err.Error())
+				WriteJSONError(rw, r,http.StatusInternalServerError, "PR write failed: "+err.Error())
 				return
 			}
 
@@ -107,7 +107,7 @@ func PutTenant(d *Deps) http.HandlerFunc {
 			)
 			if err != nil {
 				provider := d.PRClient.ProviderName()
-				writeJSONError(rw, r,http.StatusServiceUnavailable, fmt.Sprintf("%s PR/MR creation failed: %s", provider, err.Error()))
+				WriteJSONError(rw, r,http.StatusServiceUnavailable, fmt.Sprintf("%s PR/MR creation failed: %s", provider, err.Error()))
 				return
 			}
 
@@ -125,10 +125,10 @@ func PutTenant(d *Deps) http.HandlerFunc {
 		// Default: direct commit-on-write (ADR-009)
 		if err := d.Writer.Write(tenantID, email, string(body)); err != nil {
 			if errors.Is(err, gitops.ErrConflict) {
-				writeJSONError(rw, r,http.StatusConflict, err.Error())
+				WriteJSONError(rw, r,http.StatusConflict, err.Error())
 				return
 			}
-			writeJSONError(rw, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(rw, r,http.StatusBadRequest, err.Error())
 			return
 		}
 

--- a/components/tenant-api/internal/handler/tenant_search.go
+++ b/components/tenant-api/internal/handler/tenant_search.go
@@ -138,13 +138,13 @@ func SearchTenants(d *Deps) http.HandlerFunc {
 
 		params, err := parseSearchParams(r)
 		if err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, err.Error())
 			return
 		}
 
 		all, err := d.SearchCache.snapshot(d.ConfigDir)
 		if err != nil {
-			writeJSONError(w, r,http.StatusInternalServerError, err.Error())
+			WriteJSONError(w, r,http.StatusInternalServerError, err.Error())
 			return
 		}
 

--- a/components/tenant-api/internal/handler/tenant_validate.go
+++ b/components/tenant-api/internal/handler/tenant_validate.go
@@ -32,13 +32,13 @@ func ValidateTenant(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tenantID := chi.URLParam(r, "id")
 		if err := ValidateTenantID(tenantID); err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, err.Error())
 			return
 		}
 
 		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 		if err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, "failed to read request body: "+err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, "failed to read request body: "+err.Error())
 			return
 		}
 

--- a/components/tenant-api/internal/handler/view.go
+++ b/components/tenant-api/internal/handler/view.go
@@ -61,13 +61,13 @@ func GetView(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		viewID := chi.URLParam(r, "id")
 		if err := views.ValidateViewID(viewID); err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, err.Error())
 			return
 		}
 
 		v, ok := d.Views.GetView(viewID)
 		if !ok {
-			writeJSONError(w, r,http.StatusNotFound, "view not found: "+viewID)
+			WriteJSONError(w, r,http.StatusNotFound, "view not found: "+viewID)
 			return
 		}
 
@@ -111,7 +111,7 @@ func PutView(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		viewID := chi.URLParam(r, "id")
 		if err := views.ValidateViewID(viewID); err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -119,13 +119,13 @@ func PutView(d *Deps) http.HandlerFunc {
 
 		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 		if err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, "failed to read request body: "+err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, "failed to read request body: "+err.Error())
 			return
 		}
 
 		var req PutViewRequest
 		if err := json.Unmarshal(body, &req); err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, "invalid JSON: "+err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, "invalid JSON: "+err.Error())
 			return
 		}
 
@@ -134,10 +134,10 @@ func PutView(d *Deps) http.HandlerFunc {
 		// Filters element-count; per-pair Filters value length goes
 		// through validateFilterMap because validator's `dive` doesn't
 		// surface the offending key in the violation field path.
-		violations := validateStructTags(&req)
+		violations := ValidateStructTags(&req)
 		violations = append(violations, validateFilterMap(req.Filters, "filters")...)
 		if len(violations) > 0 {
-			writeValidationErrors(w, r,violations)
+			WriteValidationErrors(w, r,violations)
 			return
 		}
 
@@ -157,16 +157,16 @@ func PutView(d *Deps) http.HandlerFunc {
 
 		yamlBytes, err := views.MarshalConfig(newCfg)
 		if err != nil {
-			writeJSONError(w, r,http.StatusInternalServerError, "marshal views: "+err.Error())
+			WriteJSONError(w, r,http.StatusInternalServerError, "marshal views: "+err.Error())
 			return
 		}
 
 		if err := d.Writer.WriteViewsFile(email, string(yamlBytes)); err != nil {
 			if errors.Is(err, gitops.ErrConflict) {
-				writeJSONError(w, r,http.StatusConflict, err.Error())
+				WriteJSONError(w, r,http.StatusConflict, err.Error())
 				return
 			}
-			writeJSONError(w, r,http.StatusInternalServerError, err.Error())
+			WriteJSONError(w, r,http.StatusInternalServerError, err.Error())
 			return
 		}
 
@@ -195,7 +195,7 @@ func DeleteView(d *Deps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		viewID := chi.URLParam(r, "id")
 		if err := views.ValidateViewID(viewID); err != nil {
-			writeJSONError(w, r,http.StatusBadRequest, err.Error())
+			WriteJSONError(w, r,http.StatusBadRequest, err.Error())
 			return
 		}
 
@@ -203,7 +203,7 @@ func DeleteView(d *Deps) http.HandlerFunc {
 
 		cfg := d.Views.Get()
 		if _, ok := cfg.Views[viewID]; !ok {
-			writeJSONError(w, r,http.StatusNotFound, "view not found: "+viewID)
+			WriteJSONError(w, r,http.StatusNotFound, "view not found: "+viewID)
 			return
 		}
 
@@ -218,16 +218,16 @@ func DeleteView(d *Deps) http.HandlerFunc {
 
 		yamlBytes, err := views.MarshalConfig(newCfg)
 		if err != nil {
-			writeJSONError(w, r,http.StatusInternalServerError, "marshal views: "+err.Error())
+			WriteJSONError(w, r,http.StatusInternalServerError, "marshal views: "+err.Error())
 			return
 		}
 
 		if err := d.Writer.WriteViewsFile(email, string(yamlBytes)); err != nil {
 			if errors.Is(err, gitops.ErrConflict) {
-				writeJSONError(w, r,http.StatusConflict, err.Error())
+				WriteJSONError(w, r,http.StatusConflict, err.Error())
 				return
 			}
-			writeJSONError(w, r,http.StatusInternalServerError, err.Error())
+			WriteJSONError(w, r,http.StatusInternalServerError, err.Error())
 			return
 		}
 


### PR DESCRIPTION
## Summary

Phase C of #537, deferred at PR #558 due to helper-export cost. This PR closes that scope gap.

### Moved files
- `handler/federation.go` → `handler/federation/handlers.go`
- `handler/federation_policy.go` → `handler/federation/policy.go`
- `handler/federation_test.go` → `handler/federation/handlers_test.go`
- `handler/federation_policy_test.go` → `handler/federation/policy_test.go`

### Exported helpers in `handler/`
Required by the new sub-package; word-boundary sed across ~17 callers for `WriteJSONError` alone:
- `writeJSONError` → `WriteJSONError`
- `writeJSONErrorWithCode` → `WriteJSONErrorWithCode`
- `validateStructTags` → `ValidateStructTags`
- `writeValidationErrors` → `WriteValidationErrors`
- `writeErrorEnvelope` → `WriteErrorEnvelope`

### Federation-only helpers / types stay unexported in the sub-package
`toViolations`, `addedFederationMetrics`, `toFederationTokenRecord`, `CreateFederationTokenRequest`, `FederationTokenRecord`, `CreateFederationTokenResponse`. API surface stays minimal — they were federation-only callers/callees.

### Test helpers
New `federation/testhelpers_test.go` duplicates 8 unexported test helpers (`setupConfigDir`, `newTestWriter`, `newRBACManager`, `wrapWithRBACMiddleware`, `executeWithRBAC`, `newRequestWithChiParam`, `setRequestIdentity`, `initGitRepo`) from `handler_test.go` / `group_test.go`. Kept here rather than exported so the handler package's production API isn't expanded for test-only convenience.

### Router
`cmd/server/main.go`: 7 federation handler routes → `federation.X(deps)`. Federation sub-package import added.

### OpenAPI spec
Regenerated via `make api-docs` (federation types moved one level deeper in the import path).

## Test plan

- [x] `go build ./...` clean
- [x] Federation sub-package tests pass
- [x] `pr-preflight` READY
- [ ] CI green

(`TestDiffTenant_RawYAML` / `TestDiff_ModifiedContent` still fail in worktree+container — known env limitation documented in #558; CI clean.)

Closes #559