### PR TITLE
feat(tenant-api): --dev-bypass-auth + 4-layer containment (ADR-022, #464)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,11 @@ jobs:
           # (pure-Python class-(b), diff-only). fetch-depth: 0 above gives the
           # diff base; PR_BODY env (set on this job) carries the bypass tag.
           pre-commit run helm-values-secrets-check --all-files
+          # ADR-022 Layer 4: forbid tenant-api's --dev-bypass-auth /
+          # TA_DEV_BYPASS_AUTH switch from any deploy manifest (helm/k8s/
+          # operator-manifests). Deploy-time complement to the runtime k8s
+          # poison pill. HARD block.
+          pre-commit run dev-bypass-manifest-guard --all-files
 
   lint-rule-packs:
     # Custom Prometheus rule-pack governance linter.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -167,6 +167,19 @@ repos:
         # admin/admin literal lived there, unscanned by any layer).
         files: '^helm/.*\.ya?ml$|^k8s/.*\.ya?ml$|^scripts/tools/lint/check_helm_values_secrets\.py$'
 
+      # --- ADR-022 Layer 4: forbid the dev-auth-bypass switch in manifests ---
+      # tenant-api's --dev-bypass-auth / TA_DEV_BYPASS_AUTH is a LOCAL-DEV-ONLY
+      # identity bypass; it must NEVER reach a deploy manifest. Deploy-time
+      # complement to the runtime k8s poison pill (the binary panics if the flag
+      # is set in-cluster) — and covers NON-k8s manifests the runtime cannot see.
+      # HARD block: no bypass tag.
+      - id: dev-bypass-manifest-guard
+        name: "ADR-022 L4: forbid TA_DEV_BYPASS_AUTH in deploy manifests"
+        entry: python3 -X utf8 scripts/tools/lint/check_dev_bypass_manifest.py --ci
+        language: python
+        pass_filenames: false
+        files: '^helm/.*\.ya?ml$|^k8s/.*\.ya?ml$|^operator-manifests/.*\.ya?ml$|^scripts/tools/lint/check_dev_bypass_manifest\.py$'
+
       # --- Container/k8s IaC SAST Layer 4 (#448 / TRK-314) ---
       # Raw k8s manifest security: `kube-linter lint k8s/` (no helm render —
       # the files are concrete objects). Reuses L2's kube-linter engine +

--- a/components/tenant-api/cmd/server/main.go
+++ b/components/tenant-api/cmd/server/main.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -96,6 +97,18 @@ func main() {
 	reloadInterval := flag.Duration("reload-interval", 30*time.Second,
 		"How often to check for RBAC config changes")
 
+	// LOCAL-DEV-ONLY auth bypass (ADR-022). Default off. When on, a dev
+	// identity is injected for requests lacking an oauth2-proxy header so the
+	// stack works without oauth2-proxy (try-local compose). RBAC still applies
+	// to the injected group. Guarded by a runtime poison pill (panics in k8s)
+	// + /metrics tripwire + #448 SAST (forbids the env var in manifests).
+	devBypassAuth := flag.Bool("dev-bypass-auth", envBool("TA_DEV_BYPASS_AUTH"),
+		"LOCAL DEV ONLY: inject a dev identity when no oauth2-proxy header is present (default off; panics if run in Kubernetes)")
+	devBypassEmail := flag.String("dev-bypass-email", envOrDefault("TA_DEV_BYPASS_EMAIL", "dev@local"),
+		"Identity email injected by --dev-bypass-auth")
+	devBypassGroups := flag.String("dev-bypass-groups", envOrDefault("TA_DEV_BYPASS_GROUPS", "demo-admins"),
+		"Comma-separated IdP groups injected by --dev-bypass-auth (must map to tenants in _rbac.yaml)")
+
 	// v2.6.0: PR-based write-back mode (ADR-011)
 	// Supports: "direct" (default), "pr" or "pr-github" (GitHub PRs), "pr-gitlab" (GitLab MRs)
 	writeMode := flag.String("write-mode", envOrDefault("TA_WRITE_MODE", "direct"),
@@ -164,6 +177,16 @@ func main() {
 	configureLogger()
 
 	slog.Info("tenant-api starting", "config_dir", *configDir, "addr", *listenAddr)
+
+	// ── dev-auth-bypass safety (ADR-022) ──────────────────────────────────────
+	// Layer 3: runtime poison pill — refuse (panic) to start with the bypass
+	// inside a Kubernetes cluster. Layer 2: loud WARN + /metrics tripwire gauge.
+	if *devBypassAuth {
+		rbac.DevBypassK8sGuard(os.Getenv, pathExists)
+		handler.SetDevBypassActive(true)
+		slog.Warn("⚠️  DEV AUTH BYPASS ACTIVE — a dev identity is injected for requests without an oauth2-proxy header. LOCAL DEV ONLY; never enable in production.",
+			"inject_email", *devBypassEmail, "inject_groups", *devBypassGroups)
+	}
 
 	// ── Dependencies ──────────────────────────────────────────────────────────
 	rbacMgr, err := rbac.NewManager(*rbacPath)
@@ -291,6 +314,13 @@ func main() {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(30 * time.Second))
 	r.Use(handler.MetricsMiddleware)
+
+	// dev-auth-bypass (ADR-022): mounted only when --dev-bypass-auth is set
+	// (Layer 1 = default off). Placed before the rate limiter so the injected
+	// X-Forwarded-Email is the bucketing key; downstream RBAC enforces normally.
+	if *devBypassAuth {
+		r.Use(rbac.DevBypassMiddleware(*devBypassEmail, *devBypassGroups))
+	}
 
 	// v2.8.0 B-6 PR-1: per-caller rate limiter. Mounted AFTER
 	// the chi standard chain so the limiter sees the caller
@@ -515,4 +545,21 @@ func envOrDefault(key, def string) string {
 		return v
 	}
 	return def
+}
+
+// envBool returns true when the env var is a truthy string ("true"/"1"/"yes",
+// case-insensitive). Used for the --dev-bypass-auth flag default.
+func envBool(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "true", "1", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// pathExists reports whether a filesystem path exists (used by the
+// dev-bypass Kubernetes poison-pill guard to probe the SA token mount).
+func pathExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
 }

--- a/components/tenant-api/internal/handler/metrics.go
+++ b/components/tenant-api/internal/handler/metrics.go
@@ -33,6 +33,15 @@ func (m *metricsState) IncErrors() { m.errorsTotal.Add(1) }
 // IncWrites increments the total write counter.
 func (m *metricsState) IncWrites() { m.writesTotal.Add(1) }
 
+// devBypassActive records whether --dev-bypass-auth is enabled, surfaced at
+// /metrics as the Layer-2 tripwire gauge so the dangerous local-dev mode is
+// detectable by monitoring in ANY environment (ADR-022).
+var devBypassActive atomic.Bool
+
+// SetDevBypassActive records the dev-auth-bypass state for /metrics. Called
+// once at startup from main when the flag is parsed.
+func SetDevBypassActive(on bool) { devBypassActive.Store(on) }
+
 // MetricsMiddleware is a chi middleware that increments request/error counters.
 func MetricsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -96,4 +105,14 @@ func MetricsHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = fmt.Fprintf(w, "# HELP tenant_api_federation_orphaned_subset_files Stale conf.d/_federation/<tenant>.yaml subset files whose tenant is no longer in conf.d.\n")
 	_, _ = fmt.Fprintf(w, "# TYPE tenant_api_federation_orphaned_subset_files gauge\n")
 	_, _ = fmt.Fprintf(w, "tenant_api_federation_orphaned_subset_files %d\n", orphanSubsets)
+
+	// ADR-022 Layer 2 tripwire: 1 ⇒ --dev-bypass-auth is ON (LOCAL DEV ONLY).
+	// MUST be 0 in production; alert if 1 outside a dev/compose environment.
+	devBypass := 0
+	if devBypassActive.Load() {
+		devBypass = 1
+	}
+	_, _ = fmt.Fprintf(w, "# HELP tenant_api_dev_auth_bypass_active 1 if --dev-bypass-auth is enabled (LOCAL DEV ONLY; must be 0 in production).\n")
+	_, _ = fmt.Fprintf(w, "# TYPE tenant_api_dev_auth_bypass_active gauge\n")
+	_, _ = fmt.Fprintf(w, "tenant_api_dev_auth_bypass_active %d\n", devBypass)
 }

--- a/components/tenant-api/internal/rbac/devbypass.go
+++ b/components/tenant-api/internal/rbac/devbypass.go
@@ -1,0 +1,66 @@
+package rbac
+
+// Dev-auth-bypass: a LOCAL-DEV-ONLY substitute for the oauth2-proxy identity
+// layer. See ADR-022 for the decision + the four-layer safety rationale.
+//
+// Layers:
+//  1. Default OFF — the middleware is only mounted when --dev-bypass-auth is set.
+//  2. Observability tripwire — every response carries `X-Dev-Auth-Bypass: active`,
+//     /metrics exposes `tenant_api_dev_auth_bypass_active 1`, and startup logs a
+//     loud WARN, so the mode is impossible to run unnoticed in ANY environment.
+//  3. Runtime poison pill — DevBypassK8sGuard panics if the flag is set inside a
+//     Kubernetes cluster (production), which SAST cannot see at deploy time.
+//  4. SAST block — #448 IaC lint forbids TA_DEV_BYPASS_AUTH in helm/k8s manifests.
+//
+// Identity-only: this injects an identity when the upstream proxy did not; RBAC
+// is still fully enforced against the injected group. It does NOT grant extra
+// permissions — the injected group's access comes from _rbac.yaml as usual.
+
+import (
+	"net/http"
+)
+
+// DevBypassMiddleware injects a dev identity (email + groups) when no
+// oauth2-proxy header is present, and marks every response with the
+// `X-Dev-Auth-Bypass: active` tripwire header (Layer 2). A real forwarded
+// identity is never overridden. Mounted only when --dev-bypass-auth is set.
+func DevBypassMiddleware(devEmail, devGroups string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Layer 2 tripwire: make the dangerous mode detectable on every
+			// response (monitoring / proxies / curl -I), in any environment.
+			w.Header().Set("X-Dev-Auth-Bypass", "active")
+
+			// Inject identity ONLY when the upstream proxy did not. Never
+			// override a real oauth2-proxy identity.
+			if r.Header.Get("X-Forwarded-Email") == "" {
+				r.Header.Set("X-Forwarded-Email", devEmail)
+				r.Header.Set("X-Forwarded-Groups", devGroups)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// InKubernetes reports whether the process is running inside a Kubernetes
+// cluster. Signals: the kubelet-injected KUBERNETES_SERVICE_HOST env var
+// (present in every normal pod) and the default service-account token mount.
+// The funcs are injectable so the guard is unit-testable without a cluster.
+func InKubernetes(getenv func(string) string, exists func(string) bool) bool {
+	if getenv("KUBERNETES_SERVICE_HOST") != "" {
+		return true
+	}
+	return exists("/var/run/secrets/kubernetes.io")
+}
+
+// DevBypassK8sGuard panics if --dev-bypass-auth is requested inside a
+// Kubernetes cluster (Layer 3 runtime poison pill). Fail-closed: an auth
+// bypass must NEVER run in a production cluster. SAST (Layer 4) blocks the
+// env var from manifests at deploy time; this is the runtime backstop for
+// manual or extreme misconfiguration that SAST cannot see.
+func DevBypassK8sGuard(getenv func(string) string, exists func(string) bool) {
+	if InKubernetes(getenv, exists) {
+		panic("FATAL: --dev-bypass-auth is strictly forbidden inside Kubernetes clusters " +
+			"(KUBERNETES_SERVICE_HOST or serviceaccount mount detected). This flag is local-dev-only.")
+	}
+}

--- a/components/tenant-api/internal/rbac/devbypass_test.go
+++ b/components/tenant-api/internal/rbac/devbypass_test.go
@@ -1,0 +1,117 @@
+package rbac
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// captureHandler records the identity headers it observes on the request.
+func captureHandler(gotEmail, gotGroups *string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*gotEmail = r.Header.Get("X-Forwarded-Email")
+		*gotGroups = r.Header.Get("X-Forwarded-Groups")
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestDevBypassMiddleware_InjectsWhenIdentityAbsent(t *testing.T) {
+	var gotEmail, gotGroups string
+	h := DevBypassMiddleware("dev@local", "demo-admins")(captureHandler(&gotEmail, &gotGroups))
+
+	req := httptest.NewRequest("GET", "/api/v1/me", nil) // no X-Forwarded-* headers
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if gotEmail != "dev@local" {
+		t.Errorf("injected email = %q, want dev@local", gotEmail)
+	}
+	if gotGroups != "demo-admins" {
+		t.Errorf("injected groups = %q, want demo-admins", gotGroups)
+	}
+	if got := rr.Header().Get("X-Dev-Auth-Bypass"); got != "active" {
+		t.Errorf("tripwire header = %q, want active", got)
+	}
+}
+
+func TestDevBypassMiddleware_RespectsRealIdentity(t *testing.T) {
+	var gotEmail, gotGroups string
+	h := DevBypassMiddleware("dev@local", "demo-admins")(captureHandler(&gotEmail, &gotGroups))
+
+	req := httptest.NewRequest("GET", "/api/v1/me", nil)
+	req.Header.Set("X-Forwarded-Email", "real@corp.example")
+	req.Header.Set("X-Forwarded-Groups", "platform-admins")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	// A real forwarded identity must never be overridden.
+	if gotEmail != "real@corp.example" {
+		t.Errorf("email overridden to %q, want real@corp.example", gotEmail)
+	}
+	if gotGroups != "platform-admins" {
+		t.Errorf("groups overridden to %q, want platform-admins", gotGroups)
+	}
+	// Tripwire still fires on every response while the bypass is mounted.
+	if got := rr.Header().Get("X-Dev-Auth-Bypass"); got != "active" {
+		t.Errorf("tripwire header = %q, want active (always-on while mounted)", got)
+	}
+}
+
+func TestInKubernetes(t *testing.T) {
+	noEnv := func(string) string { return "" }
+	noFile := func(string) bool { return false }
+
+	tests := []struct {
+		name   string
+		getenv func(string) string
+		exists func(string) bool
+		want   bool
+	}{
+		{"neither", noEnv, noFile, false},
+		{"service host env", func(k string) string {
+			if k == "KUBERNETES_SERVICE_HOST" {
+				return "10.0.0.1"
+			}
+			return ""
+		}, noFile, true},
+		{"sa token mount", noEnv, func(p string) bool {
+			return p == "/var/run/secrets/kubernetes.io"
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := InKubernetes(tt.getenv, tt.exists); got != tt.want {
+				t.Errorf("InKubernetes = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDevBypassK8sGuard_PanicsInCluster(t *testing.T) {
+	inK8s := func(k string) string {
+		if k == "KUBERNETES_SERVICE_HOST" {
+			return "10.0.0.1"
+		}
+		return ""
+	}
+	noFile := func(string) bool { return false }
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("DevBypassK8sGuard did not panic inside Kubernetes (poison pill failed)")
+		}
+	}()
+	DevBypassK8sGuard(inK8s, noFile)
+}
+
+func TestDevBypassK8sGuard_NoPanicOutsideCluster(t *testing.T) {
+	noEnv := func(string) string { return "" }
+	noFile := func(string) bool { return false }
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("DevBypassK8sGuard panicked outside Kubernetes: %v", r)
+		}
+	}()
+	DevBypassK8sGuard(noEnv, noFile)
+}

--- a/docs/adr/022-dev-auth-bypass-four-layer-containment.md
+++ b/docs/adr/022-dev-auth-bypass-four-layer-containment.md
@@ -1,0 +1,71 @@
+---
+title: "ADR-022: tenant-api Dev-Auth Bypass — Local-Dev Identity Substitute, Four-Layer Containment"
+tags: [adr, tenant-api, security, developer-experience, try-local]
+audience: [platform-engineers, contributors]
+version: v2.8.1
+lang: zh
+id: ADR-022
+tracking_kind: adr
+status: accepted
+domain: tenant-api
+created_at: 2026-05-25
+updated_at: 2026-05-25
+---
+# ADR-022: tenant-api Dev-Auth Bypass — Local-Dev Identity Substitute, Four-Layer Containment
+
+## 狀態
+
+✅ **Accepted**（v2.9.0 起草，2026-05-25）。實作 [#464](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/464)（epic #449 原 onboarding-ADR 子題，重定位為本 ADR 的 tracker）。由 epic [#449](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/449) 的 try-local Mode 0（portal + tenant-api 核心雙星）浮現需求。設計經 brainstorm + 自審（loopback layer 衝突修正）。
+
+## 背景
+
+tenant-api 信任 oauth2-proxy 注入的 `X-Forwarded-Email` / `X-Forwarded-Groups` header 作為身分來源（`rbac/middleware.go`：無 email → 401；group 比對 `_rbac.yaml`）。production 由 oauth2-proxy 在前面注入。
+
+但 try-local 的 **Mode 0 核心雙星**（`docker compose up da-portal tenant-api`，showcase 的中心）**沒有 oauth2-proxy**：portal 容器經 compose 網路打 tenant-api，瀏覽器無法注入 `X-Forwarded-*` → `/api/v1/me` 回 401、RBAC 全拒 → 旗艦 Tenant Manager 開不出來。
+
+需要一個「本機 dev 的身分替身」。但**在 production binary 裡放 auth bypass 本身就是資安風險**——這正是本 ADR 要謹慎處理的。
+
+## 決策
+
+新增 `--dev-bypass-auth` / `TA_DEV_BYPASS_AUTH` flag（**預設 off**）。啟用時，一個外層 middleware 在請求**缺 `X-Forwarded-Email` 時**注入 dev 身分（email + groups，預設 `dev@local` / `demo-admins`）；**有真實 forwarded 身分時絕不覆蓋**。
+
+**identity-only，非 RBAC 繞過**：注入身分後 **RBAC 照常 enforce**（針對注入的 group），不給 god-mode——注入 group 的權限仍來自 `_rbac.yaml`（try-local seed 提供）。即使被啟用，blast radius 也只限注入 group 的 RBAC 範圍。
+
+把「prod binary 帶 auth-bypass」的風險用**四層防線**圍住（對齊專案既有四層防線文化）：
+
+| 層 | 機制 | 防什麼 |
+|---|---|---|
+| **L1 預設 off** | flag 預設 false；middleware 只在 flag on 時 mount（off = 零行為改變、零開銷） | 不主動啟用 |
+| **L2 可觀測 tripwire** | 每個 response 帶 `X-Dev-Auth-Bypass: active` header + `/metrics` gauge `tenant_api_dev_auth_bypass_active 1` + startup loud WARN | **任何環境**的監控/proxy/curl 都能偵測「bypass 在 prod 開著」——包括 L3 偵測不到的非 k8s prod |
+| **L3 runtime poison pill** | startup 若 flag on 且偵測 `KUBERNETES_SERVICE_HOST` 或 `/var/run/secrets/kubernetes.io` → **panic**（fail-closed） | k8s production（auth bypass 絕不該在叢集內跑） |
+| **L4 deploy-time SAST** | `check_dev_bypass_manifest.py` HARD block `TA_DEV_BYPASS_AUTH` / `--dev-bypass-auth` 出現在 helm/ k8s/ operator-manifests（pre-commit + CI `Lint` job） | 在引入它的 PR 階段就擋下；涵蓋 L3 看不到的非 k8s manifest |
+
+L1-2 防君子與意外（含非 k8s prod 由監控抓）、L3-4 防小人與誤佈署。
+
+## 為什麼不用其他方案
+
+- **為什麼不用 nginx header-injection（掛載 nginx.conf 注 header）？** Windows/WSL2 單檔掛載易觸發 `invalid mount config` / 檔案鎖定（try-local 的 Windows 用戶會踩）。dev-bypass 由 tenant-api 自己消化，不需 portal 端掛載。
+- **為什麼 L2 不是「loopback bind only」？**（原始四層設計曾用此。）實作時自審發現它**與 Mode 0 compose 自相矛盾**：portal 容器需經 compose 網路（非 loopback）連 tenant-api，且 `-p` port-forward 也要求 bind `0.0.0.0`——loopback-only 會讓 dev-bypass 服務不了它唯一的用途。改用**可觀測 tripwire**：不衝突 compose，且補上 L3「只擋 k8s」的非 k8s-prod gap（監控可在任何環境抓到）。
+- **為什麼 identity-only 而非完整 RBAC 繞過？** 縮小 blast radius——即使啟用，也只拿到注入 group 的 RBAC-scoped 權限，不是 god-mode。bypass 的是「上游身分 proxy」，不是「授權」。
+
+## 實作
+
+- middleware + k8s guard：`internal/rbac/devbypass.go`（`DevBypassMiddleware` / `DevBypassK8sGuard` / `InKubernetes`）。
+- flag + L3 guard + L2 warn + 掛載：`cmd/server/main.go`。
+- L2 `/metrics` gauge：`internal/handler/metrics.go`（`SetDevBypassActive`）。
+- L4 SAST：`scripts/tools/lint/check_dev_bypass_manifest.py` + pre-commit `dev-bypass-manifest-guard` + ci.yml `Lint`。
+- 測試：`internal/rbac/devbypass_test.go`（注入 / 不覆蓋真身分 / tripwire header / k8s panic）+ `tests/lint/test_check_dev_bypass_manifest.py`。
+
+## 後果
+
+### 正面
+- try-local **Mode 0 portal-live（showcase 中心）解鎖**——portal 在 compose 用 published image 即活。
+- 唯一須進 `docs/adr/` 的重大平台決策落地、可追溯。
+
+### 負面 / 取捨
+- **production binary 帶一個 auth-bypass flag**——以四層防線圍住（L3 panic 在 k8s 不可繞、L4 SAST 擋 manifest）。仍是須持續審視的 surface。
+- **L3 只擋 k8s**：非 k8s prod（VM/bare-metal）L3 不觸發、L4（manifest）也不經過 → 由 **L2 tripwire（監控）** backstop；本平台 prod 以 k8s 為主，殘留風險低。
+
+## 關聯
+- [#464](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/464)（本 ADR 的 tracker）；epic [#449](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/449) Mode 0；[#448](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/448) IaC SAST（L4 之家）。
+- try-local Mode 0 / tenant-api QUICKSTART（[#466](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/466)）寫回 demo 以此 flag + seed `_rbac.yaml` 驅動。

--- a/docs/architecture-and-design.md
+++ b/docs/architecture-and-design.md
@@ -335,6 +335,7 @@ spec:
 | ADR-019 | [Planning SSOT — Frontmatter Contract + Discovery-based Index](adr/019-planning-ssot.md) | ✅ Accepted | v2.8.0 |
 | ADR-020 | [Tenant Federation — Label-Injection Proxy over Self-Built Endpoint](adr/020-tenant-federation.md) | ✅ Accepted | v2.8.0 |
 | ADR-021 | [Tenant Log Query — Authorization-Plane-Only, Ingestion-Decoupled](adr/021-tenant-log-query-federation.md) | ✅ Accepted | v2.9.0 |
+| ADR-022 | [tenant-api Dev-Auth Bypass — Local-Dev Identity Substitute, Four-Layer Containment](adr/022-dev-auth-bypass-four-layer-containment.md) | ✅ Accepted | v2.9.0 |
 
 <!-- ADR_INDEX_END -->
 

--- a/docs/internal/doc-map.md
+++ b/docs/internal/doc-map.md
@@ -33,6 +33,7 @@ lang: zh
 | `docs/adr/019-planning-ssot.md` | Platform Engineers, contributors, ai-agents | ADR-019: Planning SSOT — Frontmatter Contract + Discovery-based Index |
 | `docs/adr/020-tenant-federation.md` | Platform Engineers, contributors | ADR-020: Tenant Federation — Label-Injection Proxy over Self-Built Endpoint |
 | `docs/adr/021-tenant-log-query-federation.md` | Platform Engineers, contributors | ADR-021: Tenant Log Query — Authorization-Plane-Only, Ingestion-Decoupled |
+| `docs/adr/022-dev-auth-bypass-four-layer-containment.md` | Platform Engineers, contributors | ADR-022: tenant-api Dev-Auth Bypass — Local-Dev Identity Substitute, Four-Layer Containment |
 | `docs/api/README.md` (.en.md) | Platform Engineers, SREs | Threshold Exporter API Reference |
 | `docs/api/tenant-api-hardening.md` (.en.md) | platform-ops, sre, security | Tenant API Hardening (v2.8.0) |
 | `docs/architecture-and-design.md` (.en.md) | Platform Engineers | 架構與設計 — 動態多租戶警報平台技術白皮書 |

--- a/docs/internal/planning-index.md
+++ b/docs/internal/planning-index.md
@@ -26,7 +26,7 @@ lang: zh
 | `TRK-006` | dx | TRK-006: Skip budget CI gate | ci | — | [docs/internal/dx-tooling-backlog.md](../internal/dx-tooling-backlog.md) |
 | `TRK-010` | dx | TRK-010: Flake 自動重試 CI Policy（不是盲目全域 retry） | ci | — | [docs/internal/dx-tooling-backlog.md](../internal/dx-tooling-backlog.md) |
 
-### accepted (21)
+### accepted (22)
 
 | ID | Kind | Title | Domain | PR | Source |
 |----|------|-------|--------|------|--------|
@@ -51,6 +51,7 @@ lang: zh
 | `ADR-019` | adr | ADR-019: Planning SSOT — Frontmatter Contract + Discovery-based Index | docs | — | [docs/adr/019-planning-ssot.md](../adr/019-planning-ssot.md) |
 | `ADR-020` | adr | ADR-020: Tenant Federation — Label-Injection Proxy over Self-Built Endpoint | tenant-api | — | [docs/adr/020-tenant-federation.md](../adr/020-tenant-federation.md) |
 | `ADR-021` | adr | ADR-021: Tenant Log Query — Authorization-Plane-Only, Ingestion-Decoupled | tenant-api | — | [docs/adr/021-tenant-log-query-federation.md](../adr/021-tenant-log-query-federation.md) |
+| `ADR-022` | adr | ADR-022: tenant-api Dev-Auth Bypass — Local-Dev Identity Substitute, Four-Layer Containment | tenant-api | — | [docs/adr/022-dev-auth-bypass-four-layer-containment.md](../adr/022-dev-auth-bypass-four-layer-containment.md) |
 
 ### proposed (15)
 

--- a/docs/internal/tool-map.md
+++ b/docs/internal/tool-map.md
@@ -137,6 +137,7 @@ lang: zh
 | `check_codename_leak.py` | Block internal codenames from leaking to user-facing files. |
 | `check_commit_scope_doc.py` | Commit-scope doc drift gate (L1 pre-commit hook + validate_all integration). |
 | `check_design_token_usage.py` | JSX 設計 token 使用完整性 lint |
+| `check_dev_bypass_manifest.py` | ADR-022 Layer 4 (deploy-time guard). |
 | `check_dev_rules_enforcement.py` | detect doc-drift in dev-rules.md. |
 | `check_devrules_size.py` | Dev-rules 尺寸上限檢查。 |
 | `check_dist_source_consistency.py` | Catch portal dist commits without matching source change (testing-playbook §LL §2, TRK-239). |

--- a/scripts/tools/lint/check_dev_bypass_manifest.py
+++ b/scripts/tools/lint/check_dev_bypass_manifest.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""check_dev_bypass_manifest.py — ADR-022 Layer 4 (deploy-time guard).
+
+Forbids the tenant-api dev-auth-bypass switch (``TA_DEV_BYPASS_AUTH`` /
+``--dev-bypass-auth``) from EVER appearing in a deploy manifest. The switch is
+a LOCAL-DEV-ONLY identity bypass (it injects a dev identity when no oauth2-proxy
+header is present); if it reaches a deployment it disables the identity
+requirement.
+
+This is the deploy-time complement to the runtime poison pill (the binary
+panics if ``--dev-bypass-auth`` is set inside a Kubernetes cluster). SAST
+catches it earlier — in the PR that would introduce it — and also covers
+NON-k8s manifests the runtime k8s-detection cannot see.
+
+HARD block: there is no bypass tag. The switch must never be committed to a
+manifest. (Doc/comment lines that merely *mention* it are allowed.)
+
+Scope:   helm/**/*.ya?ml + k8s/**/*.ya?ml + operator-manifests/**/*.ya?ml
+Forbid:  TA_DEV_BYPASS_AUTH | --dev-bypass-auth | dev-bypass-auth: (case-insensitive)
+
+Usage:   python3 scripts/tools/lint/check_dev_bypass_manifest.py [--ci]
+Exit:    0 clean | 1 findings (with --ci)
+
+Lint class: (b) negative pattern (docs/internal/lint-policy.md). #448 / ADR-022.
+A Vibe wrapper — no kube-linter/trivy rule exists for a project-specific
+forbidden env var name.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCAN_DIRS = ("helm", "k8s", "operator-manifests")
+FORBIDDEN = re.compile(r"(?i)(TA_DEV_BYPASS_AUTH|dev-bypass-auth)")
+
+
+def find_violations(root: Path | None = None) -> list[tuple[str, int, str]]:
+    """Return (relpath, line_no, line) for each forbidden occurrence.
+
+    ``root`` defaults to the repo root; tests pass a temp dir.
+    """
+    base = root if root is not None else REPO_ROOT
+    out: list[tuple[str, int, str]] = []
+    for d in SCAN_DIRS:
+        scan_root = base / d
+        if not scan_root.is_dir():
+            continue
+        for p in sorted(scan_root.rglob("*.y*ml")):
+            try:
+                text = p.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            for i, line in enumerate(text.splitlines(), 1):
+                # A comment that merely mentions the switch (e.g. a "# never
+                # set this here" warning) is allowed — only an actual setting
+                # is a violation.
+                if line.lstrip().startswith("#"):
+                    continue
+                if FORBIDDEN.search(line):
+                    out.append((p.relative_to(base).as_posix(), i, line.strip()))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--ci", action="store_true", help="exit 1 on findings")
+    args = ap.parse_args()
+
+    violations = find_violations()
+    if not violations:
+        print("OK no dev-auth-bypass switch in deploy manifests.")
+        return 0
+
+    print(
+        "❌ ADR-022 Layer 4: tenant-api dev-auth-bypass switch found in deploy "
+        "manifest(s)."
+    )
+    print(
+        "   TA_DEV_BYPASS_AUTH / --dev-bypass-auth is LOCAL-DEV-ONLY and must NEVER "
+        "be deployed (it disables the oauth2-proxy identity requirement)."
+    )
+    for rel, ln, content in violations:
+        print(f"  {rel}:{ln}: {content}")
+    return 1 if args.ci else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/lint/test_check_dev_bypass_manifest.py
+++ b/tests/lint/test_check_dev_bypass_manifest.py
@@ -1,0 +1,104 @@
+"""Self-test for check_dev_bypass_manifest.py (ADR-022 Layer 4).
+
+Verifies the deploy-time guard flags the tenant-api dev-auth-bypass switch in
+helm/k8s/operator manifests, allows comment mentions, and ignores other dirs.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "scripts", "tools", "lint"
+)
+sys.path.insert(0, _TOOLS_DIR)
+
+import check_dev_bypass_manifest as guard  # noqa: E402
+
+
+def _write(root: Path, rel: str, content: str) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+def test_flags_env_var_in_helm_template(tmp_path: Path):
+    _write(
+        tmp_path,
+        "helm/tenant-api/templates/deployment.yaml",
+        'env:\n  - name: TA_DEV_BYPASS_AUTH\n    value: "true"\n',
+    )
+    v = guard.find_violations(tmp_path)
+    assert len(v) == 1
+    assert "deployment.yaml" in v[0][0]
+
+
+def test_flags_flag_form_in_k8s_manifest(tmp_path: Path):
+    _write(tmp_path, "k8s/04-tenant-api/deploy.yaml", "args: [--dev-bypass-auth]\n")
+    assert len(guard.find_violations(tmp_path)) == 1
+
+
+def test_flags_in_operator_manifests(tmp_path: Path):
+    _write(tmp_path, "operator-manifests/ta.yaml", "  TA_DEV_BYPASS_AUTH: yes\n")
+    assert len(guard.find_violations(tmp_path)) == 1
+
+
+def test_clean_manifest_passes(tmp_path: Path):
+    _write(
+        tmp_path,
+        "helm/tenant-api/values.yaml",
+        "replicaCount: 1\nimage:\n  tag: v2.8.0\n",
+    )
+    assert guard.find_violations(tmp_path) == []
+
+
+def test_comment_mention_allowed(tmp_path: Path):
+    _write(
+        tmp_path,
+        "helm/tenant-api/values.yaml",
+        "# NEVER set TA_DEV_BYPASS_AUTH here — local dev only\nreplicaCount: 1\n",
+    )
+    assert guard.find_violations(tmp_path) == []
+
+
+def test_ignores_non_scanned_dirs(tmp_path: Path):
+    _write(tmp_path, "docs/foo.yaml", "name: TA_DEV_BYPASS_AUTH\n")
+    assert guard.find_violations(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# main() exit-code contract. Both the pre-commit hook and the CI Lint job
+# invoke this script with --ci, so the HARD block depends on: clean => 0,
+# findings under --ci => 1. Without --ci it stays advisory (0) so a bare
+# local run never blocks unexpectedly.
+# ---------------------------------------------------------------------------
+def test_main_clean_returns_zero(monkeypatch, capsys):
+    monkeypatch.setattr(guard, "find_violations", lambda: [])
+    monkeypatch.setattr(sys, "argv", ["prog", "--ci"])
+    assert guard.main() == 0
+    assert "OK" in capsys.readouterr().out
+
+
+def test_main_ci_blocks_on_violation(monkeypatch, capsys):
+    monkeypatch.setattr(
+        guard,
+        "find_violations",
+        lambda: [("helm/tenant-api/templates/deployment.yaml", 3, "TA_DEV_BYPASS_AUTH")],
+    )
+    monkeypatch.setattr(sys, "argv", ["prog", "--ci"])
+    assert guard.main() == 1
+    out = capsys.readouterr().out
+    assert "Layer 4" in out
+    assert "deployment.yaml" in out
+
+
+def test_main_without_ci_is_advisory(monkeypatch):
+    monkeypatch.setattr(
+        guard,
+        "find_violations",
+        lambda: [("k8s/04-tenant-api/deploy.yaml", 1, "--dev-bypass-auth")],
+    )
+    monkeypatch.setattr(sys, "argv", ["prog"])
+    assert guard.main() == 0


### PR DESCRIPTION
## Summary
- tenant-api **`--dev-bypass-auth`**（預設 off）：try-local Mode 0（portal+tenant-api 無 oauth2-proxy）的本機身分替身。缺 `X-Forwarded-Email` 時注入 dev 身分；**identity-only — RBAC 照常 enforce**（非 god-mode）。
- **ADR-022**（`docs/adr/022-*.md`）記錄決策 + 四層防線 rationale。實作 #464（Track A 重定位為 ADR-022 tracker）。

## 四層防線
- **L1** 預設 off（middleware 只在 flag on 時 mount）。
- **L2** 可觀測 tripwire：`X-Dev-Auth-Bypass: active` header + `/metrics` gauge `tenant_api_dev_auth_bypass_active` + 啟動 WARN——任何環境可偵測（含 L3 漏的非 k8s prod）。
- **L3** runtime poison-pill：flag 設於 k8s 內 → startup **panic**。
- **L4** deploy-time SAST：`dev-bypass-manifest-guard` 禁 `TA_DEV_BYPASS_AUTH` 進 helm/k8s/operator manifest（pre-commit + CI）。

## 設計註記
L2 原為「loopback-bind only」，**self-review 發現與 Mode 0 compose 衝突**（portal 容器須跨網路連 tenant-api）→ 改 tripwire（順帶 backstop L3「只擋 k8s」的 gap）。

## Run-verified（dev container live）
- [x] `--dev-bypass-auth` + `/me` 無 header → 200 + 注入 dev@local/demo-admins + `X-Dev-Auth-Bypass: active`
- [x] `/metrics` → `tenant_api_dev_auth_bypass_active 1`
- [x] poison-pill：`KUBERNETES_SERVICE_HOST` 設 → startup panic（不啟動）
- [x] default-off：`/me` 無 header → 401（不變）、無 tripwire header
- [x] `go vet` 乾淨 + 全 tenant-api `go test` 綠 + lint self-test (6) 綠

> push 用 `MKDOCS_STRICT_BYPASS=1`：docs/ 變更撞本地 Windows `rule-packs` symlink false-fail（0 警告關於本變更；CI Linux 做真 strict）。

Resolves #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)