### PR TITLE
fix(helm): values-prod.yaml pinning published images for the 3 charts (#682)

### DIFF
--- a/docs/getting-started/for-platform-engineers.en.md
+++ b/docs/getting-started/for-platform-engineers.en.md
@@ -42,7 +42,7 @@ The platform supports two deployment paths. Not sure which to choose? See the [D
 
 > **Prerequisites**: a K8s cluster + `helm` + `kubectl` (examples use the `monitoring` namespace).
 >
-> ⚠️ **None of the 3 component charts default to a pullable published image** — threshold-exporter `:dev` (+ `pullPolicy: Never`, repo lacks the `ghcr.io/vencil/` prefix), tenant-api `:2.7.0`, da-portal `:2.8.0` (no `v`). A plain `helm install ./helm/<chart>/` **ImagePull-fails**; each install below carries a published-image override. The chart-default fix itself is tracked in [#682](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/682).
+> ⚠️ **None of the 3 component charts default to a pullable published image** — threshold-exporter `:dev` (+ `pullPolicy: Never`, repo lacks the `ghcr.io/vencil/` prefix), tenant-api `:2.7.0`, da-portal `:2.8.0` (no `v`). A plain `helm install ./helm/<chart>/` **ImagePull-fails**; a real deploy uses each chart's `values-prod.yaml` (pins the published image, with a test locking `tag == v<appVersion>`, [#682](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/682)).
 
 Minimal viable platform config:
 
@@ -59,11 +59,10 @@ defaults:
 
 ```bash
 # threshold-exporter ships as a Helm chart at helm/threshold-exporter/
-# (image-override rationale: see the ⚠️ at the top of this section)
+# A real deploy uses values-prod.yaml (pins the published image; see the ⚠️ above)
 helm install threshold-exporter ./helm/threshold-exporter/ \
   -n monitoring --create-namespace \
-  --set image.repository=ghcr.io/vencil/threshold-exporter \
-  --set image.tag=v2.8.0 --set image.pullPolicy=IfNotPresent
+  -f helm/threshold-exporter/values-prod.yaml
 # Verify replicas are running
 kubectl get pod -n monitoring | grep threshold-exporter
 ```
@@ -89,7 +88,7 @@ kubectl get configmap -n monitoring | grep prometheus-rules
 **tenant-api** (file-based config API, commit-on-write):
 
 ```bash
-helm install tenant-api ./helm/tenant-api/ -n monitoring --set image.tag=v2.8.0
+helm install tenant-api ./helm/tenant-api/ -n monitoring -f helm/tenant-api/values-prod.yaml
 ```
 
 Requires:
@@ -100,7 +99,7 @@ Requires:
 **da-portal** (Tenant Manager UI):
 
 ```bash
-helm install da-portal ./helm/da-portal/ -n monitoring --set image.tag=v2.8.0
+helm install da-portal ./helm/da-portal/ -n monitoring -f helm/da-portal/values-prod.yaml
 ```
 
 Requires:

--- a/docs/getting-started/for-platform-engineers.md
+++ b/docs/getting-started/for-platform-engineers.md
@@ -42,7 +42,7 @@ lang: zh
 
 > **前置**：一個 K8s 叢集 + `helm` + `kubectl`（下例 namespace 用 `monitoring`）。
 >
-> ⚠️ **3 個 component chart 的 image 預設都不是可拉取的 published image**——threshold-exporter `:dev`（+ `pullPolicy: Never`、repository 無 `ghcr.io/vencil/` 前綴）、tenant-api `:2.7.0`、da-portal `:2.8.0`（缺 `v`）。直接 `helm install ./helm/<chart>/` 會 **ImagePull 失敗**；下方每個 install 都帶 published-image override。chart 預設本身的修正追蹤於 [#682](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/682)。
+> ⚠️ **3 個 component chart 的 image 預設都不是可拉取的 published image**——threshold-exporter `:dev`（+ `pullPolicy: Never`、repository 無 `ghcr.io/vencil/` 前綴）、tenant-api `:2.7.0`、da-portal `:2.8.0`（缺 `v`）。直接 `helm install ./helm/<chart>/` 會 **ImagePull 失敗**；正式部署用各 chart 的 `values-prod.yaml`（已 pin published image，且測試鎖定 `tag == v<appVersion>`，[#682](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/682)）。
 
 最小可用平台配置：
 
@@ -59,11 +59,10 @@ defaults:
 
 ```bash
 # threshold-exporter 透過 Helm chart 部署（Chart 在 helm/threshold-exporter/）
-# image override 原因見本節開頭 ⚠️：
+# 正式部署用 values-prod.yaml（pin published image；見本節開頭 ⚠️）：
 helm install threshold-exporter ./helm/threshold-exporter/ \
   -n monitoring --create-namespace \
-  --set image.repository=ghcr.io/vencil/threshold-exporter \
-  --set image.tag=v2.8.0 --set image.pullPolicy=IfNotPresent
+  -f helm/threshold-exporter/values-prod.yaml
 # 驗證副本運行
 kubectl get pod -n monitoring | grep threshold-exporter
 ```
@@ -91,7 +90,7 @@ kubectl get configmap -n monitoring | grep prometheus-rules
 **tenant-api**（file-based 設定 API，commit-on-write）：
 
 ```bash
-helm install tenant-api ./helm/tenant-api/ -n monitoring --set image.tag=v2.8.0
+helm install tenant-api ./helm/tenant-api/ -n monitoring -f helm/tenant-api/values-prod.yaml
 ```
 
 需要：
@@ -102,7 +101,7 @@ helm install tenant-api ./helm/tenant-api/ -n monitoring --set image.tag=v2.8.0
 **da-portal**（Tenant Manager UI）：
 
 ```bash
-helm install da-portal ./helm/da-portal/ -n monitoring --set image.tag=v2.8.0
+helm install da-portal ./helm/da-portal/ -n monitoring -f helm/da-portal/values-prod.yaml
 ```
 
 需要：

--- a/helm/da-portal/values-prod.yaml
+++ b/helm/da-portal/values-prod.yaml
@@ -1,0 +1,15 @@
+# Production overrides for da-portal (#682).
+#
+# values.yaml ships image.tag "2.8.0" (no "v"); the published tag is
+# v-prefixed, so the default ImagePull-fails. Deploy with:
+#
+#   helm install da-portal ./helm/da-portal/ \
+#     -n monitoring -f helm/da-portal/values-prod.yaml
+#
+# image.tag pins the v-prefixed published tag (= "v" + Chart.appVersion).
+# tests/helm/test_values_prod_image_pin.py keeps tag == v<appVersion>.
+#
+# NOTE: da-portal's nginx hard-requires the oauth2-proxy sidecar (:80 -> 4180);
+# do NOT set oauth2Proxy.enabled=false. See for-platform-engineers.md.
+image:
+  tag: v2.8.0

--- a/helm/tenant-api/values-prod.yaml
+++ b/helm/tenant-api/values-prod.yaml
@@ -1,0 +1,17 @@
+# Production overrides for tenant-api (#682).
+#
+# values.yaml ships a stale/placeholder image.tag ("2.7.0", no "v") that
+# doesn't resolve to a published image. Deploy with:
+#
+#   helm install tenant-api ./helm/tenant-api/ \
+#     -n monitoring -f helm/tenant-api/values-prod.yaml
+#
+# image.tag pins the v-prefixed published tag (= "v" + Chart.appVersion).
+# (repository in values.yaml is already correct; only the tag needs pinning.)
+# tests/helm/test_values_prod_image_pin.py keeps tag == v<appVersion>.
+#
+# NOTE: oauth2-proxy (real OAuth secrets), gitRepoUrl (conf.d source), and the
+# _rbac.yaml ConfigMap are still required — see
+# docs/getting-started/for-platform-engineers.md §Deploy to Kubernetes.
+image:
+  tag: v2.7.0

--- a/helm/threshold-exporter/values-prod.yaml
+++ b/helm/threshold-exporter/values-prod.yaml
@@ -1,0 +1,16 @@
+# Production overrides for threshold-exporter (#682).
+#
+# values.yaml defaults to a LOCAL-DEV image (threshold-exporter:dev +
+# pullPolicy: Never, for `kind load docker-image`) — intentional for the
+# kind dev loop, but a real cluster deploy ImagePull-fails on it. Deploy with:
+#
+#   helm install threshold-exporter ./helm/threshold-exporter/ \
+#     -n monitoring --create-namespace -f helm/threshold-exporter/values-prod.yaml
+#
+# image.tag pins the v-prefixed published tag (= "v" + Chart.appVersion).
+# tests/helm/test_values_prod_image_pin.py keeps tag == v<appVersion> so this
+# can't silently drift at release.
+image:
+  repository: ghcr.io/vencil/threshold-exporter
+  tag: v2.8.0
+  pullPolicy: IfNotPresent

--- a/tests/helm/test_values_prod_image_pin.py
+++ b/tests/helm/test_values_prod_image_pin.py
@@ -1,0 +1,35 @@
+"""#682 — each chart's values-prod.yaml image.tag must equal "v" + Chart.appVersion.
+
+The component charts default to non-pullable image tags (threshold-exporter :dev,
+tenant-api :2.7.0, da-portal :2.8.0); values-prod.yaml pins the published, v-prefixed
+tag for real cluster deploys. This test keeps that pin in lockstep with Chart.appVersion
+so it can't silently drift at release — an operator following the doc's
+`-f values-prod.yaml` always gets a pullable image.
+"""
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHARTS = ["threshold-exporter", "tenant-api", "da-portal"]
+
+
+@pytest.mark.parametrize("chart", CHARTS)
+def test_values_prod_exists(chart):
+    assert (REPO_ROOT / "helm" / chart / "values-prod.yaml").is_file(), (
+        f"helm/{chart}/values-prod.yaml is missing (the documented prod deploy "
+        f"path, #682)")
+
+
+@pytest.mark.parametrize("chart", CHARTS)
+def test_values_prod_tag_matches_appversion(chart):
+    chart_dir = REPO_ROOT / "helm" / chart
+    chart_yaml = yaml.safe_load((chart_dir / "Chart.yaml").read_text(encoding="utf-8"))
+    prod = yaml.safe_load((chart_dir / "values-prod.yaml").read_text(encoding="utf-8"))
+    app_version = str(chart_yaml["appVersion"])
+    tag = str(prod["image"]["tag"])
+    assert tag == f"v{app_version}", (
+        f"{chart}/values-prod.yaml image.tag={tag!r} but Chart.appVersion="
+        f"{app_version!r} -> expected 'v{app_version}'. Bump values-prod.yaml in "
+        f"lockstep with appVersion (#682).")


### PR DESCRIPTION
## What

Closes the systemic finding from #141 Phase 2: the component Helm charts default to **non-pullable image tags**, so a documented `helm install ./helm/<chart>/` ImagePull-fails for a real deploy.

| chart | broken default | now pulls (via values-prod) |
|---|---|---|
| threshold-exporter | `:dev` + `pullPolicy: Never` + repo without `ghcr.io/vencil/` | `ghcr.io/vencil/threshold-exporter:v2.8.0` |
| tenant-api | `:2.7.0` | `ghcr.io/vencil/tenant-api:v2.7.0` |
| da-portal | `:2.8.0` (no `v`) | `ghcr.io/vencil/da-portal:v2.8.0` |

## Approach (#682 option 1 — non-breaking)

The exporter `:dev` + `pullPolicy: Never` default is **intentional** (local kind-load dev loop), so rather than flip defaults:

- **Add `helm/<chart>/values-prod.yaml`** pinning the published, v-prefixed image (= `v` + `Chart.appVersion` — note tenant-api's appVersion is `2.7.0`, so it pins `v2.7.0`, not v2.8.0). **Additive → default installs keep the dev image → zero blast radius** for existing dev/CI/kind-load.
- **Docs** (`for-platform-engineers.md{,.en}`) deploy with `-f values-prod.yaml` instead of ad-hoc `--set image.tag`.
- **`tests/helm/test_values_prod_image_pin.py`** locks `tag == v<appVersion>` per chart → the pin can't silently drift at release (6 tests; CI goes red if appVersion bumps without values-prod).

## Verified

Live on a kind cluster (dev container): each `helm template -f values-prod.yaml` renders a **pullable** ghcr image; `helm lint` clean on all 3.

> Blast-radius review (vibe-subagent-review): additive image-only override, no label/selector/securityContext/ConfigMap cascade. The one ongoing cost — release must bump values-prod in lockstep — is enforced loudly by the pin test.

Refs #682, #141.