### PR TITLE
chore(ci): TRK-317 rebrand bench-record nightly to release-baseline source

### DIFF
--- a/.github/workflows/bench-record.yaml
+++ b/.github/workflows/bench-record.yaml
@@ -1,11 +1,22 @@
 name: Bench Record (nightly)
 
-# Phase 1 of pre-tag benchmark gate (issue #60).
+# Release-baseline source — produces the `bench-baseline.txt` artifact that
+# `release-attach-bench-baseline.yaml` attaches to each GitHub Release as
+# `bench-baseline-<tag>.txt`.
 #
-# Purpose: collect ~28 nightly data points / 4 weeks to characterize empirical
-# variance on GitHub Actions runners. This is informational only — there is NO
-# regression gate at this stage. Phase 2 will introduce a hard gate (3× of
-# median-of-5 baseline, main+release-please only) once stability is measured.
+# Origin: Phase 1 of the pre-tag benchmark gate (issue #60, CLOSED). The
+# original goal was "~28 nightly data points / 4 weeks to characterize
+# variance on GitHub Actions runners" so Phase 2 could pick a sensible
+# threshold. That goal is met: 33 schedule data points over 4.7 weeks
+# (2026-04-26 → 2026-05-28, 33/33 green). Phase 2 now lives in
+# `bench-gate-pr.yaml` (#435, Tier 1 PR-time) and
+# `bench-gate-release.yaml` (#458, Tier 2 release-time); this workflow no
+# longer drives the variance-characterization mission and is NOT a gate.
+#
+# Why keep it running: `release-attach-bench-baseline.yaml` needs a recent
+# 03:00-UTC artifact (the schedule deliberately picks a low-contention
+# window) so each release ships with a representative baseline. Retiring
+# this workflow → releases lose their `bench-baseline-<tag>.txt` asset.
 #
 # Scope:
 #   - Runs only on main (cron + workflow_dispatch from main).

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ go-bench-clean: ## Go micro-benchmark via bench_wrapper (stdout-clean, -json fil
 		-bench=. -benchmem -count=$${COUNT:-5} -run="^$$" -timeout=15m ./...
 
 .PHONY: benchmark-report
-benchmark-report: ## 1000-scale baseline (20 benches: 8 flat + 5 hierarchical + 4 mixed-mode + 1 churn + 2 pkg/config library) → .build/bench-baseline.txt（issue #60 Phase 1, informational; COUNT/BENCHTIME 可覆寫）
+benchmark-report: ## 1000-scale baseline (20 benches: 8 flat + 5 hierarchical + 4 mixed-mode + 1 churn + 2 pkg/config library) → .build/bench-baseline.txt（release-baseline source for release-attach-bench-baseline.yaml；起於 #60 Phase 1 informational pilot，Phase 2 gate 已轉 #435/#458；COUNT/BENCHTIME 可覆寫）
 	@mkdir -p .build
 	@echo "[benchmark-report] running 1000-scale baseline (count=$${COUNT:-6}, benchtime=$${BENCHTIME:-3s}; samples 2..N treated as steady-state by Phase 2 median-of-5)"
 	@cd components/threshold-exporter/app && \


### PR DESCRIPTION
## Summary

Closes #649.

Pure-comment rebrand of `bench-record.yaml`'s header and the matching `Makefile` `benchmark-report` target description. **No behaviour change** — workflow still runs daily 03:00 UTC, same artifact, same retention.

### Why
The workflow's stated mission was «#60 Phase 1: collect ~28 nightly data points / 4 weeks, Phase 2 will introduce a hard gate». That mission is done:

- 33 schedule data points / 4.7 weeks (2026-04-26 → 2026-05-28), 33/33 green — exceeds the original ~28/4-week target.
- Phase 2 gates shipped 2026-05-12: #435 `bench-gate-pr` (Tier 1 PR-time) + #458 `bench-gate-release` (Tier 2 release-time); `bench-gate-pr` is already gating real PRs.
- Issue #60 CLOSED.

New framing in the header: «release-baseline source for `release-attach-bench-baseline.yaml`», with Phase-1 origin and Phase-2 successor links retained as historical breadcrumb.

### Why keep the workflow
`release-attach-bench-baseline.yaml` consumes the nightly's `bench-baseline.txt` artifact at release time (#60 Phase 1 acceptance #6). Retiring → releases lose the `bench-baseline-<tag>.txt` asset.

## Scope
- `.github/workflows/bench-record.yaml` — header lines 1-14 rewritten.
- `Makefile` — `benchmark-report` target description (line 55).

## Out of scope (deliberate)
- `release-attach-bench-baseline.yaml` line 1 says «closes #60 Phase 1 acceptance #6» — historically accurate, left alone.
- No changes to cron / retention / Phase 2 gates / artifact naming.

## Test plan
- [x] Diff is 2 files, +17 / −6, comments only.
- [x] `pre-commit run --files` on the two files: all hooks Passed.
- [x] `git interpret-trailers --only-trailers` parses all 6 trailer lines as one clean block.
- [x] Pre-push hooks Passed (block-main / require-preflight / mkdocs strict).
- [ ] CI green.

## Trailer
`Refs: TRK-317 / #649 / #60 / #435 / #458` + `Self-Review-Pass-2: pure-comment rebrand, 2-file diff, pre-commit green, Phase 2 IDs verified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)