### PR TITLE
ci: scope bench-gate-pr paths to benchmarkable Go changes

### DIFF
--- a/.github/workflows/bench-gate-pr.yaml
+++ b/.github/workflows/bench-gate-pr.yaml
@@ -61,7 +61,21 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     paths:
-      - 'components/threshold-exporter/app/**'
+      # Scope to benchmarkable changes only (issue #433 W3). Watching the
+      # whole app dir fired the gate on PRs with no benchmarkable Go delta —
+      # e.g. a `.dockerignore` change (#597) or a `*_test.go` deflake (#532),
+      # both pure noise that a maintainer had to override. Limit to non-test
+      # Go + module files, keeping rule-packs and this workflow's own edits.
+      # ORDER-SENSITIVE: GitHub Actions includes a path when a positive
+      # pattern matches AND no *later* `!` pattern excludes it, so the
+      # `*_test.go` exclusion must follow the `**/*.go` include. `**/*.go`
+      # is globstar (zero-or-more dirs), so it also matches non-test `.go`
+      # files directly in app/ root (config_parse.go, collector.go, …) —
+      # real-perf-PR coverage (e.g. #502) is preserved.
+      - 'components/threshold-exporter/app/**/*.go'
+      - '!components/threshold-exporter/app/**/*_test.go'
+      - 'components/threshold-exporter/app/go.mod'
+      - 'components/threshold-exporter/app/go.sum'
       - 'rule-packs/**'
       - '.github/workflows/bench-gate-pr.yaml'
 


### PR DESCRIPTION
## Summary

Tightens `on.pull_request.paths` on `bench-gate-pr.yaml` so the Tier-1 bench gate only fires on **benchmarkable** changes. It previously watched the entire app directory (`components/threshold-exporter/app/**`), firing on PRs with no Go-perf delta.

Per issue #433 W3 (2026-05-24), 3 of 4 Tier-1 friction events were scope errors:
- **#597** (TRK-311 Dockerfile SAST) fired on a `.dockerignore` change → a maintainer had to override pure noise.
- **#532** (test deflake) fired on a `*_test.go` change that can't move prod-package benchmark numbers.

New filter (order matters):
```yaml
paths:
  - 'components/threshold-exporter/app/**/*.go'
  - '!components/threshold-exporter/app/**/*_test.go'
  - 'components/threshold-exporter/app/go.mod'
  - 'components/threshold-exporter/app/go.sum'
  - 'rule-packs/**'
  - '.github/workflows/bench-gate-pr.yaml'
```

## Validation

GitHub Actions `paths` negation is order-sensitive (a path triggers iff a positive pattern matches and no *later* `!` pattern excludes it), and `**/*.go` is globstar — it matches `.go` files directly in `app/` root, not just subdirectories. That second point is the make-or-break: most perf-relevant files (`config_parse.go`, `collector.go`, `handlers.go`) live directly in `app/` root.

Verified with a faithful `minimatch` replication of GitHub's per-file include/exclude algorithm — **13/13 cases**:

| # | Scenario | Changed files | Triggers? | Want |
|---|---|---|---|---|
| a | #597 Dockerfile SAST | `.dockerignore` (+Dockerfile +workflow) | no | no |
| b | #532 test deflake | `config_slow_write_stress_test.go` | no | no |
| b2 | test in subdir | `internal/guard/routing_test.go` | no | no |
| b3 | bench harness test | `config_bench_test.go` | no | no |
| c | #502 real perf PR | `config_parse.go` + `internal/.../*.go` | yes | yes |
| c2 | **non-test .go in app/ root** | `collector.go` | yes | yes |
| c3 | non-test .go in subdir | `pkg/config/resolve.go` | yes | yes |
| c4 | mixed real + test .go | `handlers.go` + `config_test.go` | yes | yes |
| d | dependency bump | `go.mod` / `go.sum` | yes | yes |
| e | rule-packs | `rule-packs/...` | yes | yes |
| f | workflow self-edit | this file | yes | yes |
| g | docs-only | `README.md` | no | no |

The three confirmations #433 asked for all hold: (a) `.dockerignore`-only does **not** trigger, (b) `*_test.go`-only does **not** trigger, (c) a real `.go` change **still** triggers — including the make-or-break case (c2) of a non-test `.go` directly in `app/` root.

> This is a static replication of GitHub's documented semantics. Because this PR itself edits `bench-gate-pr.yaml` (case f), the live bench-gate run on *this* PR is the (f) confirmation. If a live confirmation of (a)/(b)/(c) is wanted before merge, I can spin up a throwaway PR — say the word.

## Behavior change

`*_test.go` (including `*_bench_test.go`) and non-Go files under `app/` no longer trigger the gate. A PR that only edits a benchmark file therefore won't re-run the gate against itself — acceptable, since a base-vs-PR `benchstat` can't meaningfully compare a benchmark that exists on only one side.

## Test plan

- [x] YAML parses (`yaml.safe_load`)
- [x] minimatch 13/13 cases (replicates GH per-file include/exclude + globstar zero-dir)
- [x] commitlint passes (PR title + commit)
- [x] trailer block parses via `git interpret-trailers --parse`
- [ ] `make pr-preflight` green before merge
- [ ] (optional) throwaway-PR live confirmation of (a)/(b)/(c)

Refs #433
