### PR TITLE
test(lint): exclude check_cli_coverage import-time stdout shim from coverage

### DIFF
--- a/scripts/tools/lint/check_cli_coverage.py
+++ b/scripts/tools/lint/check_cli_coverage.py
@@ -28,7 +28,8 @@ from _lint_helpers import parse_command_map_keys, REPO_ROOT, ENTRYPOINT_PATH
 # Make stdout tolerate non-ASCII (the ⊘ warning glyph) on Windows shells
 # (cp950, cp1252) so a Windows-host dev running this guard gets a report
 # instead of a UnicodeEncodeError crash. CI (utf-8) is unaffected.
-if hasattr(sys.stdout, "reconfigure"):
+# Import-time, environment-dependent defensive shim → not unit-testable.
+if hasattr(sys.stdout, "reconfigure"):  # pragma: no cover
     try:
         sys.stdout.reconfigure(encoding="utf-8", errors="replace")
     except (AttributeError, OSError):


### PR DESCRIPTION
## 摘要
follow-up to #686。coverage-delta bot 在 #686 標了 `check_cli_coverage.py` −0.7%（97.0→96.3）—— 新加的 import-time `sys.stdout.reconfigure` guard 是 env-dependent 的 defensive shim，無法有意義地 unit-test。#686 在我推這個 cleanup 前就 merge 了（merge race），故獨立補上。

標 `# pragma: no cover`（repo 既有慣例，`pyproject.toml exclude_lines` + `describe_tenant.py` 同款）→ coverage delta 回到 ~0。

## 變更
1-line（+ 一行註解說明為何 no-cover）。無行為改變。

Refs #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)