### PR TITLE
test(tenant-api): forge real-forge E2E Track 1 — GitHub per-PR (#616)

### DIFF
--- a/.github/workflows/forge-e2e-github.yaml
+++ b/.github/workflows/forge-e2e-github.yaml
@@ -1,0 +1,77 @@
+name: Forge E2E — GitHub (post-merge)
+
+# Real-forge E2E for tenant-api's PR write-back against a DEDICATED GitHub
+# sandbox repo (issue #616, Track 1). Complements the httptest unit tests
+# (#615, deterministic protocol) with real api.github.com behaviour: Link-header
+# pagination, true permission 403, full PR round-trip.
+#
+# ⛔ SECURITY: runs on same-repo events ONLY — post-merge push to main + manual
+# dispatch. NEVER `pull_request` / `pull_request_target` — a forge write-PAT in
+# a fork-influenced workflow is a classic pwn-request (token exfil). `on: push`
+# never fires for fork PRs, so fork contributors are unaffected and unblocked.
+
+on:
+  # per-PR (same-repo) + post-merge. `pull_request` (NOT `_target`) is safe:
+  # GitHub withholds secrets from FORK PRs, so loadGitHubCfg sees no token and
+  # SKIPS → fork contributors are non-blocking; same-repo PRs get secrets and
+  # run the real E2E. paths-filtered so only tenant-api changes trigger it.
+  pull_request:
+    paths:
+      - "components/tenant-api/**"
+      - ".github/workflows/forge-e2e-github.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "components/tenant-api/**"
+      - ".github/workflows/forge-e2e-github.yaml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: forge-e2e-github
+  cancel-in-progress: false
+
+env:
+  # Dedicated throwaway sandbox — NOT the real repo (the E2E opens/deletes PRs).
+  E2E_GITHUB_REPO: vencil/tenant-api-e2e-sandbox
+
+jobs:
+  github-e2e:
+    name: GitHub real-forge E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+
+      # Pre-sweep orphan PRs/branches from any prior failed/cancelled run so a
+      # stuck repo doesn't inflate this run's pagination. Skips if secrets unset.
+      - name: Janitor — pre-sweep orphans
+        working-directory: components/tenant-api
+        env:
+          E2E_GITHUB_TOKEN: ${{ secrets.E2E_GITHUB_TOKEN }}
+          E2E_GITHUB_RO_TOKEN: ${{ secrets.E2E_GITHUB_RO_TOKEN }}
+          E2E_GITHUB_JANITOR: "1"
+        run: go test -tags forge_e2e -count=1 -run TestForgeE2E_GitHub_Janitor ./test/forgee2e/... -v
+
+      - name: GitHub forge E2E scenarios
+        working-directory: components/tenant-api
+        env:
+          E2E_GITHUB_TOKEN: ${{ secrets.E2E_GITHUB_TOKEN }}
+          E2E_GITHUB_RO_TOKEN: ${{ secrets.E2E_GITHUB_RO_TOKEN }}
+        run: go test -tags forge_e2e -count=1 -timeout 20m -run TestForgeE2E_GitHub ./test/forgee2e/... -v
+
+      # always(): clean up this run's residue even if a scenario was killed
+      # mid-teardown (before its t.Cleanup ran).
+      - name: Janitor — post-sweep (always)
+        if: always()
+        working-directory: components/tenant-api
+        env:
+          E2E_GITHUB_TOKEN: ${{ secrets.E2E_GITHUB_TOKEN }}
+          E2E_GITHUB_RO_TOKEN: ${{ secrets.E2E_GITHUB_RO_TOKEN }}
+          E2E_GITHUB_JANITOR: "1"
+        run: go test -tags forge_e2e -count=1 -run TestForgeE2E_GitHub_Janitor ./test/forgee2e/... -v

--- a/components/tenant-api/test/forgee2e/github_e2e_test.go
+++ b/components/tenant-api/test/forgee2e/github_e2e_test.go
@@ -1,0 +1,90 @@
+//go:build forge_e2e
+
+package forgee2e
+
+import (
+	"os"
+	"testing"
+)
+
+// TestForgeE2E_GitHub_FullLoop exercises the real round-trip against
+// api.github.com (dedicated sandbox repo): CreateBranch/DeleteBranch lifecycle
+// + branch→commit→PR→ListOpenPRs (tenant extracted from branch prefix, state
+// open). Teardown (close PR + delete branch) runs via seedPR's t.Cleanup — the
+// sandbox repo persists, so cleanup is mandatory.
+func TestForgeE2E_GitHub_FullLoop(t *testing.T) {
+	cfg := loadGitHubCfg(t)
+	cl := cfg.clientWithToken(t, cfg.token)
+	s := newGHSeeder(cfg)
+
+	// CreateBranch + DeleteBranch directly (platform.Client methods).
+	lifecycle := uniqueBranch(e2eTenant("branchlifecycle"))
+	if err := cl.CreateBranch(lifecycle); err != nil {
+		t.Fatalf("CreateBranch %s: %v", lifecycle, err)
+	}
+	if err := cl.DeleteBranch(lifecycle); err != nil {
+		t.Fatalf("DeleteBranch %s: %v", lifecycle, err)
+	}
+
+	tenant := e2eTenant("loop")
+	branch := seedPR(t, cl, s, tenant)
+
+	prs, err := cl.ListOpenPRs()
+	if err != nil {
+		t.Fatalf("ListOpenPRs: %v", err)
+	}
+	found := false
+	for _, pr := range prs {
+		if pr.HeadRef == branch {
+			found = true
+			if pr.TenantID != tenant {
+				t.Errorf("TenantID = %q, want %q", pr.TenantID, tenant)
+			}
+			if pr.State != "open" {
+				t.Errorf("State = %q, want open", pr.State)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("seeded PR (%s) not found in ListOpenPRs (%d returned)", branch, len(prs))
+	}
+}
+
+// TestForgeE2E_GitHub_Janitor sweeps orphaned tenant-api/* state left in the
+// sandbox repo by failed/cancelled runs (defence-in-depth beyond per-test
+// t.Cleanup, which doesn't run if the job is SIGKILLed). Gated on
+// E2E_GITHUB_JANITOR=1 so it runs only when the workflow invokes it.
+//
+// Branch-primary: closing open PRs alone misses PHANTOM branches — ones created
+// when a run died after CreateBranch but before CreatePR (no PR → the PR-based
+// sweep never sees them → permanent leak). So we (1) close open PRs + delete
+// their head branches, then (2) sweep ALL remaining tenant-api/ branches.
+//
+// ⚠️ This is a BROAD sweep of the SHARED sandbox — it closes/deletes ALL open
+// tenant-api/* PRs+branches, not just one run's. CI runs are serialized by the
+// workflow's `concurrency` group so they never overlap. Do NOT run it locally
+// while CI may be running, or you'll nuke the live CI run's in-flight PRs.
+func TestForgeE2E_GitHub_Janitor(t *testing.T) {
+	if os.Getenv("E2E_GITHUB_JANITOR") != "1" {
+		t.Skip("set E2E_GITHUB_JANITOR=1 to run the orphan sweeper")
+	}
+	cfg := loadGitHubCfg(t)
+	cl := cfg.clientWithToken(t, cfg.token)
+	s := newGHSeeder(cfg)
+
+	// 1. Close open tenant-api PRs + delete their head branches.
+	prs, err := cl.ListOpenPRs()
+	if err != nil {
+		t.Fatalf("ListOpenPRs: %v", err)
+	}
+	for _, pr := range prs {
+		s.closePRBestEffort(t, pr.Number)
+		_ = cl.DeleteBranch(pr.HeadRef)
+	}
+	// 2. Sweep remaining tenant-api/ branches — the phantoms with no PR.
+	branches := s.listE2EBranches(t)
+	for _, b := range branches {
+		_ = cl.DeleteBranch(b)
+	}
+	t.Logf("janitor swept %d PR(s) + %d branch(es)", len(prs), len(branches))
+}

--- a/components/tenant-api/test/forgee2e/github_seed_test.go
+++ b/components/tenant-api/test/forgee2e/github_seed_test.go
@@ -1,0 +1,189 @@
+//go:build forge_e2e
+
+package forgee2e
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	gh "github.com/vencil/tenant-api/internal/github"
+)
+
+// ghSeeder drives the GitHub REST API directly (raw HTTP, write-scoped PAT)
+// for fixtures the platform.Client interface doesn't expose: commit a file
+// onto a branch (Contents API → gives the PR a diff) and close a PR (the
+// interface has no close method — teardown needs it because the dummy repo
+// PERSISTS, unlike GitLab's ephemeral per-test project). The methods under
+// test (CreateBranch / CreatePR / ListOpenPRs / DeleteBranch) run via gh.Client.
+type ghSeeder struct {
+	baseURL string // https://api.github.com (or GHE)
+	repo    string // owner/repo
+	token   string
+	httpc   *http.Client
+}
+
+func newGHSeeder(cfg githubCfg) *ghSeeder {
+	base := cfg.apiURL
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	return &ghSeeder{
+		baseURL: strings.TrimRight(base, "/"),
+		repo:    cfg.repo,
+		token:   cfg.token,
+		httpc:   &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+// do issues an authenticated GitHub request. Retries transport errors + 5xx
+// (and 403 secondary-rate-limit, which GitHub returns under bulk write bursts);
+// other 4xx are logic errors → fail. `fatal=false` makes it best-effort (used
+// by teardown, which must not fail a passing test).
+func (s *ghSeeder) do(t *testing.T, fatal bool, method, path string, body any) ([]byte, int) {
+	t.Helper()
+	var payload []byte
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("seed marshal: %v", err)
+		}
+		payload = b
+	}
+	var last string
+	for attempt := 1; attempt <= 4; attempt++ {
+		var r io.Reader
+		if payload != nil {
+			r = bytes.NewReader(payload)
+		}
+		req, err := http.NewRequest(method, s.baseURL+path, r)
+		if err != nil {
+			t.Fatalf("seed req: %v", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+s.token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		if payload != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		resp, err := s.httpc.Do(req)
+		if err != nil {
+			last = err.Error()
+			time.Sleep(time.Duration(attempt) * 2 * time.Second)
+			continue
+		}
+		out, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode < 300 {
+			return out, resp.StatusCode
+		}
+		// PRIMARY rate limit exhausted (the 5000/hr core budget) resets in up to
+		// an hour → retrying is futile. Distinguish it from the SECONDARY/abuse
+		// limit (transient → retried below) by the header: Remaining==0 means the
+		// core budget is gone. Fast-fail with a clear message rather than burning
+		// the backoff ladder then dying.
+		if resp.StatusCode == 403 && resp.Header.Get("X-RateLimit-Remaining") == "0" {
+			msg := fmt.Sprintf("%s %s → 403 PRIMARY rate limit exhausted (X-RateLimit-Remaining=0, Reset=%s) — not retrying",
+				method, path, resp.Header.Get("X-RateLimit-Reset"))
+			if fatal {
+				t.Fatalf("seed %s", msg)
+			}
+			return out, resp.StatusCode
+		}
+		// 403 with a rate-limit signal (and Remaining!=0) → SECONDARY/abuse limit,
+		// transient → retry. Other 403/4xx → not retryable.
+		retryable := resp.StatusCode >= 500 ||
+			(resp.StatusCode == 403 && strings.Contains(strings.ToLower(string(out)), "rate limit"))
+		if retryable {
+			last = fmt.Sprintf("%d: %s", resp.StatusCode, string(out))
+			time.Sleep(time.Duration(attempt) * 3 * time.Second)
+			continue
+		}
+		if fatal {
+			t.Fatalf("seed %s %s → %d: %s", method, path, resp.StatusCode, string(out))
+		}
+		return out, resp.StatusCode
+	}
+	if fatal {
+		t.Fatalf("seed %s %s failed after retries: %s", method, path, last)
+	}
+	return nil, 0
+}
+
+// commitFile commits a file onto an existing branch via the Contents API
+// (content base64-encoded), so an MR/PR from that branch has a real diff.
+func (s *ghSeeder) commitFile(t *testing.T, branch, path, content, msg string) {
+	t.Helper()
+	s.do(t, true, "PUT", fmt.Sprintf("/repos/%s/contents/%s", s.repo, path),
+		map[string]any{
+			"message": msg,
+			"branch":  branch,
+			"content": base64.StdEncoding.EncodeToString([]byte(content)),
+		})
+}
+
+// closePRBestEffort closes a PR (PATCH state=closed) — best-effort teardown.
+func (s *ghSeeder) closePRBestEffort(t *testing.T, number int) {
+	t.Helper()
+	s.do(t, false, "PATCH", fmt.Sprintf("/repos/%s/pulls/%d", s.repo, number),
+		map[string]any{"state": "closed"})
+}
+
+// listE2EBranches returns every branch under the tenant-api/ prefix (matching-refs
+// API), best-effort. The janitor uses it to sweep PHANTOM branches — ones left
+// when a run died after CreateBranch but before CreatePR, so the PR-based sweep
+// (ListOpenPRs) never sees them and they'd leak forever.
+//
+// per_page=100 (the GitHub list-endpoint max) gives ample headroom — realistic
+// open-branch counts are tiny. A full page loop is unnecessary unless the
+// sandbox ever holds >100 stale branches (the janitor runs every PR/merge, so
+// it catches up across runs regardless).
+func (s *ghSeeder) listE2EBranches(t *testing.T) []string {
+	out, code := s.do(t, false, "GET",
+		fmt.Sprintf("/repos/%s/git/matching-refs/heads/%s?per_page=100", s.repo, branchPrefix), nil)
+	if code != 200 {
+		return nil // best-effort (e.g. no matching refs / transient)
+	}
+	var refs []struct {
+		Ref string `json:"ref"`
+	}
+	if err := json.Unmarshal(out, &refs); err != nil {
+		t.Logf("janitor: parse matching-refs: %v", err)
+		return nil
+	}
+	branches := make([]string, 0, len(refs))
+	for _, r := range refs {
+		branches = append(branches, strings.TrimPrefix(r.Ref, "refs/heads/"))
+	}
+	return branches
+}
+
+// seedPR creates one tenant-api-prefixed OPEN PR with a real diff: CreateBranch
+// off the base (gh.Client) → commit a file (Contents API) → CreatePR (gh.Client).
+// Registers best-effort teardown (close PR + delete branch) — critical because
+// the dummy repo persists across runs. Returns the branch name.
+func seedPR(t *testing.T, cl *gh.Client, s *ghSeeder, tenant string) string {
+	t.Helper()
+	branch := uniqueBranch(tenant)
+	if err := cl.CreateBranch(branch); err != nil {
+		t.Fatalf("CreateBranch %s: %v", branch, err)
+	}
+	s.commitFile(t, branch, "e2e/"+tenant+".txt", "e2e "+runID(), "e2e seed "+tenant)
+	pr, err := cl.CreatePR("[tenant-api][e2e] "+tenant, "seed", branch, []string{"tenant-api", "e2e"})
+	if err != nil {
+		// branch was created but PR failed — still clean up the branch.
+		_ = cl.DeleteBranch(branch)
+		t.Fatalf("CreatePR %s: %v", branch, err)
+	}
+	t.Cleanup(func() {
+		s.closePRBestEffort(t, pr.Number)
+		_ = cl.DeleteBranch(branch)
+	})
+	return branch
+}


### PR DESCRIPTION
## Summary
Track 1 of #616 real-forge E2E (Track 2 GitLab CE = #628, merged). Runs the `forge_e2e` scenarios against a dedicated GitHub sandbox (`vencil/tenant-api-e2e-sandbox`) via real api.github.com. **This PR's own `pull_request` run verifies it live** (same-repo PR → secrets present → E2E runs; fork PRs get no secrets → skip).

### What's here
- `ghSeeder` — raw GitHub API (Bearer + 5xx/secondary-rate retry): Contents-API file commit (gives the PR a diff) + PR close (teardown — the sandbox repo persists). `seedPR` = CreateBranch + commit + CreatePR with `t.Cleanup` (close PR + delete branch).
- `FullLoop` (CreateBranch/DeleteBranch lifecycle + branch→commit→PR→ListOpenPRs) + `Janitor` (orphan sweep, gated on `E2E_GITHUB_JANITOR=1`).
- `forge-e2e-github.yaml`: `pull_request` (same-repo) + `push:main` + `workflow_dispatch`, paths-filtered; **never `pull_request_target`**; pre/post orphan-janitor (post = `always()`); concurrency-serialized so the janitor can't nuke a concurrent run.
- The GitHub 403 scenario (added in #628, skipped) now runs live (secrets provisioned).

### Security
`pull_request` ≠ `pull_request_target`: GitHub withholds secrets from fork PRs → `loadGitHubCfg` skips → fork contributors non-blocking; only same-repo PRs run the real E2E. Throwaway sandbox + mandatory teardown + janitor.

### Follow-ups (not in this PR)
- **Pagination** scenario (seed >100 PRs) — added once FullLoop verifies green on real GitHub (staged, like GitLab).
- `vibe-subagent-review` pass + `Self-Review-Pass-2` trailer.
- GOCOVERDIR; then close #615 + #616 together.

`Refs #616`

## Test plan
- [x] compiles + skips without env (`go test -tags forge_e2e`)
- [ ] this PR's **GitHub real-forge E2E** job: 403 + full-loop green against the sandbox (live verify)
- [ ] pagination scenario (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)