### PR TITLE
feat(ci): da-tools subcommand lint (L4) + lint-vs-dogfood SOP (defense suite capstone)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -284,6 +284,13 @@ repos:
         files: \.(md|yaml|jsx|html)$
         additional_dependencies: ['pyyaml']
 
+      - id: doc-datools-cmds
+        name: Doc da-tools wrapper subcommands valid
+        entry: python3 -X utf8 scripts/tools/lint/check_doc_datools_cmds.py --ci
+        language: python
+        pass_filenames: false
+        files: ^(docs/.*\.md|scripts/tools/ops/.*_dispatch\.py)$
+
       - id: design-token-usage
         name: Design token compliance (JSX)
         entry: python3 -X utf8 scripts/tools/lint/check_design_token_usage.py --ci

--- a/docs/internal/quarterly-audit-sop.md
+++ b/docs/internal/quarterly-audit-sop.md
@@ -56,6 +56,38 @@ report 寫到 `docs/internal/audit-reports/rules-drift-YYYY-MM.md`（atomic writ
 
 每季 audit 逐一檢查每個本地 `vibe-*` skill **過去一季是否在其領域內被實際觸發**（subagent-review: multi-file PR review；release: 發版；brainstorm: 設計討論；workflow/dev-rules/playbook-nav: 日常）。**連續 2 季 0 觸發 = dead weight，audit 時強制刪除**（對齊 `feedback_speculative_drift_prefer_remove`）。觸發案例寫進 CHANGELOG / PR body 當佐證。**理由**：epic #570 交付 3 個新 skill 但收尾時 subagent-review/release **0 觸發**、brainstorm 僅 1（Gap A）；無問責機制會養出沒人用的 skill。
 
+## 文件 staleness 防線：lint 層 vs dogfood 層（#141）
+
+客戶導入/安裝文件會悄悄 stale（命令語法、版號、路徑、workload 類型隨 code 漂移）。防線**分兩層**，邊界原則同 [`hook-vs-skill-coverage.md`](hook-vs-skill-coverage.md)：**deterministic 的交給 lint、判斷題留給人工 dogfood**。
+
+### 機械層（lint，CI/pre-commit 自動擋）
+
+| Lint | 抓的 staleness 類 | 燒過 |
+|---|---|---|
+| `validate_docs_versions.py`（`check_release_tag_currency`）| 版號字面：`tools/vX` / `--set image.tag=vX` / `da-* --version` 輸出 vs 當前 release | TB-F1 |
+| `check_doc_k8s_refs.py` | `k8s/**` manifest 路徑存在 + doc 宣稱的 workload kind vs 實際 `k8s/`（`kubectl ... statefulset/deployment <元件>`）| TB-F4 |
+| `check_doc_datools_cmds.py` | 文件裡 `da-tools guard/parser/batch-pr` 子命令 vs dispatcher 實際集 | F3（`guard /conf.d`）|
+
+> **刻意沒做的廣義版**（記取教訓，別重造）：「掃所有 repo 路徑是否存在」「驗所有 `da-tools <任意命令>`」實跑都是 **~88% false-positive**（文件充斥 example/aspirational：`my-db.yaml` / `describe-tenant` / 「PR-3 預定加」的工具）—— 廣義 lint = 你燒過的 reactive-whack-a-mole 反模式。三支都**收斂到真 artifact 才有的窄域**（k8s/、binary-wrapper 子命令）。
+
+### 人工層（dogfood，lint 抓不到的判斷題）
+
+機械抓不到、**只能靠定期 cold-walk dogfood** 的類別：
+
+- **「宣稱 future 但已出貨」**（TB-F2：文件說 cosign「後續迭代」但已隨 release 發佈）— 語義，無法 lint。
+- **UX 過度警告 / 措辭**（Track A F1：WSL2 警告比實際保守）— 判斷題。
+- **flag-level 漂移**（`--config-dir` 改名）— Go binary flag 無法從 python 內省。
+
+### Dogfood 方法（per-run log 不 commit，方法論住這裡）
+
+每次（onboarding surface 變動 / 發版前）以**新使用者冷視角只照文件**走一遍，三步：
+
+1. **Cold-walk**：清環境、只照文件跑（da-tools 安裝 + config 驗證 + try-local / 安裝路徑），卡住即記 friction。
+2. **對抗式全 repo 同類掃描**：撞到一個 bug（如某檔 stale 版號）後，**grep 整個 `docs/` 找同類**——初版只修撞到的、漏網的靠這步補（#141 Track B 這步多揪出 3 檔）。逐筆分 real-bug / example / aspirational（別誤殺 example）。
+3. **Independence baseline**：算「≥80% 步驟只照文件可自助完成」；fail 的步驟 = 真 doc bug，同 cycle 修。
+
+產出歸屬：**doc 修正 → PR**、**residue/TODO → 對應 issue**、**方法 → 本節**。per-run runbook **不 commit**（archive/ 是凍結歷史、per-run log 長期價值低；#141 移除了兩份）。
+
 ## 裁決原則（重要）
 
 - **只產 report，不自動修改**。所有合併 / 刪除 / 下放都人工決定 — speculative 自動清理會誤刪仍有效的規則。
@@ -73,3 +105,4 @@ report 寫到 `docs/internal/audit-reports/rules-drift-YYYY-MM.md`（atomic writ
 - 互補工具：`anthropic-skills:consolidate-memory`（只掃 `~/.claude` memory；本稽核補 repo 內規則語料）
 - 規範：[`dev-rules.md`](dev-rules.md)
 - epic [#570](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/570) / TRK-307
+- 文件 staleness 防線（lint L1–L4 + dogfood）：[#141](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/141)；lints 在 `scripts/tools/lint/`（`validate_docs_versions.py` / `check_doc_k8s_refs.py` / `check_doc_datools_cmds.py`）

--- a/docs/internal/tool-map.md
+++ b/docs/internal/tool-map.md
@@ -141,6 +141,7 @@ lang: zh
 | `check_dev_rules_enforcement.py` | detect doc-drift in dev-rules.md. |
 | `check_devrules_size.py` | Dev-rules 尺寸上限檢查。 |
 | `check_dist_source_consistency.py` | Catch portal dist commits without matching source change (testing-playbook §LL §2, TRK-239). |
+| `check_doc_datools_cmds.py` | documented `da-tools` binary-wrapper subcommands |
 | `check_doc_freshness.py` | 文件新鮮度檢查工具。 |
 | `check_doc_links.py` | 文件間交叉引用一致性檢查 |
 | `check_doc_reading_time.py` | 文件閱讀時間檢查工具。 |

--- a/scripts/tools/lint/check_doc_datools_cmds.py
+++ b/scripts/tools/lint/check_doc_datools_cmds.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""check_doc_datools_cmds.py — documented `da-tools` binary-wrapper subcommands
+must be valid.
+
+Static guard for the #141 Track A / F3 class: the try-local README showed
+``da-tools ... guard /conf.d``, but the shipped CLI takes ``guard
+defaults-impact --config-dir ...`` — a stale subcommand that only surfaced
+when a human ran it. No check covered command validity, so it shipped.
+
+**Scope decision.** A broader check (validate every ``da-tools <command>``
+against the full CLI command tree) was prototyped and rejected: scenario docs
+use illustrative / aspirational pseudo-commands even inside code blocks
+(``da-tools describe-tenant``, ``list-tenants``, ``upgrade-check`` per issue
+#405), giving ~88 false positives — the same noise that sank a broad
+path-existence lint. So this is scoped to the three **binary-wrapper**
+commands (``guard`` / ``parser`` / ``batch-pr``), whose subcommand sets are a
+small, stable, real contract — and which is exactly where F3 lived.
+
+Only fenced code blocks are scanned (prose mentions and inline-code
+suggestions are not runnable). Lines with a ``<placeholder>`` or an inline
+``datools-cmd-ignore`` are skipped; ``guard --help`` / ``-h`` is allowed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, NamedTuple, Set
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+OPS_DIR = REPO_ROOT / "scripts" / "tools" / "ops"
+DOCS_DIR = REPO_ROOT / "docs"
+
+# Binary-wrapper command -> valid subcommands. Source of truth: the
+# `Subcommands:` block of each dispatcher in scripts/tools/ops/*_dispatch.py
+# (mirrors the Go binary). Kept as a literal for robustness; the self-test
+# `test_subcommand_map_matches_dispatchers` greps the dispatchers so this drifts
+# loudly if a subcommand is added/removed.
+WRAPPER_SUBCOMMANDS: Dict[str, Set[str]] = {
+    "guard": {"defaults-impact"},
+    "parser": {"import", "allowlist"},
+    "batch-pr": {"apply", "refresh", "refresh-source"},
+}
+
+# `da-tools` (binary) or `da-tools:vX.Y.Z` (image), then the wrapper command +
+# whatever token follows (the candidate subcommand).
+_DATOOLS_RE = re.compile(
+    r"da-tools(?::v[0-9.]+)?\s+(guard|parser|batch-pr)(?:\s+([^\s\\]+))?")
+
+_PLACEHOLDER_CHARS = "<>${}"
+INLINE_IGNORE = "datools-cmd-ignore"
+
+
+class Issue(NamedTuple):
+    check: str
+    file: str
+    line: int
+    message: str
+
+    def to_dict(self) -> dict:
+        return self._asdict()
+
+
+def _doc_files(docs_dir: Path) -> List[Path]:
+    return [f for f in sorted(docs_dir.rglob("*.md"))
+            if "/internal/archive/" not in f.as_posix()]
+
+
+def check_datools_subcommands(doc_files: List[Path],
+                              sub_map: Dict[str, Set[str]],
+                              repo_root: Path) -> List[Issue]:
+    issues: List[Issue] = []
+    for f in doc_files:
+        try:
+            lines = f.read_text(encoding="utf-8", errors="ignore").splitlines()
+        except OSError:
+            continue
+        rel = str(f.relative_to(repo_root)).replace("\\", "/")
+        in_code = False
+        for i, line in enumerate(lines, 1):
+            if line.lstrip().startswith("```"):
+                in_code = not in_code
+                continue
+            # Only fenced code blocks hold real invocations; prose / inline-code
+            # mentions are illustrative and must not be flagged.
+            if not in_code:
+                continue
+            if INLINE_IGNORE in line or any(c in line for c in _PLACEHOLDER_CHARS):
+                continue
+            for m in _DATOOLS_RE.finditer(line):
+                wrapper, nxt = m.group(1), m.group(2)
+                valid = sub_map.get(wrapper, set())
+                # A bare `--flag` (e.g. --help) is a valid invocation.
+                if nxt is None or nxt.startswith("-"):
+                    continue
+                if nxt not in valid:
+                    issues.append(Issue(
+                        "datools-bad-subcommand", rel, i,
+                        f"da-tools {wrapper} '{nxt}' is not a subcommand "
+                        f"(valid: {', '.join(sorted(valid))})"))
+    return issues
+
+
+def run(repo_root: Path = REPO_ROOT) -> List[Issue]:
+    return check_datools_subcommands(
+        _doc_files(repo_root / "docs"), WRAPPER_SUBCOMMANDS, repo_root)
+
+
+def main() -> int:
+    for _stream in (sys.stdout, sys.stderr):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except Exception:
+            pass
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--ci", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+    issues = run()
+    if args.json:
+        print(json.dumps({"issues": [i.to_dict() for i in issues],
+                          "count": len(issues)}, ensure_ascii=False, indent=2))
+    elif issues:
+        for it in issues:
+            print(f"  ❌ [{it.check}] {it.file}:{it.line} — {it.message}",
+                  file=sys.stderr)
+        print(f"\n❌ {len(issues)} da-tools subcommand issue(s)", file=sys.stderr)
+    else:
+        print("✅ documented da-tools wrapper subcommands are valid")
+    return 1 if (issues and args.ci) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/lint/test_check_doc_datools_cmds.py
+++ b/tests/lint/test_check_doc_datools_cmds.py
@@ -1,0 +1,83 @@
+"""Tests for scripts/tools/lint/check_doc_datools_cmds.py.
+
+Pins the L4 doc-staleness defense added after #141 Track A / F3: the try-local
+README showed `da-tools ... guard /conf.d`, but the shipped CLI takes
+`guard defaults-impact`. Scoped to the binary-wrapper subcommands (guard /
+parser / batch-pr) — a broad command-tree check was rejected as too FP-heavy
+(scenario docs use illustrative pseudo-commands even in code blocks).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = REPO_ROOT / "scripts" / "tools" / "lint" / "check_doc_datools_cmds.py"
+_spec = importlib.util.spec_from_file_location("check_doc_datools_cmds", _SCRIPT)
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["check_doc_datools_cmds"] = mod
+_spec.loader.exec_module(mod)
+
+
+def _doc(tmp_path: Path, body: str) -> Path:
+    d = tmp_path / "docs"
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "g.md"
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
+def _scan(tmp_path, body):
+    return mod.check_datools_subcommands(
+        [_doc(tmp_path, body)], mod.WRAPPER_SUBCOMMANDS, tmp_path)
+
+
+_FENCE = "```bash\n{}\n```\n"
+
+
+class TestDatoolsSubcommands:
+    def test_flags_f3_guard_conf_d(self, tmp_path):
+        issues = _scan(tmp_path, _FENCE.format(
+            "docker run ghcr.io/vencil/da-tools:v2.8.0 guard /conf.d"))
+        assert len(issues) == 1
+        assert issues[0].check == "datools-bad-subcommand"
+        assert "defaults-impact" in issues[0].message
+
+    def test_passes_valid_subcommand(self, tmp_path):
+        assert _scan(tmp_path, _FENCE.format(
+            "da-tools guard defaults-impact --config-dir /conf.d")) == []
+
+    def test_passes_help_flag(self, tmp_path):
+        assert _scan(tmp_path, _FENCE.format("da-tools guard --help")) == []
+
+    def test_flags_bogus_parser_subcommand(self, tmp_path):
+        assert len(_scan(tmp_path, _FENCE.format("da-tools parser frobnicate"))) == 1
+
+    def test_passes_batchpr_refresh_source(self, tmp_path):
+        assert _scan(tmp_path, _FENCE.format("da-tools batch-pr refresh-source")) == []
+
+    def test_ignores_prose_outside_code_block(self, tmp_path):
+        # bare prose mention (no fence) must not be scanned
+        assert _scan(tmp_path, "Use `da-tools guard /conf.d` in your pipeline.\n") == []
+
+    def test_skips_placeholder_line(self, tmp_path):
+        assert _scan(tmp_path, _FENCE.format("da-tools guard <subcommand>")) == []
+
+    def test_respects_inline_ignore(self, tmp_path):
+        assert _scan(tmp_path, _FENCE.format(
+            "da-tools guard legacy  # datools-cmd-ignore: old example")) == []
+
+
+class TestSubcommandMapDrift:
+    """WRAPPER_SUBCOMMANDS must stay in sync with the dispatchers (the SOT)."""
+
+    def test_subcommand_map_matches_dispatchers(self):
+        files = {"guard": "guard_dispatch.py", "parser": "parser_dispatch.py",
+                 "batch-pr": "batchpr_dispatch.py"}
+        for wrapper, subs in mod.WRAPPER_SUBCOMMANDS.items():
+            text = (mod.OPS_DIR / files[wrapper]).read_text(encoding="utf-8")
+            for sub in subs:
+                assert sub in text, (
+                    f"{sub} not found in {files[wrapper]} — WRAPPER_SUBCOMMANDS "
+                    f"drifted from the dispatcher SOT")


### PR DESCRIPTION
## What (L4 + capstone of the doc-staleness defense suite)

Final piece of the #141 follow-up defense suite (L1=#666 merged, L2+L3=#667).

**L4 — `scripts/tools/lint/check_doc_datools_cmds.py`**: guards the #141 Track A / **F3** class (try-local README showed `da-tools ... guard /conf.d`, but the CLI takes `guard defaults-impact`). Validates documented `da-tools guard/parser/batch-pr` subcommands against each dispatcher's declared set.

> **Scope decision (same lesson as L2):** a broad `da-tools <any-command>` check was prototyped and **rejected** — scenario docs use illustrative/aspirational pseudo-commands even in code blocks (`describe-tenant`, `list-tenants`, `upgrade-check` per #405) → **88 false positives**. Scoped to the 3 binary-wrappers (small stable real contract, and where F3 lived). Fenced-code-block-only; `<placeholder>` / `datools-cmd-ignore` skipped. 9 self-tests incl. a drift-guard that the subcommand map stays in sync with the dispatchers.

**SOP capstone — `docs/internal/quarterly-audit-sop.md`**: formalizes the **lint-vs-dogfood boundary** —
- the L1–L4 lint layer + *why* each is narrowly scoped (broad L2/L4 = ~88% FP, the whack-a-mole anti-pattern);
- the **dogfood layer** for classes lints can't catch: **TB-F2** (shipped-but-claimed-future, e.g. cosign), **F1** (UX over-warning), Go-binary flag drift;
- the **dogfood method** (cold-walk → adversarial repo-wide sweep → independence baseline) — its **durable home** now that per-run runbooks aren't committed.

## Suite recap (#141 follow-up)

| | catches | class |
|---|---|---|
| L1 #666 ✅ | version literals | TB-F1 |
| L2+L3 #667 | k8s path + workload kind | TB-F4 |
| **L4 (this)** | da-tools subcommands | F3 |
| SOP (this) | the boundary + dogfood method | TB-F2 / F1 → human layer |

Wired into pre-commit; tool-map regenerated. Refs #141