### PR TITLE
fix(rule-packs): source ALERT-REFERENCE Related Metric from expr

### DIFF
--- a/rule-packs/ALERT-REFERENCE.en.md
+++ b/rule-packs/ALERT-REFERENCE.en.md
@@ -19,13 +19,13 @@ This document provides tenants with a unified reference for all alerts across Ru
 
 | Alert Name | Severity | Trigger Condition | Recommended Action | Related Metric |
 |---|---|---|---|---|
-| ClickHouseDown | critical |  | Immediately check server status and network connectivity; review system logs |  |
-| ClickHouseHighQueryRate | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse query rate elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed |  |
-| ClickHouseHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse connections exceeded  | Check connection pool configuration and potential leaks; consider increasing max connections |  |
-| ClickHouseHighPartCount | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse partition merge pressure  | Check alert metrics and review related logs; contact platform team for assistance if needed |  |
-| ClickHouseReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse replication queue high  | Check alert metrics and review related logs; contact platform team for assistance if needed |  |
-| ClickHouseHighMemoryUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse memory usage high  | Check resource consumption and optimize configuration; consider increasing memory or enabling compression |  |
-| ClickHouseHighFailedQueryRate | warning |  | Check alert metrics and review related logs; contact platform team for assistance if needed |  |
+| ClickHouseDown | critical |  | Immediately check server status and network connectivity; review system logs | up |
+| ClickHouseHighQueryRate | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse query rate elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:clickhouse_queries:rate5m |
+| ClickHouseHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse connections exceeded  | Check connection pool configuration and potential leaks; consider increasing max connections | tenant:clickhouse_active_connections:max |
+| ClickHouseHighPartCount | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse partition merge pressure  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:clickhouse_max_part_count:max |
+| ClickHouseReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse replication queue high  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:clickhouse_replication_queue:max |
+| ClickHouseHighMemoryUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse memory usage high  | Check resource consumption and optimize configuration; consider increasing memory or enabling compression | tenant:clickhouse_memory_tracking:max |
+| ClickHouseHighFailedQueryRate | warning | Failed query rate: {{ $value \| printf "%.1f" }} queries/sec | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:clickhouse_failed_queries:rate5m |
 
 ---
 
@@ -33,13 +33,13 @@ This document provides tenants with a unified reference for all alerts across Ru
 
 | Alert Name | Severity | Trigger Condition | Recommended Action | Related Metric |
 |---|---|---|---|---|
-| DB2DatabaseDown | critical |  | Immediately check server status and network connectivity; review system logs |  |
-| DB2HighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 connection usage high  | Check connection pool configuration and potential leaks; consider increasing max connections | value |
-| DB2LowBufferpoolHitRatio | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 bufferpool hit ratio low  | Check alert metrics and review related logs; contact platform team for assistance if needed | ratio |
-| DB2HighLogUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 transaction log usage high  | Check alert metrics and review related logs; contact platform team for assistance if needed | usage |
-| DB2HighDeadlockRate | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 deadlock rate elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
-| DB2TablespaceAlmostFull | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 tablespace nearing capacity  | Check alert metrics and review related logs; contact platform team for assistance if needed | usage |
-| DB2HighSortOverflow | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 sort overflow ratio high  | Check alert metrics and review related logs; contact platform team for assistance if needed | overflow |
+| DB2DatabaseDown | critical | db2_up=0 for 15s on {{ $labels.instance }} | Immediately check server status and network connectivity; review system logs | db2_up |
+| DB2HighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 connection usage high  | Check connection pool configuration and potential leaks; consider increasing max connections | tenant:db2_connections_active:max |
+| DB2LowBufferpoolHitRatio | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 bufferpool hit ratio low  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:db2_bufferpool_hit_ratio:min |
+| DB2HighLogUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 transaction log usage high  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:db2_log_usage_percent:max |
+| DB2HighDeadlockRate | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 deadlock rate elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:db2_deadlocks:rate5m |
+| DB2TablespaceAlmostFull | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 tablespace nearing capacity  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:db2_tablespace_used_percent:max |
+| DB2HighSortOverflow | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 sort overflow ratio high  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:db2_sort_overflow_ratio:avg |
 
 ---
 
@@ -47,13 +47,13 @@ This document provides tenants with a unified reference for all alerts across Ru
 
 | Alert Name | Severity | Trigger Condition | Recommended Action | Related Metric |
 |---|---|---|---|---|
-| ElasticsearchClusterRed | critical | Cluster health is RED  | Check alert metrics and review related logs; contact platform team for assistance if needed | health |
-| ElasticsearchClusterYellow | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES cluster YELLOW  | Check alert metrics and review related logs; contact platform team for assistance if needed | replica |
-| ElasticsearchHighHeapUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES heap usage high  | Check alert metrics and review related logs; contact platform team for assistance if needed | heap |
-| ElasticsearchHighDiskUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES disk usage high  | Check alert metrics and review related logs; contact platform team for assistance if needed | usage |
-| ElasticsearchHighSearchLatency | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES search latency elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | search |
-| ElasticsearchUnassignedShards | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES unassigned shards  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
-| ElasticsearchPendingTasks | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES pending cluster tasks  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
+| ElasticsearchClusterRed | critical | Cluster health is RED  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:es_cluster_health:status |
+| ElasticsearchClusterYellow | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES cluster YELLOW  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:es_cluster_health:status |
+| ElasticsearchHighHeapUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES heap usage high  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:es_heap_usage_percent:max |
+| ElasticsearchHighDiskUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES disk usage high  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:es_disk_usage_percent:max |
+| ElasticsearchHighSearchLatency | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES search latency elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:es_search_latency_ms:avg |
+| ElasticsearchUnassignedShards | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES unassigned shards  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:es_unassigned_shards:count |
+| ElasticsearchPendingTasks | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES pending cluster tasks  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:es_pending_tasks:max |
 
 ---
 
@@ -61,13 +61,13 @@ This document provides tenants with a unified reference for all alerts across Ru
 
 | Alert Name | Severity | Trigger Condition | Recommended Action | Related Metric |
 |---|---|---|---|---|
-| JVMHighGCPause | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: GC pause elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | pause |
-| JVMHighGCPauseCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical GC pause  | Check alert metrics and review related logs; contact platform team for assistance if needed | pause |
-| JVMMemoryPressure | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: heap memory pressure  | Check alert metrics and review related logs; contact platform team for assistance if needed | usage |
-| JVMMemoryPressureCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical heap pressure  | Check alert metrics and review related logs; contact platform team for assistance if needed | usage |
-| JVMThreadPoolExhaustion | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: thread pool saturation  | Check alert metrics and review related logs; contact platform team for assistance if needed | threads |
-| JVMThreadPoolExhaustionCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical thread exhaustion  | Check alert metrics and review related logs; contact platform team for assistance if needed | threads |
-| JVMPerformanceDegraded | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: multi-signal JVM degradation  | Check alert metrics and review related logs; contact platform team for assistance if needed | pause |
+| JVMHighGCPause | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: GC pause elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:jvm_gc_pause:rate5m |
+| JVMHighGCPauseCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical GC pause  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:jvm_gc_pause:rate5m |
+| JVMMemoryPressure | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: heap memory pressure  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:jvm_memory_used:percent |
+| JVMMemoryPressureCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical heap pressure  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:jvm_memory_used:percent |
+| JVMThreadPoolExhaustion | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: thread pool saturation  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:jvm_threads:current |
+| JVMThreadPoolExhaustionCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical thread exhaustion  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:jvm_threads:current |
+| JVMPerformanceDegraded | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: multi-signal JVM degradation  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:jvm_gc_pause:rate5m |
 
 ---
 
@@ -76,14 +76,14 @@ This document provides tenants with a unified reference for all alerts across Ru
 | Alert Name | Severity | Trigger Condition | Recommended Action | Related Metric |
 |---|---|---|---|---|
 | KafkaExporterAbsent | critical | No kafka_brokers metric found for 30s | Verify component is running and configured correctly; check component logs | kafka_brokers |
-| KafkaHighConsumerLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: consumer lag elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | lag |
-| KafkaHighConsumerLagCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical consumer lag  | Check alert metrics and review related logs; contact platform team for assistance if needed | lag |
-| KafkaUnderReplicatedPartitions | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: under-replicated partitions  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
-| KafkaUnderReplicatedPartitionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical under-replication  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
-| KafkaNoActiveController | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: no active Kafka controller  | Check alert metrics and review related logs; contact platform team for assistance if needed | controllers |
-| KafkaLowBrokerCount | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: broker count below minimum  | Check alert metrics and review related logs; contact platform team for assistance if needed | brokers |
-| KafkaHighRequestRate | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: message rate threshold exceeded  | Check alert metrics and review related logs; contact platform team for assistance if needed | rate |
-| KafkaHighRequestRateCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical message rate  | Check alert metrics and review related logs; contact platform team for assistance if needed | rate |
+| KafkaHighConsumerLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: consumer lag elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:kafka_consumer_lag:max |
+| KafkaHighConsumerLagCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical consumer lag  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:kafka_consumer_lag:max |
+| KafkaUnderReplicatedPartitions | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: under-replicated partitions  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:kafka_under_replicated_partitions:max |
+| KafkaUnderReplicatedPartitionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical under-replication  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:kafka_under_replicated_partitions:max |
+| KafkaNoActiveController | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: no active Kafka controller  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:kafka_active_controllers:max |
+| KafkaLowBrokerCount | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: broker count below minimum  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:kafka_broker_count:max |
+| KafkaHighRequestRate | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: message rate threshold exceeded  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:kafka_request_rate:sum |
+| KafkaHighRequestRateCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical message rate  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:kafka_request_rate:sum |
 
 ---
 
@@ -91,10 +91,13 @@ This document provides tenants with a unified reference for all alerts across Ru
 
 | Alert Name | Severity | Trigger Condition | Recommended Action | Related Metric |
 |---|---|---|---|---|
-| PodContainerHighCPU | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: container CPU pressure  | Check alert metrics and review related logs; contact platform team for assistance if needed | container |
-| PodContainerHighMemory | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: container memory pressure  | Check resource consumption and optimize configuration; consider increasing memory or enabling compression | container |
-| ContainerCrashLoop | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: crash loop detected  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
-| ContainerImagePullFailure | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: image pull failing  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
+| PodContainerHighCPU | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: container CPU pressure  | Check alert metrics and review related logs; contact platform team for assistance if needed | rule_pack_kubernetes:pod_container_high_cpu_warning:core |
+| PodContainerHighCPUCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: container CPU CRITICAL  | Check alert metrics and review related logs; contact platform team for assistance if needed | rule_pack_kubernetes:pod_container_high_cpu_critical:core |
+| PodContainerHighMemory | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: container memory pressure  | Check resource consumption and optimize configuration; consider increasing memory or enabling compression | rule_pack_kubernetes:pod_container_high_memory_warning:core |
+| PodContainerHighMemoryCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: container memory CRITICAL  | Check resource consumption and optimize configuration; consider increasing memory or enabling compression | rule_pack_kubernetes:pod_container_high_memory_critical:core |
+| ContainerCrashLoop | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: crash loop detected  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:container_waiting_reason:count |
+| ContainerImagePullFailure | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: image pull failing  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:container_waiting_reason:count |
+| VersionAwareThresholdInert | warning | {{ $value \| printf "%.0f" }} version-specific container CPU threshold(s) declared and tenant pods ar | Check alert metrics and review related logs; contact platform team for assistance if needed | user_threshold |
 
 ---
 
@@ -104,12 +107,12 @@ This document provides tenants with a unified reference for all alerts across Ru
 |---|---|---|---|---|
 | MariaDBDown | critical | mysql_up=0 for 15s on {{ $labels.instance }} | Immediately check server status and network connectivity; review system logs | mysql_up |
 | MariaDBExporterAbsent | critical | No mysql_up metric found for 30s | Verify component is running and configured correctly; check component logs | mysql_up |
-| MariaDBHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: connection threshold breached  | Check connection pool configuration and potential leaks; consider increasing max connections | value |
-| MariaDBHighConnectionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical connection saturation  | Check connection pool configuration and potential leaks; consider increasing max connections | value |
-| MariaDBSystemBottleneck | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: CPU + connections both exceeded  | Check alert metrics and review related logs; contact platform team for assistance if needed | connections |
-| MariaDBRecentRestart | info | Uptime is only {{ $value }}s (< 5 min) | Check alert metrics and review related logs; contact platform team for assistance if needed | is |
-| MariaDBHighSlowQueries | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: slow query rate elevated  | Check slow query logs, identify optimization candidates; consider parameter tuning | value |
-| MariaDBHighAbortedConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: aborted connection rate elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
+| MariaDBHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: connection threshold breached  | Check connection pool configuration and potential leaks; consider increasing max connections | tenant:mysql_threads_connected:max |
+| MariaDBHighConnectionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical connection saturation  | Check connection pool configuration and potential leaks; consider increasing max connections | tenant:mysql_threads_connected:max |
+| MariaDBSystemBottleneck | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: CPU + connections both exceeded  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:mysql_threads_connected:max |
+| MariaDBRecentRestart | info | Uptime is only {{ $value }}s (< 5 min) | Check alert metrics and review related logs; contact platform team for assistance if needed | mysql_global_status_uptime |
+| MariaDBHighSlowQueries | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: slow query rate elevated  | Check slow query logs, identify optimization candidates; consider parameter tuning | tenant:mysql_slow_queries:rate5m |
+| MariaDBHighAbortedConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: aborted connection rate elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:mysql_aborted_connections:rate5m |
 
 ---
 
@@ -117,12 +120,12 @@ This document provides tenants with a unified reference for all alerts across Ru
 
 | Alert Name | Severity | Trigger Condition | Recommended Action | Related Metric |
 |---|---|---|---|---|
-| MongoDBDown | critical |  | Immediately check server status and network connectivity; review system logs |  |
-| MongoDBHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB connection threshold breached  | Check connection pool configuration and potential leaks; consider increasing max connections | value |
-| MongoDBReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB replication lag  | Check alert metrics and review related logs; contact platform team for assistance if needed | lag |
-| MongoDBHighOperations | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB operation rate elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
-| MongoDBHighPageFaults | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB page fault rate high  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
-| MongoDBConnectionSaturation | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB connection pool near saturation  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
+| MongoDBDown | critical |  | Immediately check server status and network connectivity; review system logs | mongodb_up |
+| MongoDBHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB connection threshold breached  | Check connection pool configuration and potential leaks; consider increasing max connections | tenant:mongodb_connections_current:max |
+| MongoDBReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB replication lag  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:mongodb_replication_lag:max |
+| MongoDBHighOperations | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB operation rate elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:mongodb_opcounters:rate5m |
+| MongoDBHighPageFaults | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB page fault rate high  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:mongodb_page_faults:rate5m |
+| MongoDBConnectionSaturation | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB connection pool near saturation  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:mongodb_connection_usage:ratio |
 
 ---
 
@@ -130,12 +133,12 @@ This document provides tenants with a unified reference for all alerts across Ru
 
 | Alert Name | Severity | Trigger Condition | Recommended Action | Related Metric |
 |---|---|---|---|---|
-| NginxHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Nginx connection threshold exceeded  | Check connection pool configuration and potential leaks; consider increasing max connections | connections |
-| NginxHighConnectionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical Nginx connection saturation  | Check connection pool configuration and potential leaks; consider increasing max connections | connections |
-| NginxRequestRateSpike | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: request rate spike  | Check alert metrics and review related logs; contact platform team for assistance if needed | rate |
-| NginxRequestRateSpikeCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical request rate  | Check alert metrics and review related logs; contact platform team for assistance if needed | rate |
-| NginxConnectionBacklog | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: connection backlog building  | Check alert metrics and review related logs; contact platform team for assistance if needed | connections |
-| NginxConnectionBacklogCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical connection backlog  | Check alert metrics and review related logs; contact platform team for assistance if needed | connections |
+| NginxHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Nginx connection threshold exceeded  | Check connection pool configuration and potential leaks; consider increasing max connections | tenant:nginx_connections_active:max |
+| NginxHighConnectionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical Nginx connection saturation  | Check connection pool configuration and potential leaks; consider increasing max connections | tenant:nginx_connections_active:max |
+| NginxRequestRateSpike | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: request rate spike  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:nginx_requests:rate5m |
+| NginxRequestRateSpikeCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical request rate  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:nginx_requests:rate5m |
+| NginxConnectionBacklog | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: connection backlog building  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:nginx_connections_waiting:max |
+| NginxConnectionBacklogCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical connection backlog  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:nginx_connections_waiting:max |
 
 ---
 
@@ -143,10 +146,10 @@ This document provides tenants with a unified reference for all alerts across Ru
 
 | Alert Name | Severity | Trigger Condition | Recommended Action | Related Metric |
 |---|---|---|---|---|
-| TenantSilentWarning | none | Warning alerts for tenant {{ $labels.tenant }} will be recorded in TSDB but notifications suppressed | Check alert metrics and review related logs; contact platform team for assistance if needed | alerts |
-| TenantSilentCritical | none | Critical alerts for tenant {{ $labels.tenant }} will be recorded in TSDB but notifications suppresse | Check alert metrics and review related logs; contact platform team for assistance if needed | alerts |
-| TenantSeverityDedupEnabled | none | Warning notifications for {{ $labels.tenant }} will be suppressed when critical fires for the same m | Check alert metrics and review related logs; contact platform team for assistance if needed | notifications |
-| TenantConfigEvent | warning | Timed config for tenant {{ $labels.tenant }} has expired and auto-deactivated. Event: {{ $labels.eve | Check alert metrics and review related logs; contact platform team for assistance if needed | config |
+| TenantSilentWarning | none | Warning alerts for tenant {{ $labels.tenant }} will be recorded in TSDB but notifications suppressed | Check alert metrics and review related logs; contact platform team for assistance if needed | user_silent_mode |
+| TenantSilentCritical | none | Critical alerts for tenant {{ $labels.tenant }} will be recorded in TSDB but notifications suppresse | Check alert metrics and review related logs; contact platform team for assistance if needed | user_silent_mode |
+| TenantSeverityDedupEnabled | none | Warning notifications for {{ $labels.tenant }} will be suppressed when critical fires for the same m | Check alert metrics and review related logs; contact platform team for assistance if needed | user_severity_dedup |
+| TenantConfigEvent | warning | Timed config for tenant {{ $labels.tenant }} has expired and auto-deactivated. Event: {{ $labels.eve | Check alert metrics and review related logs; contact platform team for assistance if needed | da_config_event |
 
 ---
 
@@ -154,13 +157,13 @@ This document provides tenants with a unified reference for all alerts across Ru
 
 | Alert Name | Severity | Trigger Condition | Recommended Action | Related Metric |
 |---|---|---|---|---|
-| OracleDatabaseDown | critical |  | Immediately check server status and network connectivity; review system logs |  |
-| OracleHighActiveSessions | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle active sessions elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
-| OracleTablespaceAlmostFull | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle tablespace nearing capacity  | Check alert metrics and review related logs; contact platform team for assistance if needed | usage |
-| OracleHighWaitTime | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle wait time elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | time |
-| OracleHighProcessCount | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle process count high  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
-| OracleHighPGAUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle PGA usage high  | Check alert metrics and review related logs; contact platform team for assistance if needed | allocated |
-| OracleHighSessionUtilization | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle session limit approaching  | Check alert metrics and review related logs; contact platform team for assistance if needed | utilization |
+| OracleDatabaseDown | critical | oracledb_up=0 for 15s on {{ $labels.instance }} | Immediately check server status and network connectivity; review system logs | oracledb_up |
+| OracleHighActiveSessions | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle active sessions elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:oracle_sessions_active:max |
+| OracleTablespaceAlmostFull | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle tablespace nearing capacity  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:oracle_tablespace_used_percent:max |
+| OracleHighWaitTime | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle wait time elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:oracle_wait_time:rate5m |
+| OracleHighProcessCount | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle process count high  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:oracle_process_count:max |
+| OracleHighPGAUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle PGA usage high  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:oracle_pga_allocated_bytes:max |
+| OracleHighSessionUtilization | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle session limit approaching  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:oracle_session_utilization:ratio |
 
 ---
 
@@ -170,13 +173,13 @@ This document provides tenants with a unified reference for all alerts across Ru
 |---|---|---|---|---|
 | PostgreSQLDown | critical | pg_up=0 for 15s on {{ $labels.instance }} | Immediately check server status and network connectivity; review system logs | pg_up |
 | PostgreSQLExporterAbsent | critical | No pg_up metric found for 30s | Verify component is running and configured correctly; check component logs | pg_up |
-| PostgreSQLHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: connection usage high  | Check connection pool configuration and potential leaks; consider increasing max connections | value |
-| PostgreSQLHighConnectionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical connection saturation  | Check connection pool configuration and potential leaks; consider increasing max connections | value |
-| PostgreSQLHighReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: replication lag elevated  | Check replication status and network connectivity; inspect queue buildup | value |
-| PostgreSQLHighReplicationLagCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical replication lag  | Check replication status and network connectivity; inspect queue buildup | value |
-| PostgreSQLHighDeadlocks | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: deadlocks detected  | Analyze deadlock query logs, adjust application logic to reduce contention; consider increasing lock timeout | value |
-| PostgreSQLHighRollbackRatio | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: high rollback ratio  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
-| PostgreSQLRecentRestart | info | PostgreSQL uptime is only {{ $value | printf "%.0f" }}s (< 5 min) | Check alert metrics and review related logs; contact platform team for assistance if needed | uptime |
+| PostgreSQLHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: connection usage high  | Check connection pool configuration and potential leaks; consider increasing max connections | tenant:pg_connection_usage:ratio |
+| PostgreSQLHighConnectionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical connection saturation  | Check connection pool configuration and potential leaks; consider increasing max connections | tenant:pg_connection_usage:ratio |
+| PostgreSQLHighReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: replication lag elevated  | Check replication status and network connectivity; inspect queue buildup | tenant:pg_replication_lag:max |
+| PostgreSQLHighReplicationLagCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical replication lag  | Check replication status and network connectivity; inspect queue buildup | tenant:pg_replication_lag:max |
+| PostgreSQLHighDeadlocks | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: deadlocks detected  | Analyze deadlock query logs, adjust application logic to reduce contention; consider increasing lock timeout | tenant:pg_deadlocks:rate5m |
+| PostgreSQLHighRollbackRatio | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: high rollback ratio  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:pg_rollback_ratio:rate5m |
+| PostgreSQLRecentRestart | info | PostgreSQL uptime is only {{ $value \| printf "%.0f" }}s (< 5 min) | Check alert metrics and review related logs; contact platform team for assistance if needed | pg_postmaster_start_time_seconds |
 
 ---
 
@@ -185,13 +188,13 @@ This document provides tenants with a unified reference for all alerts across Ru
 | Alert Name | Severity | Trigger Condition | Recommended Action | Related Metric |
 |---|---|---|---|---|
 | RabbitMQExporterAbsent | critical | No rabbitmq_identity_info metric found for 30s | Verify component is running and configured correctly; check component logs | rabbitmq_identity_info |
-| RabbitMQHighQueueDepth | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: queue depth threshold exceeded  | Check alert metrics and review related logs; contact platform team for assistance if needed | ready |
-| RabbitMQHighQueueDepthCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical queue depth  | Check alert metrics and review related logs; contact platform team for assistance if needed | ready |
-| RabbitMQHighMemory | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ memory usage high  | Check resource consumption and optimize configuration; consider increasing memory or enabling compression | used |
-| RabbitMQHighMemoryCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical RabbitMQ memory  | Check resource consumption and optimize configuration; consider increasing memory or enabling compression | used |
-| RabbitMQHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ connection count high  | Check connection pool configuration and potential leaks; consider increasing max connections | connections |
-| RabbitMQLowConsumers | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ consumer count low  | Check alert metrics and review related logs; contact platform team for assistance if needed | consumers |
-| RabbitMQHighUnackedMessages | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: unacked messages piling up  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
+| RabbitMQHighQueueDepth | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: queue depth threshold exceeded  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:rabbitmq_queue_messages:max |
+| RabbitMQHighQueueDepthCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical queue depth  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:rabbitmq_queue_messages:max |
+| RabbitMQHighMemory | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ memory usage high  | Check resource consumption and optimize configuration; consider increasing memory or enabling compression | tenant:rabbitmq_node_mem_percent:ratio |
+| RabbitMQHighMemoryCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical RabbitMQ memory  | Check resource consumption and optimize configuration; consider increasing memory or enabling compression | tenant:rabbitmq_node_mem_percent:ratio |
+| RabbitMQHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ connection count high  | Check connection pool configuration and potential leaks; consider increasing max connections | tenant:rabbitmq_connections:max |
+| RabbitMQLowConsumers | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ consumer count low  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:rabbitmq_consumers:max |
+| RabbitMQHighUnackedMessages | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: unacked messages piling up  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:rabbitmq_unacked_messages:max |
 
 ---
 
@@ -199,11 +202,11 @@ This document provides tenants with a unified reference for all alerts across Ru
 
 | Alert Name | Severity | Trigger Condition | Recommended Action | Related Metric |
 |---|---|---|---|---|
-| RedisDown | critical |  | Immediately check server status and network connectivity; review system logs |  |
-| RedisHighMemory | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Redis memory threshold breached  | Check resource consumption and optimize configuration; consider increasing memory or enabling compression | usage |
-| RedisHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Redis connection count high  | Check connection pool configuration and potential leaks; consider increasing max connections | value |
-| RedisHighKeyEvictions | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: key eviction rate elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | value |
-| RedisReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Redis replication lag  | Check alert metrics and review related logs; contact platform team for assistance if needed | lag |
-| RedisLowHitRatio | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: low cache hit ratio  | Check alert metrics and review related logs; contact platform team for assistance if needed | ratio |
+| RedisDown | critical |  | Immediately check server status and network connectivity; review system logs | redis_up |
+| RedisHighMemory | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Redis memory threshold breached  | Check resource consumption and optimize configuration; consider increasing memory or enabling compression | tenant:redis_memory_used_bytes:max |
+| RedisHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Redis connection count high  | Check connection pool configuration and potential leaks; consider increasing max connections | tenant:redis_connected_clients:max |
+| RedisHighKeyEvictions | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: key eviction rate elevated  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:redis_evicted_keys:rate5m |
+| RedisReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Redis replication lag  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:redis_replication_lag:max |
+| RedisLowHitRatio | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: low cache hit ratio  | Check alert metrics and review related logs; contact platform team for assistance if needed | tenant:redis_keyspace_hit_ratio:avg |
 
 ---

--- a/rule-packs/ALERT-REFERENCE.md
+++ b/rule-packs/ALERT-REFERENCE.md
@@ -19,13 +19,13 @@ lang: zh
 
 | 告警名稱 | 嚴重度 | 觸發條件 | 建議動作 | 相關指標 |
 |---|---|---|---|---|
-| ClickHouseDown | critical |  | 立即檢查伺服器狀態、網路連線；查看系統日誌 |  |
-| ClickHouseHighQueryRate | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse query rate elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 |  |
-| ClickHouseHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse connections exceeded  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 |  |
-| ClickHouseHighPartCount | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse partition merge pressure  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 |  |
-| ClickHouseReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse replication queue high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 |  |
-| ClickHouseHighMemoryUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse memory usage high  | 檢查資源消耗、優化配置；考慮增加記憶體或啟用壓縮 |  |
-| ClickHouseHighFailedQueryRate | warning |  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 |  |
+| ClickHouseDown | critical |  | 立即檢查伺服器狀態、網路連線；查看系統日誌 | up |
+| ClickHouseHighQueryRate | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse query rate elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:clickhouse_queries:rate5m |
+| ClickHouseHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse connections exceeded  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | tenant:clickhouse_active_connections:max |
+| ClickHouseHighPartCount | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse partition merge pressure  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:clickhouse_max_part_count:max |
+| ClickHouseReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse replication queue high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:clickhouse_replication_queue:max |
+| ClickHouseHighMemoryUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse memory usage high  | 檢查資源消耗、優化配置；考慮增加記憶體或啟用壓縮 | tenant:clickhouse_memory_tracking:max |
+| ClickHouseHighFailedQueryRate | warning | Failed query rate: {{ $value \| printf "%.1f" }} queries/sec | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:clickhouse_failed_queries:rate5m |
 
 ---
 
@@ -33,13 +33,13 @@ lang: zh
 
 | 告警名稱 | 嚴重度 | 觸發條件 | 建議動作 | 相關指標 |
 |---|---|---|---|---|
-| DB2DatabaseDown | critical |  | 立即檢查伺服器狀態、網路連線；查看系統日誌 |  |
-| DB2HighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 connection usage high  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | value |
-| DB2LowBufferpoolHitRatio | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 bufferpool hit ratio low  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | ratio |
-| DB2HighLogUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 transaction log usage high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | usage |
-| DB2HighDeadlockRate | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 deadlock rate elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
-| DB2TablespaceAlmostFull | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 tablespace nearing capacity  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | usage |
-| DB2HighSortOverflow | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 sort overflow ratio high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | overflow |
+| DB2DatabaseDown | critical | db2_up=0 for 15s on {{ $labels.instance }} | 立即檢查伺服器狀態、網路連線；查看系統日誌 | db2_up |
+| DB2HighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 connection usage high  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | tenant:db2_connections_active:max |
+| DB2LowBufferpoolHitRatio | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 bufferpool hit ratio low  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:db2_bufferpool_hit_ratio:min |
+| DB2HighLogUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 transaction log usage high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:db2_log_usage_percent:max |
+| DB2HighDeadlockRate | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 deadlock rate elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:db2_deadlocks:rate5m |
+| DB2TablespaceAlmostFull | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 tablespace nearing capacity  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:db2_tablespace_used_percent:max |
+| DB2HighSortOverflow | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: DB2 sort overflow ratio high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:db2_sort_overflow_ratio:avg |
 
 ---
 
@@ -47,13 +47,13 @@ lang: zh
 
 | 告警名稱 | 嚴重度 | 觸發條件 | 建議動作 | 相關指標 |
 |---|---|---|---|---|
-| ElasticsearchClusterRed | critical | Cluster health is RED  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | health |
-| ElasticsearchClusterYellow | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES cluster YELLOW  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | replica |
-| ElasticsearchHighHeapUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES heap usage high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | heap |
-| ElasticsearchHighDiskUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES disk usage high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | usage |
-| ElasticsearchHighSearchLatency | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES search latency elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | search |
-| ElasticsearchUnassignedShards | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES unassigned shards  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
-| ElasticsearchPendingTasks | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES pending cluster tasks  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
+| ElasticsearchClusterRed | critical | Cluster health is RED  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:es_cluster_health:status |
+| ElasticsearchClusterYellow | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES cluster YELLOW  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:es_cluster_health:status |
+| ElasticsearchHighHeapUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES heap usage high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:es_heap_usage_percent:max |
+| ElasticsearchHighDiskUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES disk usage high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:es_disk_usage_percent:max |
+| ElasticsearchHighSearchLatency | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES search latency elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:es_search_latency_ms:avg |
+| ElasticsearchUnassignedShards | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES unassigned shards  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:es_unassigned_shards:count |
+| ElasticsearchPendingTasks | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: ES pending cluster tasks  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:es_pending_tasks:max |
 
 ---
 
@@ -61,13 +61,13 @@ lang: zh
 
 | 告警名稱 | 嚴重度 | 觸發條件 | 建議動作 | 相關指標 |
 |---|---|---|---|---|
-| JVMHighGCPause | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: GC pause elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | pause |
-| JVMHighGCPauseCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical GC pause  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | pause |
-| JVMMemoryPressure | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: heap memory pressure  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | usage |
-| JVMMemoryPressureCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical heap pressure  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | usage |
-| JVMThreadPoolExhaustion | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: thread pool saturation  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | threads |
-| JVMThreadPoolExhaustionCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical thread exhaustion  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | threads |
-| JVMPerformanceDegraded | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: multi-signal JVM degradation  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | pause |
+| JVMHighGCPause | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: GC pause elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:jvm_gc_pause:rate5m |
+| JVMHighGCPauseCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical GC pause  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:jvm_gc_pause:rate5m |
+| JVMMemoryPressure | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: heap memory pressure  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:jvm_memory_used:percent |
+| JVMMemoryPressureCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical heap pressure  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:jvm_memory_used:percent |
+| JVMThreadPoolExhaustion | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: thread pool saturation  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:jvm_threads:current |
+| JVMThreadPoolExhaustionCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical thread exhaustion  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:jvm_threads:current |
+| JVMPerformanceDegraded | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: multi-signal JVM degradation  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:jvm_gc_pause:rate5m |
 
 ---
 
@@ -76,14 +76,14 @@ lang: zh
 | 告警名稱 | 嚴重度 | 觸發條件 | 建議動作 | 相關指標 |
 |---|---|---|---|---|
 | KafkaExporterAbsent | critical | No kafka_brokers metric found for 30s | 確認相關元件已啟動、配置正確；檢查元件日誌 | kafka_brokers |
-| KafkaHighConsumerLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: consumer lag elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | lag |
-| KafkaHighConsumerLagCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical consumer lag  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | lag |
-| KafkaUnderReplicatedPartitions | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: under-replicated partitions  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
-| KafkaUnderReplicatedPartitionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical under-replication  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
-| KafkaNoActiveController | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: no active Kafka controller  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | controllers |
-| KafkaLowBrokerCount | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: broker count below minimum  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | brokers |
-| KafkaHighRequestRate | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: message rate threshold exceeded  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | rate |
-| KafkaHighRequestRateCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical message rate  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | rate |
+| KafkaHighConsumerLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: consumer lag elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:kafka_consumer_lag:max |
+| KafkaHighConsumerLagCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical consumer lag  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:kafka_consumer_lag:max |
+| KafkaUnderReplicatedPartitions | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: under-replicated partitions  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:kafka_under_replicated_partitions:max |
+| KafkaUnderReplicatedPartitionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical under-replication  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:kafka_under_replicated_partitions:max |
+| KafkaNoActiveController | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: no active Kafka controller  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:kafka_active_controllers:max |
+| KafkaLowBrokerCount | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: broker count below minimum  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:kafka_broker_count:max |
+| KafkaHighRequestRate | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: message rate threshold exceeded  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:kafka_request_rate:sum |
+| KafkaHighRequestRateCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical message rate  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:kafka_request_rate:sum |
 
 ---
 
@@ -91,10 +91,13 @@ lang: zh
 
 | 告警名稱 | 嚴重度 | 觸發條件 | 建議動作 | 相關指標 |
 |---|---|---|---|---|
-| PodContainerHighCPU | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: container CPU pressure  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | container |
-| PodContainerHighMemory | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: container memory pressure  | 檢查資源消耗、優化配置；考慮增加記憶體或啟用壓縮 | container |
-| ContainerCrashLoop | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: crash loop detected  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
-| ContainerImagePullFailure | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: image pull failing  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
+| PodContainerHighCPU | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: container CPU pressure  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | rule_pack_kubernetes:pod_container_high_cpu_warning:core |
+| PodContainerHighCPUCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: container CPU CRITICAL  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | rule_pack_kubernetes:pod_container_high_cpu_critical:core |
+| PodContainerHighMemory | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: container memory pressure  | 檢查資源消耗、優化配置；考慮增加記憶體或啟用壓縮 | rule_pack_kubernetes:pod_container_high_memory_warning:core |
+| PodContainerHighMemoryCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: container memory CRITICAL  | 檢查資源消耗、優化配置；考慮增加記憶體或啟用壓縮 | rule_pack_kubernetes:pod_container_high_memory_critical:core |
+| ContainerCrashLoop | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: crash loop detected  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:container_waiting_reason:count |
+| ContainerImagePullFailure | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: image pull failing  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:container_waiting_reason:count |
+| VersionAwareThresholdInert | warning | {{ $value \| printf "%.0f" }} version-specific container CPU threshold(s) declared and tenant pods ar | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | user_threshold |
 
 ---
 
@@ -104,12 +107,12 @@ lang: zh
 |---|---|---|---|---|
 | MariaDBDown | critical | mysql_up=0 for 15s on {{ $labels.instance }} | 立即檢查伺服器狀態、網路連線；查看系統日誌 | mysql_up |
 | MariaDBExporterAbsent | critical | No mysql_up metric found for 30s | 確認相關元件已啟動、配置正確；檢查元件日誌 | mysql_up |
-| MariaDBHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: connection threshold breached  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | value |
-| MariaDBHighConnectionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical connection saturation  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | value |
-| MariaDBSystemBottleneck | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: CPU + connections both exceeded  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | connections |
-| MariaDBRecentRestart | info | Uptime is only {{ $value }}s (< 5 min) | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | is |
-| MariaDBHighSlowQueries | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: slow query rate elevated  | 檢查慢查詢日誌，找出優化候選；考慮調整相關參數 | value |
-| MariaDBHighAbortedConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: aborted connection rate elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
+| MariaDBHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: connection threshold breached  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | tenant:mysql_threads_connected:max |
+| MariaDBHighConnectionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical connection saturation  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | tenant:mysql_threads_connected:max |
+| MariaDBSystemBottleneck | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: CPU + connections both exceeded  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:mysql_threads_connected:max |
+| MariaDBRecentRestart | info | Uptime is only {{ $value }}s (< 5 min) | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | mysql_global_status_uptime |
+| MariaDBHighSlowQueries | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: slow query rate elevated  | 檢查慢查詢日誌，找出優化候選；考慮調整相關參數 | tenant:mysql_slow_queries:rate5m |
+| MariaDBHighAbortedConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: aborted connection rate elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:mysql_aborted_connections:rate5m |
 
 ---
 
@@ -117,12 +120,12 @@ lang: zh
 
 | 告警名稱 | 嚴重度 | 觸發條件 | 建議動作 | 相關指標 |
 |---|---|---|---|---|
-| MongoDBDown | critical |  | 立即檢查伺服器狀態、網路連線；查看系統日誌 |  |
-| MongoDBHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB connection threshold breached  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | value |
-| MongoDBReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB replication lag  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | lag |
-| MongoDBHighOperations | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB operation rate elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
-| MongoDBHighPageFaults | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB page fault rate high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
-| MongoDBConnectionSaturation | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB connection pool near saturation  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
+| MongoDBDown | critical |  | 立即檢查伺服器狀態、網路連線；查看系統日誌 | mongodb_up |
+| MongoDBHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB connection threshold breached  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | tenant:mongodb_connections_current:max |
+| MongoDBReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB replication lag  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:mongodb_replication_lag:max |
+| MongoDBHighOperations | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB operation rate elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:mongodb_opcounters:rate5m |
+| MongoDBHighPageFaults | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB page fault rate high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:mongodb_page_faults:rate5m |
+| MongoDBConnectionSaturation | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB connection pool near saturation  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:mongodb_connection_usage:ratio |
 
 ---
 
@@ -130,12 +133,12 @@ lang: zh
 
 | 告警名稱 | 嚴重度 | 觸發條件 | 建議動作 | 相關指標 |
 |---|---|---|---|---|
-| NginxHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Nginx connection threshold exceeded  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | connections |
-| NginxHighConnectionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical Nginx connection saturation  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | connections |
-| NginxRequestRateSpike | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: request rate spike  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | rate |
-| NginxRequestRateSpikeCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical request rate  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | rate |
-| NginxConnectionBacklog | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: connection backlog building  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | connections |
-| NginxConnectionBacklogCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical connection backlog  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | connections |
+| NginxHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Nginx connection threshold exceeded  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | tenant:nginx_connections_active:max |
+| NginxHighConnectionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical Nginx connection saturation  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | tenant:nginx_connections_active:max |
+| NginxRequestRateSpike | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: request rate spike  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:nginx_requests:rate5m |
+| NginxRequestRateSpikeCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical request rate  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:nginx_requests:rate5m |
+| NginxConnectionBacklog | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: connection backlog building  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:nginx_connections_waiting:max |
+| NginxConnectionBacklogCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical connection backlog  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:nginx_connections_waiting:max |
 
 ---
 
@@ -143,10 +146,10 @@ lang: zh
 
 | 告警名稱 | 嚴重度 | 觸發條件 | 建議動作 | 相關指標 |
 |---|---|---|---|---|
-| TenantSilentWarning | none | Warning alerts for tenant {{ $labels.tenant }} will be recorded in TSDB but notifications suppressed | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | alerts |
-| TenantSilentCritical | none | Critical alerts for tenant {{ $labels.tenant }} will be recorded in TSDB but notifications suppresse | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | alerts |
-| TenantSeverityDedupEnabled | none | Warning notifications for {{ $labels.tenant }} will be suppressed when critical fires for the same m | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | notifications |
-| TenantConfigEvent | warning | Timed config for tenant {{ $labels.tenant }} has expired and auto-deactivated. Event: {{ $labels.eve | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | config |
+| TenantSilentWarning | none | Warning alerts for tenant {{ $labels.tenant }} will be recorded in TSDB but notifications suppressed | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | user_silent_mode |
+| TenantSilentCritical | none | Critical alerts for tenant {{ $labels.tenant }} will be recorded in TSDB but notifications suppresse | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | user_silent_mode |
+| TenantSeverityDedupEnabled | none | Warning notifications for {{ $labels.tenant }} will be suppressed when critical fires for the same m | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | user_severity_dedup |
+| TenantConfigEvent | warning | Timed config for tenant {{ $labels.tenant }} has expired and auto-deactivated. Event: {{ $labels.eve | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | da_config_event |
 
 ---
 
@@ -154,13 +157,13 @@ lang: zh
 
 | 告警名稱 | 嚴重度 | 觸發條件 | 建議動作 | 相關指標 |
 |---|---|---|---|---|
-| OracleDatabaseDown | critical |  | 立即檢查伺服器狀態、網路連線；查看系統日誌 |  |
-| OracleHighActiveSessions | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle active sessions elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
-| OracleTablespaceAlmostFull | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle tablespace nearing capacity  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | usage |
-| OracleHighWaitTime | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle wait time elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | time |
-| OracleHighProcessCount | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle process count high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
-| OracleHighPGAUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle PGA usage high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | allocated |
-| OracleHighSessionUtilization | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle session limit approaching  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | utilization |
+| OracleDatabaseDown | critical | oracledb_up=0 for 15s on {{ $labels.instance }} | 立即檢查伺服器狀態、網路連線；查看系統日誌 | oracledb_up |
+| OracleHighActiveSessions | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle active sessions elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:oracle_sessions_active:max |
+| OracleTablespaceAlmostFull | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle tablespace nearing capacity  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:oracle_tablespace_used_percent:max |
+| OracleHighWaitTime | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle wait time elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:oracle_wait_time:rate5m |
+| OracleHighProcessCount | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle process count high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:oracle_process_count:max |
+| OracleHighPGAUsage | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle PGA usage high  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:oracle_pga_allocated_bytes:max |
+| OracleHighSessionUtilization | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Oracle session limit approaching  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:oracle_session_utilization:ratio |
 
 ---
 
@@ -170,13 +173,13 @@ lang: zh
 |---|---|---|---|---|
 | PostgreSQLDown | critical | pg_up=0 for 15s on {{ $labels.instance }} | 立即檢查伺服器狀態、網路連線；查看系統日誌 | pg_up |
 | PostgreSQLExporterAbsent | critical | No pg_up metric found for 30s | 確認相關元件已啟動、配置正確；檢查元件日誌 | pg_up |
-| PostgreSQLHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: connection usage high  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | value |
-| PostgreSQLHighConnectionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical connection saturation  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | value |
-| PostgreSQLHighReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: replication lag elevated  | 檢查複寫狀態、網路連線；檢查複寫隊列堆積情況 | value |
-| PostgreSQLHighReplicationLagCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical replication lag  | 檢查複寫狀態、網路連線；檢查複寫隊列堆積情況 | value |
-| PostgreSQLHighDeadlocks | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: deadlocks detected  | 分析死鎖查詢日誌、調整應用邏輯減少衝突；考慮增加鎖定超時時間 | value |
-| PostgreSQLHighRollbackRatio | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: high rollback ratio  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
-| PostgreSQLRecentRestart | info | PostgreSQL uptime is only {{ $value | printf "%.0f" }}s (< 5 min) | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | uptime |
+| PostgreSQLHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: connection usage high  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | tenant:pg_connection_usage:ratio |
+| PostgreSQLHighConnectionsCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical connection saturation  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | tenant:pg_connection_usage:ratio |
+| PostgreSQLHighReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: replication lag elevated  | 檢查複寫狀態、網路連線；檢查複寫隊列堆積情況 | tenant:pg_replication_lag:max |
+| PostgreSQLHighReplicationLagCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical replication lag  | 檢查複寫狀態、網路連線；檢查複寫隊列堆積情況 | tenant:pg_replication_lag:max |
+| PostgreSQLHighDeadlocks | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: deadlocks detected  | 分析死鎖查詢日誌、調整應用邏輯減少衝突；考慮增加鎖定超時時間 | tenant:pg_deadlocks:rate5m |
+| PostgreSQLHighRollbackRatio | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: high rollback ratio  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:pg_rollback_ratio:rate5m |
+| PostgreSQLRecentRestart | info | PostgreSQL uptime is only {{ $value \| printf "%.0f" }}s (< 5 min) | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | pg_postmaster_start_time_seconds |
 
 ---
 
@@ -185,13 +188,13 @@ lang: zh
 | 告警名稱 | 嚴重度 | 觸發條件 | 建議動作 | 相關指標 |
 |---|---|---|---|---|
 | RabbitMQExporterAbsent | critical | No rabbitmq_identity_info metric found for 30s | 確認相關元件已啟動、配置正確；檢查元件日誌 | rabbitmq_identity_info |
-| RabbitMQHighQueueDepth | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: queue depth threshold exceeded  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | ready |
-| RabbitMQHighQueueDepthCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical queue depth  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | ready |
-| RabbitMQHighMemory | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ memory usage high  | 檢查資源消耗、優化配置；考慮增加記憶體或啟用壓縮 | used |
-| RabbitMQHighMemoryCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical RabbitMQ memory  | 檢查資源消耗、優化配置；考慮增加記憶體或啟用壓縮 | used |
-| RabbitMQHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ connection count high  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | connections |
-| RabbitMQLowConsumers | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ consumer count low  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | consumers |
-| RabbitMQHighUnackedMessages | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: unacked messages piling up  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
+| RabbitMQHighQueueDepth | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: queue depth threshold exceeded  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:rabbitmq_queue_messages:max |
+| RabbitMQHighQueueDepthCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical queue depth  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:rabbitmq_queue_messages:max |
+| RabbitMQHighMemory | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ memory usage high  | 檢查資源消耗、優化配置；考慮增加記憶體或啟用壓縮 | tenant:rabbitmq_node_mem_percent:ratio |
+| RabbitMQHighMemoryCritical | critical | [{{ $labels.tier }}] {{ $labels.tenant }}: critical RabbitMQ memory  | 檢查資源消耗、優化配置；考慮增加記憶體或啟用壓縮 | tenant:rabbitmq_node_mem_percent:ratio |
+| RabbitMQHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ connection count high  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | tenant:rabbitmq_connections:max |
+| RabbitMQLowConsumers | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ consumer count low  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:rabbitmq_consumers:max |
+| RabbitMQHighUnackedMessages | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: unacked messages piling up  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:rabbitmq_unacked_messages:max |
 
 ---
 
@@ -199,11 +202,11 @@ lang: zh
 
 | 告警名稱 | 嚴重度 | 觸發條件 | 建議動作 | 相關指標 |
 |---|---|---|---|---|
-| RedisDown | critical |  | 立即檢查伺服器狀態、網路連線；查看系統日誌 |  |
-| RedisHighMemory | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Redis memory threshold breached  | 檢查資源消耗、優化配置；考慮增加記憶體或啟用壓縮 | usage |
-| RedisHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Redis connection count high  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | value |
-| RedisHighKeyEvictions | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: key eviction rate elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | value |
-| RedisReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Redis replication lag  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | lag |
-| RedisLowHitRatio | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: low cache hit ratio  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | ratio |
+| RedisDown | critical |  | 立即檢查伺服器狀態、網路連線；查看系統日誌 | redis_up |
+| RedisHighMemory | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Redis memory threshold breached  | 檢查資源消耗、優化配置；考慮增加記憶體或啟用壓縮 | tenant:redis_memory_used_bytes:max |
+| RedisHighConnections | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Redis connection count high  | 檢查連線池配置、應用連線是否有洩漏；考慮增加最大連線數 | tenant:redis_connected_clients:max |
+| RedisHighKeyEvictions | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: key eviction rate elevated  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:redis_evicted_keys:rate5m |
+| RedisReplicationLag | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: Redis replication lag  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:redis_replication_lag:max |
+| RedisLowHitRatio | warning | [{{ $labels.tier }}] {{ $labels.tenant }}: low cache hit ratio  | 檢查告警指標、查看相關日誌；如需協助請聯絡平台團隊 | tenant:redis_keyspace_hit_ratio:avg |
 
 ---

--- a/scripts/tools/dx/generate_alert_reference.py
+++ b/scripts/tools/dx/generate_alert_reference.py
@@ -239,6 +239,37 @@ _GROUPING_CLAUSE = re.compile(
 )
 
 
+# Delimiter characters that must NEVER survive _strip_non_metric_syntax: if
+# any leak through, the identifier scan can mistake a fragment bounded by them
+# (a subquery step, a quoted `}`) for a metric. Asserted as an invariant in
+# tests (TestStripInvariant) — the durable guard against a future missed span.
+_NON_METRIC_DELIMITERS = "[]{}\"'`"
+
+
+def _strip_non_metric_syntax(expr: str) -> str:
+    """Remove every PromQL span that is NOT a series identifier.
+
+    Strips, in order, the spans that can hide a stray ``}`` / ``]`` / ``:``
+    before the later strips that rely on those delimiters:
+
+      1. string literals — may contain ``}`` / ``[`` / ``:`` inside quotes
+      2. range / subquery brackets — ``[5m]`` / ``[30m:1m]`` (the ``:`` is a
+         step, not a recording-rule separator)
+      3. label selectors ``{...}`` — contents are label names/values
+      4. grouping clauses ``by(...)`` / ``on(...)`` / ``group_left(...)`` —
+         their parenthesised body is a label list, not a series
+
+    The result holds only bare operators, numbers, parentheses, and series
+    identifiers. Crucially **none of ``_NON_METRIC_DELIMITERS`` survive**, so
+    ``get_metric_from_expr`` can scan for the first identifier safely.
+    """
+    cleaned = _PROMQL_STRINGS.sub(" ", expr)
+    cleaned = _PROMQL_RANGE_SUBQUERY.sub(" ", cleaned)
+    cleaned = re.sub(r"\{[^}]*\}", " ", cleaned)
+    cleaned = _GROUPING_CLAUSE.sub(" ", cleaned)
+    return cleaned
+
+
 def get_metric_from_expr(expr: str) -> str:
     """Extract the primary metric / series name from a rule's PromQL ``expr``.
 
@@ -253,17 +284,7 @@ def get_metric_from_expr(expr: str) -> str:
     """
     if not expr:
         return ""
-    # Order matters — strip the spans that can hide stray `}` / `]` / `:`
-    # before the brace/range/grouping strips that rely on those delimiters:
-    #   1. string literals (may contain `}`, `[`, `:` inside quotes)
-    cleaned = _PROMQL_STRINGS.sub(" ", expr)
-    #   2. range / subquery brackets ([5m] / [30m:1m] — the ':' is a step,
-    #      not a recording-rule separator)
-    cleaned = _PROMQL_RANGE_SUBQUERY.sub(" ", cleaned)
-    #   3. label selectors ({...}) — their contents are label names/values
-    cleaned = re.sub(r"\{[^}]*\}", " ", cleaned)
-    #   4. grouping clauses (by(...)/on(...)/group_left(...)) — label lists
-    cleaned = _GROUPING_CLAUSE.sub(" ", cleaned)
+    cleaned = _strip_non_metric_syntax(expr)
     for token in _PROMQL_IDENT.finditer(cleaned):
         ident = token.group(0)
         if ident in _PROMQL_KEYWORDS:

--- a/scripts/tools/dx/generate_alert_reference.py
+++ b/scripts/tools/dx/generate_alert_reference.py
@@ -22,6 +22,7 @@ SAST Rules:
 
 import argparse
 import os
+import re
 import sys
 import yaml
 import difflib
@@ -150,6 +151,11 @@ def extract_alerts(yaml_content: Dict[str, Any]) -> List[Dict[str, Any]]:
             # Use platform_summary if available (for dual-perspective alerts)
             platform_summary = annotations.get("platform_summary", "")
 
+            # The related metric comes from the rule's PromQL `expr` (the real
+            # series the alert evaluates), NOT the prose description.
+            expr = rule.get("expr", "")
+            metric = get_metric_from_expr(expr)
+
             alerts.append(
                 {
                     "name": alert_name,
@@ -157,6 +163,8 @@ def extract_alerts(yaml_content: Dict[str, Any]) -> List[Dict[str, Any]]:
                     "summary": summary,
                     "description": description,
                     "platform_summary": platform_summary,
+                    "expr": expr,
+                    "metric": metric,
                 }
             )
 
@@ -172,13 +180,85 @@ def get_recommended_action(alert_name: str) -> Dict[str, str]:
     return RECOMMENDED_ACTIONS["default"]
 
 
-def get_metric_from_description(description: str) -> str:
-    """Extract primary metric name from description if available."""
-    # Simple extraction: look for metric patterns like "mysql_up", "pg_up", etc.
-    import re
+# PromQL aggregation operators, binary-op modifiers, and built-in functions.
+# When scanning an `expr` for the primary series, these are NOT metrics and
+# must be skipped (e.g. the leading `count`/`max`/`absent`/`time` of a query).
+_PROMQL_KEYWORDS = frozenset(
+    {
+        # aggregation operators
+        "sum", "min", "max", "avg", "group", "stddev", "stdvar", "count",
+        "count_values", "bottomk", "topk", "quantile", "limitk", "limit_ratio",
+        # aggregation / binary-op modifiers
+        "by", "without", "on", "ignoring", "group_left", "group_right",
+        # set / logical binary operators + keywords
+        "and", "or", "unless", "atan2", "offset", "bool",
+        "inf", "nan", "start", "end",
+        # instant-vector functions
+        "abs", "absent", "ceil", "changes", "clamp", "clamp_max", "clamp_min",
+        "day_of_month", "day_of_week", "day_of_year", "days_in_month", "delta",
+        "deriv", "exp", "floor", "histogram_avg", "histogram_count",
+        "histogram_fraction", "histogram_quantile", "histogram_stddev",
+        "histogram_stdvar", "histogram_sum", "holt_winters",
+        "double_exponential_smoothing", "hour", "idelta", "increase", "irate",
+        "label_join", "label_replace", "ln", "log10", "log2", "minute",
+        "month", "predict_linear", "rate", "resets", "round", "scalar", "sgn",
+        "sort", "sort_desc", "sort_by_label", "sort_by_label_desc", "sqrt",
+        "time", "timestamp", "vector", "year",
+        # range-vector (*_over_time) functions
+        "absent_over_time", "avg_over_time", "min_over_time", "max_over_time",
+        "sum_over_time", "count_over_time", "quantile_over_time",
+        "stddev_over_time", "stdvar_over_time", "last_over_time",
+        "present_over_time", "mad_over_time",
+    }
+)
 
-    match = re.search(r"\b([a-z_]+(?:_[a-z]+)*)\b", description)
-    return match.group(1) if match else ""
+# A PromQL metric / series identifier. Includes ':' so recording-rule names
+# like `tenant:db2_connections_active:max` are captured as a single token.
+_PROMQL_IDENT = re.compile(r"[a-zA-Z_:][a-zA-Z0-9_:]*")
+
+# Grouping clauses whose parenthesised body is a LABEL list, not a series:
+# `by(tenant, version)`, `on(tenant)`, `group_left(runbook_url, owner)`, etc.
+# Stripped first so their label names aren't mistaken for the metric.
+_GROUPING_CLAUSE = re.compile(
+    r"\b(?:by|without|on|ignoring|group_left|group_right)\s*\([^)]*\)"
+)
+
+
+def get_metric_from_expr(expr: str) -> str:
+    """Extract the primary metric / series name from a rule's PromQL ``expr``.
+
+    Returns the first real series identifier the alert evaluates — including
+    recording-rule names like ``tenant:db2_connections_active:max`` — after
+    skipping function names, aggregation operators, label selectors, and
+    grouping clauses. This is the series an operator can actually query,
+    unlike the previous "first lowercase word in the prose description"
+    heuristic which produced noise ("for", "value", "query").
+
+    Returns "" when no identifier can be found.
+    """
+    if not expr:
+        return ""
+    # Drop label selectors ({...}); their contents are label names/values.
+    cleaned = re.sub(r"\{[^}]*\}", " ", expr)
+    # Drop grouping clauses (by(...)/on(...)/group_left(...)); label lists.
+    cleaned = _GROUPING_CLAUSE.sub(" ", cleaned)
+    for token in _PROMQL_IDENT.finditer(cleaned):
+        ident = token.group(0)
+        if ident in _PROMQL_KEYWORDS:
+            continue
+        return ident
+    return ""
+
+
+def _escape_table_cell(text: str) -> str:
+    """Escape a value for safe inclusion in a Markdown table cell.
+
+    ``|`` delimits columns, so a literal pipe — e.g. from a Go template like
+    ``{{ $value | printf "%.0f" }}`` in an alert's trigger text — would split
+    the row into phantom columns and break rendering. Escape pipes and flatten
+    any stray newline so each alert stays on one table row.
+    """
+    return text.replace("\n", " ").replace("|", "\\|")
 
 
 def generate_markdown_zh(alerts_by_pack: Dict[str, List[Dict]]) -> str:
@@ -192,6 +272,8 @@ def generate_markdown_zh(alerts_by_pack: Dict[str, List[Dict]]) -> str:
         "lang: zh",
         "---",
         "# Rule Pack 告警參考指南 (Alert Reference Guide)",
+        "",
+        "> **Language / 語言：** **中文 (Current)** | [English](./ALERT-REFERENCE.en.md)",
         "",
         "本文件為租戶提供各 Rule Pack 中所有告警的統一參考，包括告警含義、觸發條件和建議動作。",
         "",
@@ -222,13 +304,15 @@ def generate_markdown_zh(alerts_by_pack: Dict[str, List[Dict]]) -> str:
             if trigger_condition:
                 sentences = trigger_condition.split("—")
                 trigger_condition = sentences[0][:100]
+            # Escape pipes/newlines so Go-template trigger text (e.g.
+            # `{{ $value | printf ... }}`) doesn't break the table row.
+            trigger_condition = _escape_table_cell(trigger_condition)
 
             recommended_action = get_recommended_action(name)["zh"]
 
-            # Extract metric from description
-            metric = get_metric_from_description(alert["description"])
-            if not metric:
-                metric = ""
+            # Related metric: the primary series from the rule's PromQL expr
+            # (computed in extract_alerts).
+            metric = alert.get("metric", "")
 
             lines.append(
                 f"| {name} | {severity} | {trigger_condition} | {recommended_action} | {metric} |"
@@ -252,6 +336,8 @@ def generate_markdown_en(alerts_by_pack: Dict[str, List[Dict]]) -> str:
         "lang: en",
         "---",
         "# Rule Pack Alert Reference Guide",
+        "",
+        "> **Language / 語言：** **English (Current)** | [中文](./ALERT-REFERENCE.md)",
         "",
         "This document provides tenants with a unified reference for all alerts across Rule Packs, including alert meanings, trigger conditions, and recommended actions.",
         "",
@@ -280,13 +366,15 @@ def generate_markdown_en(alerts_by_pack: Dict[str, List[Dict]]) -> str:
             if trigger_condition:
                 sentences = trigger_condition.split("—")
                 trigger_condition = sentences[0][:100]
+            # Escape pipes/newlines so Go-template trigger text (e.g.
+            # `{{ $value | printf ... }}`) doesn't break the table row.
+            trigger_condition = _escape_table_cell(trigger_condition)
 
             recommended_action = get_recommended_action(name)["en"]
 
-            # Extract metric from description
-            metric = get_metric_from_description(alert["description"])
-            if not metric:
-                metric = ""
+            # Related metric: the primary series from the rule's PromQL expr
+            # (computed in extract_alerts).
+            metric = alert.get("metric", "")
 
             lines.append(
                 f"| {name} | {severity} | {trigger_condition} | {recommended_action} | {metric} |"

--- a/scripts/tools/dx/generate_alert_reference.py
+++ b/scripts/tools/dx/generate_alert_reference.py
@@ -216,9 +216,24 @@ _PROMQL_KEYWORDS = frozenset(
 # like `tenant:db2_connections_active:max` are captured as a single token.
 _PROMQL_IDENT = re.compile(r"[a-zA-Z_:][a-zA-Z0-9_:]*")
 
+# String literals — double / single / backtick quoted, honouring `\"` escapes.
+# Stripped FIRST: a label value or annotation may legitimately contain `}`,
+# `[`, or `:` (e.g. `handler="abc}def"`), which would otherwise leak into the
+# brace/range strips below and corrupt the scan.
+_PROMQL_STRINGS = re.compile(
+    r"\"[^\"\\]*(?:\\.[^\"\\]*)*\""
+    r"|'[^'\\]*(?:\\.[^'\\]*)*'"
+    r"|`[^`]*`"
+)
+
+# Range / subquery brackets: `[5m]`, `[30m:1m]`. The ':' in a subquery step
+# would otherwise let `_PROMQL_IDENT` match a junk token like `m:1m` for a
+# metric-less expr such as `vector(0)[5m:1m]`. Strip whole `[...]` spans.
+_PROMQL_RANGE_SUBQUERY = re.compile(r"\[[^\]]*\]")
+
 # Grouping clauses whose parenthesised body is a LABEL list, not a series:
 # `by(tenant, version)`, `on(tenant)`, `group_left(runbook_url, owner)`, etc.
-# Stripped first so their label names aren't mistaken for the metric.
+# Stripped so their label names aren't mistaken for the metric.
 _GROUPING_CLAUSE = re.compile(
     r"\b(?:by|without|on|ignoring|group_left|group_right)\s*\([^)]*\)"
 )
@@ -238,9 +253,16 @@ def get_metric_from_expr(expr: str) -> str:
     """
     if not expr:
         return ""
-    # Drop label selectors ({...}); their contents are label names/values.
-    cleaned = re.sub(r"\{[^}]*\}", " ", expr)
-    # Drop grouping clauses (by(...)/on(...)/group_left(...)); label lists.
+    # Order matters — strip the spans that can hide stray `}` / `]` / `:`
+    # before the brace/range/grouping strips that rely on those delimiters:
+    #   1. string literals (may contain `}`, `[`, `:` inside quotes)
+    cleaned = _PROMQL_STRINGS.sub(" ", expr)
+    #   2. range / subquery brackets ([5m] / [30m:1m] — the ':' is a step,
+    #      not a recording-rule separator)
+    cleaned = _PROMQL_RANGE_SUBQUERY.sub(" ", cleaned)
+    #   3. label selectors ({...}) — their contents are label names/values
+    cleaned = re.sub(r"\{[^}]*\}", " ", cleaned)
+    #   4. grouping clauses (by(...)/on(...)/group_left(...)) — label lists
     cleaned = _GROUPING_CLAUSE.sub(" ", cleaned)
     for token in _PROMQL_IDENT.finditer(cleaned):
         ident = token.group(0)
@@ -256,9 +278,19 @@ def _escape_table_cell(text: str) -> str:
     ``|`` delimits columns, so a literal pipe — e.g. from a Go template like
     ``{{ $value | printf "%.0f" }}`` in an alert's trigger text — would split
     the row into phantom columns and break rendering. Escape pipes and flatten
-    any stray newline so each alert stays on one table row.
+    any stray newline (incl. Windows ``\\r\\n`` / lone ``\\r``) so each alert
+    stays on one table row.
+
+    The pipe-escape is idempotent: an already-escaped ``\\|`` is collapsed
+    before re-escaping so re-running the generator never produces ``\\\\|``
+    (a literal backslash + column break, which re-breaks the table).
     """
-    return text.replace("\n", " ").replace("|", "\\|")
+    if not text:
+        return ""
+    flattened = (
+        text.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+    )
+    return flattened.replace("\\|", "|").replace("|", "\\|")
 
 
 def generate_markdown_zh(alerts_by_pack: Dict[str, List[Dict]]) -> str:

--- a/tests/dx/test_generate_alert_reference.py
+++ b/tests/dx/test_generate_alert_reference.py
@@ -262,6 +262,66 @@ class TestGetMetricFromExpr:
 
 
 # ---------------------------------------------------------------------------
+# _strip_non_metric_syntax — the cleaner invariant
+# ---------------------------------------------------------------------------
+class TestStripInvariant:
+    """The durable guard the example tests above can't be: rather than enumerate
+    *known* bypasses, assert the INVARIANT — after cleaning, no delimiter that
+    could fence off a fake identifier (`[ ] { } " ' \\``) may survive. This is
+    what the original review missed: it validated outputs for the 14 current
+    packs (a corpus) instead of the property over the PromQL grammar. A future
+    construct that introduces a new delimiter-bounded span fails HERE even if
+    no one wrote a bespoke example for it.
+    """
+
+    # One representative of every delimiter-bearing PromQL construct, plus
+    # adversarial mixes (quoted delimiters, nested ranges, subqueries).
+    _EXPRS = [
+        "db2_up == 0",
+        'up{job="clickhouse"} == 0',
+        'absent(kafka_brokers{job="tenant-exporters"})',
+        "(time() - pg_postmaster_start_time_seconds) < 300",
+        'rate(http_requests_total{job="api"}[5m])[30m:1m] > 0',
+        'env_metric{info="broken}bracket", cluster="main"} > 5',
+        "vector(0)[5m:1m]",
+        'label_replace(foo, "dst", "}", "src", ".*[")',
+        "sum(rate(x[5m])) and `raw{string}`",
+        "(count(max by(tenant, version, severity) "
+        '(user_threshold{component="container"})) or vector(0)) > 0',
+    ]
+
+    @pytest.mark.parametrize("expr", _EXPRS)
+    def test_no_delimiter_residue(self, expr):
+        cleaned = gar._strip_non_metric_syntax(expr)
+        leaked = [c for c in gar._NON_METRIC_DELIMITERS if c in cleaned]
+        assert not leaked, f"delimiters {leaked} leaked from {expr!r} -> {cleaned!r}"
+
+    @pytest.mark.parametrize("expr", _EXPRS)
+    def test_result_is_valid_identifier_or_empty(self, expr):
+        # The output must always be a real PromQL identifier (metric or
+        # recording-rule name) or empty — never a fragment.
+        import re as _re
+        result = gar.get_metric_from_expr(expr)
+        assert result == "" or _re.fullmatch(r"[a-zA-Z_:][a-zA-Z0-9_:]*", result), (
+            f"{expr!r} -> {result!r} is not a valid identifier"
+        )
+
+    def test_invariant_holds_on_every_real_alert(self):
+        # Tie the invariant to production data: every alert expr across all
+        # shipped rule packs must clean to zero delimiter residue.
+        from pathlib import Path
+        repo_root = Path(gar.__file__).resolve().parents[3]
+        packs_dir = repo_root / "rule-packs"
+        alerts_by_pack = gar.load_rule_packs(str(packs_dir))
+        assert alerts_by_pack, "no rule packs loaded — path wrong?"
+        for pack, alerts in alerts_by_pack.items():
+            for a in alerts:
+                cleaned = gar._strip_non_metric_syntax(a["expr"])
+                leaked = [c for c in gar._NON_METRIC_DELIMITERS if c in cleaned]
+                assert not leaked, f"{pack}/{a['name']}: {leaked} leaked"
+
+
+# ---------------------------------------------------------------------------
 # extract_alerts wires expr → metric
 # ---------------------------------------------------------------------------
 class TestExtractAlertsMetric:

--- a/tests/dx/test_generate_alert_reference.py
+++ b/tests/dx/test_generate_alert_reference.py
@@ -5,7 +5,7 @@ Closes the audit gap (P1-5 / 456 LOC tool was 0% covered). Targets the spine:
   - get_display_name (lookup with fallback)
   - extract_alerts (YAML traversal, recording-rule skip, default severity)
   - get_recommended_action (substring pattern → action dict)
-  - get_metric_from_description (regex extraction)
+  - get_metric_from_expr (PromQL series extraction from expr)
   - generate_markdown_zh / _en (smoke + frontmatter sanity)
   - load_rule_packs (file IO, glob, skip non-rule-pack files)
   - main() CLI (dry-run, --check synced + drift, --output-dir, write mode)
@@ -164,20 +164,97 @@ class TestGetRecommendedAction:
 
 
 # ---------------------------------------------------------------------------
-# get_metric_from_description
+# get_metric_from_expr
 # ---------------------------------------------------------------------------
-class TestGetMetricFromDescription:
-    def test_extracts_first_snake_token(self):
-        # The regex matches the first lowercase + underscore identifier.
-        result = gar.get_metric_from_description("mysql_up == 0 for 5 minutes")
-        assert result == "mysql_up"
+class TestGetMetricFromExpr:
+    """The Related Metric column is sourced from the rule's PromQL ``expr``
+    (the real series the alert evaluates), NOT the prose description. The old
+    description heuristic produced noise like "for"/"value"/"query"; these
+    tests lock in that the expr parser returns genuine series names.
+    """
 
     def test_empty_string_returns_empty(self):
-        assert gar.get_metric_from_description("") == ""
+        assert gar.get_metric_from_expr("") == ""
 
-    def test_uppercase_only_returns_empty(self):
-        # No lowercase identifier found.
-        assert gar.get_metric_from_description("ALERT FIRED") == ""
+    def test_simple_up_comparison(self):
+        # `db2_up == 0` → the bare metric.
+        assert gar.get_metric_from_expr("db2_up == 0") == "db2_up"
+
+    def test_label_selector_stripped(self):
+        # `up{job="clickhouse"} == 0` → `up`, not the label name/value.
+        assert gar.get_metric_from_expr('up{job="clickhouse"} == 0') == "up"
+
+    def test_recording_rule_name_with_colons(self):
+        # Recording-rule series names contain ':' and are returned whole.
+        expr = (
+            "( ( tenant:db2_connections_active:max > on(tenant) group_left "
+            "tenant:alert_threshold:db2_connections_active ) )"
+        )
+        assert (
+            gar.get_metric_from_expr(expr)
+            == "tenant:db2_connections_active:max"
+        )
+
+    def test_skips_leading_function_absent(self):
+        # `absent(...)` is a function, not the metric.
+        expr = 'absent(kafka_brokers{job="tenant-exporters"})'
+        assert gar.get_metric_from_expr(expr) == "kafka_brokers"
+
+    def test_skips_leading_function_time(self):
+        # `(time() - pg_postmaster_start_time_seconds) < 300`
+        expr = "(time() - pg_postmaster_start_time_seconds) < 300"
+        assert (
+            gar.get_metric_from_expr(expr)
+            == "pg_postmaster_start_time_seconds"
+        )
+
+    def test_skips_grouping_label_list(self):
+        # `by(tenant, version, severity)` is a LABEL list — those names must
+        # not be mistaken for the metric. The version-aware inert sentinel.
+        expr = (
+            "(count(max by(tenant, version, severity) "
+            '(user_threshold{component="container", metric="cpu"})) '
+            "or vector(0)) > 0"
+        )
+        assert gar.get_metric_from_expr(expr) == "user_threshold"
+
+    def test_kubernetes_recording_rule_first(self):
+        # The version-aware k8s alerts reference a recording rule first.
+        expr = (
+            "( rule_pack_kubernetes:pod_container_high_cpu_warning:core "
+            "* on(tenant) group_left(runbook_url, owner, tier) "
+            "tenant_metadata_info )"
+        )
+        assert (
+            gar.get_metric_from_expr(expr)
+            == "rule_pack_kubernetes:pod_container_high_cpu_warning:core"
+        )
+
+    def test_no_identifier_returns_empty(self):
+        # Pure punctuation / numbers → no series identifier.
+        assert gar.get_metric_from_expr("42 > 0") == ""
+
+
+# ---------------------------------------------------------------------------
+# extract_alerts wires expr → metric
+# ---------------------------------------------------------------------------
+class TestExtractAlertsMetric:
+    def test_metric_computed_from_expr(self):
+        content = {"groups": [{"name": "g", "rules": [
+            {"alert": "Down", "expr": "redis_up == 0",
+             "labels": {"severity": "critical"}, "annotations": {}},
+        ]}]}
+        out = gar.extract_alerts(content)
+        assert out[0]["metric"] == "redis_up"
+        assert out[0]["expr"] == "redis_up == 0"
+
+    def test_missing_expr_yields_empty_metric(self):
+        content = {"groups": [{"name": "g", "rules": [
+            {"alert": "Bare", "labels": {"severity": "warning"},
+             "annotations": {}},
+        ]}]}
+        out = gar.extract_alerts(content)
+        assert out[0]["metric"] == ""
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +289,56 @@ class TestGenerateMarkdown:
         out = gar.generate_markdown_zh(alerts)
         # Severity appears somewhere in the rendering.
         assert "critical" in out
+
+    def test_metric_column_rendered_from_metric_key(self):
+        # The Related Metric column surfaces the precomputed `metric` value.
+        alerts = {"mariadb": [
+            {"name": "MariaDBDown", "severity": "critical",
+             "summary": "s", "description": "d", "platform_summary": "",
+             "expr": "mysql_up == 0", "metric": "mysql_up"},
+        ]}
+        out_zh = gar.generate_markdown_zh(alerts)
+        out_en = gar.generate_markdown_en(alerts)
+        assert "mysql_up" in out_zh
+        assert "mysql_up" in out_en
+
+    def test_missing_metric_key_renders_blank(self):
+        # Manually-built dicts without a `metric` key must not crash.
+        alerts = {"mariadb": [
+            {"name": "NoMetric", "severity": "warning",
+             "summary": "s", "description": "d", "platform_summary": ""},
+        ]}
+        out = gar.generate_markdown_zh(alerts)
+        assert "NoMetric" in out
+
+    def test_pipe_in_trigger_condition_escaped(self):
+        # A Go-template trigger like `{{ $value | printf ... }}` carries a
+        # literal `|` that would split the Markdown row — it must be escaped.
+        alerts = {"kubernetes": [
+            {"name": "PipeAlert", "severity": "warning", "summary": "s",
+             "description": '{{ $value | printf "%.0f" }} thresholds declared',
+             "platform_summary": "", "expr": "user_threshold",
+             "metric": "user_threshold"},
+        ]}
+        for out in (gar.generate_markdown_zh(alerts),
+                    gar.generate_markdown_en(alerts)):
+            row = [ln for ln in out.splitlines() if "PipeAlert" in ln][0]
+            assert "\\|" in row, "literal pipe was not escaped"
+            assert "{{ $value | printf" not in row, "unescaped pipe leaked"
+
+
+# ---------------------------------------------------------------------------
+# _escape_table_cell
+# ---------------------------------------------------------------------------
+class TestEscapeTableCell:
+    def test_escapes_pipe(self):
+        assert gar._escape_table_cell("a | b") == "a \\| b"
+
+    def test_flattens_newline(self):
+        assert gar._escape_table_cell("a\nb") == "a b"
+
+    def test_plain_text_unchanged(self):
+        assert gar._escape_table_cell("plain text") == "plain text"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/dx/test_generate_alert_reference.py
+++ b/tests/dx/test_generate_alert_reference.py
@@ -234,6 +234,32 @@ class TestGetMetricFromExpr:
         # Pure punctuation / numbers → no series identifier.
         assert gar.get_metric_from_expr("42 > 0") == ""
 
+    # --- adversarial parser-bypass cases (Gemini review) ---
+
+    def test_subquery_colon_protection(self):
+        # A subquery step `[30m:1m]` must not leak a junk `m:1m` token; the
+        # range brackets are stripped before the identifier scan.
+        expr = 'rate(http_requests_total{job="api"}[5m])[30m:1m] > 0'
+        assert gar.get_metric_from_expr(expr) == "http_requests_total"
+
+    def test_string_containing_closing_brace(self):
+        # A label value containing `}` must not break the brace strip and
+        # leak a later label name as the metric.
+        expr = 'env_metric{info="broken}bracket", cluster="main"} > 5'
+        assert gar.get_metric_from_expr(expr) == "env_metric"
+
+    def test_range_vector_strip(self):
+        # A bare range vector `[5m]` after a function still resolves to the
+        # wrapped series, with no `m`/`5m`-derived junk.
+        expr = "sum(rate(http_errors_total[5m]))"
+        assert gar.get_metric_from_expr(expr) == "http_errors_total"
+
+    def test_subquery_step_no_junk_token(self):
+        # Load-bearing for the range/subquery strip: a metric-less subquery
+        # expr would otherwise leak the step `m:1m` as a "metric" (the ':'
+        # makes `_PROMQL_IDENT` greedy). With the strip it resolves to "".
+        assert gar.get_metric_from_expr("vector(0)[5m:1m]") == ""
+
 
 # ---------------------------------------------------------------------------
 # extract_alerts wires expr → metric
@@ -339,6 +365,19 @@ class TestEscapeTableCell:
 
     def test_plain_text_unchanged(self):
         assert gar._escape_table_cell("plain text") == "plain text"
+
+    def test_flattens_crlf(self):
+        # Windows CRLF and a lone CR both flatten to a space.
+        assert gar._escape_table_cell("a\r\nb") == "a b"
+        assert gar._escape_table_cell("a\rb") == "a b"
+
+    def test_escape_is_idempotent(self):
+        # An already-escaped `\|` must not become `\\|` on a second pass.
+        assert gar._escape_table_cell("value \\| printf") == "value \\| printf"
+        assert gar._escape_table_cell("value |\nprintf") == "value \\| printf"
+
+    def test_empty_returns_empty(self):
+        assert gar._escape_table_cell("") == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The **相關指標 / Related Metric** column in `rule-packs/ALERT-REFERENCE.md`
and `.en.md` was scraped from each alert's **prose description** via a
"first lowercase word" regex (`get_metric_from_description`). That produced
meaningless values — `for` (from `"...for 15s..."`), `query`, `value`,
`count`, `tracked`. None were real series names.

## Fix

Source the column from the rule's **PromQL `expr`** — the actual series the
alert evaluates — via a new `get_metric_from_expr()`:

- Returns the first real series identifier, skipping PromQL functions
  (`absent`/`time`/`count`…), aggregation operators, label selectors `{…}`,
  and grouping clauses `by(…)`/`on(…)`/`group_left(…)` so label names like
  `(tenant, version, severity)` aren't mistaken for the metric.
- Recording-rule names (e.g. `tenant:db2_connections_active:max`) are
  returned whole — they are real, queryable series.
- `extract_alerts()` computes `metric` from `expr` where it already holds
  the full rule dict; both generators read the precomputed value.

All 96 alerts across the 14 packs now yield a genuine series, e.g.
`DB2DatabaseDown → db2_up`, `KafkaExporterAbsent → kafka_brokers`,
`VersionAwareThresholdInert → user_threshold`, `PostgreSQLRecentRestart →
pg_postmaster_start_time_seconds`.

Also **escape literal pipes** in the trigger-condition column so Go-template
text like `{{ $value | printf "%.0f" }}` no longer splits the Markdown row
(`VersionAwareThresholdInert`, `ClickHouseHighFailedQueryRate`).

## Verification

- Regenerated both files in the dev container; drift gate
  `generate_alert_reference.py --check` returns **0**.
- `tests/dx/test_generate_alert_reference.py` — **47 passed** (new
  `TestGetMetricFromExpr`, `TestExtractAlertsMetric`, `TestEscapeTableCell`,
  pipe-escape render test).
- mkdocs strict (site-root) build: **0 actionable warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
