### PR TITLE
docs: fix ADR-023 frontmatter version drift (unblocks main Version Consistency)

### DIFF
--- a/docs/adr/023-write-plane-single-writer-invariant.md
+++ b/docs/adr/023-write-plane-single-writer-invariant.md
@@ -2,7 +2,7 @@
 title: "ADR-023: tenant-api 寫入平面 — Single-Writer Invariant 與韌性圍堵"
 tags: [adr, tenant-api, gitops, scalability, resilience]
 audience: [platform-engineers, contributors]
-version: v2.9.0
+version: v2.8.1
 lang: zh
 id: ADR-023
 tracking_kind: adr


### PR DESCRIPTION
ADR-023 (merged via #669) shipped with `version: v2.9.0` in its frontmatter, but the platform version is `v2.8.1`. So `bump_docs.py --check` (the **Version Consistency** CI job) fails on **main** — and therefore on every PR branched off it (e.g. #683).

One-line frontmatter fix: `v2.9.0` → `v2.8.1`. `bump_docs --check` is green after. (Same class as the historical ADR-021 drift.)

ADR-023 is ZH-only (no `.en.md` pair). Refs #669.