### PR TITLE
ci(dx): gate ALERT-REFERENCE drift in CI + pre-commit + lint-docs

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -315,7 +315,7 @@ jobs:
       - name: Run drift checks (versions, tool-map, doc-map, rule-pack-stats)
         run: |
           python scripts/tools/validate_all.py \
-            --only versions,tool_map,doc_map,rule_pack_stats,changelog,glossary,includes,repo_name \
+            --only versions,tool_map,doc_map,rule_pack_stats,changelog,glossary,includes,repo_name,alerts \
             --ci
 
   i4-runbook-smoke-test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -260,6 +260,14 @@ repos:
         files: ^(rule-packs/|k8s/03-monitoring/).*\.yaml$
         additional_dependencies: ['pyyaml']
 
+      - id: alert-reference-check
+        name: Alert reference drift (ALERT-REFERENCE.md/.en.md)
+        entry: python3 -X utf8 scripts/tools/dx/generate_alert_reference.py --check
+        language: python
+        pass_filenames: false
+        files: ^rule-packs/.*\.ya?ml$
+        additional_dependencies: ['pyyaml']
+
       - id: glossary-check
         name: Glossary abbreviation sync
         entry: python3 -X utf8 scripts/tools/dx/sync_glossary_abbr.py --check

--- a/Makefile
+++ b/Makefile
@@ -684,7 +684,7 @@ lint-extract: ## 拆新 lint script（PR #154/#162/#166/#169/#170 共通 boilerp
 
 lint-docs: ## 一站式文件 lint（versions + drift + tool consistency，支援 ARGS="--parallel"）
 	@python3 ./scripts/tools/validate_all.py \
-		--only versions,tool_map,doc_map,rule_pack_stats,changelog,glossary,includes,platform_data,tool_consistency \
+		--only versions,tool_map,doc_map,rule_pack_stats,changelog,glossary,includes,platform_data,tool_consistency,alerts \
 		$(ARGS)
 
 .PHONY: lint-egress


### PR DESCRIPTION
## What

Wire the existing `generate_alert_reference.py --check` drift check into the
three enforcement paths that were silently missing it.

The `alerts` check already lived in `validate_all.py`'s `TOOLS` list, but
**nothing actually ran it**:
- CI `docs-ci.yaml` drift-checks `--only` list omitted it
- `make lint-docs` `--only` list omitted it
- no dedicated pre-commit hook covered it

So `rule-packs/ALERT-REFERENCE.md` / `.en.md` could drift from the rule packs
with zero signal — exactly how the `VersionAwareThresholdInert` sentinel (#697)
and `PodContainerHighMemoryCritical` (memory mirror PR) rows went stale before
#701 regenerated them.

## Changes (gate wiring only — 3 files)

- **`.pre-commit-config.yaml`** — new `alert-reference-check` hook, mirroring
  `rule-pack-stats-check`; triggers on `^rule-packs/.*\.ya?ml$`
- **`.github/workflows/docs-ci.yaml`** — add `alerts` to the drift-checks `--only`
- **`Makefile`** — add `alerts` to `lint-docs`'s `--only`

The generator change (language-switch banner emission + Related-Metric-from-expr)
and the regenerated reference files landed separately in #701; this PR is the
**enforcement wiring only**.

## Verification

- `generate_alert_reference.py --check` → exit 0 (synchronized)
- `bump_docs.py --check` → consistent (hook-count line needs no bump)
- `make pr-preflight` → READY
- Behaviour: editing a rule-pack alert without regenerating now turns CI red.

Refs: TRK-304

🤖 Generated with [Claude Code](https://claude.com/claude-code)
