### PR TITLE
feat(ci): multi-arch (amd64+arm64) release images + da-tools build (#463)

### DIFF
--- a/.github/workflows/component-docker-build.yaml
+++ b/.github/workflows/component-docker-build.yaml
@@ -99,9 +99,12 @@ jobs:
         if: matrix.name == 'da-tools'
         run: |
           mkdir -p components/da-tools/app/tools
-          touch components/da-tools/app/da-guard \
-                components/da-tools/app/da-batchpr \
-                components/da-tools/app/da-parser
+          # #463 multi-arch: Dockerfile now COPYs da-<tool>.${TARGETARCH}.
+          for b in da-guard da-batchpr da-parser; do
+            for a in amd64 arm64; do
+              touch "components/da-tools/app/$b.$a"
+            done
+          done
 
       # Hard gate: build must succeed. Catches #472/#473-class dormant breaks.
       - name: Build image (load, no push)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,7 +67,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # --- Docker image ---
+      # --- Docker image (multi-arch: amd64 + arm64, #463) ---
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -75,10 +77,14 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: components/threshold-exporter/app
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/threshold-exporter:v${{ steps.version.outputs.VERSION }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/threshold-exporter:latest
+
+      - name: Verify multi-arch manifest (#463)
+        run: bash scripts/ops/verify_multiarch.sh ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/threshold-exporter:v${{ steps.version.outputs.VERSION }}
 
       # --- L3 supply-chain digest verification (#445 AC iii) ---
       # Verifies the image at Chart.yaml `appVersion` tag actually exists
@@ -203,6 +209,10 @@ jobs:
           cd components/da-tools/app
           bash build.sh --assemble-only
 
+      # Multi-arch (#463): build.sh above cross-compiled the bundled binaries
+      # per-arch (da-guard.amd64/.arm64 …); the Dockerfile COPYs by TARGETARCH.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -210,10 +220,14 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: components/da-tools/app
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/da-tools:v${{ steps.version.outputs.VERSION }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/da-tools:latest
+
+      - name: Verify multi-arch manifest (#463)
+        run: bash scripts/ops/verify_multiarch.sh ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/da-tools:v${{ steps.version.outputs.VERSION }}
 
       # --- L3 supply-chain digest verification (#445 AC iii) ---
       # da-tools has no Helm chart — components/da-tools/app/VERSION is the
@@ -481,6 +495,8 @@ jobs:
       - name: Download vendor files for offline mode
         run: bash scripts/tools/vendor_download.sh
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -489,10 +505,14 @@ jobs:
         with:
           context: .
           file: components/da-portal/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/da-portal:v${{ steps.version.outputs.VERSION }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/da-portal:latest
+
+      - name: Verify multi-arch manifest (#463)
+        run: bash scripts/ops/verify_multiarch.sh ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/da-portal:v${{ steps.version.outputs.VERSION }}
 
       # --- L3 supply-chain digest verification (#445 AC iii) ---
       - name: Verify image digest (#445 AC iii)
@@ -538,7 +558,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # --- Docker image ---
+      # --- Docker image (multi-arch: amd64 + arm64, #463) ---
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -547,10 +569,14 @@ jobs:
         with:
           context: .
           file: components/tenant-api/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/tenant-api:v${{ steps.version.outputs.VERSION }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/tenant-api:latest
+
+      - name: Verify multi-arch manifest (#463)
+        run: bash scripts/ops/verify_multiarch.sh ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/tenant-api:v${{ steps.version.outputs.VERSION }}
 
       # --- L3 supply-chain digest verification (#445 AC iii) ---
       # ⚠️ tenant-api intentionally has Chart.yaml appVersion ≠ version

--- a/Makefile
+++ b/Makefile
@@ -547,8 +547,9 @@ docker-build-all: ## 建 4 個 production component image（local --load，無 p
 	@docker buildx build --load -t local-test:tenant-api -f components/tenant-api/Dockerfile .
 	@# da-tools：stub build.sh-assembled tools/ + 預編 Go binary（COPY-path smoke，不編 Go；
 	@# Dockerfile 只 COPY+chmod 不執行 binary，故 stub 可驗 COPY 路徑 / 語法）。
+	@# #463 multi-arch：Dockerfile 改 COPY 帶 arch 後綴（da-guard.<arch>），stub 須對應。
 	@mkdir -p components/da-tools/app/tools
-	@touch components/da-tools/app/da-guard components/da-tools/app/da-batchpr components/da-tools/app/da-parser
+	@for b in da-guard da-batchpr da-parser; do for a in amd64 arm64; do touch "components/da-tools/app/$$b.$$a"; done; done
 	@docker buildx build --load -t local-test:da-tools components/da-tools/app
 
 trivy-scan-all: docker-build-all ## Trivy CVE scan 4 個 image（informational：印出但不擋，#448）

--- a/components/da-tools/app/Dockerfile
+++ b/components/da-tools/app/Dockerfile
@@ -40,27 +40,24 @@ COPY VERSION .
 # Tool scripts + metric-dictionary.yaml (assembled by build.sh from scripts/tools/)
 COPY tools/ ./
 
-# ── Bundle da-guard binary (v2.8.0 C-11) ──────────────────────────
-# `da-tools guard <subcommand>` shells out to da-guard (see
-# scripts/tools/ops/guard_dispatch.py). Bundling the binary at
-# /usr/local/bin/da-guard lets the image work in air-gapped
-# environments (no $PATH lookup outside the container, no extra
-# install step). The binary is built linux/amd64 by build.sh from
-# components/threshold-exporter/app/cmd/da-guard before docker
-# build runs.
-COPY da-guard /usr/local/bin/da-guard
+# ── Bundle da-guard / da-batchpr / da-parser binaries ─────────────
+# `da-tools guard|batch-pr|parser <subcommand>` shells out to these Go
+# binaries (see the *_dispatch.py shims). Bundling them at
+# /usr/local/bin lets the image work air-gapped (no $PATH lookup
+# outside the container, no extra install step).
+#
+# #463 multi-arch: build.sh cross-compiles a per-arch suffix
+# (da-guard.amd64 / da-guard.arm64); TARGETARCH (set by buildx per
+# platform, or the host arch on a plain `docker build`) selects the
+# matching binary so the image is native on amd64 AND arm64.
+ARG TARGETARCH
+COPY da-guard.${TARGETARCH} /usr/local/bin/da-guard
 RUN chmod +x /usr/local/bin/da-guard
 
-# ── Bundle da-batchpr binary (v2.8.0 C-10 PR-5) ───────────────────
-# `da-tools batch-pr <subcommand>` (apply / refresh / refresh-source)
-# shells out to da-batchpr. Same air-gapped friendliness as da-guard.
-COPY da-batchpr /usr/local/bin/da-batchpr
+COPY da-batchpr.${TARGETARCH} /usr/local/bin/da-batchpr
 RUN chmod +x /usr/local/bin/da-batchpr
 
-# ── Bundle da-parser binary (v2.8.0 C-8 PR-2) ─────────────────────
-# `da-tools parser <subcommand>` (import / allowlist) shells out to
-# da-parser. Same air-gapped friendliness as da-guard / da-batchpr.
-COPY da-parser /usr/local/bin/da-parser
+COPY da-parser.${TARGETARCH} /usr/local/bin/da-parser
 RUN chmod +x /usr/local/bin/da-parser
 
 # ── Entrypoint ────────────────────────────────────────────────────

--- a/components/da-tools/app/build.sh
+++ b/components/da-tools/app/build.sh
@@ -192,61 +192,42 @@ for py in "$SCRIPT_DIR"/tools/*.py; do
 done
 echo "  Stripped repo-layout sys.path from Docker copies"
 
-# ── Build da-guard binary (v2.8.0 C-11) ──────────────────────────────
-# da-tools' `guard` subcommand shells out to the da-guard Go binary
-# (see scripts/tools/ops/guard_dispatch.py). Bundle the linux/amd64
-# binary into the image so customers running `da-tools guard ...` in
-# the container don't need to install or download it separately.
+# ── Build bundled Go binaries (v2.8.0 C-8/C-10/C-11) ─────────────────
+# da-tools' `guard` / `batch-pr` / `parser` subcommands shell out to the
+# da-guard / da-batchpr / da-parser Go binaries (see the *_dispatch.py
+# shims). Bundling them into the image keeps the container air-gapped
+# friendly (no $PATH lookup outside the container, no extra install).
+#
+# #463 multi-arch: build BOTH linux/amd64 and linux/arm64 (per-arch
+# suffix), so the Dockerfile can `COPY da-guard.${TARGETARCH}` and the
+# image works natively on Apple Silicon. CGO_ENABLED=0 cross-compiles
+# on the amd64 builder with no libc / QEMU dependency.
 #
 # Local devs without Go on PATH get a clear "Go not found" error
 # (rather than a cryptic Dockerfile COPY failure later). Production
 # CI has Go via actions/setup-go in release.yaml.
 EXPORTER_APP="$PROJECT_ROOT/components/threshold-exporter/app"
-echo "▸ Building da-guard binary for da-tools image bundling..."
 if [ ! -d "$EXPORTER_APP" ]; then
     echo "  ✗ threshold-exporter source not found at $EXPORTER_APP" >&2
     exit 1
 fi
 if ! command -v go >/dev/null 2>&1; then
-    echo "  ✗ go not on PATH; install Go 1.26+ to bundle da-guard, or use the prebuilt binary from a tools/v* release" >&2
+    echo "  ✗ go not on PATH; install Go 1.26+ to bundle the binaries, or use prebuilt binaries from a tools/v* release" >&2
     exit 1
 fi
 DA_TOOLS_VERSION=$(cat "$SCRIPT_DIR/VERSION" | tr -d '[:space:]')
-(cd "$EXPORTER_APP" && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-        -buildvcs=false \
-        -ldflags "-X main.Version=v${DA_TOOLS_VERSION}" \
-        -o "$SCRIPT_DIR/da-guard" \
-        ./cmd/da-guard)
-echo "  Built da-guard linux/amd64 (DA_TOOLS_VERSION=v${DA_TOOLS_VERSION})"
-
-# ── Build da-batchpr binary (v2.8.0 C-10 PR-5) ──────────────────────
-# da-tools' `batch-pr` subcommand shells out to the da-batchpr Go
-# binary (subcommands: apply / refresh / refresh-source). Bundle the
-# linux/amd64 binary so customers running `da-tools batch-pr ...` in
-# the container don't need to install or download it separately.
-echo "▸ Building da-batchpr binary for da-tools image bundling..."
-(cd "$EXPORTER_APP" && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-        -buildvcs=false \
-        -ldflags "-X main.Version=v${DA_TOOLS_VERSION}" \
-        -o "$SCRIPT_DIR/da-batchpr" \
-        ./cmd/da-batchpr)
-echo "  Built da-batchpr linux/amd64 (DA_TOOLS_VERSION=v${DA_TOOLS_VERSION})"
-
-# ── Build da-parser binary (v2.8.0 C-8 PR-2) ────────────────────────
-# da-tools' `parser` subcommand shells out to the da-parser Go binary
-# (subcommands: import / allowlist). Bundle the linux/amd64 binary so
-# customers running `da-tools parser import ...` in the container
-# don't need to install or download it separately.
-echo "▸ Building da-parser binary for da-tools image bundling..."
-(cd "$EXPORTER_APP" && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-        -buildvcs=false \
-        -ldflags "-X main.Version=v${DA_TOOLS_VERSION}" \
-        -o "$SCRIPT_DIR/da-parser" \
-        ./cmd/da-parser)
-echo "  Built da-parser linux/amd64 (DA_TOOLS_VERSION=v${DA_TOOLS_VERSION})"
+echo "▸ Cross-compiling da-guard / da-batchpr / da-parser for amd64 + arm64..."
+for cmd in da-guard da-batchpr da-parser; do
+    for arch in amd64 arm64; do
+        (cd "$EXPORTER_APP" && \
+            CGO_ENABLED=0 GOOS=linux GOARCH="$arch" go build \
+                -buildvcs=false \
+                -ldflags "-X main.Version=v${DA_TOOLS_VERSION}" \
+                -o "$SCRIPT_DIR/${cmd}.${arch}" \
+                "./cmd/${cmd}")
+    done
+    echo "  Built ${cmd}.{amd64,arm64} (DA_TOOLS_VERSION=v${DA_TOOLS_VERSION})"
+done
 
 # ── Assemble-only mode (for CI — Buildx handles the docker build) ──
 if [ "$ASSEMBLE_ONLY" = true ]; then
@@ -260,7 +241,7 @@ docker build -t "$IMAGE_NAME" "$SCRIPT_DIR"
 
 # ── Cleanup temporary copies ────────────────────────────────────────
 rm -rf "$SCRIPT_DIR/tools"
-rm -f "$SCRIPT_DIR/da-guard" "$SCRIPT_DIR/da-batchpr" "$SCRIPT_DIR/da-parser"
+rm -f "$SCRIPT_DIR"/da-guard.* "$SCRIPT_DIR"/da-batchpr.* "$SCRIPT_DIR"/da-parser.*
 
 echo "✓ Built: $IMAGE_NAME"
 echo ""

--- a/components/tenant-api/Dockerfile
+++ b/components/tenant-api/Dockerfile
@@ -11,7 +11,10 @@
 #   docker run -p 8080:8080 -v $(pwd)/conf.d:/conf.d ghcr.io/vencil/tenant-api:2.4.0
 
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM golang:1.26.3-alpine3.22 AS builder
+# #463 multi-arch: builder pinned to the native BUILDPLATFORM, cross-compiles
+# to TARGETARCH below (CGO_ENABLED=0 → no cross-toolchain, no QEMU for the Go
+# compile). The final alpine stage's `apk add` still runs under QEMU for arm64.
+FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine3.22 AS builder
 
 WORKDIR /src
 
@@ -30,7 +33,8 @@ COPY components/tenant-api/ components/tenant-api/
 COPY components/threshold-exporter/app/ components/threshold-exporter/app/
 
 WORKDIR /src/components/tenant-api
-RUN CGO_ENABLED=0 GOOS=linux go build \
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags="-s -w" \
     -o /tenant-api \
     ./cmd/server

--- a/components/threshold-exporter/app/Dockerfile
+++ b/components/threshold-exporter/app/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.26.3-alpine3.22 AS builder
+# #463 multi-arch: pin the builder to the native BUILDPLATFORM and
+# cross-compile to TARGETARCH below — far faster than emulating the Go
+# compile under QEMU.
+FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine3.22 AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./
@@ -11,7 +14,8 @@ RUN go mod download
 # provides package github.com/vencil/threshold-exporter/pkg/config".
 COPY *.go ./
 COPY pkg ./pkg
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /threshold-exporter .
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -o /threshold-exporter .
 
 FROM gcr.io/distroless/static-debian12:nonroot
 

--- a/scripts/ops/verify_multiarch.sh
+++ b/scripts/ops/verify_multiarch.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# verify_multiarch.sh — #463 (Track C1): assert a pushed image's manifest list
+# contains BOTH linux/amd64 and linux/arm64. Exit 1 if either is missing.
+#
+# Run after `docker buildx build --push --platform linux/amd64,linux/arm64`
+# in release.yaml, so a single-arch regression (e.g. a `platforms:` line
+# dropped) fails the release instead of silently shipping amd64-only.
+#
+# Usage:  verify_multiarch.sh <image-ref>
+# Needs:  docker (logged in for private images) + jq.
+set -euo pipefail
+
+IMG="${1:?usage: verify_multiarch.sh <image-ref>}"
+
+echo "▸ Inspecting multi-arch manifest for ${IMG}"
+# Filter to real OS/arch platforms — buildx also attaches an
+# attestation manifest with platform.os == "unknown" which we ignore.
+archs="$(docker manifest inspect "${IMG}" \
+    | jq -r '.manifests[] | select(.platform.os == "linux") | .platform.architecture' \
+    | sort -u)"
+echo "  linux architectures present: $(echo "${archs}" | tr '\n' ' ')"
+
+missing=0
+for want in amd64 arm64; do
+    if ! echo "${archs}" | grep -qx "${want}"; then
+        echo "::error::${IMG} manifest is missing linux/${want}" >&2
+        missing=1
+    fi
+done
+[ "${missing}" -eq 0 ] || exit 1
+
+echo "✓ ${IMG} is multi-arch (linux/amd64 + linux/arm64)"


### PR DESCRIPTION
## Summary
Multi-arch (linux/amd64 + linux/arm64) release images for the #449 try-local showcase — so Apple Silicon contributors get native images instead of slow Rosetta emulation (which breaks the 5-min SLI). All 4 release build steps were amd64-only (no `platforms:`).

- **release.yaml**: each of the 4 `build-push-action` steps gains `setup-qemu` + `platforms: linux/amd64,linux/arm64` + a manifest-inspect verify step (`scripts/ops/verify_multiarch.sh` — fails the release if either arch is missing).
- **exporter + tenant-api** Dockerfiles: builder pinned to `--platform=$BUILDPLATFORM` + cross-compiles with `GOARCH=$TARGETARCH` (CGO_ENABLED=0 → no emulated Go compile).
- **da-tools**: `build.sh` cross-compiles each bundled binary for both arches (`da-guard.amd64`/`.arm64` …); Dockerfile `COPY da-guard.${TARGETARCH}`. Removed the amd64-only comment.
- **Blast-radius fix**: two consumers stubbed the old *unsuffixed* binaries and would have broken — `make docker-build-all` (pre-tag gate) + `component-docker-build.yaml` (runs on this very PR). Both now stub per-arch.

## Verified locally (buildx + QEMU)
- exporter / tenant-api / da-tools all build for **both** linux/amd64 + linux/arm64.
- arm64 da-tools image **runs**: `da-parser --version` → `da-parser v2.8.0`, `da-guard --version` → `da-guard v2.8.0` (the DoD's "runs natively on arm64").
- cross-compiled binaries are correct arch (`file` → `x86-64` + `ARM aarch64`).
- `verify_multiarch.sh` arch-detection validated against a known multi-arch image.

## Test plan
- [x] buildx multi-arch build: exporter, tenant-api, da-tools (both arches)
- [x] arm64 bundled binaries execute (`--version`)
- [x] da-tools per-arch cross-compile (`file` → x86-64 + ARM aarch64)
- [x] fixed both stub consumers (docker-build-all + component-docker-build)
- [x] shellcheck clean (verify_multiarch.sh, build.sh); workflows parse
- [ ] Next release tag publishes multi-arch manifests (verify step gates it) — release-gated

## Notes
- da-portal needs no Dockerfile change (nginx:alpine is multi-arch; its only arch-specific step is `apk`, proven on arm64 via tenant-api/da-tools). Its local build is blocked only by the `make vendor-download` artifact — unrelated to multi-arch.
- Multi-arch publish only runs on release tags, so this PR's CI exercises the single-arch COPY-path smoke (component-docker-build) + lints; the live multi-arch manifest is gated at the next release by `verify_multiarch.sh`.

Refs #449, #463. (Final DoD — M1 `docker pull` with no emulation warning — confirmable at the next release.)