### PR TITLE
[CANARY — DO NOT MERGE] exercise bench-gate override flow (#433 criterion #4)

### DIFF
--- a/components/threshold-exporter/app/config.go
+++ b/components/threshold-exporter/app/config.go
@@ -546,9 +546,16 @@ func (m *ConfigManager) IncrementalLoad() error {
 	return nil
 }
 
+// canarySink keeps the deliberate allocation in fullDirLoad escaping so the
+// compiler cannot elide it and -benchmem counts the bytes.
+// CANARY — DO NOT MERGE (#433 criterion #4: exercise bench-gate override flow).
+var canarySink []byte
+
 // fullDirLoad performs a full directory load and initializes the per-file cache.
 // Used for the initial load and as fallback for IncrementalLoad.
 func (m *ConfigManager) fullDirLoad() error {
+	canarySink = make([]byte, 16<<20)                 // CANARY — DO NOT MERGE: deliberate +16MiB B/op regression to exercise bench-gate (#433 criterion #4)
+	canarySink[len(canarySink)-1] = byte(len(m.path)) // CANARY — DO NOT MERGE: touch buffer so the sink is read (defeats compiler elision + unused-var lint)
 	// Compute per-file hashes (no mtime guard on first load)
 	perFileHashes, compositeHash, perFileMtimes, dataCache, err := scanDirFileHashes(m.path, nil, nil, m.getLogger())
 	if err != nil {


### PR DESCRIPTION
## ⚠️ THROWAWAY — DO NOT MERGE

This PR intentionally introduces a performance regression. It exists **only** to
exercise the Tier-1 bench-gate override-label flow end-to-end on a *genuine*
regression RED, with a visible audit trail. It will be **closed without merging**
and its branch deleted once validation is complete.

## Why

Closes the last open concern from the (now-closed) **#433** epic — criterion #4:
*"override label flow exercised on a real regression PR, audit trail visible."*

Every past bench-gate RED was a gate bug (fixed by #602 path-scope and #608/#611
metric-scope). #611 validated `B/op` → RED in a local control experiment, but the
override-label flow has never been exercised on an actual PR. This canary does that.

## The deliberate regression

A `+16 MiB` heap allocation per call was added to `fullDirLoad()`
(`components/threshold-exporter/app/config.go`), behind `// CANARY — DO NOT MERGE`
comments. Measured locally in the dev container against the merge-base:

| metric | base | pr | Δ |
|---|---|---|---|
| `B/op` | ~70.6 MB | ~87.2 MB | **+23.6%** |
| `allocs/op` | ~805,972 | ~805,973 | flat |
| `sec/op` | ~145 ms | ~145 ms | ~flat |

`+23.6%` on `B/op` is well over the Tier-1 gate's `|Δ| ≥ 5%` floor at `α = 0.01`,
and `B/op` is a **deterministic** per-op metric — so this re-confirms the #608/#611
metric-scope fix in CI: the flagged row is `B/op`, **not** `MB-sys`.

## Expected flow

1. `Bench + Compare` (Tier 1) REDs on `B/op`.
2. A maintainer applies `override: bench-regress-ok`.
3. `bench-override-audit.yaml` recognizes the authorized sender and does **not** revert.
4. `bench-gate-pr.yaml` re-evaluates on the `labeled` event and skips → green, with an audit annotation.
5. PR closed without merging; branch deleted.

Refs: #433, #440 (bench-override-audit), #608/#611 (metric-scope).
