### PR TITLE
fix(lint): make check_cli_coverage stdout utf-8-safe on Windows host

### DIFF
--- a/scripts/tools/lint/check_cli_coverage.py
+++ b/scripts/tools/lint/check_cli_coverage.py
@@ -25,6 +25,15 @@ from pathlib import Path
 
 from _lint_helpers import parse_command_map_keys, REPO_ROOT, ENTRYPOINT_PATH
 
+# Make stdout tolerate non-ASCII (the ⊘ warning glyph) on Windows shells
+# (cp950, cp1252) so a Windows-host dev running this guard gets a report
+# instead of a UnicodeEncodeError crash. CI (utf-8) is unaffected.
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except (AttributeError, OSError):
+        pass
+
 CHEAT_SHEET_ZH = REPO_ROOT / "docs" / "cheat-sheet.md"
 CHEAT_SHEET_EN = REPO_ROOT / "docs" / "cheat-sheet.en.md"
 CLI_REF_ZH = REPO_ROOT / "docs" / "cli-reference.md"


### PR DESCRIPTION
## 摘要
`check_cli_coverage.py` 印 warning 用的 `⊘` glyph 在 Windows 預設 cp950 console 丟 `UnicodeEncodeError` → **Windows-host 開發者直接跑這支 guard 會 crash 而非拿到報告**（CI 的 utf-8 不受影響）。

沿用 repo 既有 pattern（`check_codename_leak` / `check_design_token_usage` / `check_helm_values_secrets` 等 5 支 sibling lint）在 import 後加 guarded `sys.stdout.reconfigure(encoding="utf-8", errors="replace")`。

## 背景
於 #662 收尾驗證時發現 —— `check_cli_coverage` 正是 #662「每個 COMMAND_MAP 命令都列在 `--help`」兩條 regression guard 之一，讓它在 Windows host 也能可靠跑起來。

## 驗證
- Windows host 直接 `py scripts/tools/lint/check_cli_coverage.py`：**exit 0**（修前 crash），正常印出 `⊘` warning glyph
- `tests/lint/test_check_cli_coverage.py`：36 passed

Refs #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)