### PR TITLE
docs: fix Phase 2 runtime install-doc bugs (image override + rule-pack names)

### DIFF
--- a/docs/getting-started/for-platform-engineers.en.md
+++ b/docs/getting-started/for-platform-engineers.en.md
@@ -55,8 +55,13 @@ defaults:
 
 ```bash
 # threshold-exporter ships as a Helm chart at helm/threshold-exporter/
+# ⚠️ the chart defaults to a LOCAL-DEV image (threshold-exporter:dev +
+#    pullPolicy: Never, for `kind load docker-image`); a real deploy must point
+#    at the published image, otherwise the pod ErrImageNeverPulls:
 helm install threshold-exporter ./helm/threshold-exporter/ \
-  -n monitoring --create-namespace
+  -n monitoring --create-namespace \
+  --set image.repository=ghcr.io/vencil/threshold-exporter \
+  --set image.tag=v2.8.0 --set image.pullPolicy=IfNotPresent
 # Verify replicas are running
 kubectl get pod -n monitoring | grep threshold-exporter
 ```
@@ -66,9 +71,13 @@ kubectl get pod -n monitoring | grep threshold-exporter
 ### Mount Rule Packs
 
 ```bash
-# Prometheus Deployment uses Projected Volume
+# Deploy the monitoring stack (Prometheus + rule-pack ConfigMaps). The *.json
+# files in k8s/03-monitoring/ are Grafana dashboards, NOT k8s manifests, so apply
+# only *.yaml (a plain `kubectl apply -f k8s/03-monitoring/` errors on the 3 .json):
+for f in k8s/03-monitoring/*.yaml; do kubectl apply -f "$f"; done
+# Prometheus Deployment mounts the rule-pack ConfigMaps via a Projected Volume
 # Confirm volume section in k8s/03-monitoring/deployment-prometheus.yaml
-kubectl get configmap -n monitoring | grep rule-pack
+kubectl get configmap -n monitoring | grep prometheus-rules
 ```
 
 ## Common Operations
@@ -101,8 +110,8 @@ python3 scripts/tools/ops/validate_config.py --config-dir conf.d/
 List mounted Rule Packs:
 
 ```bash
-kubectl get configmap -n monitoring | grep rule-pack
-# Possible output: rule-pack-mariadb, rule-pack-postgresql, rule-pack-redis...
+kubectl get configmap -n monitoring | grep prometheus-rules
+# Possible output: prometheus-rules-mariadb, prometheus-rules-postgresql, prometheus-rules-redis...
 ```
 
 Remove unwanted Rule Pack (edit Prometheus Deployment):

--- a/docs/getting-started/for-platform-engineers.md
+++ b/docs/getting-started/for-platform-engineers.md
@@ -55,8 +55,13 @@ defaults:
 
 ```bash
 # threshold-exporter 透過 Helm chart 部署（Chart 在 helm/threshold-exporter/）
+# ⚠️ chart 預設 image 為本地開發用（threshold-exporter:dev + pullPolicy: Never，
+#    搭配 `kind load docker-image`）；正式部署須改指向 published image，否則
+#    pod 會 ErrImageNeverPull：
 helm install threshold-exporter ./helm/threshold-exporter/ \
-  -n monitoring --create-namespace
+  -n monitoring --create-namespace \
+  --set image.repository=ghcr.io/vencil/threshold-exporter \
+  --set image.tag=v2.8.0 --set image.pullPolicy=IfNotPresent
 # 驗證副本運行
 kubectl get pod -n monitoring | grep threshold-exporter
 ```
@@ -66,9 +71,13 @@ kubectl get pod -n monitoring | grep threshold-exporter
 ### 掛載 Rule Pack
 
 ```bash
-# Prometheus Deployment 使用 Projected Volume
+# 部署監控堆疊（Prometheus + rule-pack ConfigMap）。k8s/03-monitoring/ 內的
+# *.json 是 Grafana dashboard、非 k8s manifest，故只 apply *.yaml（直接
+# `kubectl apply -f k8s/03-monitoring/` 會在那 3 個 .json 上 validation error）：
+for f in k8s/03-monitoring/*.yaml; do kubectl apply -f "$f"; done
+# Prometheus Deployment 透過 Projected Volume 掛載 rule-pack ConfigMap
 # 確認 k8s/03-monitoring/deployment-prometheus.yaml 的 volume 部分
-kubectl get configmap -n monitoring | grep rule-pack
+kubectl get configmap -n monitoring | grep prometheus-rules
 ```
 
 > 💡 **互動工具** — 不確定需要哪些 Rule Pack？用 [Rule Pack Selector](https://vencil.github.io/Dynamic-Alerting-Integrations/assets/jsx-loader.html?component=../interactive/tools/rule-pack-selector.jsx) 互動選取。想估算叢集資源需求？試試 [Capacity Planner](https://vencil.github.io/Dynamic-Alerting-Integrations/assets/jsx-loader.html?component=../interactive/tools/capacity-planner.jsx)。不確定該選哪種架構？[Architecture Quiz](https://vencil.github.io/Dynamic-Alerting-Integrations/assets/jsx-loader.html?component=../interactive/tools/architecture-quiz.jsx) 幫你做決定。想在瀏覽器中體驗完整的工作流？[Platform Demo](https://vencil.github.io/Dynamic-Alerting-Integrations/assets/jsx-loader.html?component=../interactive/tools/platform-demo.jsx) 展示 scaffold → validate → deploy。
@@ -103,8 +112,8 @@ python3 scripts/tools/ops/validate_config.py --config-dir conf.d/
 檢視已掛載的 Rule Pack：
 
 ```bash
-kubectl get configmap -n monitoring | grep rule-pack
-# 可能輸出：rule-pack-mariadb, rule-pack-postgresql, rule-pack-redis...
+kubectl get configmap -n monitoring | grep prometheus-rules
+# 可能輸出：prometheus-rules-mariadb, prometheus-rules-postgresql, prometheus-rules-redis...
 ```
 
 移除不需要的 Rule Pack（編輯 Prometheus Deployment）：


### PR DESCRIPTION
## What

#141 **Track B Phase 2 — live verification**. Ran the documented platform install on a real **kind cluster inside the dev container** (Linux, faithful). Three **runtime** bugs that static Phase 1 couldn't catch (it only checked the command was path-correct):

| | Bug | Fix |
|---|---|---|
| **TB-P2-F1** | bare `helm install ./helm/threshold-exporter/` (presented as the prod deploy) → pods **ErrImageNeverPull**: the chart defaults to a local-dev image (`threshold-exporter:dev` + `pullPolicy: Never`) | show the published-image `--set image.repository/tag/pullPolicy` override + note the dev default |
| **TB-P2-F2** | the §Mount Rule Packs step assumed the stack was deployed but never showed how; `kubectl apply -f k8s/03-monitoring/` **errors on 3 Grafana dashboard `.json`** there | documented a yaml-only deploy loop with the caveat |
| **TB-P2-F3** | `kubectl get configmap \| grep rule-pack` returns **nothing** — configmaps are named `prometheus-rules-*` | fixed grep + example output (both occurrences) |

## Live-verified on the cluster

corrected install → pod Ready · `user_threshold` metric from config · **in-place hot-reload** (configmap patch → metric updates, **no pod restart**) · Prometheus scrapes the exporter + loads the rule-packs (293 groups).

Doc-only, ZH+EN in sync. Refs #141 (Phase 2 core chain; full-stack follow-up tracked separately).