### PR TITLE
feat(dx): try-local one-command compose showcase stack (#465)

### DIFF
--- a/.github/workflows/try-local-smoke.yaml
+++ b/.github/workflows/try-local-smoke.yaml
@@ -1,0 +1,105 @@
+# Nightly verification that the try-local onboarding stack still works
+# end-to-end (#449 / #465). This is the showcase visitors run first, so a
+# silent rot here is high-impact. NOT wired into release.yaml — it must never
+# gate a release; it only guards the onboarding experience.
+name: try-local nightly smoke
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # 02:00 UTC daily
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  smoke:
+    name: try-local stack smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Bring up the stack
+        working-directory: try-local
+        run: |
+          cp .env.example .env
+          docker compose up -d
+
+      - name: Wait for healthchecked services (max 5 min)
+        working-directory: try-local
+        run: |
+          deadline=$(( $(date +%s) + 300 ))
+          while :; do
+            unhealthy="$(docker compose ps --format json \
+              | jq -r 'select(.Health != "" and .Health != "healthy") | .Service' 2>/dev/null || true)"
+            if [ -z "$unhealthy" ]; then
+              echo "all healthchecked services healthy"
+              break
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::services not healthy within 5min: $unhealthy"
+              docker compose ps
+              exit 1
+            fi
+            sleep 5
+          done
+
+      - name: Run smoke.sh
+        working-directory: try-local
+        run: bash smoke.sh
+
+      - name: Dump compose logs on failure
+        if: failure()
+        working-directory: try-local
+        run: docker compose logs --no-color | tail -n 300
+
+      - name: Tear down
+        if: always()
+        working-directory: try-local
+        run: docker compose down -v --remove-orphans
+
+  # File a tracking issue only when this run AND the previous 2 completed runs
+  # all failed (3+ consecutive). Schedule-only so manual dispatch never files.
+  notify-on-streak:
+    name: file issue on 3+ consecutive failures
+    needs: smoke
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check failure streak and open issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # The 2 most recent COMPLETED runs (this run is still in progress).
+          prev="$(gh run list --repo "$REPO" --workflow try-local-smoke.yaml \
+                    --branch main --status completed --limit 2 \
+                    --json conclusion --jq '[.[].conclusion] | @tsv')"
+          echo "previous 2 conclusions: ${prev:-<none>}"
+          fails="$(printf '%s' "$prev" | tr '\t' '\n' | grep -c '^failure$' || true)"
+          if [ "${fails:-0}" -lt 2 ]; then
+            echo "not 3 consecutive failures yet — skipping."
+            exit 0
+          fi
+          # Dedup: don't pile on if a tracking issue is already open.
+          open_count="$(gh issue list --repo "$REPO" --label try-local-broken \
+                          --state open --json number --jq 'length')"
+          if [ "${open_count:-0}" -gt 0 ]; then
+            echo "an open try-local-broken issue already exists — not duplicating."
+            exit 0
+          fi
+          # Ensure the label exists (P1 / documentation already do).
+          gh label create try-local-broken --repo "$REPO" --color B60205 \
+            --description "try-local onboarding stack is broken" --force || true
+          last3="$(gh run list --repo "$REPO" --workflow try-local-smoke.yaml \
+                     --branch main --limit 3 \
+                     --json createdAt,conclusion,url \
+                     --jq '.[] | "- \(.createdAt) [\(.conclusion)] \(.url)"')"
+          body="$(printf 'The try-local stack smoke test has failed 3+ consecutive nightly runs — the #449 onboarding showcase is likely broken.\n\nLast 3 runs:\n%s\n\nTriage locally:\n```\ncd try-local && cp .env.example .env && docker compose up -d\nbash smoke.sh\n```\n' "$last3")"
+          gh issue create --repo "$REPO" \
+            --title "try-local nightly smoke failing for 3+ runs" \
+            --label try-local-broken --label P1 --label documentation \
+            --assignee vencil \
+            --body "$body"

--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,10 @@ docs/internal/_project-structure-audit-*
 CUsersvencs*
 /C:\*
 .vite/
+
+# --- try-local runtime artifacts (#449 / #465) ---
+# The seed git-inits the bind-mounted config repo at runtime; its .git lives
+# inside a tracked dir — ignore it so it isn't nested-committed into this repo.
+try-local/seed/conf.d/.git/
+# A visitor's local .env (ports/tags) is theirs; only .env.example is tracked.
+try-local/.env

--- a/Makefile
+++ b/Makefile
@@ -916,6 +916,17 @@ vendor-download: ## 下載 CDN 資源到 vendor/（離線環境用）
 vendor-check: ## 檢查 vendor/ 資源是否完整
 	@bash scripts/tools/vendor_download.sh --check
 
+# ----------------------------------------------------------
+# try-local — onboarding showcase stack (#449 / #465)
+# ----------------------------------------------------------
+.PHONY: smoke-local
+smoke-local: ## try-local：跑 smoke（驗 critical firing + /me 200 + 2 tenants + portal 200）
+	@bash try-local/smoke.sh
+
+.PHONY: clean-local
+clean-local: ## try-local：完整清理 stack（down -v --remove-orphans，含匿名 volume）
+	@docker compose -f try-local/docker-compose.yaml down -v --remove-orphans
+
 .PHONY: help
 help: ## 顯示說明
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/README.en.md
+++ b/README.en.md
@@ -108,6 +108,10 @@ Full comparison with Alertmanager routing examples: [Config-Driven Design](docs/
 
 ### Local Experience (5 minutes)
 
+> **Fastest: the one-command [`try-local/`](try-local/README.md) compose stack** — no Kubernetes. `cd try-local && cp .env.example .env && docker compose up -d` and see the Tenant Manager (2 demo tenants + a saved view) plus a real firing alert in ~1 minute. Windows requires **WSL2 + Docker Desktop (WSL2 backend)**.
+
+Or run the full K8s version via the Dev Container:
+
 ```bash
 # VS Code → "Reopen in Container"
 make setup && make verify && make test-alert

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ graph TD
 
 ### 本地體驗（5 分鐘）
 
+> **最快：一鍵 compose stack [`try-local/`](try-local/README.md)** —— 不需 Kubernetes。`cd try-local && cp .env.example .env && docker compose up -d`，約 1 分鐘看到 Tenant Manager（2 個 demo 租戶 + 預存 Saved View）+ 一個真實 firing 告警。Windows 需 **WSL2 + Docker Desktop（WSL2 backend）**。
+
+或用 Dev Container 跑完整 K8s 版：
+
 ```bash
 # VS Code → "Reopen in Container"
 make setup && make verify && make test-alert

--- a/try-local/.env.example
+++ b/try-local/.env.example
@@ -1,0 +1,23 @@
+# Copy to .env and edit as needed:  cp .env.example .env
+#
+# ── Component image tags ─────────────────────────────────────────────────
+# Per-line versioning (the platform ships 5 independent version lines), so
+# each component is pinned separately — a single shared IMAGE_TAG would break
+# the moment one component is bumped on its own. Image tag form is ":v2.8.0".
+EXPORTER_TAG=v2.8.0
+PORTAL_TAG=v2.8.0
+# NOTE: tenant-api currently BUILDS FROM SOURCE — the --dev-bypass-auth flag it
+# needs (#619 / ADR-022) isn't in a published image yet. TENANT_API_TAG is
+# reserved for when a dev-bypass-capable image ships (then swap build:→image:
+# in docker-compose.yaml). It is unused until then.
+TENANT_API_TAG=v2.8.0
+# da-tools is a CLI image (not a compose service). Used by the optional
+# `docker run ghcr.io/vencil/da-tools:$TOOLS_TAG guard ...` one-liner in README.
+TOOLS_TAG=v2.8.0
+
+# ── Host ports (change any that collide with something already running) ──
+EXPOSE_API_PORT=8080         # tenant-api
+EXPOSE_PORTAL_PORT=8081      # da-portal (Tenant Manager UI)
+EXPOSE_PROM_PORT=9090        # prometheus (/alerts)
+EXPOSE_AM_PORT=9093          # alertmanager
+EXPOSE_PUSHGATEWAY_PORT=9091 # pushgateway

--- a/try-local/README.md
+++ b/try-local/README.md
@@ -1,0 +1,101 @@
+# Try it locally — Dynamic Alerting in one command
+
+> Spin up the whole platform on your laptop and watch a real alert fire. No Kubernetes, no cloud, no signup. / 一鍵在本機跑起整套平台，看著一個真實告警亮紅燈。
+
+```bash
+cd try-local
+cp .env.example .env
+docker compose up -d
+```
+
+> ℹ️ 首次啟動會從原始碼 **build tenant-api**（~1 分鐘）—— 它依賴的 `--dev-bypass-auth`（讓瀏覽器免 oauth2-proxy 也能登入）尚未發佈成 published image。之後的啟動會重用已 build 的 image；改了 tenant-api 原始碼後用 `docker compose up -d --build` 重建。其餘 3 個 component 用 published image。
+
+Give it ~1 minute, then open:
+
+| 產品 | 開這個 | 你會看到 |
+|---|---|---|
+| **Tenant Manager**（da-portal） | <http://localhost:8081> | 2 個 demo 租戶 + 一個預存的 Saved View；建立/儲存一個 Saved View 會落一個**真實 git commit** |
+| **Tenant API**（tenant-api） | <http://localhost:8080/api/v1/me> | file-based 設定 API（commit-on-write），oauth2-proxy 身分模型 |
+| **Prometheus** | <http://localhost:9090/alerts> | `MariaDBHighConnectionsCritical` **正在 firing**（紅燈） |
+| **Alertmanager** | <http://localhost:9093> | 同一個 firing 告警，路由到 null receiver |
+
+背後還有 **threshold-exporter**（把 config 變成 `user_threshold` 指標）和 **pushgateway**（裝載 seed 推進去的合成 DB 指標）。
+
+驗證整條鏈是否正常：
+
+```bash
+make smoke-local      # 需要 curl + jq
+```
+
+完整清理（含匿名 volume，第二次啟動乾淨無殘留）：
+
+```bash
+make clean-local
+```
+
+---
+
+## 兩種跑法
+
+**① 完整 stack**（上面那個）— 6 個服務 + 2 個 one-shot seed，能看到 live 告警紅燈。
+
+**② 只跑核心雙星**（Tenant Manager，不含監控）：
+
+```bash
+docker compose up da-portal tenant-api
+```
+
+只起 portal + tenant-api（外加一個秒退的 git-init one-shot）。打開 <http://localhost:8081>，瀏覽 2 個租戶、建立一個 Saved View 按 **Save** —— 然後在 host 上看 seed 設定 repo 多了一個真實 commit：
+
+```bash
+git -C try-local/seed/conf.d log --oneline
+```
+
+這就是「設定即 GitOps」最直接的體感：UI 一按 = 一個 commit。
+
+## 看點
+
+- **紅燈在哪**：告警狀態看 Prometheus `:9090/alerts` 和 Alertmanager `:9093` —— **portal 不顯示 live 告警**（它管設定，不管告警路由）。
+- **為什麼會 fire**：seed 往 pushgateway 推了一筆 `mysql_global_status_threads_connected{tenant="db-demo"}=200`，超過 `db-demo` 設定的 critical 閾值 120 → DB rule pack 的 critical 規則 `for:30s` 後觸發。
+- **設計概念展示**：第二個租戶 `cache-demo` 開了 silent_mode + severity dedup，會產生 v2.8.0 的 **Sentinel Alert / Severity Dedup** sentinel（`severity:none`，notification inhibit 來源）。
+
+## 關於身分（dev-only auth bypass）
+
+完整 production 由 oauth2-proxy 在前面注入 `X-Forwarded-Email` / `X-Forwarded-Groups`。try-local 沒有 oauth2-proxy，所以 tenant-api 用 `--dev-bypass-auth`（**僅限本機**）在缺 header 時注入一個 dev 身分（`dev@local` / `demo-admins`），瀏覽器才打得開 Tenant Manager。
+
+> ⚠️ 這個 flag 嚴禁進 production：在 Kubernetes 內啟動會直接 panic，且 SAST 禁止它出現在任何部署 manifest。細節見 ADR-022。
+
+`demo-admins` 在 `seed/conf.d/_rbac.yaml` 對應 `tenants: ["*"]`（這是 `/api/v1/me` 通過授權閘所必需的）。因此 `/api/v1/me` 回的 `accessible_tenants` 是 `["*"]`；想看到 2 個租戶清單請打 `GET /api/v1/tenants`（這也是 portal Tenant Manager 顯示的來源）。
+
+## Port 衝突
+
+預設用 8080 / 8081 / 9090 / 9091 / 9093。若被占用，編輯 `.env`（從 `.env.example` 複製來的）改任一 `EXPOSE_*_PORT` 後重啟：
+
+```bash
+make clean-local && docker compose up -d
+```
+
+## Windows / WSL2（必讀）
+
+- Windows 使用者**必須**用 **WSL2 + Docker Desktop（WSL2 backend）**。
+- **不要**從原生 Windows 路徑（`C:\...`）跑 —— bind mount 行為不保證。把 repo clone 到 **WSL2 檔案系統內**（如 `~/…`）再跑。
+- 本 stack 多用匿名 volume；唯一 bind mount 是 `seed/conf.d`（read-write，用來承接 portal Save 的 git commit）。
+- seed 會在 `seed/conf.d` 內 `git init`（runtime 產生的 `.git/` 已被 `.gitignore` 忽略）。Save 會改到這些被追蹤的 YAML —— `make clean-local` 後用 `git checkout try-local/seed/conf.d` 可還原 demo 初始狀態。
+
+## 排錯
+
+| 症狀 | 處理 |
+|---|---|
+| `docker compose up` 拉不到 image | image 在 `ghcr.io/vencil/*`；確認網路可達 ghcr.io。arm64（Apple Silicon）需多架構 image 發佈完成（見 #463）。 |
+| `:9090/alerts` 一直沒紅燈 | 給它 ≥30s（規則 `for:30s`）。仍沒有就 `docker compose logs seed-metrics prometheus`。 |
+| portal 開了但 API 502 | tenant-api 還在起；稍等。確認 `docker compose ps` 中 tenant-api 是 running。 |
+| `make smoke-local` 說找不到 jq | 安裝 `jq`（smoke 需要 curl + jq）。 |
+
+## 想試 da-tools（CLI）？
+
+對 seed 設定跑一次護欄檢查（cardinality / schema / routing）：
+
+```bash
+docker run --rm -v "$PWD/seed/conf.d:/conf.d:ro" \
+  ghcr.io/vencil/da-tools:${TOOLS_TAG:-v2.8.0} guard /conf.d
+```

--- a/try-local/README.md
+++ b/try-local/README.md
@@ -90,6 +90,7 @@ make clean-local && docker compose up -d
 |---|---|
 | `docker compose up` 拉不到 image | image 在 `ghcr.io/vencil/*`；確認網路可達 ghcr.io。exporter/portal 目前是 amd64-only，Apple Silicon 會以 emulation 跑（較慢；原生多架構見 #463）。tenant-api 從源碼 build，為主機原生 arch。 |
 | `:9090/alerts` 一直沒紅燈 | 給它 ~1–2 分鐘（recording rule 15s interval + 規則 `for:30s`）。仍沒有就 `docker compose logs seed-metrics prometheus`。 |
+| 紅燈本來有、後來消失了 | pushgateway 是記憶體型（無持久化）—— 若單獨重啟它，seed 推的合成值會消失。重推：`docker compose up -d seed-metrics`。 |
 | portal 開了但 API 502 | tenant-api 還在起；稍等。確認 `docker compose ps` 中 tenant-api 是 running。 |
 | `make smoke-local` 說找不到 jq | 安裝 `jq`（smoke 需要 curl + jq）。 |
 

--- a/try-local/README.md
+++ b/try-local/README.md
@@ -69,6 +69,8 @@ git -C try-local/seed/conf.d log --oneline
 
 ## Port 衝突
 
+所有 port 只綁 `127.0.0.1`（本機限定）—— dev-bypass 會為無 header 的請求注入 **admin** 身分，故刻意不對 LAN 開放（避免同網段他人取得寫入/commit 權）。要從別台裝置連，請自行改 compose 的 port binding。
+
 預設用 8080 / 8081 / 9090 / 9091 / 9093。若被占用，編輯 `.env`（從 `.env.example` 複製來的）改任一 `EXPOSE_*_PORT` 後重啟：
 
 ```bash
@@ -86,8 +88,8 @@ make clean-local && docker compose up -d
 
 | 症狀 | 處理 |
 |---|---|
-| `docker compose up` 拉不到 image | image 在 `ghcr.io/vencil/*`；確認網路可達 ghcr.io。arm64（Apple Silicon）需多架構 image 發佈完成（見 #463）。 |
-| `:9090/alerts` 一直沒紅燈 | 給它 ≥30s（規則 `for:30s`）。仍沒有就 `docker compose logs seed-metrics prometheus`。 |
+| `docker compose up` 拉不到 image | image 在 `ghcr.io/vencil/*`；確認網路可達 ghcr.io。exporter/portal 目前是 amd64-only，Apple Silicon 會以 emulation 跑（較慢；原生多架構見 #463）。tenant-api 從源碼 build，為主機原生 arch。 |
+| `:9090/alerts` 一直沒紅燈 | 給它 ~1–2 分鐘（recording rule 15s interval + 規則 `for:30s`）。仍沒有就 `docker compose logs seed-metrics prometheus`。 |
 | portal 開了但 API 502 | tenant-api 還在起；稍等。確認 `docker compose ps` 中 tenant-api 是 running。 |
 | `make smoke-local` 說找不到 jq | 安裝 `jq`（smoke 需要 curl + jq）。 |
 

--- a/try-local/alertmanager.yml
+++ b/try-local/alertmanager.yml
@@ -1,0 +1,34 @@
+# Alertmanager config for the try-local stack.
+#
+# receiver 'null' — alerts reach a firing state and stay there (visible at
+# :9093) but nothing is sent outbound. The demo's value is SEEING the firing
+# state, not delivering a notification.
+#
+# The inhibit_rules mirror the platform's operational design: the sentinel
+# alerts emitted by rule-pack-operational (severity=none) suppress
+# notifications for the matching real alerts — Silent Mode + Severity Dedup.
+route:
+  receiver: 'null'
+  group_by: ['tenant', 'alertname']
+  group_wait: 5s
+  group_interval: 1m
+  repeat_interval: 1h
+
+receivers:
+  - name: 'null'
+
+inhibit_rules:
+  # Silent Mode (warning): TenantSilentWarning suppresses warning notifications
+  # for the same tenant.
+  - source_matchers: ['alertname = "TenantSilentWarning"']
+    target_matchers: ['severity = "warning"']
+    equal: ['tenant']
+  # Silent Mode (critical).
+  - source_matchers: ['alertname = "TenantSilentCritical"']
+    target_matchers: ['severity = "critical"']
+    equal: ['tenant']
+  # Severity Dedup: when dedup is enabled and a critical fires, suppress the
+  # paired warning notification for the same tenant + metric_group.
+  - source_matchers: ['alertname = "TenantSeverityDedupEnabled"']
+    target_matchers: ['severity = "warning"']
+    equal: ['tenant', 'metric_group']

--- a/try-local/docker-compose.yaml
+++ b/try-local/docker-compose.yaml
@@ -1,0 +1,172 @@
+# try-local — a one-command showcase of the Dynamic Alerting platform.
+#
+#   cd try-local && cp .env.example .env && docker compose up -d
+#
+# What you get (full stack):
+#   - da-portal      :8081  live Tenant Manager (2 demo tenants + a saved view)
+#   - tenant-api     :8080  file-based config API (commit-on-write, dev-bypass auth)
+#   - prometheus     :9090  /alerts shows the headline critical FIRING
+#   - alertmanager   :9093  the firing alert, routed to a null receiver
+#   - threshold-exporter    config-driven user_threshold metrics (internal)
+#   - pushgateway    :9091  holds the synthetic DB metric the seed pushed
+#
+# Mode 0 (core twins) — just the live Tenant Manager, no monitoring:
+#   docker compose up da-portal tenant-api
+# (pulls in only the fast seed-git one-shot; pushgateway/prometheus/etc. stay down)
+#
+# Ports are overridable via .env (see .env.example). Component image tags are
+# per-line (EXPORTER_TAG/TENANT_API_TAG/PORTAL_TAG), default v2.8.0.
+name: da-try-local
+
+services:
+  # ── Self-built component images (ghcr.io/vencil/*) ───────────────────────
+  threshold-exporter:
+    image: ghcr.io/vencil/threshold-exporter:${EXPORTER_TAG:-v2.8.0}
+    command:
+      - "--config-dir=/etc/threshold-exporter/conf.d"
+      - "--listen=:8080"
+    volumes:
+      - ./seed/conf.d:/etc/threshold-exporter/conf.d:ro
+    expose:
+      - "8080"
+    restart: unless-stopped
+    # Distroless image (no shell/wget) → no compose healthcheck; Prometheus's
+    # scrape success is the effective health signal.
+
+  tenant-api:
+    # Built from source. The --dev-bypass-auth flag this stack relies on
+    # (#619 / ADR-022) is NOT in any published image yet — v2.8.0 predates it
+    # and v2.9.0 is unreleased. try-local users already clone the repo, so a
+    # one-time local build is fine, and it builds for the host's native arch
+    # (no arm64 wait). When a dev-bypass-capable image ships, delete `build:`
+    # and use:  image: ghcr.io/vencil/tenant-api:${TENANT_API_TAG:-v2.9.0}
+    build:
+      context: ..
+      dockerfile: components/tenant-api/Dockerfile
+    image: da-try-local/tenant-api:source
+    environment:
+      TA_CONFIG_DIR: /conf.d
+      TA_RBAC_PATH: /conf.d/_rbac.yaml
+      TA_WRITE_MODE: direct
+      TA_ADDR: ":8080"
+      # LOCAL-DEV-ONLY auth bypass (ADR-022). Injects a dev identity when no
+      # oauth2-proxy header is present, so the browser (and Mode 0) work without
+      # an auth proxy. Panics if ever run inside Kubernetes; SAST forbids this
+      # var in deploy manifests. try-local/ is intentionally NOT scanned by L4.
+      TA_DEV_BYPASS_AUTH: "true"
+      TA_DEV_BYPASS_EMAIL: dev@local
+      TA_DEV_BYPASS_GROUPS: demo-admins
+      # commit-on-write runs `git` inside the container against the bind-mounted
+      # /conf.d, which git rejects as "dubious ownership" (host uid != container
+      # uid). Mark it safe via env-config (git 2.31+; no file mount needed).
+      GIT_CONFIG_COUNT: "1"
+      GIT_CONFIG_KEY_0: safe.directory
+      GIT_CONFIG_VALUE_0: "*"
+    volumes:
+      - ./seed/conf.d:/conf.d:rw
+    ports:
+      - "${EXPOSE_API_PORT:-8080}:8080"
+    depends_on:
+      seed-git:
+        condition: service_completed_successfully
+    networks:
+      default:
+        # da-portal's nginx has a baked-in upstream of this exact FQDN
+        # (components/da-portal/nginx.conf). The alias makes it resolve inside
+        # compose so the published portal image runs UNCHANGED (no file mount).
+        aliases:
+          - tenant-api.monitoring.svc.cluster.local
+    restart: unless-stopped
+
+  da-portal:
+    image: ghcr.io/vencil/da-portal:${PORTAL_TAG:-v2.8.0}
+    ports:
+      - "${EXPOSE_PORTAL_PORT:-8081}:80"
+    depends_on:
+      # nginx resolves the upstream FQDN at startup with no `resolver`, so the
+      # tenant-api container (which owns the alias) MUST be started first or
+      # nginx dies with `host not found in upstream`. service_started is enough
+      # — Docker DNS registers the alias as soon as the container starts.
+      tenant-api:
+        condition: service_started
+    restart: unless-stopped
+
+  # ── Monitoring stack (official multi-arch images) ────────────────────────
+  pushgateway:
+    image: prom/pushgateway:v1.10.0
+    ports:
+      - "${EXPOSE_PUSHGATEWAY_PORT:-9091}:9091"
+    restart: unless-stopped
+    # No shell in the image → no CMD healthcheck. Dependents use
+    # service_started; the seed's curl --retry-connrefused covers listen lag.
+
+  prometheus:
+    image: prom/prometheus:v3.11.2
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--web.enable-lifecycle"
+      - "--storage.tsdb.retention.time=1h"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      # Rule packs from the repo's single source of truth (mounted read-only).
+      - ../rule-packs:/etc/prometheus/rules:ro
+    ports:
+      - "${EXPOSE_PROM_PORT:-9090}:9090"
+    depends_on:
+      threshold-exporter:
+        condition: service_started
+      pushgateway:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/-/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    restart: unless-stopped
+
+  alertmanager:
+    image: prom/alertmanager:v0.32.0
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--web.listen-address=:9093"
+    volumes:
+      - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    ports:
+      - "${EXPOSE_AM_PORT:-9093}:9093"
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9093/-/ready"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    restart: unless-stopped
+
+  # ── Seed one-shots (run to completion, then exit) ────────────────────────
+  seed-git:
+    # git-init the config repo so commit-on-write has a repo. No monitoring
+    # dependency → Mode 0 stays minimal. Directory mount (not single-file) to
+    # avoid the WSL2 single-file bind-mount landmine.
+    image: alpine/git:latest
+    entrypoint: ["/bin/sh"]
+    command: ["/seed/git-init.sh"]
+    environment:
+      CONF_DIR: /seed/conf.d
+    volumes:
+      - ./seed:/seed:rw
+    restart: "no"
+
+  seed-metrics:
+    # Push the synthetic high-connections metric so the headline critical fires.
+    image: curlimages/curl:latest
+    entrypoint: ["/bin/sh"]
+    command: ["/seed/push-metrics.sh"]
+    environment:
+      PUSHGATEWAY_URL: http://pushgateway:9091
+    volumes:
+      - ./seed:/seed:ro
+    depends_on:
+      pushgateway:
+        condition: service_started
+    restart: "no"

--- a/try-local/docker-compose.yaml
+++ b/try-local/docker-compose.yaml
@@ -65,7 +65,10 @@ services:
     volumes:
       - ./seed/conf.d:/conf.d:rw
     ports:
-      - "${EXPOSE_API_PORT:-8080}:8080"
+      # Loopback-only: dev-bypass injects an ADMIN identity for header-less
+      # requests, so exposing this on 0.0.0.0 would hand anyone on the LAN
+      # write/commit access. try-local is local-only by design.
+      - "127.0.0.1:${EXPOSE_API_PORT:-8080}:8080"
     depends_on:
       seed-git:
         condition: service_completed_successfully
@@ -81,7 +84,9 @@ services:
   da-portal:
     image: ghcr.io/vencil/da-portal:${PORTAL_TAG:-v2.8.0}
     ports:
-      - "${EXPOSE_PORTAL_PORT:-8081}:80"
+      # Loopback-only: the portal proxies to tenant-api, so LAN exposure here
+      # is the same admin-access risk as exposing tenant-api directly.
+      - "127.0.0.1:${EXPOSE_PORTAL_PORT:-8081}:80"
     depends_on:
       # nginx resolves the upstream FQDN at startup with no `resolver`, so the
       # tenant-api container (which owns the alias) MUST be started first or
@@ -95,7 +100,7 @@ services:
   pushgateway:
     image: prom/pushgateway:v1.10.0
     ports:
-      - "${EXPOSE_PUSHGATEWAY_PORT:-9091}:9091"
+      - "127.0.0.1:${EXPOSE_PUSHGATEWAY_PORT:-9091}:9091"
     restart: unless-stopped
     # No shell in the image → no CMD healthcheck. Dependents use
     # service_started; the seed's curl --retry-connrefused covers listen lag.
@@ -111,7 +116,7 @@ services:
       # Rule packs from the repo's single source of truth (mounted read-only).
       - ../rule-packs:/etc/prometheus/rules:ro
     ports:
-      - "${EXPOSE_PROM_PORT:-9090}:9090"
+      - "127.0.0.1:${EXPOSE_PROM_PORT:-9090}:9090"
     depends_on:
       threshold-exporter:
         condition: service_started
@@ -132,7 +137,7 @@ services:
     volumes:
       - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
     ports:
-      - "${EXPOSE_AM_PORT:-9093}:9093"
+      - "127.0.0.1:${EXPOSE_AM_PORT:-9093}:9093"
     depends_on:
       prometheus:
         condition: service_healthy

--- a/try-local/prometheus.yml
+++ b/try-local/prometheus.yml
@@ -1,7 +1,7 @@
 # Prometheus config for the try-local stack.
 #
 # 5s scrape + eval keeps the demo snappy; the headline alert has for:30s, so
-# smoke.sh polls /api/v1/alerts for ~90s (>= 30s + scrape/eval slack).
+# smoke.sh polls /api/v1/alerts for ~120s (>= 15s rule interval + 30s for + slack).
 #
 # Rule packs are mounted read-only from the repo's single source of truth
 # (../rule-packs). Only the two the demo exercises are loaded:

--- a/try-local/prometheus.yml
+++ b/try-local/prometheus.yml
@@ -1,0 +1,34 @@
+# Prometheus config for the try-local stack.
+#
+# 5s scrape + eval keeps the demo snappy; the headline alert has for:30s, so
+# smoke.sh polls /api/v1/alerts for ~90s (>= 30s + scrape/eval slack).
+#
+# Rule packs are mounted read-only from the repo's single source of truth
+# (../rule-packs). Only the two the demo exercises are loaded:
+#   - rule-pack-mariadb       → MariaDBHighConnections{,Critical} (the red light)
+#   - rule-pack-operational   → TenantSilent*/TenantSeverityDedup sentinels
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+rule_files:
+  - /etc/prometheus/rules/rule-pack-mariadb.yaml
+  - /etc/prometheus/rules/rule-pack-operational.yaml
+
+scrape_configs:
+  - job_name: threshold-exporter
+    static_configs:
+      - targets: ["threshold-exporter:8080"]
+
+  - job_name: pushgateway
+    # honor_labels keeps the pushed series' own labels (tenant, job) instead of
+    # overwriting them with the scrape job — so the seed's synthetic
+    # mysql_global_status_threads_connected{tenant="db-demo"} survives intact.
+    honor_labels: true
+    static_configs:
+      - targets: ["pushgateway:9091"]
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]

--- a/try-local/seed/conf.d/_defaults.yaml
+++ b/try-local/seed/conf.d/_defaults.yaml
@@ -1,0 +1,11 @@
+# Platform default thresholds (try-local seed).
+#
+# The threshold-exporter only emits a `user_threshold` series for metric keys
+# that appear HERE (resolve.go iterates `defaults`). A tenant override for a
+# key absent from defaults is silently ignored — so every demo threshold key
+# below must be declared. Values are numbers (float64), tenant overrides are
+# strings ("70", "70:critical", "disable").
+defaults:
+  mysql_connections: 80      # db-demo overrides → drives the headline critical alert
+  mysql_cpu: 80
+  redis_connected_clients: 8000  # cache-demo (sentinel/dedup concept demo)

--- a/try-local/seed/conf.d/_rbac.yaml
+++ b/try-local/seed/conf.d/_rbac.yaml
@@ -1,0 +1,17 @@
+# RBAC for the try-local demo (group → tenants → permissions).
+#
+# tenant-api trusts X-Forwarded-Groups (injected by --dev-bypass-auth for the
+# browser, or sent explicitly by smoke.sh). The injected group name, this
+# group's name, and smoke.sh's X-Forwarded-Groups are ALL "demo-admins" — a
+# single SSOT (me.go does an exact-string group match; one typo → empty
+# accessible_tenants → a silently blank Tenant Manager).
+#
+# tenants:["*"] is required so GET /api/v1/me passes its route gate
+# (HasPermission(groups,"*",read) only matches a literal "*" pattern). The
+# wildcard also makes GET /api/v1/tenants list BOTH seed tenants, which is
+# what the portal Tenant Manager renders. (Note: /api/v1/me therefore reports
+# accessible_tenants:["*"] — see try-local/README.md.)
+groups:
+  - name: demo-admins
+    tenants: ["*"]
+    permissions: [read, write, admin]

--- a/try-local/seed/conf.d/_views.yaml
+++ b/try-local/seed/conf.d/_views.yaml
@@ -1,0 +1,11 @@
+# A pre-seeded Saved View so the portal Tenant Manager ships with one
+# example filter on first launch (C6 acceptance criterion). Saving a new view
+# in the UI writes this file and lands a real git commit (the Day-0 wow).
+views:
+  prod-ecommerce:
+    label: "Production · E-commerce"
+    description: "Tier-1 production tenants in the ecommerce domain"
+    created_by: "dev@local"
+    filters:
+      environment: "production"
+      domain: "ecommerce"

--- a/try-local/seed/conf.d/cache-demo.yaml
+++ b/try-local/seed/conf.d/cache-demo.yaml
@@ -1,0 +1,21 @@
+# cache-demo — the "design-concept" tenant (the secondary signal).
+# It carries silent_mode + severity_dedup so the operational rule pack's
+# sentinel alerts fire (severity=none, inhibit sources) WITHOUT a real
+# breach: this showcases v2.8.0 Sentinel Alert + Severity Dedup.
+#   user_silent_mode{tenant=cache-demo,target_severity=warning}=1
+#       → TenantSilentWarning sentinel (severity=none)
+#   user_severity_dedup{tenant=cache-demo,mode=enable}=1
+#       → TenantSeverityDedupEnabled sentinel (severity=none)
+# It is also the 2nd tenant the portal Tenant Manager lists.
+tenants:
+  cache-demo:
+    redis_connected_clients: "5000"
+    _silent_mode: "warning"     # sentinel: notifications suppressed, alert still in TSDB
+    _severity_dedup: "enable"   # default; explicit here for the demo
+    _metadata:
+      owner: "cache-team"
+      tier: "tier-2"
+      runbook_url: "https://runbooks.demo.local/redis-clients"
+      environment: "staging"
+      domain: "cache"
+      db_type: "redis"

--- a/try-local/seed/conf.d/db-demo.yaml
+++ b/try-local/seed/conf.d/db-demo.yaml
@@ -1,0 +1,22 @@
+# db-demo — the headline tenant. The seed one-shot pushes a synthetic
+# mysql_global_status_threads_connected{tenant="db-demo"}=200 to pushgateway;
+# 200 > the critical threshold (120) below → rule-pack-mariadb's
+# MariaDBHighConnectionsCritical fires (severity=critical). This is the red
+# light visible in Prometheus :9090/alerts and Alertmanager :9093.
+#
+# The fire-chain (verified against rule-pack-mariadb.yaml + resolve.go):
+#   user_threshold{tenant=db-demo,metric=connections,severity=warning}=50
+#   user_threshold{tenant=db-demo,metric=connections,severity=critical}=120
+#   tenant_metadata_info{tenant=db-demo,...}=1   (from _metadata, group_left join)
+tenants:
+  db-demo:
+    mysql_connections: "50"            # warning threshold
+    mysql_connections_critical: "120"  # critical threshold → headline alert
+    mysql_cpu: "75"
+    _metadata:
+      owner: "platform-db-team"
+      tier: "tier-1"
+      runbook_url: "https://runbooks.demo.local/mysql-high-connections"
+      environment: "production"
+      domain: "ecommerce"
+      db_type: "mariadb"

--- a/try-local/seed/git-init.sh
+++ b/try-local/seed/git-init.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# try-local seed (1/2): git-init the bind-mounted config repo.
+#
+# tenant-api runs TA_WRITE_MODE=direct (commit-on-write), so a portal "Save"
+# needs a real git repo to commit into. This one-shot creates it (idempotent),
+# so even Mode 0 (`docker compose up da-portal tenant-api`) gets the
+# Save-lands-a-real-commit wow. It has NO dependency on the monitoring stack,
+# which keeps Mode 0 to just the core twins (+ this fast git init).
+set -eu
+
+CONF_DIR="${CONF_DIR:-/conf.d}"
+
+# git refuses to operate in a bind-mounted dir owned by another uid without
+# this ("detected dubious ownership").
+git config --global --add safe.directory '*' 2>/dev/null || true
+
+cd "$CONF_DIR"
+if [ ! -d .git ]; then
+  git init -q
+  git config user.email "seed@local"
+  git config user.name "try-local seed"
+  git add -A
+  git commit -q -m "try-local seed: initial tenant config" || true
+  echo "[git-init] initialized config repo at ${CONF_DIR}"
+else
+  echo "[git-init] repo already present at ${CONF_DIR} (idempotent skip)"
+fi
+
+# This seed runs as root, but tenant-api (commit-on-write) runs as a non-root
+# user and shares this .git via the bind mount. Make .git group/world-writable
+# so tenant-api can create .git/index.lock and commit. Local-dev only.
+chmod -R a+rwX "$CONF_DIR/.git" 2>/dev/null || true

--- a/try-local/seed/push-metrics.sh
+++ b/try-local/seed/push-metrics.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# try-local seed (2/2): push synthetic DB metrics to pushgateway.
+#
+# This is the "signal" half of seed-with-signal: a one-shot push of a high
+# connection count for db-demo so rule-pack-mariadb's
+# MariaDBHighConnectionsCritical fires (the headline red light at
+# :9090/alerts and :9093). Pushgateway retains the series after this exits,
+# so the alert stays firing. Part of the FULL stack only (Mode 0 skips it).
+set -eu
+
+PUSHGATEWAY_URL="${PUSHGATEWAY_URL:-http://pushgateway:9091}"
+SEED_TENANT="${SEED_TENANT:-db-demo}"
+THREADS_CONNECTED="${THREADS_CONNECTED:-200}"
+
+# Push to job=tenant-exporters so absent(mysql_up{job="tenant-exporters"}) is
+# satisfied (MariaDBExporterAbsent stays quiet); prometheus honor_labels keeps
+# the tenant + job labels intact.
+#   mysql_up=1                                → suppresses MariaDBDown
+#   mysql_global_status_uptime=86400          → suppresses MariaDBRecentRestart
+#   mysql_global_status_threads_connected=200 → 200 > critical(120) → HEADLINE
+cat > /tmp/seed-metrics.prom <<EOF
+# TYPE mysql_up gauge
+mysql_up{tenant="${SEED_TENANT}"} 1
+# TYPE mysql_global_status_uptime gauge
+mysql_global_status_uptime{tenant="${SEED_TENANT}"} 86400
+# TYPE mysql_global_status_threads_connected gauge
+mysql_global_status_threads_connected{tenant="${SEED_TENANT}"} ${THREADS_CONNECTED}
+EOF
+
+echo "[push-metrics] pushing synthetic metrics for ${SEED_TENANT} (threads_connected=${THREADS_CONNECTED} > critical 120)"
+# --retry-connrefused rides out pushgateway's listen lag (it has no compose
+# healthcheck — see docker-compose.yaml).
+curl -sf --retry 10 --retry-delay 2 --retry-connrefused \
+  --data-binary @/tmp/seed-metrics.prom \
+  "${PUSHGATEWAY_URL}/metrics/job/tenant-exporters"
+echo "[push-metrics] done — MariaDBHighConnectionsCritical should fire within ~30s (rule for:30s)"

--- a/try-local/smoke.sh
+++ b/try-local/smoke.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# try-local smoke test — verifies the PAYLOAD, not just liveness (ADR D7-3).
+#
+# Checks, any failure → exit 1 with a reason on stderr:
+#   1. Prometheus :9090/api/v1/alerts — POLL until a critical alert is firing
+#      (proves the exporter→prometheus→rule-pack fire-chain end to end).
+#   2. tenant-api :8080/api/v1/me — oauth2-proxy-style headers → HTTP 200.
+#   3. tenant-api :8080/api/v1/tenants — RBAC-filtered list == 2 tenants
+#      (db-demo + cache-demo). NOTE: the literal C7 AC said /me
+#      accessible_tenants==2, but that is impossible with the published
+#      tenant-api — the /me gate needs tenants:["*"], which makes
+#      accessible_tenants==["*"]. The "2 tenants" the portal shows come from
+#      /api/v1/tenants, so that is what we assert. See README.
+#   4. da-portal :8081/ — Tenant Manager UI served (HTTP 200).
+#
+# Requires: curl, jq. Honors port overrides from a sibling .env.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "${SCRIPT_DIR}/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "${SCRIPT_DIR}/.env"
+  set +a
+fi
+
+HOST="${SMOKE_HOST:-localhost}"
+PROM_PORT="${EXPOSE_PROM_PORT:-9090}"
+API_PORT="${EXPOSE_API_PORT:-8080}"
+PORTAL_PORT="${EXPOSE_PORTAL_PORT:-8081}"
+ALERT_TIMEOUT="${SMOKE_ALERT_TIMEOUT:-90}"
+
+fail() { echo "SMOKE FAIL: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || fail "jq not found (required); install jq and retry"
+
+# 1. Poll for a firing critical alert. The headline rule has for:30s, so allow
+#    >= 30s + scrape/eval slack (default 90s).
+echo "[smoke] polling for a firing critical alert (<=${ALERT_TIMEOUT}s)..."
+deadline=$(( $(date +%s) + ALERT_TIMEOUT ))
+while :; do
+  body="$(curl -sf "http://${HOST}:${PROM_PORT}/api/v1/alerts" 2>/dev/null || true)"
+  if [ -n "$body" ]; then
+    n="$(printf '%s' "$body" | jq '[.data.alerts[] | select(.labels.severity=="critical" and .state=="firing")] | length' 2>/dev/null || echo 0)"
+    if [ "${n:-0}" -ge 1 ]; then
+      echo "[smoke] OK: ${n} critical alert(s) firing"
+      break
+    fi
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    fail "no critical alert firing within ${ALERT_TIMEOUT}s (exporter→prometheus→rule chain)"
+  fi
+  sleep 3
+done
+
+# 2. /api/v1/me → 200.
+code="$(curl -s -o /dev/null -w '%{http_code}' \
+  -H 'X-Forwarded-Email: dev@local' -H 'X-Forwarded-Groups: demo-admins' \
+  "http://${HOST}:${API_PORT}/api/v1/me")"
+[ "$code" = "200" ] || fail "/api/v1/me returned HTTP ${code} (want 200)"
+echo "[smoke] OK: /api/v1/me 200"
+
+# 2b. Browser path: portal proxy → tenant-api /api/v1/me with NO identity
+#     headers. This is exactly what a real browser sends; the dev-bypass MUST
+#     inject an identity or the Tenant Manager renders blank. This catches a
+#     tenant-api image that lacks --dev-bypass-auth (a header-only check on
+#     :8080 would pass while the actual showcase is broken).
+code="$(curl -s -o /dev/null -w '%{http_code}' "http://${HOST}:${PORTAL_PORT}/api/v1/me")"
+[ "$code" = "200" ] || fail "portal-proxied /api/v1/me (no headers) returned HTTP ${code} (want 200 — dev-bypass must inject identity for the browser path)"
+echo "[smoke] OK: browser path /api/v1/me via portal (dev-bypass injected) 200"
+
+# 3. /api/v1/tenants → exactly 2 tenants (db-demo, cache-demo).
+count="$(curl -sf \
+  -H 'X-Forwarded-Email: dev@local' -H 'X-Forwarded-Groups: demo-admins' \
+  "http://${HOST}:${API_PORT}/api/v1/tenants" | jq 'length')"
+[ "$count" = "2" ] || fail "/api/v1/tenants listed '${count}' tenants (want 2: db-demo, cache-demo)"
+echo "[smoke] OK: /api/v1/tenants lists 2 tenants"
+
+# 4. portal UI → 200.
+code="$(curl -s -o /dev/null -w '%{http_code}' "http://${HOST}:${PORTAL_PORT}/")"
+[ "$code" = "200" ] || fail "portal / returned HTTP ${code} (want 200)"
+echo "[smoke] OK: portal 200"
+
+echo "[smoke] ALL CHECKS PASSED"

--- a/try-local/smoke.sh
+++ b/try-local/smoke.sh
@@ -28,14 +28,16 @@ HOST="${SMOKE_HOST:-localhost}"
 PROM_PORT="${EXPOSE_PROM_PORT:-9090}"
 API_PORT="${EXPOSE_API_PORT:-8080}"
 PORTAL_PORT="${EXPOSE_PORTAL_PORT:-8081}"
-ALERT_TIMEOUT="${SMOKE_ALERT_TIMEOUT:-90}"
+# Headroom: the mariadb pack's recording rules run at interval:15s, then the
+# alert is for:30s — plus scrape/eval slack and slow CI runners.
+ALERT_TIMEOUT="${SMOKE_ALERT_TIMEOUT:-120}"
 
 fail() { echo "SMOKE FAIL: $*" >&2; exit 1; }
 
 command -v jq >/dev/null 2>&1 || fail "jq not found (required); install jq and retry"
 
-# 1. Poll for a firing critical alert. The headline rule has for:30s, so allow
-#    >= 30s + scrape/eval slack (default 90s).
+# 1. Poll for a firing critical alert. The headline rule has for:30s on top of
+#    a 15s recording-rule interval, so allow generous slack (default 120s).
 echo "[smoke] polling for a firing critical alert (<=${ALERT_TIMEOUT}s)..."
 deadline=$(( $(date +%s) + ALERT_TIMEOUT ))
 while :; do


### PR DESCRIPTION
## Summary
`try-local/` — a one-command (`cd try-local && cp .env.example .env && docker compose up -d`) showcase for the #449 onboarding epic. 6 services + 2 seed one-shots:
- **da-portal** `:8081` — live Tenant Manager (2 demo tenants + a saved view)
- **tenant-api** `:8080` — file-based config API, commit-on-write, dev-bypass auth
- **prometheus** `:9090` / **alertmanager** `:9093` — a real `MariaDBHighConnectionsCritical` firing
- **threshold-exporter** + **pushgateway** — config→metrics + the synthetic signal

**Mode 0 (core twins):** `docker compose up da-portal tenant-api` → just the live Tenant Manager; saving a view lands a real git commit.

## Verified live (end-to-end, on this branch)
- `smoke.sh` **5/5**: critical firing (poll), `/me` 200, **browser-path** `/me` via portal proxy 200 (dev-bypass injects), `/api/v1/tenants`==2, portal 200.
- **Save → real git commit** (Saved-View PUT → commit in `seed/conf.d`).
- `make clean-local` tears down cleanly.
- Both sentinels fire (`TenantSilentWarning` + `TenantSeverityDedupEnabled`) — the secondary Sentinel/Dedup concept demo.

## Notable decisions (the live run drove these)
1. **tenant-api builds from source.** `--dev-bypass-auth` (#619) is in `main` but NOT in any published image (v2.8.0 predates it; v2.9.0 unreleased) — without it the browser path 401s. The other 3 use published `v2.8.0`. Building also yields the visitor's native arch. Flip to `image:` when a dev-bypass image ships.
2. **Network alias** `tenant-api.monitoring.svc.cluster.local` + `depends_on` so the published portal's baked-in nginx upstream resolves — portal image runs unchanged, no file mount (avoids the WSL2 single-file-mount landmine).
3. **Seed split into two one-shots** — `git-init` (no monitoring dep → Mode 0 stays minimal) + `metric-push`.
4. **git fixes for the bind-mounted repo**: `safe.directory` via `GIT_CONFIG_*` env + seed makes `.git` group-writable (tenant-api runs as nonroot, seed as root).

## AC deviations (vs literal #465 ACs)
- **C7 `/me accessible_tenants==2`** is impossible with the published tenant-api: the `/me` gate needs `tenants:["*"]`, which makes `accessible_tenants==["*"]`. The "2 tenants" the portal shows come from `/api/v1/tenants` → smoke asserts that (+ `/me` 200 + the browser-path check).
- **Save→commit** is demoed via **Saved Views** (the portal's only write action; there is no threshold-edit PUT in the UI), not threshold edits. Threshold-key writes also hit a pre-existing tenant-api validation quirk (PUT body validated without merging `_defaults`).

## Test plan
- [x] `docker compose up -d` (tenant-api built from source) → all healthy
- [x] `make smoke-local` → 5/5
- [x] Browser path `:8081/api/v1/me` (no headers) → 200
- [x] Save a view → real commit
- [x] `make clean-local` → clean teardown
- [x] static: `docker compose config`, yaml parse, `bash -n`, mkdocs strict (no new warnings)
- [ ] Nightly `try-local-smoke.yaml` green at 02:00 UTC (post-merge)

## Notes
- **arm64 (Apple Silicon)**: tenant-api builds natively, but the published `threshold-exporter`/`da-portal` images need multi-arch (#463) before a `pull` works on arm64 — so the cold-M1 DoD bullet remains gated on #463.
- Nightly workflow files an auto-issue on 3 consecutive failures; not in any release chain.

Refs #449, #465. (Leaving #465 open until #463 unblocks arm64 + the first nightly is green.)