### PR TITLE
fix(docs): ADR-021 frontmatter version v2.9.0 -> v2.8.1

### DIFF
--- a/docs/adr/021-tenant-log-query-federation.md
+++ b/docs/adr/021-tenant-log-query-federation.md
@@ -2,7 +2,7 @@
 title: "ADR-021: Tenant Log Query — Authorization-Plane-Only, Ingestion-Decoupled"
 tags: [adr, federation, multi-tenant, logs, observability, security]
 audience: [platform-engineers, contributors]
-version: v2.9.0
+version: v2.8.1
 lang: zh
 id: ADR-021
 tracking_kind: adr


### PR DESCRIPTION
## Summary
- ADR-021 frontmatter `version: v2.9.0` → `v2.8.1`（#610 引入的 authoring slip）。
- ADR-021 是 188 份 doc 中**唯一**非 v2.8.1 者（同期 ADR-020 federation 亦為 v2.8.1）；專案慣例 = frontmatter 追 last-released、release 時 `bump_docs` 整批 bump。
- 以 `bump_docs --platform 2.8.1` 對齊；dry-run 確認**僅動此檔、零副作用**。

## Why this matters（main-health）
此 drift 令**每個 PR 的 Version Consistency check 都紅**（repo-wide，非單一 PR 問題）。修掉後解全 repo 的紅——例如 #617（Track B QUICKSTARTs）唯一的非軟性紅就是它。

## Test plan
- [x] `bump_docs --check` → ✅ All version references are consistent
- [x] git diff = 1 行（僅 version line）
- [x] `pr-preflight` READY
- [ ] CI Version Consistency 轉綠

> push 用 `MKDOCS_STRICT_BYPASS=1`：本地 Windows `docs/rule-packs` symlink false-fail（37 warnings 全 rule-packs、**0 關於本改動**）；CI Linux 做真正 strict。

Refs: #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)