### PR TITLE
fix(ci): replace docs/rule-packs symlink with mkdocs build-time hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ CUsersvencs*
 try-local/seed/conf.d/.git/
 # A visitor's local .env (ports/tags) is theirs; only .env.example is tracked.
 try-local/.env
+
+# Transient mkdocs build copy of repo-root rule-packs/*.md (scripts/mkdocs/rule_packs_bridge.py)
+docs/rule-packs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,10 @@ All notable changes to the **Dynamic Alerting Integrations** project will be doc
 
 - **tenant-api forge client 正確性修正三則**（[#615](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/615)）：① **GitHub PR 分頁**——`ListOpenPRs` 原單頁抓取（`per_page=100` 無迴圈），open PR >100 筆時漏看 → dedup 判斷失準、對同一租戶重複開 PR；改為 `Link` header（`rel="next"`）驅動翻頁，對齊既有 GitLab 行為。② **create-time 403 graceful handling**——read-scoped token 過得了 `ValidateToken`（打 `/user`），卻在開 PR/MR 時才 403；新增 `platform.APIError` + `platform.ErrForbidden`，兩 forge client 的 403 譯為 **clean HTTP 403**（`code: FORBIDDEN`，不外洩上游 response body、不再回 500），讓 da-portal 能精準觸發權限錯誤 UI。③ **同租戶並發寫 TOCTOU**——`HasPendingPR` 檢查與 `RegisterPR` 之間有空窗，兩並發請求可同時開單；改以 tracker 的**同步原子** `ClaimTenant` / `ReleaseClaim` 去重（check-and-set，不依賴 async poll cadence，避免類比 #527 的 poll 空窗 race）。**設計決策**：dedup 維持單副本約束（in-memory tracker + claim 不跨 pod）——PR 寫回模式須 `replicaCount=1`，已於 `helm/tenant-api/values.yaml` 與 `internal/platform/tracker.go`（`ClaimTenant` doc）明文記錄。測試：httptest 驗 >100 分頁不漏 + create-time 403 clean error；並發 single-winner 測試驗只開一張 PR。
 
+### Changed
+
+- **mkdocs build：移除 `docs/rule-packs` symlink，改用 build-time hook**：root `rule-packs/*.md`（Rule Packs / Alert 速查兩頁）改由 mkdocs hook（`scripts/mkdocs/rule_packs_bridge.py`，`on_pre_build` 複製進 `docs/rule-packs/`、`on_post_build` 清除，gitignored）surfacing 進站，取代原 `docs/rule-packs -> ../rule-packs` 的 git symlink。根因：Windows `core.symlinks=false` 把 symlink 材料化成 13-byte 文字檔、`mkdocs build` 走不進去 → 本機 strict build 噴 ~32 條 `rule-packs/* not found` 假警示（CI/Linux 正常），逼迫 `MKDOCS_STRICT_BYPASS=1` 推送。改 hook 後 local／docs-ci／`mkdocs gh-deploy` 三路徑一致、跨平台不再 false-fail；`rule-packs/` 仍留在 repo root（da-tools 與產生器消費）。
+
 ---
 
 ## [v2.8.1] — secret-scan 四層防線 + Planning SSOT + DX 工具鏈收斂 (2026-05-16)

--- a/docs/internal/windows-mcp-playbook.md
+++ b/docs/internal/windows-mcp-playbook.md
@@ -546,7 +546,7 @@ done > _bulk_candidates.txt
 | `docs/README-root.md` | file symlink | `file-hygiene` exclude regex ✅ |
 | `docs/README-root.en.md` | file symlink | `file-hygiene` exclude regex ✅ |
 | `docs/CHANGELOG.md` | file symlink | `file-hygiene` exclude regex ✅（v2.7.1 補） |
-| `docs/rule-packs` | dir symlink | 目錄不走 `file-hygiene`，天然安全 |
+| `docs/rule-packs` | ~~dir symlink~~ 已移除 | 改由 mkdocs hook（`scripts/mkdocs/rule_packs_bridge.py`）build 時複製 root `rule-packs/*.md` 進站、gitignored；移除 symlink 是為了根治 Windows `core.symlinks=false` 把它材料化成文字檔導致的 mkdocs strict false-fail |
 
 ## FUSE Phantom Lock 防治
 

--- a/docs/rule-packs
+++ b/docs/rule-packs
@@ -1,1 +1,0 @@
-../rule-packs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,11 @@ theme:
     edit: material/pencil
     view: material/eye
 
+# Bridge repo-root rule-packs/*.md into the site without a git symlink
+# (replaces docs/rule-packs -> ../rule-packs; see the hook docstring).
+hooks:
+  - scripts/mkdocs/rule_packs_bridge.py
+
 plugins:
   - search:
       lang:

--- a/scripts/mkdocs/rule_packs_bridge.py
+++ b/scripts/mkdocs/rule_packs_bridge.py
@@ -1,0 +1,54 @@
+"""mkdocs hook — materialize repo-root ``rule-packs/*.md`` into ``docs/rule-packs/`` for
+the build, symlink-free and cross-platform.
+
+Replaces the former ``docs/rule-packs -> ../rule-packs`` git symlink. That symlink
+materialized as a 13-byte text file on Windows (``core.symlinks=false``), so
+``mkdocs build`` could not traverse it and emitted ~32 ``rule-packs/* not found``
+warnings locally that were green on Linux CI (where the symlink resolved) — forcing
+``MKDOCS_STRICT_BYPASS=1`` pushes. Copying the markdown in ``on_pre_build`` (before
+mkdocs' file discovery and the static-i18n plugin run) lets the files be processed
+natively — including i18n ``.en.md`` pairing — exactly as the symlink used to, on
+every platform, so the local strict build now matches CI.
+
+Why a pre-build copy rather than an ``on_files`` File injection: ``hooks:`` run *after*
+plugins for a given event, so files appended in ``on_files`` arrive too late for
+mkdocs-static-i18n and trip its "Unhandled file case" warning. Seeding them on disk
+before discovery avoids that entirely.
+
+``rule-packs/`` stays at the repo root: it is a real artifact dir consumed by da-tools
+and the generators (generate_platform_data / generate_rule_pack_readme / …). Only its
+markdown docs are surfaced as site pages (nav: ``rule-packs/README.md`` +
+``rule-packs/ALERT-REFERENCE.md``); the rule-pack YAMLs stay data, not pages. The
+transient ``docs/rule-packs/`` copy is gitignored and removed in ``on_post_build``.
+
+This hook runs for every mkdocs invocation (local wrapper, docs-ci, and the raw
+``mkdocs gh-deploy`` in mkdocs-deploy.yaml), so one mechanism covers all paths.
+"""
+
+import shutil
+from pathlib import Path
+
+# Markdown docs surfaced into the site. ALERT-REFERENCE.en.md is the i18n EN pair
+# of ALERT-REFERENCE.md (docs_structure: suffix); README.md is ZH-only today.
+_RULE_PACK_DOCS = ("README.md", "ALERT-REFERENCE.md", "ALERT-REFERENCE.en.md")
+
+
+def _dest_dir(config):
+    repo_root = Path(config["config_file_path"]).parent
+    return repo_root / "docs" / "rule-packs", repo_root / "rule-packs"
+
+
+def on_pre_build(config):
+    """Seed docs/rule-packs/ from the repo-root rule-packs/ before file discovery."""
+    dest, src = _dest_dir(config)
+    dest.mkdir(parents=True, exist_ok=True)
+    for name in _RULE_PACK_DOCS:
+        s = src / name
+        if s.is_file():
+            shutil.copy2(s, dest / name)
+
+
+def on_post_build(config):
+    """Remove the transient copy so the working tree stays clean."""
+    dest, _ = _dest_dir(config)
+    shutil.rmtree(dest, ignore_errors=True)

--- a/scripts/tools/dx/generate_doc_map.py
+++ b/scripts/tools/dx/generate_doc_map.py
@@ -250,8 +250,9 @@ def gather_docs(lang: str = "zh", include_adr: bool = False) -> list:
     # We use os.walk with manual pruning (instead of Path.rglob) for two
     # reasons:
     #   1. Prune SKIP_DIRS early so we never descend into them — critical
-    #      for avoiding broken/phantom symlinks like `docs/rule-packs`
-    #      which raise OSError: [Errno 5] on FUSE-mounted Cowork VMs.
+    #      for avoiding broken/phantom symlinks (and historically
+    #      `docs/rule-packs`, now a gitignored mkdocs build-time copy rather
+    #      than a symlink) which raise OSError: [Errno 5] on FUSE Cowork VMs.
     #   2. Enforce a deterministic, case-insensitive sort that matches on
     #      both Linux (CI) and Windows (local dev). Python's `Path.__lt__`
     #      uses `_str_normcase` which differs by OS (lowercased on Windows,

--- a/scripts/tools/lint/check_doc_links.py
+++ b/scripts/tools/lint/check_doc_links.py
@@ -359,10 +359,14 @@ class DocLinkChecker:
         except ValueError:
             pass
 
-        # FUSE fallback: docs/rule-packs 是指向 ../rule-packs 的 symlink，
-        # 但 WSL/Cowork FUSE 會把它材料化成絕對 Windows 路徑導致 broken link。
-        # 在 resolve 之前用 lexical 路徑判斷：只要命中 docs/rule-packs/... 就直接
-        # 轉到 rule-packs/...，避開 broken symlink 查找。
+        # rule-packs/ lives at the repo ROOT (real artifact dir); the docs site
+        # surfaces its *.md via a mkdocs build-time hook (scripts/mkdocs/
+        # rule_packs_bridge.py) — there is no docs/rule-packs symlink anymore.
+        # In-content links use site-root form (e.g. `../rule-packs/README.md`)
+        # that resolves lexically to docs/rule-packs/..., which does not exist on
+        # disk at lint time. Rewrite that prefix to the real root rule-packs/...
+        # so filesystem link validation still passes. (Also covers the legacy
+        # symlink-as-text / FUSE-materialized cases for older checkouts.)
         if (lexical_rel.startswith("docs/rule-packs/")
                 or lexical_rel == "docs/rule-packs"):
             alt_rel = lexical_rel.replace("docs/rule-packs", "rule-packs", 1)


### PR DESCRIPTION
## Problem

`docs/rule-packs` is a git symlink (`-> ../rule-packs`). On Windows with `core.symlinks=false` (the default), git checks it out as a **13-byte text file**, so `mkdocs build` can't traverse it and emits ~32 `rule-packs/* not found` warnings. Those are green on Linux CI (where the symlink resolves), but locally they make:

- `make lint-docs-mkdocs` → `STATUS=FAIL ACTIONABLE_WARNINGS=32`, and
- the **docs-changed pre-push guard** block every push,

forcing contributors to `MKDOCS_STRICT_BYPASS=1 git push` on any doc change. (Surfaced while pushing #661.)

## Fix

Remove the symlink; surface the rule-packs markdown via a **native mkdocs hook** (`scripts/mkdocs/rule_packs_bridge.py`):

- `on_pre_build` copies the repo-root `rule-packs/*.md` into `docs/rule-packs/` **before** mkdocs' file discovery and the `static-i18n` plugin run — so `.en.md` pairing works natively (an `on_files` File injection does **not** work: `hooks:` run after plugins, so i18n rejects late-added files with "Unhandled file case").
- `on_post_build` removes the transient copy; `docs/rule-packs/` is gitignored.
- The hook is declared in `mkdocs.yml`, so it covers **all** build paths: the local strict wrapper, `docs-ci`, and the raw `mkdocs gh-deploy` in `mkdocs-deploy.yaml` (which does not use the wrapper).

`rule-packs/` stays at the repo root — it's a real artifact dir consumed by da-tools and the generators; only its 2 nav docs are surfaced.

## Verification (Windows)

- `mkdocs_strict_check.sh` → **`STATUS=PASS`** (was `FAIL ACTIONABLE=32`); pre-push mkdocs guard now passes **without** `MKDOCS_STRICT_BYPASS`.
- `check_doc_links.py` → all valid; `generate_doc_map.py --check` → up to date; transient copy cleaned up; `site/rule-packs/` renders.

## Notes

- `check_doc_links.py`'s lexical `docs/rule-packs/ → rule-packs/` rewrite is **kept** (still needed — links land lexically in `docs/rule-packs/` which no longer exists on disk); only its comment is updated. `windows-mcp-playbook.md` + `generate_doc_map.py` comments updated to drop the stale "symlink" description.
- Independent of #661 (try-local doc fixes); discovered during that work.
- Once merged, doc PRs no longer need the mkdocs bypass on Windows.
