### PR TITLE
fix(rule-packs): left-outer-join metadata enrichment across all packs (onboarding-vacuum)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -722,6 +722,18 @@ repos:
         # labels so dimensional thresholds (env/version/tablespace_re) keep their
         # dimensions. Caught a ~2-month silent prod drift in 4 packs (ADR-024).
 
+      - id: leftouterjoin-enrichment
+        name: "ADR-024: alert metadata enrichment must be left-outer-join (no onboarding-vacuum drop)"
+        entry: python3 -X utf8 scripts/tools/lint/check_leftouterjoin_enrichment.py --ci
+        language: python
+        pass_filenames: false
+        files: ^rule-packs/rule-pack-.*\.yaml$
+        # Every `* on(tenant) group_left(runbook_url, owner, tier) tenant_metadata_info`
+        # (inner join — drops a tenant with metrics but no metadata row) must be
+        # paired with an `or (… unless on(tenant) tenant_metadata_info)` void
+        # branch. Source-only: configmaps are sync-checked against source
+        # separately. Semantic proof: tests/rulepacks/*-void_test.yaml.
+
       - id: ksm-version-allowlist
         name: "ADR-024: kube-state-metrics must allowlist app.kubernetes.io/version (test/rulepack-e2e)"
         entry: python3 -X utf8 scripts/tools/lint/check_ksm_version_allowlist.py --ci

--- a/docs/internal/tool-map.en.md
+++ b/docs/internal/tool-map.en.md
@@ -164,6 +164,7 @@ lang: en
 | `check_jsx_loader_compat.py` | Detect JSX-loader-incompatible module syntax (named exports / non-allowlist imports / require() calls). |
 | `check_k8s_manifests.py` | Container/k8s IaC SAST, Layer 4 (raw k8s manifests). |
 | `check_ksm_version_allowlist.py` | KSM version-allowlist invariant lint (ADR-024 partial-misconfig defense). |
+| `check_leftouterjoin_enrichment.py` | Left-outer-join enrichment invariant lint (ADR-024 PR3-pre Commit 3). |
 | `check_log_egress_policy.py` | #566 batch D (T4-1/T4-2) egress allowlist gate. |
 | `check_makefile_targets.py` | Makefile target 與 DX 工具聯動檢查 |
 | `check_md_yaml_drift.py` | Markdown 內 YAML 範例與 Schema 漂移偵測 |

--- a/docs/internal/tool-map.md
+++ b/docs/internal/tool-map.md
@@ -164,6 +164,7 @@ lang: zh
 | `check_jsx_loader_compat.py` | Detect JSX-loader-incompatible module syntax (named exports / non-allowlist imports / require() calls). |
 | `check_k8s_manifests.py` | Container/k8s IaC SAST, Layer 4 (raw k8s manifests). |
 | `check_ksm_version_allowlist.py` | KSM version-allowlist invariant lint (ADR-024 partial-misconfig defense). |
+| `check_leftouterjoin_enrichment.py` | Left-outer-join enrichment invariant lint (ADR-024 PR3-pre Commit 3). |
 | `check_log_egress_policy.py` | #566 batch D (T4-1/T4-2) egress allowlist gate. |
 | `check_makefile_targets.py` | Makefile target 與 DX 工具聯動檢查 |
 | `check_md_yaml_drift.py` | Markdown 內 YAML 範例與 Schema 漂移偵測 |

--- a/k8s/03-monitoring/configmap-rules-clickhouse.yaml
+++ b/k8s/03-monitoring/configmap-rules-clickhouse.yaml
@@ -1,3 +1,9 @@
+# ============================================================
+# clickhouse Rule Pack — Recording & Alert Rules (ConfigMap)
+# GENERATED from rule-packs/rule-pack-clickhouse.yaml by
+# scripts/tools/dx/generate_rulepack_configmaps.py — DO NOT EDIT.
+# Run `make rulepack-configmaps` after editing the rule pack.
+# ============================================================
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,156 +13,124 @@ metadata:
     app: prometheus
     rule-pack: clickhouse
 data:
-  clickhouse-recording.yml: |
-    groups:
-      - name: clickhouse-normalization
-        rules:
-          - record: tenant:clickhouse_queries:rate5m
-            expr: |
-              sum by(tenant) (
-                rate(ClickHouseProfileEvents_Query{tenant!=""}[5m])
-              )
-          - record: tenant:clickhouse_active_connections:max
-            expr: |
-              max by(tenant) (
-                ClickHouseMetrics_TCPConnection{tenant!=""}
-              )
-          - record: tenant:clickhouse_max_part_count:max
-            expr: |
-              max by(tenant) (
-                ClickHouseAsyncMetrics_MaxPartCountForPartition{tenant!=""}
-              )
-          - record: tenant:clickhouse_replication_queue:max
-            expr: |
-              max by(tenant) (
-                ClickHouseMetrics_ReplicatedSendQueueSize{tenant!=""}
-                + ClickHouseMetrics_ReplicatedFetchQueueSize{tenant!=""}
-              )
-          - record: tenant:clickhouse_memory_tracking:max
-            expr: |
-              max by(tenant) (
-                ClickHouseMetrics_MemoryTracking{tenant!=""}
-              )
-          - record: tenant:clickhouse_merges_rate:rate5m
-            expr: |
-              sum by(tenant) (
-                rate(ClickHouseProfileEvents_MergedRows{tenant!=""}[5m])
-              )
-          - record: tenant:clickhouse_failed_queries:rate5m
-            expr: |
-              sum by(tenant) (
-                rate(ClickHouseProfileEvents_FailedQuery{tenant!=""}[5m])
-              )
-
-      - name: clickhouse-threshold-normalization
-        rules:
-          - record: tenant:alert_threshold:clickhouse_queries_rate
-            expr: |
-              max by(tenant) (
-                user_threshold{metric="clickhouse_queries_rate", severity="warning"}
-              )
-          - record: tenant:alert_threshold:clickhouse_active_connections
-            expr: |
-              max by(tenant) (
-                user_threshold{metric="clickhouse_active_connections", severity="warning"}
-              )
-          - record: tenant:alert_threshold:clickhouse_max_part_count
-            expr: |
-              max by(tenant) (
-                user_threshold{metric="clickhouse_max_part_count", severity="warning"}
-              )
-          - record: tenant:alert_threshold:clickhouse_replication_queue
-            expr: |
-              max by(tenant) (
-                user_threshold{metric="clickhouse_replication_queue", severity="warning"}
-              )
-          - record: tenant:alert_threshold:clickhouse_memory_tracking_bytes
-            expr: |
-              max by(tenant) (
-                user_threshold{metric="clickhouse_memory_tracking_bytes", severity="warning"}
-              )
-
-  clickhouse-alert.yml: |
-    groups:
-      - name: clickhouse-alerts
-        rules:
-          - alert: ClickHouseDown
-            expr: up{job="clickhouse"} == 0
-            for: 2m
-            labels:
-              severity: critical
-            annotations:
-              summary: "ClickHouse instance is DOWN"
-          - alert: ClickHouseHighQueryRate
-            expr: |
-              (
-                tenant:clickhouse_queries:rate5m
-                > on(tenant) group_left
-                tenant:alert_threshold:clickhouse_queries_rate
-              )
-              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "ClickHouse query rate exceeds threshold"
-          - alert: ClickHouseHighConnections
-            expr: |
-              (
-                tenant:clickhouse_active_connections:max
-                > on(tenant) group_left
-                tenant:alert_threshold:clickhouse_active_connections
-              )
-              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "ClickHouse active connections exceed threshold"
-          - alert: ClickHouseHighPartCount
-            expr: |
-              (
-                tenant:clickhouse_max_part_count:max
-                > on(tenant) group_left
-                tenant:alert_threshold:clickhouse_max_part_count
-              )
-              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
-            for: 10m
-            labels:
-              severity: warning
-            annotations:
-              summary: "ClickHouse max part count per partition exceeds threshold (merge pressure)"
-          - alert: ClickHouseReplicationLag
-            expr: |
-              (
-                tenant:clickhouse_replication_queue:max
-                > on(tenant) group_left
-                tenant:alert_threshold:clickhouse_replication_queue
-              )
-              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "ClickHouse replication queue size exceeds threshold"
-          - alert: ClickHouseHighMemoryUsage
-            expr: |
-              (
-                tenant:clickhouse_memory_tracking:max
-                > on(tenant) group_left
-                tenant:alert_threshold:clickhouse_memory_tracking_bytes
-              )
-              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "ClickHouse memory tracking exceeds threshold"
-          - alert: ClickHouseHighFailedQueryRate
-            expr: |
-              tenant:clickhouse_failed_queries:rate5m > 10
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "ClickHouse failed query rate > 10/s"
+  clickhouse-recording.yml: "groups:\n- name: clickhouse-normalization\n  rules:\n\
+    \  - record: tenant:clickhouse_queries:rate5m\n    expr: \"sum by(tenant) (\\\
+    n  rate(ClickHouseProfileEvents_Query{tenant!=\\\"\\\"}[5m])\\n)\\n\"\n  - record:\
+    \ tenant:clickhouse_active_connections:max\n    expr: \"max by(tenant) (\\n  ClickHouseMetrics_TCPConnection{tenant!=\\\
+    \"\\\"}\\n)\\n\"\n  - record: tenant:clickhouse_max_part_count:max\n    expr:\
+    \ \"max by(tenant) (\\n  ClickHouseAsyncMetrics_MaxPartCountForPartition{tenant!=\\\
+    \"\\\"}\\n)\\n\"\n  - record: tenant:clickhouse_replication_queue:max\n    expr:\
+    \ \"max by(tenant) (\\n  ClickHouseMetrics_ReplicatedSendQueueSize{tenant!=\\\"\
+    \\\"}\\n  + ClickHouseMetrics_ReplicatedFetchQueueSize{tenant!=\\\"\\\"}\\n)\\\
+    n\"\n  - record: tenant:clickhouse_memory_tracking:max\n    expr: \"max by(tenant)\
+    \ (\\n  ClickHouseMetrics_MemoryTracking{tenant!=\\\"\\\"}\\n)\\n\"\n  - record:\
+    \ tenant:clickhouse_merges_rate:rate5m\n    expr: \"sum by(tenant) (\\n  rate(ClickHouseProfileEvents_MergedRows{tenant!=\\\
+    \"\\\"}[5m])\\n)\\n\"\n  - record: tenant:clickhouse_failed_queries:rate5m\n \
+    \   expr: \"sum by(tenant) (\\n  rate(ClickHouseProfileEvents_FailedQuery{tenant!=\\\
+    \"\\\"}[5m])\\n)\\n\"\n- name: clickhouse-threshold-normalization\n  rules:\n\
+    \  - record: tenant:alert_threshold:clickhouse_queries_rate\n    expr: \"max by(tenant)\
+    \ (\\n  user_threshold{metric=\\\"clickhouse_queries_rate\\\", severity=\\\"warning\\\
+    \"}\\n)\\n\"\n  - record: tenant:alert_threshold:clickhouse_active_connections\n\
+    \    expr: \"max by(tenant) (\\n  user_threshold{metric=\\\"clickhouse_active_connections\\\
+    \", severity=\\\"warning\\\"}\\n)\\n\"\n  - record: tenant:alert_threshold:clickhouse_max_part_count\n\
+    \    expr: \"max by(tenant) (\\n  user_threshold{metric=\\\"clickhouse_max_part_count\\\
+    \", severity=\\\"warning\\\"}\\n)\\n\"\n  - record: tenant:alert_threshold:clickhouse_replication_queue\n\
+    \    expr: \"max by(tenant) (\\n  user_threshold{metric=\\\"clickhouse_replication_queue\\\
+    \", severity=\\\"warning\\\"}\\n)\\n\"\n  - record: tenant:alert_threshold:clickhouse_memory_tracking_bytes\n\
+    \    expr: \"max by(tenant) (\\n  user_threshold{metric=\\\"clickhouse_memory_tracking_bytes\\\
+    \", severity=\\\"warning\\\"}\\n)\\n\"\n"
+  clickhouse-alert.yml: "groups:\n- name: clickhouse-alerts\n  rules:\n  - alert:\
+    \ ClickHouseDown\n    expr: up{job=\"clickhouse\"} == 0\n    for: 2m\n    labels:\n\
+    \      severity: critical\n      tenant: '{{ $labels.tenant }}'\n    annotations:\n\
+    \      summary: ClickHouse instance is DOWN\n      summary_zh: ClickHouse 實例已關閉\n\
+    \  - alert: ClickHouseHighQueryRate\n    expr: \"(\\n  (\\n    (\\n      tenant:clickhouse_queries:rate5m\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:clickhouse_queries_rate\\\
+    n    )\\n    unless on(tenant) (user_state_filter{filter=\\\"maintenance\\\"}\
+    \ == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:clickhouse_queries:rate5m\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:clickhouse_queries_rate\\n    )\\\
+    n    unless on(tenant) (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\\
+    n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n\
+    \      severity: warning\n      tenant: '{{ $labels.tenant }}'\n    annotations:\n\
+    \      summary: ClickHouse query rate exceeds threshold\n      summary_zh: ClickHouse\
+    \ 查詢率超出閾值\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}:\
+    \ ClickHouse query rate elevated — workload review'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}：ClickHouse 查詢率升高 — 工作負載審查'\n    \
+    \  description: '{{ $value | printf \"%.1f\" }} queries/sec exceeds threshold'\n\
+    \      description_zh: '{{ $value | printf \"%.1f\" }} 次查詢/秒超出閾值'\n      runbook_url:\
+    \ '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n      tier:\
+    \ '{{ $labels.tier }}'\n  - alert: ClickHouseHighConnections\n    expr: \"(\\\
+    n  (\\n    (\\n      tenant:clickhouse_active_connections:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:clickhouse_active_connections\\n \
+    \   )\\n    unless on(tenant) (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:clickhouse_active_connections:max\\n\
+    \      > on(tenant) group_left\\n      tenant:alert_threshold:clickhouse_active_connections\\\
+    n    )\\n    unless on(tenant) (user_state_filter{filter=\\\"maintenance\\\"}\
+    \ == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n\
+    \    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: ClickHouse active connections exceed threshold\n\
+    \      summary_zh: ClickHouse 活動連線超出閾值\n      platform_summary: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}: ClickHouse connections exceeded — client pool review'\n\
+    \      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant }}：ClickHouse\
+    \ 連線已超出 — client pool 審查'\n      description: '{{ $value | printf \"%.0f\" }}\
+    \ active connections'\n      description_zh: '{{ $value | printf \"%.0f\" }} 個活動連線'\n\
+    \      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n  - alert: ClickHouseHighPartCount\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:clickhouse_max_part_count:max\\n \
+    \     > on(tenant) group_left\\n      tenant:alert_threshold:clickhouse_max_part_count\\\
+    n    )\\n    unless on(tenant) (user_state_filter{filter=\\\"maintenance\\\"}\
+    \ == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:clickhouse_max_part_count:max\\n    \
+    \  > on(tenant) group_left\\n      tenant:alert_threshold:clickhouse_max_part_count\\\
+    n    )\\n    unless on(tenant) (user_state_filter{filter=\\\"maintenance\\\"}\
+    \ == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 10m\n\
+    \    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: ClickHouse max part count per partition exceeds\
+    \ threshold (merge pressure)\n      summary_zh: ClickHouse partition 最大 part 數超出閾值（merge\
+    \ 壓力）\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: ClickHouse\
+    \ partition merge pressure — part count review'\n      platform_summary_zh: '[{{\
+    \ $labels.tier }}] {{ $labels.tenant }}：ClickHouse partition merge 壓力 — part 數量審查'\n\
+    \      description: 'Part count: {{ $value | printf \"%.0f\" }} exceeds threshold'\n\
+    \      description_zh: Part 數量：{{ $value | printf \"%.0f\" }} 超出閾值\n      runbook_url:\
+    \ '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n      tier:\
+    \ '{{ $labels.tier }}'\n  - alert: ClickHouseReplicationLag\n    expr: \"(\\n\
+    \  (\\n    (\\n      tenant:clickhouse_replication_queue:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:clickhouse_replication_queue\\n  \
+    \  )\\n    unless on(tenant) (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:clickhouse_replication_queue:max\\n \
+    \     > on(tenant) group_left\\n      tenant:alert_threshold:clickhouse_replication_queue\\\
+    n    )\\n    unless on(tenant) (user_state_filter{filter=\\\"maintenance\\\"}\
+    \ == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n\
+    \    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: ClickHouse replication queue size exceeds threshold\n\
+    \      summary_zh: ClickHouse 複寫隊列大小超出閾值\n      platform_summary: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}: ClickHouse replication queue high — replica health\
+    \ check'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant }}：ClickHouse\
+    \ 複寫隊列過高 — replica 健康檢查'\n      description: 'Queue size: {{ $value | printf \"\
+    %.0f\" }} tasks pending'\n      description_zh: 隊列大小：{{ $value | printf \"%.0f\"\
+    \ }} 個待處理任務\n      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{\
+    \ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert: ClickHouseHighMemoryUsage\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:clickhouse_memory_tracking:max\\n\
+    \      > on(tenant) group_left\\n      tenant:alert_threshold:clickhouse_memory_tracking_bytes\\\
+    n    )\\n    unless on(tenant) (user_state_filter{filter=\\\"maintenance\\\"}\
+    \ == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:clickhouse_memory_tracking:max\\n   \
+    \   > on(tenant) group_left\\n      tenant:alert_threshold:clickhouse_memory_tracking_bytes\\\
+    n    )\\n    unless on(tenant) (user_state_filter{filter=\\\"maintenance\\\"}\
+    \ == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n\
+    \    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: ClickHouse memory tracking exceeds threshold\n\
+    \      summary_zh: ClickHouse 記憶體追蹤超出閾值\n      platform_summary: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}: ClickHouse memory usage high — resource sizing review'\n\
+    \      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant }}：ClickHouse\
+    \ 記憶體使用率過高 — 資源大小調整審查'\n      description: 'Memory tracked: {{ $value | humanize1024\
+    \ }}B'\n      description_zh: 追蹤的記憶體：{{ $value | humanize1024 }}B\n      runbook_url:\
+    \ '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n      tier:\
+    \ '{{ $labels.tier }}'\n  - alert: ClickHouseHighFailedQueryRate\n    expr: 'tenant:clickhouse_failed_queries:rate5m\
+    \ > 10\n\n      '\n    for: 5m\n    labels:\n      severity: warning\n      tenant:\
+    \ '{{ $labels.tenant }}'\n    annotations:\n      summary: ClickHouse failed query\
+    \ rate > 10/s\n      summary_zh: ClickHouse 查詢失敗率 > 10/秒\n      description: 'Failed\
+    \ query rate: {{ $value | printf \"%.1f\" }} queries/sec'\n      description_zh:\
+    \ 查詢失敗率：{{ $value | printf \"%.1f\" }} 次查詢/秒\n"

--- a/k8s/03-monitoring/configmap-rules-db2.yaml
+++ b/k8s/03-monitoring/configmap-rules-db2.yaml
@@ -1,7 +1,8 @@
 # ============================================================
-# DB2 Rule Pack — Recording Rules & Alert Rules
-# Canonical source: rule-packs/rule-pack-db2.yaml
-# Maintained by: DBA Team / DB2 Team
+# db2 Rule Pack — Recording & Alert Rules (ConfigMap)
+# GENERATED from rule-packs/rule-pack-db2.yaml by
+# scripts/tools/dx/generate_rulepack_configmaps.py — DO NOT EDIT.
+# Run `make rulepack-configmaps` after editing the rule pack.
 # ============================================================
 apiVersion: v1
 kind: ConfigMap
@@ -12,152 +13,130 @@ metadata:
     app: prometheus
     rule-pack: db2
 data:
-  db2-recording.yml: |
-    groups:
-      - name: db2-normalization
-        interval: 15s
-        rules:
-          - record: tenant:db2_connections_active:max
-            expr: max by(tenant) (db2_connections_active)
-
-          - record: tenant:db2_bufferpool_hit_ratio:min
-            expr: min by(tenant) (db2_bufferpool_hit_ratio)
-
-          - record: tenant:db2_log_usage_percent:max
-            expr: max by(tenant) (db2_log_usage_percent)
-
-          - record: tenant:db2_deadlocks:rate5m
-            expr: sum by(tenant) (rate(db2_deadlocks_total[5m]))
-
-          - record: tenant:db2_tablespace_used_percent:max
-            expr: max by(tenant) (db2_tablespace_used_percent)
-
-          - record: tenant:db2_lock_wait_time:rate5m
-            expr: sum by(tenant) (rate(db2_lock_wait_time_seconds_total[5m]))
-
-          - record: tenant:db2_sort_overflow_ratio:avg
-            expr: |
-              sum by(tenant) (db2_sort_overflows)
-              / (sum by(tenant) (db2_total_sorts) > 0)
-
-      - name: db2-threshold-normalization
-        interval: 15s
-        rules:
-          - record: tenant:alert_threshold:db2_connections_active
-            expr: max by(tenant) (user_threshold{metric="db2_connections_active", severity="warning"})
-
-          - record: tenant:alert_threshold:db2_bufferpool_hit_ratio
-            expr: max by(tenant) (user_threshold{metric="db2_bufferpool_hit_ratio", severity="warning"})
-
-          - record: tenant:alert_threshold:db2_log_usage_percent
-            expr: max by(tenant) (user_threshold{metric="db2_log_usage_percent", severity="warning"})
-
-          - record: tenant:alert_threshold:db2_deadlock_rate
-            expr: max by(tenant) (user_threshold{metric="db2_deadlock_rate", severity="warning"})
-
-          - record: tenant:alert_threshold:db2_tablespace_used_percent
-            expr: max by(tenant) (user_threshold{metric="db2_tablespace_used_percent", severity="warning"})
-
-  db2-alert.yml: |
-    groups:
-      - name: db2-alerts
-        rules:
-          - alert: DB2DatabaseDown
-            expr: db2_up == 0
-            for: 15s
-            labels:
-              severity: critical
-            annotations:
-              summary: "DB2 instance {{ $labels.instance }} is DOWN"
-
-          - alert: DB2HighConnections
-            expr: |
-              (
-                tenant:db2_connections_active:max
-                > on(tenant) group_left
-                tenant:alert_threshold:db2_connections_active
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "DB2 high active connections on {{ $labels.tenant }}"
-              description: "{{ $value | printf \"%.0f\" }} active connections"
-
-          - alert: DB2LowBufferpoolHitRatio
-            expr: |
-              (
-                tenant:db2_bufferpool_hit_ratio:min
-                < on(tenant) group_left
-                tenant:alert_threshold:db2_bufferpool_hit_ratio
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 10m
-            labels:
-              severity: warning
-            annotations:
-              summary: "DB2 low bufferpool hit ratio on {{ $labels.tenant }}"
-              description: "Hit ratio: {{ $value | printf \"%.4f\" }} — check bufferpool sizing"
-
-          - alert: DB2HighLogUsage
-            expr: |
-              (
-                tenant:db2_log_usage_percent:max
-                > on(tenant) group_left
-                tenant:alert_threshold:db2_log_usage_percent
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "DB2 high transaction log usage on {{ $labels.tenant }}"
-              description: "Log usage: {{ $value | printf \"%.1f\" }}%"
-
-          - alert: DB2HighDeadlockRate
-            expr: |
-              (
-                tenant:db2_deadlocks:rate5m
-                > on(tenant) group_left
-                tenant:alert_threshold:db2_deadlock_rate
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "DB2 high deadlock rate on {{ $labels.tenant }}"
-              description: "{{ $value | printf \"%.1f\" }} deadlocks/sec"
-
-          - alert: DB2TablespaceAlmostFull
-            expr: |
-              (
-                tenant:db2_tablespace_used_percent:max
-                > on(tenant) group_left
-                tenant:alert_threshold:db2_tablespace_used_percent
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "DB2 tablespace nearing capacity on {{ $labels.tenant }}"
-              description: "Tablespace usage: {{ $value | printf \"%.1f\" }}%"
-
-          - alert: DB2HighSortOverflow
-            expr: |
-              tenant:db2_sort_overflow_ratio:avg > 0.05
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 10m
-            labels:
-              severity: warning
-            annotations:
-              summary: "DB2 high sort overflow ratio on {{ $labels.tenant }}"
-              description: "Sort overflow ratio: {{ $value | printf \"%.2f\" }} — consider increasing SORTHEAP"
+  db2-recording.yml: "groups:\n- name: db2-normalization\n  interval: 15s\n  rules:\n\
+    \  - record: tenant:db2_connections_active:max\n    expr: max by(tenant) (db2_connections_active)\n\
+    \  - record: tenant:db2_bufferpool_hit_ratio:min\n    expr: min by(tenant) (db2_bufferpool_hit_ratio)\n\
+    \  - record: tenant:db2_log_usage_percent:max\n    expr: max by(tenant) (db2_log_usage_percent)\n\
+    \  - record: tenant:db2_deadlocks:rate5m\n    expr: sum by(tenant) (rate(db2_deadlocks_total[5m]))\n\
+    \  - record: tenant:db2_tablespace_used_percent:max\n    expr: max by(tenant)\
+    \ (db2_tablespace_used_percent)\n  - record: tenant:db2_lock_wait_time:rate5m\n\
+    \    expr: sum by(tenant) (rate(db2_lock_wait_time_seconds_total[5m]))\n  - record:\
+    \ tenant:db2_sort_overflow_ratio:avg\n    expr: 'sum by(tenant) (db2_sort_overflows)\n\
+    \n      / (sum by(tenant) (db2_total_sorts) > 0)\n\n      '\n- name: db2-threshold-normalization\n\
+    \  interval: 15s\n  rules:\n  - record: tenant:alert_threshold:db2_connections_active\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"db2_connections_active\", severity=\"\
+    warning\"})\n  - record: tenant:alert_threshold:db2_bufferpool_hit_ratio\n   \
+    \ expr: max by(tenant) (user_threshold{metric=\"db2_bufferpool_hit_ratio\", severity=\"\
+    warning\"})\n  - record: tenant:alert_threshold:db2_log_usage_percent\n    expr:\
+    \ max by(tenant) (user_threshold{metric=\"db2_log_usage_percent\", severity=\"\
+    warning\"})\n  - record: tenant:alert_threshold:db2_deadlock_rate\n    expr: max\
+    \ by(tenant) (user_threshold{metric=\"db2_deadlock_rate\", severity=\"warning\"\
+    })\n  - record: tenant:alert_threshold:db2_tablespace_used_percent\n    expr:\
+    \ max by(tenant) (user_threshold{metric=\"db2_tablespace_used_percent\", severity=\"\
+    warning\"})\n"
+  db2-alert.yml: "groups:\n- name: db2-alerts\n  rules:\n  - alert: DB2DatabaseDown\n\
+    \    expr: db2_up == 0\n    for: 15s\n    labels:\n      severity: critical\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: DB2 instance\
+    \ {{ $labels.instance }} is DOWN\n      summary_zh: DB2 實例 {{ $labels.instance\
+    \ }} 已關閉\n      description: db2_up=0 for 15s on {{ $labels.instance }}\n    \
+    \  description_zh: db2_up=0，持續 15 秒，實例：{{ $labels.instance }}\n  - alert: DB2HighConnections\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:db2_connections_active:max\\n    \
+    \  > on(tenant) group_left\\n      tenant:alert_threshold:db2_connections_active\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:db2_connections_active:max\\n      >\
+    \ on(tenant) group_left\\n      tenant:alert_threshold:db2_connections_active\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 5m\n    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: DB2 high active connections on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 上 DB2 連線數過高'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: DB2 connection usage high — pool\
+    \ sizing review'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}：DB2 連線使用率過高 — pool 大小調整審查'\n      description: '{{ $value | printf \"%.0f\"\
+    \ }} active connections'\n      description_zh: '{{ $value | printf \"%.0f\" }}\
+    \ 個活動連線'\n      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n  - alert: DB2LowBufferpoolHitRatio\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:db2_bufferpool_hit_ratio:min\\n  \
+    \    < on(tenant) group_left\\n      tenant:alert_threshold:db2_bufferpool_hit_ratio\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:db2_bufferpool_hit_ratio:min\\n     \
+    \ < on(tenant) group_left\\n      tenant:alert_threshold:db2_bufferpool_hit_ratio\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 10m\n    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant\
+    \ }}'\n    annotations:\n      summary: DB2 low bufferpool hit ratio on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 上 DB2 bufferpool 命中率偏低'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: DB2 bufferpool hit ratio low — memory\
+    \ tuning review'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}：DB2 bufferpool 命中率偏低 — 記憶體調優審查'\n      description: 'Hit ratio: {{ $value\
+    \ | printf \"%.4f\" }} — check bufferpool sizing'\n      description_zh: 命中率：{{\
+    \ $value | printf \"%.4f\" }} — 檢查 bufferpool 大小調整\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: DB2HighLogUsage\n    expr: \"(\\n  (\\n    (\\n      tenant:db2_log_usage_percent:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:db2_log_usage_percent\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:db2_log_usage_percent:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:db2_log_usage_percent\\n    )\\n \
+    \   unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n\
+    \    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: DB2 high transaction log usage on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 上 DB2 交易日誌使用率過高'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: DB2 transaction log usage high —\
+    \ log space review'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}：DB2 交易日誌使用率過高 — 日誌空間審查'\n      description: 'Log usage: {{ $value | printf\
+    \ \"%.1f\" }}%'\n      description_zh: 日誌使用率：{{ $value | printf \"%.1f\" }}%\n\
+    \      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n  - alert: DB2HighDeadlockRate\n    expr:\
+    \ \"(\\n  (\\n    (\\n      tenant:db2_deadlocks:rate5m\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:db2_deadlock_rate\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  * on(tenant)\
+    \ group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\\
+    n  (\\n    (\\n      tenant:db2_deadlocks:rate5m\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:db2_deadlock_rate\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n      severity: warning\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: DB2 high\
+    \ deadlock rate on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 上 DB2 死鎖率過高'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: DB2 deadlock rate elevated — application contention review'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}：DB2 死鎖率升高 — 應用程式爭用審查'\n      description:\
+    \ '{{ $value | printf \"%.1f\" }} deadlocks/sec'\n      description_zh: '{{ $value\
+    \ | printf \"%.1f\" }} 個死鎖/秒'\n      runbook_url: '{{ $labels.runbook_url }}'\n\
+    \      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert:\
+    \ DB2TablespaceAlmostFull\n    expr: \"(\\n  (\\n    (\\n      tenant:db2_tablespace_used_percent:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:db2_tablespace_used_percent\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:db2_tablespace_used_percent:max\\n  \
+    \    > on(tenant) group_left\\n      tenant:alert_threshold:db2_tablespace_used_percent\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 5m\n    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: DB2 tablespace nearing capacity on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 上 DB2 tablespace 即將滿容'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: DB2 tablespace nearing capacity\
+    \ — storage review'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}：DB2 tablespace 即將滿容 — 儲存審查'\n      description: 'Tablespace usage: {{ $value\
+    \ | printf \"%.1f\" }}%'\n      description_zh: Tablespace 使用率：{{ $value | printf\
+    \ \"%.1f\" }}%\n      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{\
+    \ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert: DB2HighSortOverflow\n\
+    \    expr: \"(\\n  (\\n    tenant:db2_sort_overflow_ratio:avg > 0.05\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    tenant:db2_sort_overflow_ratio:avg > 0.05\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 10m\n    labels:\n\
+    \      severity: warning\n      tenant: '{{ $labels.tenant }}'\n    annotations:\n\
+    \      summary: DB2 high sort overflow ratio on {{ $labels.tenant }}\n      summary_zh:\
+    \ '{{ $labels.tenant }} 上 DB2 sort overflow 比率過高'\n      platform_summary: '[{{\
+    \ $labels.tier }}] {{ $labels.tenant }}: DB2 sort overflow ratio high — SORTHEAP\
+    \ tuning review'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}：DB2 sort overflow 比率過高 — SORTHEAP 調優審查'\n      description: 'Sort overflow\
+    \ ratio: {{ $value | printf \"%.2f\" }} — consider increasing SORTHEAP'\n    \
+    \  description_zh: Sort overflow 比率：{{ $value | printf \"%.2f\" }} — 考慮增加 SORTHEAP\n\
+    \      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n"

--- a/k8s/03-monitoring/configmap-rules-elasticsearch.yaml
+++ b/k8s/03-monitoring/configmap-rules-elasticsearch.yaml
@@ -1,7 +1,8 @@
 # ============================================================
-# Elasticsearch Rule Pack — Recording Rules & Alert Rules
-# Canonical source: rule-packs/rule-pack-elasticsearch.yaml
-# Maintained by: Search / Observability Team
+# elasticsearch Rule Pack — Recording & Alert Rules (ConfigMap)
+# GENERATED from rule-packs/rule-pack-elasticsearch.yaml by
+# scripts/tools/dx/generate_rulepack_configmaps.py — DO NOT EDIT.
+# Run `make rulepack-configmaps` after editing the rule pack.
 # ============================================================
 apiVersion: v1
 kind: ConfigMap
@@ -12,159 +13,130 @@ metadata:
     app: prometheus
     rule-pack: elasticsearch
 data:
-  elasticsearch-recording.yml: |
-    groups:
-      - name: elasticsearch-normalization
-        interval: 15s
-        rules:
-          - record: tenant:es_cluster_health:status
-            expr: max by(tenant) (elasticsearch_cluster_health_status{color="red"}) * 2
-                  + max by(tenant) (elasticsearch_cluster_health_status{color="yellow"})
-
-          - record: tenant:es_heap_usage_percent:max
-            expr: |
-              max by(tenant) (
-                elasticsearch_jvm_memory_used_bytes{area="heap"}
-                / elasticsearch_jvm_memory_max_bytes{area="heap"}
-              ) * 100
-
-          - record: tenant:es_disk_usage_percent:max
-            expr: |
-              max by(tenant) (
-                1 - (
-                  elasticsearch_filesystem_data_available_bytes
-                  / elasticsearch_filesystem_data_size_bytes
-                )
-              ) * 100
-
-          - record: tenant:es_search_latency_ms:avg
-            expr: |
-              sum by(tenant) (rate(elasticsearch_indices_search_query_time_seconds[5m]))
-              / sum by(tenant) (rate(elasticsearch_indices_search_query_total[5m]))
-              * 1000
-
-          - record: tenant:es_indexing:rate5m
-            expr: sum by(tenant) (rate(elasticsearch_indices_indexing_index_total[5m]))
-
-          - record: tenant:es_pending_tasks:max
-            expr: max by(tenant) (elasticsearch_cluster_health_number_of_pending_tasks)
-
-          - record: tenant:es_unassigned_shards:count
-            expr: max by(tenant) (elasticsearch_cluster_health_unassigned_shards)
-
-      - name: elasticsearch-threshold-normalization
-        interval: 15s
-        rules:
-          - record: tenant:alert_threshold:es_heap_usage_percent
-            expr: max by(tenant) (user_threshold{metric="es_heap_usage_percent", severity="warning"})
-
-          - record: tenant:alert_threshold:es_disk_usage_percent
-            expr: max by(tenant) (user_threshold{metric="es_disk_usage_percent", severity="warning"})
-
-          - record: tenant:alert_threshold:es_search_latency_ms
-            expr: max by(tenant) (user_threshold{metric="es_search_latency_ms", severity="warning"})
-
-          - record: tenant:alert_threshold:es_pending_tasks
-            expr: max by(tenant) (user_threshold{metric="es_pending_tasks", severity="warning"})
-
-  elasticsearch-alert.yml: |
-    groups:
-      - name: elasticsearch-alerts
-        rules:
-          - alert: ElasticsearchClusterRed
-            expr: |
-              tenant:es_cluster_health:status == 2
-            for: 30s
-            labels:
-              severity: critical
-            annotations:
-              summary: "Elasticsearch cluster RED on {{ $labels.tenant }}"
-              description: "Cluster health is RED — data loss or unavailability possible"
-
-          - alert: ElasticsearchClusterYellow
-            expr: |
-              tenant:es_cluster_health:status == 1
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Elasticsearch cluster YELLOW on {{ $labels.tenant }}"
-              description: "Some replica shards are unassigned"
-
-          - alert: ElasticsearchHighHeapUsage
-            expr: |
-              (
-                tenant:es_heap_usage_percent:max
-                > on(tenant) group_left
-                tenant:alert_threshold:es_heap_usage_percent
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Elasticsearch high heap usage on {{ $labels.tenant }}"
-              description: "JVM heap: {{ $value | printf \"%.1f\" }}%"
-
-          - alert: ElasticsearchHighDiskUsage
-            expr: |
-              (
-                tenant:es_disk_usage_percent:max
-                > on(tenant) group_left
-                tenant:alert_threshold:es_disk_usage_percent
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Elasticsearch high disk usage on {{ $labels.tenant }}"
-              description: "Disk usage: {{ $value | printf \"%.1f\" }}%"
-
-          - alert: ElasticsearchHighSearchLatency
-            expr: |
-              (
-                tenant:es_search_latency_ms:avg
-                > on(tenant) group_left
-                tenant:alert_threshold:es_search_latency_ms
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Elasticsearch high search latency on {{ $labels.tenant }}"
-              description: "Average search latency: {{ $value | printf \"%.0f\" }}ms"
-
-          - alert: ElasticsearchUnassignedShards
-            expr: |
-              tenant:es_unassigned_shards:count > 0
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 10m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Elasticsearch has unassigned shards on {{ $labels.tenant }}"
-              description: "{{ $value }} unassigned shards — check node capacity"
-
-          - alert: ElasticsearchPendingTasks
-            expr: |
-              (
-                tenant:es_pending_tasks:max
-                > on(tenant) group_left
-                tenant:alert_threshold:es_pending_tasks
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Elasticsearch pending cluster tasks on {{ $labels.tenant }}"
-              description: "{{ $value }} pending tasks — cluster may be overloaded"
+  elasticsearch-recording.yml: "groups:\n- name: elasticsearch-normalization\n  interval:\
+    \ 15s\n  rules:\n  - record: tenant:es_cluster_health:status\n    expr: max by(tenant)\
+    \ (elasticsearch_cluster_health_status{color=\"red\"}) * 2 + max by(tenant) (elasticsearch_cluster_health_status{color=\"\
+    yellow\"})\n  - record: tenant:es_heap_usage_percent:max\n    expr: \"max by(tenant)\
+    \ (\\n  elasticsearch_jvm_memory_used_bytes{area=\\\"heap\\\"}\\n  / elasticsearch_jvm_memory_max_bytes{area=\\\
+    \"heap\\\"}\\n) * 100\\n\"\n  - record: tenant:es_disk_usage_percent:max\n   \
+    \ expr: \"max by(tenant) (\\n  1 - (\\n    elasticsearch_filesystem_data_available_bytes\\\
+    n    / elasticsearch_filesystem_data_size_bytes\\n  )\\n) * 100\\n\"\n  - record:\
+    \ tenant:es_search_latency_ms:avg\n    expr: 'sum by(tenant) (rate(elasticsearch_indices_search_query_time_seconds[5m]))\n\
+    \n      / sum by(tenant) (rate(elasticsearch_indices_search_query_total[5m]))\n\
+    \n      * 1000\n\n      '\n  - record: tenant:es_indexing:rate5m\n    expr: sum\
+    \ by(tenant) (rate(elasticsearch_indices_indexing_index_total[5m]))\n  - record:\
+    \ tenant:es_pending_tasks:max\n    expr: max by(tenant) (elasticsearch_cluster_health_number_of_pending_tasks)\n\
+    \  - record: tenant:es_unassigned_shards:count\n    expr: max by(tenant) (elasticsearch_cluster_health_unassigned_shards)\n\
+    - name: elasticsearch-threshold-normalization\n  interval: 15s\n  rules:\n  -\
+    \ record: tenant:alert_threshold:es_heap_usage_percent\n    expr: max by(tenant)\
+    \ (user_threshold{metric=\"es_heap_usage_percent\", severity=\"warning\"})\n \
+    \ - record: tenant:alert_threshold:es_disk_usage_percent\n    expr: max by(tenant)\
+    \ (user_threshold{metric=\"es_disk_usage_percent\", severity=\"warning\"})\n \
+    \ - record: tenant:alert_threshold:es_search_latency_ms\n    expr: max by(tenant)\
+    \ (user_threshold{metric=\"es_search_latency_ms\", severity=\"warning\"})\n  -\
+    \ record: tenant:alert_threshold:es_pending_tasks\n    expr: max by(tenant) (user_threshold{metric=\"\
+    es_pending_tasks\", severity=\"warning\"})\n"
+  elasticsearch-alert.yml: "groups:\n- name: elasticsearch-alerts\n  rules:\n  - alert:\
+    \ ElasticsearchClusterRed\n    expr: 'tenant:es_cluster_health:status == 2\n\n\
+    \      '\n    for: 30s\n    labels:\n      severity: critical\n      tenant: '{{\
+    \ $labels.tenant }}'\n    annotations:\n      summary: Elasticsearch cluster RED\
+    \ on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 的 Elasticsearch\
+    \ 叢集狀態為 RED'\n      description: Cluster health is RED — data loss or unavailability\
+    \ possible\n      description_zh: 叢集健康狀態為 RED — 可能造成資料遺失或無法使用\n  - alert: ElasticsearchClusterYellow\n\
+    \    expr: \"(\\n  (\\n    tenant:es_cluster_health:status == 1\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  * on(tenant)\
+    \ group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\\
+    n  (\\n    tenant:es_cluster_health:status == 1\\n    unless on(tenant)\\n   \
+    \ (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n      severity: warning\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Elasticsearch\
+    \ cluster YELLOW on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 的 Elasticsearch 叢集狀態為 YELLOW'\n      platform_summary: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}: ES cluster YELLOW — replica shards unassigned'\n \
+    \     platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant }}: Elasticsearch\
+    \ 叢集 YELLOW — 副本分片未分配'\n      description: Some replica shards are unassigned\n\
+    \      description_zh: 部分副本分片未分配\n      runbook_url: '{{ $labels.runbook_url }}'\n\
+    \      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert:\
+    \ ElasticsearchHighHeapUsage\n    expr: \"(\\n  (\\n    (\\n      tenant:es_heap_usage_percent:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:es_heap_usage_percent\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:es_heap_usage_percent:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:es_heap_usage_percent\\n    )\\n \
+    \   unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n\
+    \    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: Elasticsearch high heap usage on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 的 Elasticsearch JVM heap 使用率過高'\n\
+    \      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: ES heap usage\
+    \ high — JVM sizing review'\n      platform_summary_zh: '[{{ $labels.tier }}]\
+    \ {{ $labels.tenant }}: Elasticsearch heap 使用率過高 — 請檢查 JVM 大小'\n      description:\
+    \ 'JVM heap: {{ $value | printf \"%.1f\" }}%'\n      description_zh: 'JVM heap:\
+    \ {{ $value | printf \"%.1f\" }}%'\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: ElasticsearchHighDiskUsage\n    expr: \"(\\n  (\\n    (\\n      tenant:es_disk_usage_percent:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:es_disk_usage_percent\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:es_disk_usage_percent:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:es_disk_usage_percent\\n    )\\n \
+    \   unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n\
+    \    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: Elasticsearch high disk usage on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 的 Elasticsearch 磁碟使用率過高'\n     \
+    \ platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: ES disk usage\
+    \ high — storage capacity review'\n      platform_summary_zh: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}: Elasticsearch 磁碟使用率過高 — 請檢查儲存容量'\n      description:\
+    \ 'Disk usage: {{ $value | printf \"%.1f\" }}%'\n      description_zh: '磁碟使用率:\
+    \ {{ $value | printf \"%.1f\" }}%'\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: ElasticsearchHighSearchLatency\n    expr: \"(\\n  (\\n    (\\n   \
+    \   tenant:es_search_latency_ms:avg\\n      > on(tenant) group_left\\n      tenant:alert_threshold:es_search_latency_ms\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:es_search_latency_ms:avg\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:es_search_latency_ms\\n    )\\n  \
+    \  unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\\
+    n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n\
+    \      severity: warning\n      tenant: '{{ $labels.tenant }}'\n    annotations:\n\
+    \      summary: Elasticsearch high search latency on {{ $labels.tenant }}\n  \
+    \    summary_zh: '{{ $labels.tenant }} 的 Elasticsearch 搜尋延遲過高'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: ES search latency elevated — query/index\
+    \ optimization review'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: Elasticsearch 搜尋延遲提升 — 請最佳化查詢和索引'\n      description: 'Average search latency:\
+    \ {{ $value | printf \"%.0f\" }}ms'\n      description_zh: '平均搜尋延遲: {{ $value\
+    \ | printf \"%.0f\" }}ms'\n      runbook_url: '{{ $labels.runbook_url }}'\n  \
+    \    owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert:\
+    \ ElasticsearchUnassignedShards\n    expr: \"(\\n  (\\n    tenant:es_unassigned_shards:count\
+    \ > 0\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    tenant:es_unassigned_shards:count > 0\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 10m\n    labels:\n      severity: warning\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Elasticsearch\
+    \ has unassigned shards on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 的 Elasticsearch 有未分配的分片'\n      platform_summary: '[{{ $labels.tier }}] {{\
+    \ $labels.tenant }}: ES unassigned shards — check node capacity'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: Elasticsearch 未分配分片 — 請檢查節點容量'\n\
+    \      description: '{{ $value }} unassigned shards — check node capacity'\n \
+    \     description_zh: '{{ $value }} 個未分配的分片 — 請檢查節點容量'\n      runbook_url: '{{\
+    \ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{\
+    \ $labels.tier }}'\n  - alert: ElasticsearchPendingTasks\n    expr: \"(\\n  (\\\
+    n    (\\n      tenant:es_pending_tasks:max\\n      > on(tenant) group_left\\n\
+    \      tenant:alert_threshold:es_pending_tasks\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  * on(tenant)\
+    \ group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\\
+    n  (\\n    (\\n      tenant:es_pending_tasks:max\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:es_pending_tasks\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n      severity: warning\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Elasticsearch\
+    \ pending cluster tasks on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 的 Elasticsearch 有待處理的叢集工作'\n      platform_summary: '[{{ $labels.tier }}]\
+    \ {{ $labels.tenant }}: ES pending cluster tasks — cluster overload review'\n\
+    \      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant }}: Elasticsearch\
+    \ 待處理叢集工作 — 請檢查叢集負載'\n      description: '{{ $value }} pending tasks — cluster\
+    \ may be overloaded'\n      description_zh: '{{ $value }} 個待處理工作 — 叢集可能負載過高'\n\
+    \      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n"

--- a/k8s/03-monitoring/configmap-rules-jvm.yaml
+++ b/k8s/03-monitoring/configmap-rules-jvm.yaml
@@ -1,7 +1,8 @@
 # ============================================================
-# JVM Rule Pack — Recording Rules & Alert Rules
-# Canonical source: rule-packs/rule-pack-jvm.yaml
-# Maintained by: Platform Team
+# jvm Rule Pack — Recording & Alert Rules (ConfigMap)
+# GENERATED from rule-packs/rule-pack-jvm.yaml by
+# scripts/tools/dx/generate_rulepack_configmaps.py — DO NOT EDIT.
+# Run `make rulepack-configmaps` after editing the rule pack.
 # ============================================================
 apiVersion: v1
 kind: ConfigMap
@@ -12,212 +13,140 @@ metadata:
     app: prometheus
     rule-pack: jvm
 data:
-  jvm-recording.yml: |
-    groups:
-      - name: jvm-normalization
-        interval: 15s
-        rules:
-          - record: tenant:jvm_gc_pause:rate5m
-            expr: |
-              sum by(tenant) (
-                rate(jvm_gc_pause_seconds_sum[5m])
-              )
-          - record: tenant:jvm_memory_used:percent
-            expr: |
-              max by(tenant) (
-                jvm_memory_used_bytes{area="heap"}
-                / jvm_memory_max_bytes{area="heap"}
-                * 100
-              )
-          - record: tenant:jvm_threads:current
-            expr: |
-              max by(tenant) (
-                jvm_threads_current
-              )
-      - name: jvm-threshold-normalization
-        interval: 15s
-        rules:
-          - record: tenant:alert_threshold:jvm_gc_pause
-            expr: max by(tenant) (user_threshold{metric="jvm_gc_pause", severity="warning"})
-          - record: tenant:alert_threshold:jvm_gc_pause_critical
-            expr: max by(tenant) (user_threshold{metric="jvm_gc_pause", severity="critical"})
-          - record: tenant:alert_threshold:jvm_memory
-            expr: max by(tenant) (user_threshold{metric="jvm_memory", severity="warning"})
-          - record: tenant:alert_threshold:jvm_memory_critical
-            expr: max by(tenant) (user_threshold{metric="jvm_memory", severity="critical"})
-          - record: tenant:alert_threshold:jvm_threads
-            expr: max by(tenant) (user_threshold{metric="jvm_threads", severity="warning"})
-          - record: tenant:alert_threshold:jvm_threads_critical
-            expr: max by(tenant) (user_threshold{metric="jvm_threads", severity="critical"})
-
-  jvm-alert.yml: |
-    groups:
-      - name: jvm-alerts
-        rules:
-          - alert: JVMHighGCPause
-            expr: |
-              (
-                (
-                  tenant:jvm_gc_pause:rate5m
-                  > on(tenant) group_left
-                  tenant:alert_threshold:jvm_gc_pause
-                )
-                unless on(tenant)
-                (user_state_filter{filter="maintenance"} == 1)
-              )
-              * on(tenant) group_left(runbook_url, owner, tier)
-                tenant_metadata_info
-            for: 5m
-            labels:
-              severity: warning
-              metric_group: "jvm_gc_pause"
-            annotations:
-              summary: "JVMHighGCPause on {{ $labels.tenant }}"
-              description: "GC pause rate {{ $value }}s/5m exceeds threshold"
-              runbook_url: "{{ $labels.runbook_url }}"
-              owner: "{{ $labels.owner }}"
-              tier: "{{ $labels.tier }}"
-
-          - alert: JVMHighGCPauseCritical
-            expr: |
-              (
-                (
-                  tenant:jvm_gc_pause:rate5m
-                  > on(tenant) group_left
-                  tenant:alert_threshold:jvm_gc_pause_critical
-                )
-                unless on(tenant)
-                (user_state_filter{filter="maintenance"} == 1)
-              )
-              * on(tenant) group_left(runbook_url, owner, tier)
-                tenant_metadata_info
-            for: 3m
-            labels:
-              severity: critical
-              metric_group: "jvm_gc_pause"
-            annotations:
-              summary: "JVMHighGCPauseCritical on {{ $labels.tenant }}"
-              description: "GC pause rate {{ $value }}s/5m exceeds critical threshold"
-              runbook_url: "{{ $labels.runbook_url }}"
-              owner: "{{ $labels.owner }}"
-              tier: "{{ $labels.tier }}"
-
-          - alert: JVMMemoryPressure
-            expr: |
-              (
-                (
-                  tenant:jvm_memory_used:percent
-                  > on(tenant) group_left
-                  tenant:alert_threshold:jvm_memory
-                )
-                unless on(tenant)
-                (user_state_filter{filter="maintenance"} == 1)
-              )
-              * on(tenant) group_left(runbook_url, owner, tier)
-                tenant_metadata_info
-            for: 5m
-            labels:
-              severity: warning
-              metric_group: "jvm_memory"
-            annotations:
-              summary: "JVMMemoryPressure on {{ $labels.tenant }}"
-              description: "Heap usage {{ $value }}% exceeds threshold"
-              runbook_url: "{{ $labels.runbook_url }}"
-              owner: "{{ $labels.owner }}"
-              tier: "{{ $labels.tier }}"
-
-          - alert: JVMMemoryPressureCritical
-            expr: |
-              (
-                (
-                  tenant:jvm_memory_used:percent
-                  > on(tenant) group_left
-                  tenant:alert_threshold:jvm_memory_critical
-                )
-                unless on(tenant)
-                (user_state_filter{filter="maintenance"} == 1)
-              )
-              * on(tenant) group_left(runbook_url, owner, tier)
-                tenant_metadata_info
-            for: 3m
-            labels:
-              severity: critical
-              metric_group: "jvm_memory"
-            annotations:
-              summary: "JVMMemoryPressureCritical on {{ $labels.tenant }}"
-              description: "Heap usage {{ $value }}% exceeds critical threshold"
-              runbook_url: "{{ $labels.runbook_url }}"
-              owner: "{{ $labels.owner }}"
-              tier: "{{ $labels.tier }}"
-
-          - alert: JVMThreadPoolExhaustion
-            expr: |
-              (
-                (
-                  tenant:jvm_threads:current
-                  > on(tenant) group_left
-                  tenant:alert_threshold:jvm_threads
-                )
-                unless on(tenant)
-                (user_state_filter{filter="maintenance"} == 1)
-              )
-              * on(tenant) group_left(runbook_url, owner, tier)
-                tenant_metadata_info
-            for: 5m
-            labels:
-              severity: warning
-              metric_group: "jvm_threads"
-            annotations:
-              summary: "JVMThreadPoolExhaustion on {{ $labels.tenant }}"
-              description: "Active threads {{ $value }} exceeds threshold"
-              runbook_url: "{{ $labels.runbook_url }}"
-              owner: "{{ $labels.owner }}"
-              tier: "{{ $labels.tier }}"
-
-          - alert: JVMThreadPoolExhaustionCritical
-            expr: |
-              (
-                (
-                  tenant:jvm_threads:current
-                  > on(tenant) group_left
-                  tenant:alert_threshold:jvm_threads_critical
-                )
-                unless on(tenant)
-                (user_state_filter{filter="maintenance"} == 1)
-              )
-              * on(tenant) group_left(runbook_url, owner, tier)
-                tenant_metadata_info
-            for: 3m
-            labels:
-              severity: critical
-              metric_group: "jvm_threads"
-            annotations:
-              summary: "JVMThreadPoolExhaustionCritical on {{ $labels.tenant }}"
-              description: "Active threads {{ $value }} exceeds critical threshold"
-              runbook_url: "{{ $labels.runbook_url }}"
-              owner: "{{ $labels.owner }}"
-              tier: "{{ $labels.tier }}"
-
-          - alert: JVMPerformanceDegraded
-            expr: |
-              (
-                (
-                  tenant:jvm_gc_pause:rate5m > on(tenant) group_left tenant:alert_threshold:jvm_gc_pause
-                  and on(tenant)
-                  tenant:jvm_memory_used:percent > on(tenant) group_left tenant:alert_threshold:jvm_memory
-                )
-                unless on(tenant)
-                (user_state_filter{filter="maintenance"} == 1)
-              )
-              * on(tenant) group_left(runbook_url, owner, tier)
-                tenant_metadata_info
-            for: 5m
-            labels:
-              severity: critical
-              metric_group: "jvm_performance"
-            annotations:
-              summary: "JVMPerformanceDegraded on {{ $labels.tenant }}"
-              description: "Both GC pause and memory exceed thresholds — JVM performance degraded"
-              runbook_url: "{{ $labels.runbook_url }}"
-              owner: "{{ $labels.owner }}"
-              tier: "{{ $labels.tier }}"
+  jvm-recording.yml: "groups:\n- name: jvm-normalization\n  interval: 15s\n  rules:\n\
+    \  - record: tenant:jvm_gc_pause:rate5m\n    expr: \"sum by(tenant) (\\n  rate(jvm_gc_pause_seconds_sum[5m])\\\
+    n)\\n\"\n  - record: tenant:jvm_memory_used:percent\n    expr: \"max by(tenant)\
+    \ (\\n  jvm_memory_used_bytes{area=\\\"heap\\\"}\\n  / jvm_memory_max_bytes{area=\\\
+    \"heap\\\"}\\n  * 100\\n)\\n\"\n  - record: tenant:jvm_threads:current\n    expr:\
+    \ \"max by(tenant) (\\n  jvm_threads_current\\n)\\n\"\n- name: jvm-threshold-normalization\n\
+    \  interval: 15s\n  rules:\n  - record: tenant:alert_threshold:jvm_gc_pause\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"jvm_gc_pause\", severity=\"\
+    warning\"})\n  - record: tenant:alert_threshold:jvm_gc_pause_critical\n    expr:\
+    \ max by(tenant) (user_threshold{metric=\"jvm_gc_pause\", severity=\"critical\"\
+    })\n  - record: tenant:alert_threshold:jvm_memory\n    expr: max by(tenant) (user_threshold{metric=\"\
+    jvm_memory\", severity=\"warning\"})\n  - record: tenant:alert_threshold:jvm_memory_critical\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"jvm_memory\", severity=\"critical\"\
+    })\n  - record: tenant:alert_threshold:jvm_threads\n    expr: max by(tenant) (user_threshold{metric=\"\
+    jvm_threads\", severity=\"warning\"})\n  - record: tenant:alert_threshold:jvm_threads_critical\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"jvm_threads\", severity=\"\
+    critical\"})\n"
+  jvm-alert.yml: "groups:\n- name: jvm-alerts\n  rules:\n  - alert: JVMHighGCPause\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:jvm_gc_pause:rate5m\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:jvm_gc_pause\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:jvm_gc_pause:rate5m\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:jvm_gc_pause\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n\
+    \      severity: warning\n      metric_group: jvm_gc_pause\n      tenant: '{{\
+    \ $labels.tenant }}'\n    annotations:\n      summary: JVMHighGCPause on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 上 JVM GC pause 過高'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: GC pause elevated — JVM tuning review'\n\
+    \      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant }}：GC pause\
+    \ 升高 — JVM 調優審查'\n      description: GC pause rate {{ $value }}s/5m exceeds threshold\n\
+    \      description_zh: GC pause 速率 {{ $value }}秒/5分鐘 超出閾值\n      runbook_url:\
+    \ '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n      tier:\
+    \ '{{ $labels.tier }}'\n  - alert: JVMHighGCPauseCritical\n    expr: \"(\\n  (\\\
+    n    (\\n      tenant:jvm_gc_pause:rate5m\\n      > on(tenant) group_left\\n \
+    \     tenant:alert_threshold:jvm_gc_pause_critical\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  * on(tenant)\
+    \ group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\\
+    n  (\\n    (\\n      tenant:jvm_gc_pause:rate5m\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:jvm_gc_pause_critical\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 3m\n    labels:\n      severity: critical\n\
+    \      metric_group: jvm_gc_pause\n      tenant: '{{ $labels.tenant }}'\n    annotations:\n\
+    \      summary: JVMHighGCPauseCritical on {{ $labels.tenant }}\n      summary_zh:\
+    \ '{{ $labels.tenant }} 上 JVM GC pause 嚴重過高'\n      platform_summary: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}: critical GC pause — application performance impacted'\n\
+    \      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant }}：嚴重 GC pause\
+    \ — 應用程式效能受影響'\n      description: GC pause rate {{ $value }}s/5m exceeds critical\
+    \ threshold\n      description_zh: GC pause 速率 {{ $value }}秒/5分鐘 超出嚴重閾值\n    \
+    \  runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n\
+    \      tier: '{{ $labels.tier }}'\n  - alert: JVMMemoryPressure\n    expr: \"\
+    (\\n  (\\n    (\\n      tenant:jvm_memory_used:percent\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:jvm_memory\\n    )\\n    unless on(tenant)\\n  \
+    \  (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  * on(tenant)\
+    \ group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\\
+    n  (\\n    (\\n      tenant:jvm_memory_used:percent\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:jvm_memory\\n    )\\n    unless on(tenant)\\n  \
+    \  (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n      severity: warning\n\
+    \      metric_group: jvm_memory\n      tenant: '{{ $labels.tenant }}'\n    annotations:\n\
+    \      summary: JVMMemoryPressure on {{ $labels.tenant }}\n      summary_zh: '{{\
+    \ $labels.tenant }} 上 JVM 記憶體壓力'\n      platform_summary: '[{{ $labels.tier }}]\
+    \ {{ $labels.tenant }}: heap memory pressure — JVM sizing review'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}：heap 記憶體壓力 — JVM 大小調整審查'\n      description:\
+    \ Heap usage {{ $value }}% exceeds threshold\n      description_zh: Heap 使用率 {{\
+    \ $value }}% 超出閾值\n      runbook_url: '{{ $labels.runbook_url }}'\n      owner:\
+    \ '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert: JVMMemoryPressureCritical\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:jvm_memory_used:percent\\n      >\
+    \ on(tenant) group_left\\n      tenant:alert_threshold:jvm_memory_critical\\n\
+    \    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:jvm_memory_used:percent\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:jvm_memory_critical\\n    )\\n   \
+    \ unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\\
+    n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 3m\n    labels:\n\
+    \      severity: critical\n      metric_group: jvm_memory\n      tenant: '{{ $labels.tenant\
+    \ }}'\n    annotations:\n      summary: JVMMemoryPressureCritical on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 上 JVM 記憶體壓力嚴重'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: critical heap pressure — OOM risk,\
+    \ escalate'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}：嚴重 heap 記憶體壓力 — OOM 風險，需升級處理'\n      description: Heap usage {{ $value }}%\
+    \ exceeds critical threshold\n      description_zh: Heap 使用率 {{ $value }}% 超出嚴重閾值\n\
+    \      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n  - alert: JVMThreadPoolExhaustion\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:jvm_threads:current\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:jvm_threads\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  * on(tenant)\
+    \ group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\\
+    n  (\\n    (\\n      tenant:jvm_threads:current\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:jvm_threads\\n    )\\n    unless on(tenant)\\n \
+    \   (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n      severity: warning\n\
+    \      metric_group: jvm_threads\n      tenant: '{{ $labels.tenant }}'\n    annotations:\n\
+    \      summary: JVMThreadPoolExhaustion on {{ $labels.tenant }}\n      summary_zh:\
+    \ '{{ $labels.tenant }} 上 JVM thread pool 耗盡'\n      platform_summary: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}: thread pool saturation — request backlog risk'\n \
+    \     platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant }}：thread pool\
+    \ 飽和 — request 積壓風險'\n      description: Active threads {{ $value }} exceeds threshold\n\
+    \      description_zh: 活動 thread 數 {{ $value }} 超出閾值\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: JVMThreadPoolExhaustionCritical\n    expr: \"(\\n  (\\n    (\\n  \
+    \    tenant:jvm_threads:current\\n      > on(tenant) group_left\\n      tenant:alert_threshold:jvm_threads_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:jvm_threads:current\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:jvm_threads_critical\\n    )\\n  \
+    \  unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\\
+    n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 3m\n    labels:\n\
+    \      severity: critical\n      metric_group: jvm_threads\n      tenant: '{{\
+    \ $labels.tenant }}'\n    annotations:\n      summary: JVMThreadPoolExhaustionCritical\
+    \ on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 上 JVM thread\
+    \ pool 嚴重耗盡'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: critical thread exhaustion — service degradation likely'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}：嚴重 thread 耗盡 — 服務降級可能性高'\n      description:\
+    \ Active threads {{ $value }} exceeds critical threshold\n      description_zh:\
+    \ 活動 thread 數 {{ $value }} 超出嚴重閾值\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: JVMPerformanceDegraded\n    expr: \"(\\n  (\\n    (\\n      tenant:jvm_gc_pause:rate5m\
+    \ > on(tenant) group_left tenant:alert_threshold:jvm_gc_pause\\n      and on(tenant)\\\
+    n      tenant:jvm_memory_used:percent > on(tenant) group_left tenant:alert_threshold:jvm_memory\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:jvm_gc_pause:rate5m > on(tenant) group_left\
+    \ tenant:alert_threshold:jvm_gc_pause\\n      and on(tenant)\\n      tenant:jvm_memory_used:percent\
+    \ > on(tenant) group_left tenant:alert_threshold:jvm_memory\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n\
+    \      severity: critical\n      metric_group: jvm_performance\n      tenant:\
+    \ '{{ $labels.tenant }}'\n    annotations:\n      summary: JVMPerformanceDegraded\
+    \ on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 上 JVM 效能降級'\n\
+    \      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: multi-signal\
+    \ JVM degradation — escalate'\n      platform_summary_zh: '[{{ $labels.tier }}]\
+    \ {{ $labels.tenant }}：多訊號 JVM 降級 — 需升級處理'\n      description: Both GC pause and\
+    \ memory exceed thresholds — JVM performance degraded\n      description_zh: GC\
+    \ pause 和記憶體皆超出閾值 — JVM 效能降級\n      runbook_url: '{{ $labels.runbook_url }}'\n\
+    \      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n"

--- a/k8s/03-monitoring/configmap-rules-kafka.yaml
+++ b/k8s/03-monitoring/configmap-rules-kafka.yaml
@@ -1,7 +1,8 @@
 # ============================================================
-# Kafka Rule Pack — Recording Rules & Alert Rules
-# Canonical source: rule-packs/rule-pack-kafka.yaml
-# Maintained by: Platform Team
+# kafka Rule Pack — Recording & Alert Rules (ConfigMap)
+# GENERATED from rule-packs/rule-pack-kafka.yaml by
+# scripts/tools/dx/generate_rulepack_configmaps.py — DO NOT EDIT.
+# Run `make rulepack-configmaps` after editing the rule pack.
 # ============================================================
 apiVersion: v1
 kind: ConfigMap
@@ -12,198 +13,178 @@ metadata:
     app: prometheus
     rule-pack: kafka
 data:
-  kafka-recording.yml: |
-    groups:
-      - name: kafka-normalization
-        interval: 15s
-        rules:
-          - record: tenant:kafka_consumer_lag:max
-            expr: max by(tenant) (kafka_consumergroup_lag_sum)
-
-          - record: tenant:kafka_under_replicated_partitions:max
-            expr: max by(tenant) (kafka_topic_partition_under_replicated_partition)
-
-          - record: tenant:kafka_active_controllers:max
-            expr: max by(tenant) (kafka_controller_active_controller_count)
-
-          - record: tenant:kafka_broker_count:max
-            expr: max by(tenant) (kafka_brokers)
-
-          - record: tenant:kafka_request_rate:sum
-            expr: sum by(tenant) (rate(kafka_server_brokertopicmetrics_messagesin_total[5m]))
-
-      - name: kafka-threshold-normalization
-        interval: 15s
-        rules:
-          - record: tenant:alert_threshold:kafka_consumer_lag
-            expr: max by(tenant) (user_threshold{metric="kafka_consumer_lag", severity="warning"})
-
-          - record: tenant:alert_threshold:kafka_consumer_lag_critical
-            expr: max by(tenant) (user_threshold{metric="kafka_consumer_lag", severity="critical"})
-
-          - record: tenant:alert_threshold:kafka_under_replicated_partitions
-            expr: max by(tenant) (user_threshold{metric="kafka_under_replicated_partitions", severity="warning"})
-
-          - record: tenant:alert_threshold:kafka_under_replicated_partitions_critical
-            expr: max by(tenant) (user_threshold{metric="kafka_under_replicated_partitions", severity="critical"})
-
-          - record: tenant:alert_threshold:kafka_broker_count
-            expr: max by(tenant) (user_threshold{metric="kafka_broker_count", severity="warning"})
-
-          - record: tenant:alert_threshold:kafka_active_controllers
-            expr: max by(tenant) (user_threshold{metric="kafka_active_controllers", severity="warning"})
-
-          - record: tenant:alert_threshold:kafka_request_rate
-            expr: max by(tenant) (user_threshold{metric="kafka_request_rate", severity="warning"})
-
-          - record: tenant:alert_threshold:kafka_request_rate_critical
-            expr: max by(tenant) (user_threshold{metric="kafka_request_rate", severity="critical"})
-
-  kafka-alert.yml: |
-    groups:
-      - name: kafka-alerts
-        rules:
-          - alert: KafkaExporterAbsent
-            expr: absent(kafka_brokers{job="tenant-exporters"})
-            for: 30s
-            labels:
-              severity: critical
-            annotations:
-              summary: "Kafka exporter target missing"
-              description: "No kafka_brokers metric found for 30s"
-
-          - alert: KafkaHighConsumerLag
-            expr: |
-              (
-                tenant:kafka_consumer_lag:max
-                > on(tenant) group_left
-                tenant:alert_threshold:kafka_consumer_lag
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: warning
-              metric_group: "kafka_consumer_lag"
-            annotations:
-              summary: "High Kafka consumer lag on {{ $labels.tenant }}"
-              description: "Consumer lag: {{ $value | printf \"%.0f\" }} (warning threshold exceeded)"
-
-          - alert: KafkaHighConsumerLagCritical
-            expr: |
-              (
-                tenant:kafka_consumer_lag:max
-                > on(tenant) group_left
-                tenant:alert_threshold:kafka_consumer_lag_critical
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: critical
-              metric_group: "kafka_consumer_lag"
-            annotations:
-              summary: "Critical Kafka consumer lag on {{ $labels.tenant }}"
-              description: "Consumer lag: {{ $value | printf \"%.0f\" }} (critical threshold exceeded)"
-
-          - alert: KafkaUnderReplicatedPartitions
-            expr: |
-              (
-                tenant:kafka_under_replicated_partitions:max
-                > on(tenant) group_left
-                tenant:alert_threshold:kafka_under_replicated_partitions
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: warning
-              metric_group: "kafka_under_replicated_partitions"
-            annotations:
-              summary: "Under-replicated partitions detected on {{ $labels.tenant }}"
-              description: "{{ $value | printf \"%.0f\" }} partitions lack in-sync replicas (warning threshold exceeded)"
-
-          - alert: KafkaUnderReplicatedPartitionsCritical
-            expr: |
-              (
-                tenant:kafka_under_replicated_partitions:max
-                > on(tenant) group_left
-                tenant:alert_threshold:kafka_under_replicated_partitions_critical
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: critical
-              metric_group: "kafka_under_replicated_partitions"
-            annotations:
-              summary: "Critical under-replicated partitions on {{ $labels.tenant }}"
-              description: "{{ $value | printf \"%.0f\" }} partitions lack in-sync replicas (critical threshold exceeded)"
-
-          - alert: KafkaNoActiveController
-            expr: |
-              (
-                tenant:kafka_active_controllers:max
-                < on(tenant) group_left
-                tenant:alert_threshold:kafka_active_controllers
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: critical
-              metric_group: "kafka_active_controllers"
-            annotations:
-              summary: "No active Kafka controller on {{ $labels.tenant }}"
-              description: "Active controllers: {{ $value | printf \"%.0f\" }} (expected at least 1)"
-
-          - alert: KafkaLowBrokerCount
-            expr: |
-              (
-                tenant:kafka_broker_count:max
-                < on(tenant) group_left
-                tenant:alert_threshold:kafka_broker_count
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: warning
-              metric_group: "kafka_broker_count"
-            annotations:
-              summary: "Low Kafka broker count on {{ $labels.tenant }}"
-              description: "Active brokers: {{ $value | printf \"%.0f\" }} (below minimum threshold)"
-
-          - alert: KafkaHighRequestRate
-            expr: |
-              (
-                tenant:kafka_request_rate:sum
-                > on(tenant) group_left
-                tenant:alert_threshold:kafka_request_rate
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: warning
-              metric_group: "kafka_request_rate"
-            annotations:
-              summary: "High Kafka request rate on {{ $labels.tenant }}"
-              description: "Message rate: {{ $value | printf \"%.1f\" }} msg/s (warning threshold exceeded)"
-
-          - alert: KafkaHighRequestRateCritical
-            expr: |
-              (
-                tenant:kafka_request_rate:sum
-                > on(tenant) group_left
-                tenant:alert_threshold:kafka_request_rate_critical
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: critical
-              metric_group: "kafka_request_rate"
-            annotations:
-              summary: "Critical Kafka request rate on {{ $labels.tenant }}"
-              description: "Message rate: {{ $value | printf \"%.1f\" }} msg/s (critical threshold exceeded)"
+  kafka-recording.yml: "groups:\n- name: kafka-normalization\n  interval: 15s\n  rules:\n\
+    \  - record: tenant:kafka_consumer_lag:max\n    expr: max by(tenant) (kafka_consumergroup_lag_sum)\n\
+    \  - record: tenant:kafka_under_replicated_partitions:max\n    expr: max by(tenant)\
+    \ (kafka_topic_partition_under_replicated_partition)\n  - record: tenant:kafka_active_controllers:max\n\
+    \    expr: max by(tenant) (kafka_controller_active_controller_count)\n  - record:\
+    \ tenant:kafka_broker_count:max\n    expr: max by(tenant) (kafka_brokers)\n  -\
+    \ record: tenant:kafka_request_rate:sum\n    expr: sum by(tenant) (rate(kafka_server_brokertopicmetrics_messagesin_total[5m]))\n\
+    - name: kafka-threshold-normalization\n  interval: 15s\n  rules:\n  - record:\
+    \ tenant:alert_threshold:kafka_consumer_lag\n    expr: max by(tenant) (user_threshold{metric=\"\
+    kafka_consumer_lag\", severity=\"warning\"})\n  - record: tenant:alert_threshold:kafka_consumer_lag_critical\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"kafka_consumer_lag\", severity=\"\
+    critical\"})\n  - record: tenant:alert_threshold:kafka_under_replicated_partitions\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"kafka_under_replicated_partitions\"\
+    , severity=\"warning\"})\n  - record: tenant:alert_threshold:kafka_under_replicated_partitions_critical\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"kafka_under_replicated_partitions\"\
+    , severity=\"critical\"})\n  - record: tenant:alert_threshold:kafka_broker_count\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"kafka_broker_count\", severity=\"\
+    warning\"})\n  - record: tenant:alert_threshold:kafka_active_controllers\n   \
+    \ expr: max by(tenant) (user_threshold{metric=\"kafka_active_controllers\", severity=\"\
+    warning\"})\n  - record: tenant:alert_threshold:kafka_request_rate\n    expr:\
+    \ max by(tenant) (user_threshold{metric=\"kafka_request_rate\", severity=\"warning\"\
+    })\n  - record: tenant:alert_threshold:kafka_request_rate_critical\n    expr:\
+    \ max by(tenant) (user_threshold{metric=\"kafka_request_rate\", severity=\"critical\"\
+    })\n"
+  kafka-alert.yml: "groups:\n- name: kafka-alerts\n  rules:\n  - alert: KafkaExporterAbsent\n\
+    \    expr: absent(kafka_brokers{job=\"tenant-exporters\"})\n    for: 30s\n   \
+    \ labels:\n      severity: critical\n      tenant: '{{ $labels.tenant }}'\n  \
+    \  annotations:\n      summary: Kafka exporter target missing\n      summary_zh:\
+    \ Kafka exporter 目標缺失\n      description: No kafka_brokers metric found for 30s\n\
+    \      description_zh: 30 秒內未找到 kafka_brokers metric\n  - alert: KafkaHighConsumerLag\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:kafka_consumer_lag:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:kafka_consumer_lag\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:kafka_consumer_lag:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:kafka_consumer_lag\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 30s\n    labels:\n\
+    \      severity: warning\n      metric_group: kafka_consumer_lag\n      tenant:\
+    \ '{{ $labels.tenant }}'\n    annotations:\n      summary: High Kafka consumer\
+    \ lag on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 的 Kafka\
+    \ 消費者延遲過高'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}:\
+    \ consumer lag elevated — consumer capacity review'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: 消費者延遲提升 — 請檢查消費者容量'\n      description:\
+    \ 'Consumer lag: {{ $value | printf \"%.0f\" }} (warning threshold exceeded)'\n\
+    \      description_zh: '消費者延遲: {{ $value | printf \"%.0f\" }} (超過警告閾值)'\n    \
+    \  runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n\
+    \      tier: '{{ $labels.tier }}'\n  - alert: KafkaHighConsumerLagCritical\n \
+    \   expr: \"(\\n  (\\n    (\\n      tenant:kafka_consumer_lag:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:kafka_consumer_lag_critical\\n   \
+    \ )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"\
+    } == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:kafka_consumer_lag:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:kafka_consumer_lag_critical\\n   \
+    \ )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"\
+    } == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 30s\n\
+    \    labels:\n      severity: critical\n      metric_group: kafka_consumer_lag\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Critical\
+    \ Kafka consumer lag on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 的 Kafka 消費者延遲嚴重'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: critical consumer lag — immediate consumer scaling needed'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: 消費者延遲嚴重 — 需要立即擴展消費者'\n      description:\
+    \ 'Consumer lag: {{ $value | printf \"%.0f\" }} (critical threshold exceeded)'\n\
+    \      description_zh: '消費者延遲: {{ $value | printf \"%.0f\" }} (超過嚴重閾值)'\n    \
+    \  runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n\
+    \      tier: '{{ $labels.tier }}'\n  - alert: KafkaUnderReplicatedPartitions\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:kafka_under_replicated_partitions:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:kafka_under_replicated_partitions\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:kafka_under_replicated_partitions:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:kafka_under_replicated_partitions\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 30s\n    labels:\n      severity: warning\n      metric_group: kafka_under_replicated_partitions\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Under-replicated\
+    \ partitions detected on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 偵測到複製不足的分割區'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: under-replicated partitions — broker health check'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: 複製不足分割區 — 請檢查 broker 健康狀態'\n   \
+    \   description: '{{ $value | printf \"%.0f\" }} partitions lack in-sync replicas\
+    \ (warning threshold exceeded)'\n      description_zh: '{{ $value | printf \"\
+    %.0f\" }} 個分割區缺少同步副本 (超過警告閾值)'\n      runbook_url: '{{ $labels.runbook_url }}'\n\
+    \      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert:\
+    \ KafkaUnderReplicatedPartitionsCritical\n    expr: \"(\\n  (\\n    (\\n     \
+    \ tenant:kafka_under_replicated_partitions:max\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:kafka_under_replicated_partitions_critical\\n  \
+    \  )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:kafka_under_replicated_partitions:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:kafka_under_replicated_partitions_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 30s\n    labels:\n      severity: critical\n      metric_group: kafka_under_replicated_partitions\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Critical\
+    \ under-replicated partitions on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 的複製不足分割區情況嚴重'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: critical under-replication — data durability at risk, escalate'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: 複製不足情況嚴重 — 資料耐久性有風險，請上報'\n     \
+    \ description: '{{ $value | printf \"%.0f\" }} partitions lack in-sync replicas\
+    \ (critical threshold exceeded)'\n      description_zh: '{{ $value | printf \"\
+    %.0f\" }} 個分割區缺少同步副本 (超過嚴重閾值)'\n      runbook_url: '{{ $labels.runbook_url }}'\n\
+    \      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert:\
+    \ KafkaNoActiveController\n    expr: \"(\\n  (\\n    (\\n      tenant:kafka_active_controllers:max\\\
+    n      < on(tenant) group_left\\n      tenant:alert_threshold:kafka_active_controllers\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:kafka_active_controllers:max\\n     \
+    \ < on(tenant) group_left\\n      tenant:alert_threshold:kafka_active_controllers\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 30s\n    labels:\n      severity: critical\n      metric_group: kafka_active_controllers\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: No active\
+    \ Kafka controller on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 上沒有活躍的 Kafka controller'\n      platform_summary: '[{{ $labels.tier }}] {{\
+    \ $labels.tenant }}: no active Kafka controller — cluster leadership lost, escalate'\n\
+    \      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant }}: 沒有活躍的\
+    \ Kafka controller — 叢集領導已遺失，請上報'\n      description: 'Active controllers: {{\
+    \ $value | printf \"%.0f\" }} (expected at least 1)'\n      description_zh: '活躍的\
+    \ controller: {{ $value | printf \"%.0f\" }} (預期至少 1 個)'\n      runbook_url: '{{\
+    \ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{\
+    \ $labels.tier }}'\n  - alert: KafkaLowBrokerCount\n    expr: \"(\\n  (\\n   \
+    \ (\\n      tenant:kafka_broker_count:max\\n      < on(tenant) group_left\\n \
+    \     tenant:alert_threshold:kafka_broker_count\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  * on(tenant)\
+    \ group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\\
+    n  (\\n    (\\n      tenant:kafka_broker_count:max\\n      < on(tenant) group_left\\\
+    n      tenant:alert_threshold:kafka_broker_count\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 30s\n    labels:\n      severity: warning\n\
+    \      metric_group: kafka_broker_count\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: Low Kafka broker count on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 的 Kafka broker 數量過少'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: broker count below minimum — cluster\
+    \ availability at risk'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: broker 數量低於最小值 — 叢集可用性有風險'\n      description: 'Active brokers: {{ $value\
+    \ | printf \"%.0f\" }} (below minimum threshold)'\n      description_zh: '活躍的\
+    \ broker: {{ $value | printf \"%.0f\" }} (低於最小閾值)'\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: KafkaHighRequestRate\n    expr: \"(\\n  (\\n    (\\n      tenant:kafka_request_rate:sum\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:kafka_request_rate\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:kafka_request_rate:sum\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:kafka_request_rate\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 30s\n    labels:\n\
+    \      severity: warning\n      metric_group: kafka_request_rate\n      tenant:\
+    \ '{{ $labels.tenant }}'\n    annotations:\n      summary: High Kafka request\
+    \ rate on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 的 Kafka\
+    \ 請求率過高'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}:\
+    \ message rate threshold exceeded — throughput review'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: 訊息率超過閾值 — 請檢查吞吐量'\n      description:\
+    \ 'Message rate: {{ $value | printf \"%.1f\" }} msg/s (warning threshold exceeded)'\n\
+    \      description_zh: '訊息速率: {{ $value | printf \"%.1f\" }} 訊息/秒 (超過警告閾值)'\n\
+    \      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n  - alert: KafkaHighRequestRateCritical\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:kafka_request_rate:sum\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:kafka_request_rate_critical\\n   \
+    \ )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"\
+    } == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:kafka_request_rate:sum\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:kafka_request_rate_critical\\n   \
+    \ )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"\
+    } == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 30s\n\
+    \    labels:\n      severity: critical\n      metric_group: kafka_request_rate\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Critical\
+    \ Kafka request rate on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 的 Kafka 請求率嚴重過高'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: critical message rate — broker saturation risk, escalate'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: 訊息率嚴重過高 — broker 飽和風險，請上報'\n   \
+    \   description: 'Message rate: {{ $value | printf \"%.1f\" }} msg/s (critical\
+    \ threshold exceeded)'\n      description_zh: '訊息速率: {{ $value | printf \"%.1f\"\
+    \ }} 訊息/秒 (超過嚴重閾值)'\n      runbook_url: '{{ $labels.runbook_url }}'\n      owner:\
+    \ '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n"

--- a/k8s/03-monitoring/configmap-rules-kubernetes.yaml
+++ b/k8s/03-monitoring/configmap-rules-kubernetes.yaml
@@ -135,11 +135,16 @@ data:
     \ {{ $value | printf \"%.1f\" }}% (超過臨界閾值)'\n      runbook_url: '{{ $labels.runbook_url\
     \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
     - name: kubernetes-pod-state-alerts\n  rules:\n  - alert: ContainerCrashLoop\n\
-    \    expr: \"(\\n  (\\n    (\\n      tenant:container_waiting_reason:count{reason=\\\
-    \"CrashLoopBackOff\\\"}\\n      * on(tenant) group_left\\n      user_state_filter{filter=\\\
-    \"container_crashloop\\\"}\\n    ) > 0\\n  )\\n  unless on(tenant)\\n  (user_state_filter{filter=\\\
-    \"maintenance\\\"} == 1)\\n)\\n* on(tenant) group_left(runbook_url, owner, tier)\\\
-    n  tenant_metadata_info\\n\"\n    for: 30s\n    labels:\n      severity: critical\n\
+    \    expr: \"(\\n  (\\n    (\\n      (\\n        tenant:container_waiting_reason:count{reason=\\\
+    \"CrashLoopBackOff\\\"}\\n        * on(tenant) group_left\\n        user_state_filter{filter=\\\
+    \"container_crashloop\\\"}\\n      ) > 0\\n    )\\n    unless on(tenant)\\n  \
+    \  (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  * on(tenant)\
+    \ group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\\
+    n  (\\n    (\\n      (\\n        tenant:container_waiting_reason:count{reason=\\\
+    \"CrashLoopBackOff\\\"}\\n        * on(tenant) group_left\\n        user_state_filter{filter=\\\
+    \"container_crashloop\\\"}\\n      ) > 0\\n    )\\n    unless on(tenant)\\n  \
+    \  (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 30s\n    labels:\n      severity: critical\n\
     \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Container\
     \ crash loop detected in {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
     \ }} 偵測到容器崩潰迴圈'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant\
@@ -148,11 +153,16 @@ data:
     \ '{{ $value }} container(s) in CrashLoopBackOff state'\n      description_zh:\
     \ '{{ $value }} 個容器處於 CrashLoopBackOff 狀態'\n      runbook_url: '{{ $labels.runbook_url\
     \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
-    \  - alert: ContainerImagePullFailure\n    expr: \"(\\n  (\\n    (\\n      tenant:container_waiting_reason:count{reason=~\\\
-    \"ImagePullBackOff|InvalidImageName\\\"}\\n      * on(tenant) group_left\\n  \
-    \    user_state_filter{filter=\\\"container_imagepull\\\"}\\n    ) > 0\\n  )\\\
-    n  unless on(tenant)\\n  (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\\
-    n)\\n* on(tenant) group_left(runbook_url, owner, tier)\\n  tenant_metadata_info\\\
+    \  - alert: ContainerImagePullFailure\n    expr: \"(\\n  (\\n    (\\n      (\\\
+    n        tenant:container_waiting_reason:count{reason=~\\\"ImagePullBackOff|InvalidImageName\\\
+    \"}\\n        * on(tenant) group_left\\n        user_state_filter{filter=\\\"\
+    container_imagepull\\\"}\\n      ) > 0\\n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\
+    \"maintenance\\\"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner,\
+    \ tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\n  (\\n    (\\n      (\\n   \
+    \     tenant:container_waiting_reason:count{reason=~\\\"ImagePullBackOff|InvalidImageName\\\
+    \"}\\n        * on(tenant) group_left\\n        user_state_filter{filter=\\\"\
+    container_imagepull\\\"}\\n      ) > 0\\n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\
+    \"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\\
     n\"\n    for: 30s\n    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant\
     \ }}'\n    annotations:\n      summary: Image pull failure detected in {{ $labels.tenant\
     \ }}\n      summary_zh: '{{ $labels.tenant }} 偵測到映像檔案拉取失敗'\n      platform_summary:\

--- a/k8s/03-monitoring/configmap-rules-mariadb.yaml
+++ b/k8s/03-monitoring/configmap-rules-mariadb.yaml
@@ -1,7 +1,8 @@
 # ============================================================
-# MariaDB Rule Pack — Recording Rules & Alert Rules
-# Canonical source: rule-packs/rule-pack-mariadb.yaml
-# Maintained by: DBA Team
+# mariadb Rule Pack — Recording & Alert Rules (ConfigMap)
+# GENERATED from rule-packs/rule-pack-mariadb.yaml by
+# scripts/tools/dx/generate_rulepack_configmaps.py — DO NOT EDIT.
+# Run `make rulepack-configmaps` after editing the rule pack.
 # ============================================================
 apiVersion: v1
 kind: ConfigMap
@@ -12,176 +13,122 @@ metadata:
     app: prometheus
     rule-pack: mariadb
 data:
-  mariadb-recording.yml: |
-    groups:
-      - name: mariadb-normalization
-        interval: 15s
-        rules:
-          - record: tenant:mysql_cpu_usage:rate5m
-            expr: sum by(tenant) (rate(mysql_global_status_threads_running[5m]))
-
-          - record: tenant:mysql_threads_connected:max
-            expr: max by(tenant) (mysql_global_status_threads_connected)
-
-          - record: tenant:mysql_connection_usage:ratio
-            expr: |
-              sum by(tenant) (mysql_global_status_threads_connected)
-              / sum by(tenant) (mysql_global_variables_max_connections)
-
-          - record: tenant:mysql_uptime:hours
-            expr: min by(tenant) (mysql_global_status_uptime) / 3600
-
-          - record: tenant:mysql_slow_queries:rate5m
-            expr: sum by(tenant) (rate(mysql_global_status_slow_queries[5m]))
-
-          - record: tenant:mysql_aborted_connections:rate5m
-            expr: sum by(tenant) (rate(mysql_global_status_aborted_connects[5m]))
-
-          - record: tenant:mysql_buffer_pool_usage:ratio
-            expr: |
-              sum by(tenant) (mysql_global_status_innodb_buffer_pool_pages_data)
-              / sum by(tenant) (mysql_global_status_innodb_buffer_pool_pages_total)
-
-      - name: mariadb-threshold-normalization
-        interval: 15s
-        rules:
-          - record: tenant:alert_threshold:connections
-            expr: max by(tenant) (user_threshold{metric="connections", severity="warning"})
-
-          - record: tenant:alert_threshold:cpu
-            expr: max by(tenant) (user_threshold{metric="cpu", severity="warning"})
-
-          - record: tenant:alert_threshold:connections_critical
-            expr: max by(tenant) (user_threshold{metric="connections", severity="critical"})
-
-          - record: tenant:alert_threshold:cpu_critical
-            expr: max by(tenant) (user_threshold{metric="cpu", severity="critical"})
-
-  mariadb-alert.yml: |
-    groups:
-      - name: mariadb-alerts
-        rules:
-          - alert: MariaDBDown
-            expr: mysql_up == 0
-            for: 15s
-            labels:
-              severity: critical
-            annotations:
-              summary: "MariaDB instance {{ $labels.instance }} is DOWN"
-              summary_zh: "MariaDB 實例 {{ $labels.instance }} 已關閉"
-              description: "mysql_up=0 for 15s on {{ $labels.instance }}"
-              description_zh: "mysql_up=0，持續 15 秒，實例：{{ $labels.instance }}"
-
-          - alert: MariaDBExporterAbsent
-            expr: absent(mysql_up{job="tenant-exporters"})
-            for: 30s
-            labels:
-              severity: critical
-            annotations:
-              summary: "mysqld-exporter target missing"
-              summary_zh: "mysqld-exporter 目標缺失"
-              description: "No mysql_up metric found for 30s"
-              description_zh: "找不到 mysql_up 指標，持續 30 秒"
-
-          - alert: MariaDBHighConnections
-            expr: |
-              (
-                tenant:mysql_threads_connected:max
-                > on(tenant) group_left
-                tenant:alert_threshold:connections
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: warning
-              metric_group: "connections"
-            annotations:
-              summary: "High connections on {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 連線數過高"
-              description: "{{ $value }} threads connected (warning threshold exceeded)"
-              description_zh: "{{ $value }} 個執行緒已連接（超過警告閾值）"
-
-          - alert: MariaDBHighConnectionsCritical
-            expr: |
-              (
-                tenant:mysql_threads_connected:max
-                > on(tenant) group_left
-                tenant:alert_threshold:connections_critical
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: critical
-              metric_group: "connections"
-            annotations:
-              summary: "Critical connections on {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 連線數嚴重過高"
-              description: "{{ $value }} threads connected (critical threshold exceeded)"
-              description_zh: "{{ $value }} 個執行緒已連接（超過嚴重閾值）"
-
-          - alert: MariaDBSystemBottleneck
-            expr: |
-              (
-                (
-                  tenant:mysql_threads_connected:max
-                  > on(tenant) group_left
-                  tenant:alert_threshold:connections
-                )
-                and on(tenant)
-                (
-                  tenant:mysql_cpu_usage:rate5m
-                  > on(tenant) group_left
-                  tenant:alert_threshold:cpu
-                )
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 60s
-            labels:
-              severity: critical
-            annotations:
-              summary: "System bottleneck on {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 系統瓶頸"
-              description: "Both connections AND CPU thresholds exceeded simultaneously"
-              description_zh: "CPU 與連線數閾值同時超出"
-
-          - alert: MariaDBRecentRestart
-            expr: mysql_global_status_uptime < 300
-            for: 0s
-            labels:
-              severity: info
-            annotations:
-              summary: "{{ $labels.instance }} restarted recently"
-              summary_zh: "{{ $labels.instance }} 最近已重新啟動"
-              description: "Uptime is only {{ $value }}s (< 5 min)"
-              description_zh: "運行時間僅 {{ $value }}s（少於 5 分鐘）"
-
-          - alert: MariaDBHighSlowQueries
-            expr: |
-              tenant:mysql_slow_queries:rate5m > 1
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "High slow query rate on {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 慢查詢率過高"
-              description: "{{ $value | printf \"%.2f\" }} slow queries/sec"
-              description_zh: "{{ $value | printf \"%.2f\" }} 次慢查詢／秒"
-
-          - alert: MariaDBHighAbortedConnections
-            expr: |
-              tenant:mysql_aborted_connections:rate5m > 5
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "High aborted connections on {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 中止的連線數過高"
-              description: "{{ $value | printf \"%.2f\" }} aborted connections/sec"
-              description_zh: "{{ $value | printf \"%.2f\" }} 次中止連線／秒"
+  mariadb-recording.yml: "groups:\n- name: mariadb-normalization\n  interval: 15s\n\
+    \  rules:\n  - record: tenant:mysql_cpu_usage:rate5m\n    expr: sum by(tenant)\
+    \ (rate(mysql_global_status_threads_running[5m]))\n  - record: tenant:mysql_threads_connected:max\n\
+    \    expr: max by(tenant) (mysql_global_status_threads_connected)\n  - record:\
+    \ tenant:mysql_connection_usage:ratio\n    expr: 'sum by(tenant) (mysql_global_status_threads_connected)\n\
+    \n      / sum by(tenant) (mysql_global_variables_max_connections)\n\n      '\n\
+    \  - record: tenant:mysql_uptime:hours\n    expr: min by(tenant) (mysql_global_status_uptime)\
+    \ / 3600\n  - record: tenant:mysql_slow_queries:rate5m\n    expr: sum by(tenant)\
+    \ (rate(mysql_global_status_slow_queries[5m]))\n  - record: tenant:mysql_aborted_connections:rate5m\n\
+    \    expr: sum by(tenant) (rate(mysql_global_status_aborted_connects[5m]))\n \
+    \ - record: tenant:mysql_buffer_pool_usage:ratio\n    expr: 'sum by(tenant) (mysql_global_status_innodb_buffer_pool_pages_data)\n\
+    \n      / sum by(tenant) (mysql_global_status_innodb_buffer_pool_pages_total)\n\
+    \n      '\n- name: mariadb-threshold-normalization\n  interval: 15s\n  rules:\n\
+    \  - record: tenant:alert_threshold:connections\n    expr: max by(tenant) (user_threshold{metric=\"\
+    connections\", severity=\"warning\"})\n  - record: tenant:alert_threshold:cpu\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"cpu\", severity=\"warning\"\
+    })\n  - record: tenant:alert_threshold:connections_critical\n    expr: max by(tenant)\
+    \ (user_threshold{metric=\"connections\", severity=\"critical\"})\n  - record:\
+    \ tenant:alert_threshold:cpu_critical\n    expr: max by(tenant) (user_threshold{metric=\"\
+    cpu\", severity=\"critical\"})\n"
+  mariadb-alert.yml: "groups:\n- name: mariadb-alerts\n  rules:\n  - alert: MariaDBDown\n\
+    \    expr: mysql_up == 0\n    for: 15s\n    labels:\n      severity: critical\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: MariaDB\
+    \ instance {{ $labels.instance }} is DOWN\n      summary_zh: MariaDB 實例 {{ $labels.instance\
+    \ }} 已關閉\n      description: mysql_up=0 for 15s on {{ $labels.instance }}\n  \
+    \    description_zh: mysql_up=0，持續 15 秒，實例：{{ $labels.instance }}\n  - alert:\
+    \ MariaDBExporterAbsent\n    expr: absent(mysql_up{job=\"tenant-exporters\"})\n\
+    \    for: 30s\n    labels:\n      severity: critical\n      tenant: '{{ $labels.tenant\
+    \ }}'\n    annotations:\n      summary: mysqld-exporter target missing\n     \
+    \ summary_zh: mysqld-exporter 目標缺失\n      description: No mysql_up metric found\
+    \ for 30s\n      description_zh: 找不到 mysql_up 指標，持續 30 秒\n  - alert: MariaDBHighConnections\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:mysql_threads_connected:max\\n   \
+    \   > on(tenant) group_left\\n      tenant:alert_threshold:connections\\n    )\\\
+    n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:mysql_threads_connected:max\\n      >\
+    \ on(tenant) group_left\\n      tenant:alert_threshold:connections\\n    )\\n\
+    \    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 30s\n\
+    \    labels:\n      severity: warning\n      metric_group: connections\n     \
+    \ tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: High connections\
+    \ on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 連線數過高'\n  \
+    \    platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: connection\
+    \ threshold breached — review connection pool sizing'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}：連線數閾值超出 — 檢查連線集區大小設定'\n      description:\
+    \ '{{ $value }} threads connected (warning threshold exceeded)'\n      description_zh:\
+    \ '{{ $value }} 個執行緒已連接（超過警告閾值）'\n      runbook_url: '{{ $labels.runbook_url }}'\n\
+    \      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert:\
+    \ MariaDBHighConnectionsCritical\n    expr: \"(\\n  (\\n    (\\n      tenant:mysql_threads_connected:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:connections_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:mysql_threads_connected:max\\n      >\
+    \ on(tenant) group_left\\n      tenant:alert_threshold:connections_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 30s\n    labels:\n      severity: critical\n      metric_group: connections\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Critical\
+    \ connections on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }}\
+    \ 連線數嚴重過高'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}:\
+    \ critical connection saturation — immediate capacity action needed'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}：連線數飽和 — 需立即採取容量擴增行動'\n      description:\
+    \ '{{ $value }} threads connected (critical threshold exceeded)'\n      description_zh:\
+    \ '{{ $value }} 個執行緒已連接（超過嚴重閾值）'\n      runbook_url: '{{ $labels.runbook_url }}'\n\
+    \      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert:\
+    \ MariaDBSystemBottleneck\n    expr: \"(\\n  (\\n    (\\n      (\\n        tenant:mysql_threads_connected:max\\\
+    n        > on(tenant) group_left\\n        tenant:alert_threshold:connections\\\
+    n      )\\n      and on(tenant)\\n      (\\n        tenant:mysql_cpu_usage:rate5m\\\
+    n        > on(tenant) group_left\\n        tenant:alert_threshold:cpu\\n     \
+    \ )\\n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      (\\n        tenant:mysql_threads_connected:max\\\
+    n        > on(tenant) group_left\\n        tenant:alert_threshold:connections\\\
+    n      )\\n      and on(tenant)\\n      (\\n        tenant:mysql_cpu_usage:rate5m\\\
+    n        > on(tenant) group_left\\n        tenant:alert_threshold:cpu\\n     \
+    \ )\\n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 60s\n    labels:\n      severity: critical\n      tenant: '{{ $labels.tenant\
+    \ }}'\n    annotations:\n      summary: System bottleneck on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 系統瓶頸'\n      platform_summary: '[{{\
+    \ $labels.tier }}] {{ $labels.tenant }}: CPU + connections both exceeded — multi-resource\
+    \ bottleneck, escalate'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}：CPU 與連線皆超出 — 多資源瓶頸，需升級處理'\n      description: Both connections AND CPU thresholds\
+    \ exceeded simultaneously\n      description_zh: CPU 與連線數閾值同時超出\n      runbook_url:\
+    \ '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n      tier:\
+    \ '{{ $labels.tier }}'\n  - alert: MariaDBRecentRestart\n    expr: mysql_global_status_uptime\
+    \ < 300\n    for: 0s\n    labels:\n      severity: info\n      tenant: '{{ $labels.tenant\
+    \ }}'\n    annotations:\n      summary: '{{ $labels.instance }} restarted recently'\n\
+    \      summary_zh: '{{ $labels.instance }} 最近已重新啟動'\n      description: Uptime\
+    \ is only {{ $value }}s (< 5 min)\n      description_zh: 運行時間僅 {{ $value }}s（少於\
+    \ 5 分鐘）\n  - alert: MariaDBHighSlowQueries\n    expr: \"(\\n  (\\n    tenant:mysql_slow_queries:rate5m\
+    \ > 1\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    tenant:mysql_slow_queries:rate5m > 1\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n      severity: warning\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: High slow\
+    \ query rate on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }}\
+    \ 慢查詢率過高'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}:\
+    \ slow query rate elevated — query optimization review'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}：慢查詢率升高 — 需進行查詢最佳化檢查'\n      description:\
+    \ '{{ $value | printf \"%.2f\" }} slow queries/sec'\n      description_zh: '{{\
+    \ $value | printf \"%.2f\" }} 次慢查詢／秒'\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: MariaDBHighAbortedConnections\n    expr: \"(\\n  (\\n    tenant:mysql_aborted_connections:rate5m\
+    \ > 5\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    tenant:mysql_aborted_connections:rate5m > 5\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n\
+    \      severity: warning\n      tenant: '{{ $labels.tenant }}'\n    annotations:\n\
+    \      summary: High aborted connections on {{ $labels.tenant }}\n      summary_zh:\
+    \ '{{ $labels.tenant }} 中止的連線數過高'\n      platform_summary: '[{{ $labels.tier }}]\
+    \ {{ $labels.tenant }}: aborted connection rate elevated — check client connectivity'\n\
+    \      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant }}：中止連線率升高\
+    \ — 檢查客戶端連線狀態'\n      description: '{{ $value | printf \"%.2f\" }} aborted connections/sec'\n\
+    \      description_zh: '{{ $value | printf \"%.2f\" }} 次中止連線／秒'\n      runbook_url:\
+    \ '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n      tier:\
+    \ '{{ $labels.tier }}'\n"

--- a/k8s/03-monitoring/configmap-rules-mongodb.yaml
+++ b/k8s/03-monitoring/configmap-rules-mongodb.yaml
@@ -1,7 +1,8 @@
 # ============================================================
-# MongoDB Rule Pack — Recording Rules & Alert Rules
-# Canonical source: rule-packs/rule-pack-mongodb.yaml
-# Maintained by: DBA Team
+# mongodb Rule Pack — Recording & Alert Rules (ConfigMap)
+# GENERATED from rule-packs/rule-pack-mongodb.yaml by
+# scripts/tools/dx/generate_rulepack_configmaps.py — DO NOT EDIT.
+# Run `make rulepack-configmaps` after editing the rule pack.
 # ============================================================
 apiVersion: v1
 kind: ConfigMap
@@ -12,129 +13,108 @@ metadata:
     app: prometheus
     rule-pack: mongodb
 data:
-  mongodb-recording.yml: |
-    groups:
-      - name: mongodb-normalization
-        interval: 15s
-        rules:
-          - record: tenant:mongodb_connections_current:max
-            expr: max by(tenant) (mongodb_connections{state="current"})
-
-          - record: tenant:mongodb_connections_available:min
-            expr: min by(tenant) (mongodb_connections{state="available"})
-
-          - record: tenant:mongodb_connection_usage:ratio
-            expr: |
-              max by(tenant) (mongodb_connections{state="current"})
-              / (
-                max by(tenant) (mongodb_connections{state="current"})
-                + min by(tenant) (mongodb_connections{state="available"})
-              )
-
-          - record: tenant:mongodb_replication_lag:max
-            expr: max by(tenant) (mongodb_mongod_replset_member_replication_lag)
-
-          - record: tenant:mongodb_opcounters:rate5m
-            expr: sum by(tenant) (rate(mongodb_opcounters_total[5m]))
-
-          - record: tenant:mongodb_document_ops:rate5m
-            expr: sum by(tenant) (rate(mongodb_mongod_metrics_document_total[5m]))
-
-          - record: tenant:mongodb_page_faults:rate5m
-            expr: sum by(tenant) (rate(mongodb_extra_info_page_faults_total[5m]))
-
-      - name: mongodb-threshold-normalization
-        interval: 15s
-        rules:
-          - record: tenant:alert_threshold:mongodb_connections_current
-            expr: max by(tenant) (user_threshold{metric="mongodb_connections_current", severity="warning"})
-
-          - record: tenant:alert_threshold:mongodb_replication_lag
-            expr: max by(tenant) (user_threshold{metric="mongodb_replication_lag", severity="warning"})
-
-          - record: tenant:alert_threshold:mongodb_opcounters_rate
-            expr: max by(tenant) (user_threshold{metric="mongodb_opcounters_rate", severity="warning"})
-
-  mongodb-alert.yml: |
-    groups:
-      - name: mongodb-alerts
-        rules:
-          - alert: MongoDBDown
-            expr: mongodb_up == 0
-            for: 15s
-            labels:
-              severity: critical
-            annotations:
-              summary: "MongoDB instance {{ $labels.instance }} is DOWN"
-
-          - alert: MongoDBHighConnections
-            expr: |
-              (
-                tenant:mongodb_connections_current:max
-                > on(tenant) group_left
-                tenant:alert_threshold:mongodb_connections_current
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "MongoDB high connection count on {{ $labels.tenant }}"
-              description: "{{ $value }} current connections"
-
-          - alert: MongoDBReplicationLag
-            expr: |
-              (
-                tenant:mongodb_replication_lag:max
-                > on(tenant) group_left
-                tenant:alert_threshold:mongodb_replication_lag
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 2m
-            labels:
-              severity: warning
-            annotations:
-              summary: "MongoDB replication lag on {{ $labels.tenant }}"
-              description: "Replication lag: {{ $value | printf \"%.1f\" }}s behind primary"
-
-          - alert: MongoDBHighOperations
-            expr: |
-              (
-                tenant:mongodb_opcounters:rate5m
-                > on(tenant) group_left
-                tenant:alert_threshold:mongodb_opcounters_rate
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "MongoDB high operation rate on {{ $labels.tenant }}"
-              description: "{{ $value | printf \"%.0f\" }} ops/sec"
-
-          - alert: MongoDBHighPageFaults
-            expr: |
-              tenant:mongodb_page_faults:rate5m > 100
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "MongoDB high page faults on {{ $labels.tenant }}"
-              description: "{{ $value | printf \"%.1f\" }} page faults/sec — check memory"
-
-          - alert: MongoDBConnectionSaturation
-            expr: |
-              tenant:mongodb_connection_usage:ratio > 0.8
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "MongoDB connection pool near saturation on {{ $labels.tenant }}"
-              description: "{{ $value | printf \"%.0f\" }}% of connections used"
+  mongodb-recording.yml: "groups:\n- name: mongodb-normalization\n  interval: 15s\n\
+    \  rules:\n  - record: tenant:mongodb_connections_current:max\n    expr: max by(tenant)\
+    \ (mongodb_connections{state=\"current\"})\n  - record: tenant:mongodb_connections_available:min\n\
+    \    expr: min by(tenant) (mongodb_connections{state=\"available\"})\n  - record:\
+    \ tenant:mongodb_connection_usage:ratio\n    expr: \"max by(tenant) (mongodb_connections{state=\\\
+    \"current\\\"})\\n/ (\\n  max by(tenant) (mongodb_connections{state=\\\"current\\\
+    \"})\\n  + min by(tenant) (mongodb_connections{state=\\\"available\\\"})\\n)\\\
+    n\"\n  - record: tenant:mongodb_replication_lag:max\n    expr: max by(tenant)\
+    \ (mongodb_mongod_replset_member_replication_lag)\n  - record: tenant:mongodb_opcounters:rate5m\n\
+    \    expr: sum by(tenant) (rate(mongodb_opcounters_total[5m]))\n  - record: tenant:mongodb_document_ops:rate5m\n\
+    \    expr: sum by(tenant) (rate(mongodb_mongod_metrics_document_total[5m]))\n\
+    \  - record: tenant:mongodb_page_faults:rate5m\n    expr: sum by(tenant) (rate(mongodb_extra_info_page_faults_total[5m]))\n\
+    - name: mongodb-threshold-normalization\n  interval: 15s\n  rules:\n  - record:\
+    \ tenant:alert_threshold:mongodb_connections_current\n    expr: max by(tenant)\
+    \ (user_threshold{metric=\"mongodb_connections_current\", severity=\"warning\"\
+    })\n  - record: tenant:alert_threshold:mongodb_replication_lag\n    expr: max\
+    \ by(tenant) (user_threshold{metric=\"mongodb_replication_lag\", severity=\"warning\"\
+    })\n  - record: tenant:alert_threshold:mongodb_opcounters_rate\n    expr: max\
+    \ by(tenant) (user_threshold{metric=\"mongodb_opcounters_rate\", severity=\"warning\"\
+    })\n"
+  mongodb-alert.yml: "groups:\n- name: mongodb-alerts\n  rules:\n  - alert: MongoDBDown\n\
+    \    expr: mongodb_up == 0\n    for: 15s\n    labels:\n      severity: critical\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: MongoDB\
+    \ instance {{ $labels.instance }} is DOWN\n      summary_zh: MongoDB 實例 {{ $labels.instance\
+    \ }} 已停機\n  - alert: MongoDBHighConnections\n    expr: \"(\\n  (\\n    (\\n  \
+    \    tenant:mongodb_connections_current:max\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:mongodb_connections_current\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:mongodb_connections_current:max\\n  \
+    \    > on(tenant) group_left\\n      tenant:alert_threshold:mongodb_connections_current\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 5m\n    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: MongoDB high connection count on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 的 MongoDB 連線數過高'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB connection threshold breached\
+    \ — pool sizing review'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: MongoDB 連線閾值超過 — 請檢查連線池大小'\n      description: '{{ $value }} current connections'\n\
+    \      description_zh: '{{ $value }} 個目前連線'\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: MongoDBReplicationLag\n    expr: \"(\\n  (\\n    (\\n      tenant:mongodb_replication_lag:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:mongodb_replication_lag\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:mongodb_replication_lag:max\\n      >\
+    \ on(tenant) group_left\\n      tenant:alert_threshold:mongodb_replication_lag\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 2m\n    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: MongoDB replication lag on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 的 MongoDB 複製延遲'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB replication lag — check\
+    \ replica health'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: MongoDB 複製延遲 — 請檢查副本狀態'\n      description: 'Replication lag: {{ $value\
+    \ | printf \"%.1f\" }}s behind primary'\n      description_zh: '複製延遲: 落後 Primary\
+    \ {{ $value | printf \"%.1f\" }}s'\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: MongoDBHighOperations\n    expr: \"(\\n  (\\n    (\\n      tenant:mongodb_opcounters:rate5m\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:mongodb_opcounters_rate\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:mongodb_opcounters:rate5m\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:mongodb_opcounters_rate\\n    )\\\
+    n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n\
+    \    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: MongoDB high operation rate on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 的 MongoDB 作業率過高'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB operation rate elevated\
+    \ — workload review'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: MongoDB 作業率提升 — 請檢查工作負載'\n      description: '{{ $value | printf \"%.0f\"\
+    \ }} ops/sec'\n      description_zh: '{{ $value | printf \"%.0f\" }} 作業/秒'\n \
+    \     runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n  - alert: MongoDBHighPageFaults\n  \
+    \  expr: \"(\\n  (\\n    tenant:mongodb_page_faults:rate5m > 100\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    tenant:mongodb_page_faults:rate5m > 100\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n      severity: warning\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: MongoDB\
+    \ high page faults on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 的 MongoDB Page Fault 過多'\n      platform_summary: '[{{ $labels.tier }}] {{\
+    \ $labels.tenant }}: MongoDB page fault rate high — memory sizing review'\n  \
+    \    platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB\
+    \ Page Fault 率過高 — 請檢查記憶體大小'\n      description: '{{ $value | printf \"%.1f\"\
+    \ }} page faults/sec — check memory'\n      description_zh: '{{ $value | printf\
+    \ \"%.1f\" }} Page Fault/秒 — 請檢查記憶體'\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: MongoDBConnectionSaturation\n    expr: \"(\\n  (\\n    tenant:mongodb_connection_usage:ratio\
+    \ > 0.8\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    tenant:mongodb_connection_usage:ratio > 0.8\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n\
+    \      severity: warning\n      tenant: '{{ $labels.tenant }}'\n    annotations:\n\
+    \      summary: MongoDB connection pool near saturation on {{ $labels.tenant }}\n\
+    \      summary_zh: '{{ $labels.tenant }} 的 MongoDB 連線池接近飽和'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: MongoDB connection pool near saturation\
+    \ — capacity action needed'\n      platform_summary_zh: '[{{ $labels.tier }}]\
+    \ {{ $labels.tenant }}: MongoDB 連線池接近飽和 — 需要容量擴展'\n      description: '{{ $value\
+    \ | printf \"%.0f\" }}% of connections used'\n      description_zh: 已使用 {{ $value\
+    \ | printf \"%.0f\" }}% 的連線\n      runbook_url: '{{ $labels.runbook_url }}'\n\
+    \      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n"

--- a/k8s/03-monitoring/configmap-rules-nginx.yaml
+++ b/k8s/03-monitoring/configmap-rules-nginx.yaml
@@ -1,7 +1,8 @@
 # ============================================================
-# Nginx Rule Pack — Recording Rules & Alert Rules
-# Canonical source: rule-packs/rule-pack-nginx.yaml
-# Maintained by: Platform Team
+# nginx Rule Pack — Recording & Alert Rules (ConfigMap)
+# GENERATED from rule-packs/rule-pack-nginx.yaml by
+# scripts/tools/dx/generate_rulepack_configmaps.py — DO NOT EDIT.
+# Run `make rulepack-configmaps` after editing the rule pack.
 # ============================================================
 apiVersion: v1
 kind: ConfigMap
@@ -12,186 +13,125 @@ metadata:
     app: prometheus
     rule-pack: nginx
 data:
-  nginx-recording.yml: |
-    groups:
-      - name: nginx-normalization
-        interval: 15s
-        rules:
-          - record: tenant:nginx_connections_active:max
-            expr: |
-              max by(tenant) (
-                nginx_connections_active
-              )
-          - record: tenant:nginx_requests:rate5m
-            expr: |
-              sum by(tenant) (
-                rate(nginx_http_requests_total[5m])
-              )
-          - record: tenant:nginx_connections_waiting:max
-            expr: |
-              max by(tenant) (
-                nginx_connections_waiting
-              )
-      - name: nginx-threshold-normalization
-        interval: 15s
-        rules:
-          - record: tenant:alert_threshold:nginx_connections
-            expr: max by(tenant) (user_threshold{metric="nginx_connections", severity="warning"})
-          - record: tenant:alert_threshold:nginx_connections_critical
-            expr: max by(tenant) (user_threshold{metric="nginx_connections", severity="critical"})
-          - record: tenant:alert_threshold:nginx_request_rate
-            expr: max by(tenant) (user_threshold{metric="nginx_request_rate", severity="warning"})
-          - record: tenant:alert_threshold:nginx_request_rate_critical
-            expr: max by(tenant) (user_threshold{metric="nginx_request_rate", severity="critical"})
-          - record: tenant:alert_threshold:nginx_waiting
-            expr: max by(tenant) (user_threshold{metric="nginx_waiting", severity="warning"})
-          - record: tenant:alert_threshold:nginx_waiting_critical
-            expr: max by(tenant) (user_threshold{metric="nginx_waiting", severity="critical"})
-
-  nginx-alert.yml: |
-    groups:
-      - name: nginx-alerts
-        rules:
-          - alert: NginxHighConnections
-            expr: |
-              (
-                (
-                  tenant:nginx_connections_active:max
-                  > on(tenant) group_left
-                  tenant:alert_threshold:nginx_connections
-                )
-                unless on(tenant)
-                (user_state_filter{filter="maintenance"} == 1)
-              )
-              * on(tenant) group_left(runbook_url, owner, tier)
-                tenant_metadata_info
-            for: 5m
-            labels:
-              severity: warning
-              metric_group: "nginx_connections"
-            annotations:
-              summary: "NginxHighConnections on {{ $labels.tenant }}"
-              description: "Active connections {{ $value }} exceeds threshold"
-              runbook_url: "{{ $labels.runbook_url }}"
-              owner: "{{ $labels.owner }}"
-              tier: "{{ $labels.tier }}"
-
-          - alert: NginxHighConnectionsCritical
-            expr: |
-              (
-                (
-                  tenant:nginx_connections_active:max
-                  > on(tenant) group_left
-                  tenant:alert_threshold:nginx_connections_critical
-                )
-                unless on(tenant)
-                (user_state_filter{filter="maintenance"} == 1)
-              )
-              * on(tenant) group_left(runbook_url, owner, tier)
-                tenant_metadata_info
-            for: 3m
-            labels:
-              severity: critical
-              metric_group: "nginx_connections"
-            annotations:
-              summary: "NginxHighConnectionsCritical on {{ $labels.tenant }}"
-              description: "Active connections {{ $value }} exceeds critical threshold"
-              runbook_url: "{{ $labels.runbook_url }}"
-              owner: "{{ $labels.owner }}"
-              tier: "{{ $labels.tier }}"
-
-          - alert: NginxRequestRateSpike
-            expr: |
-              (
-                (
-                  tenant:nginx_requests:rate5m
-                  > on(tenant) group_left
-                  tenant:alert_threshold:nginx_request_rate
-                )
-                unless on(tenant)
-                (user_state_filter{filter="maintenance"} == 1)
-              )
-              * on(tenant) group_left(runbook_url, owner, tier)
-                tenant_metadata_info
-            for: 5m
-            labels:
-              severity: warning
-              metric_group: "nginx_request_rate"
-            annotations:
-              summary: "NginxRequestRateSpike on {{ $labels.tenant }}"
-              description: "Request rate {{ $value }} req/s exceeds threshold"
-              runbook_url: "{{ $labels.runbook_url }}"
-              owner: "{{ $labels.owner }}"
-              tier: "{{ $labels.tier }}"
-
-          - alert: NginxRequestRateSpikeCritical
-            expr: |
-              (
-                (
-                  tenant:nginx_requests:rate5m
-                  > on(tenant) group_left
-                  tenant:alert_threshold:nginx_request_rate_critical
-                )
-                unless on(tenant)
-                (user_state_filter{filter="maintenance"} == 1)
-              )
-              * on(tenant) group_left(runbook_url, owner, tier)
-                tenant_metadata_info
-            for: 3m
-            labels:
-              severity: critical
-              metric_group: "nginx_request_rate"
-            annotations:
-              summary: "NginxRequestRateSpikeCritical on {{ $labels.tenant }}"
-              description: "Request rate {{ $value }} req/s exceeds critical threshold"
-              runbook_url: "{{ $labels.runbook_url }}"
-              owner: "{{ $labels.owner }}"
-              tier: "{{ $labels.tier }}"
-
-          - alert: NginxConnectionBacklog
-            expr: |
-              (
-                (
-                  tenant:nginx_connections_waiting:max
-                  > on(tenant) group_left
-                  tenant:alert_threshold:nginx_waiting
-                )
-                unless on(tenant)
-                (user_state_filter{filter="maintenance"} == 1)
-              )
-              * on(tenant) group_left(runbook_url, owner, tier)
-                tenant_metadata_info
-            for: 5m
-            labels:
-              severity: warning
-              metric_group: "nginx_waiting"
-            annotations:
-              summary: "NginxConnectionBacklog on {{ $labels.tenant }}"
-              description: "Waiting connections {{ $value }} exceeds threshold"
-              runbook_url: "{{ $labels.runbook_url }}"
-              owner: "{{ $labels.owner }}"
-              tier: "{{ $labels.tier }}"
-
-          - alert: NginxConnectionBacklogCritical
-            expr: |
-              (
-                (
-                  tenant:nginx_connections_waiting:max
-                  > on(tenant) group_left
-                  tenant:alert_threshold:nginx_waiting_critical
-                )
-                unless on(tenant)
-                (user_state_filter{filter="maintenance"} == 1)
-              )
-              * on(tenant) group_left(runbook_url, owner, tier)
-                tenant_metadata_info
-            for: 3m
-            labels:
-              severity: critical
-              metric_group: "nginx_waiting"
-            annotations:
-              summary: "NginxConnectionBacklogCritical on {{ $labels.tenant }}"
-              description: "Waiting connections {{ $value }} exceeds critical threshold"
-              runbook_url: "{{ $labels.runbook_url }}"
-              owner: "{{ $labels.owner }}"
-              tier: "{{ $labels.tier }}"
+  nginx-recording.yml: "groups:\n- name: nginx-normalization\n  interval: 15s\n  rules:\n\
+    \  - record: tenant:nginx_connections_active:max\n    expr: \"max by(tenant) (\\\
+    n  nginx_connections_active\\n)\\n\"\n  - record: tenant:nginx_requests:rate5m\n\
+    \    expr: \"sum by(tenant) (\\n  rate(nginx_http_requests_total[5m])\\n)\\n\"\
+    \n  - record: tenant:nginx_connections_waiting:max\n    expr: \"max by(tenant)\
+    \ (\\n  nginx_connections_waiting\\n)\\n\"\n- name: nginx-threshold-normalization\n\
+    \  interval: 15s\n  rules:\n  - record: tenant:alert_threshold:nginx_connections\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"nginx_connections\", severity=\"\
+    warning\"})\n  - record: tenant:alert_threshold:nginx_connections_critical\n \
+    \   expr: max by(tenant) (user_threshold{metric=\"nginx_connections\", severity=\"\
+    critical\"})\n  - record: tenant:alert_threshold:nginx_request_rate\n    expr:\
+    \ max by(tenant) (user_threshold{metric=\"nginx_request_rate\", severity=\"warning\"\
+    })\n  - record: tenant:alert_threshold:nginx_request_rate_critical\n    expr:\
+    \ max by(tenant) (user_threshold{metric=\"nginx_request_rate\", severity=\"critical\"\
+    })\n  - record: tenant:alert_threshold:nginx_waiting\n    expr: max by(tenant)\
+    \ (user_threshold{metric=\"nginx_waiting\", severity=\"warning\"})\n  - record:\
+    \ tenant:alert_threshold:nginx_waiting_critical\n    expr: max by(tenant) (user_threshold{metric=\"\
+    nginx_waiting\", severity=\"critical\"})\n"
+  nginx-alert.yml: "groups:\n- name: nginx-alerts\n  rules:\n  - alert: NginxHighConnections\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:nginx_connections_active:max\\n  \
+    \    > on(tenant) group_left\\n      tenant:alert_threshold:nginx_connections\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:nginx_connections_active:max\\n     \
+    \ > on(tenant) group_left\\n      tenant:alert_threshold:nginx_connections\\n\
+    \    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 5m\n    labels:\n      severity: warning\n      metric_group: nginx_connections\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: NginxHighConnections\
+    \ on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 上 Nginx 連線數過高'\n\
+    \      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: Nginx connection\
+    \ threshold exceeded — upstream review'\n      platform_summary_zh: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}：Nginx 連線閾值已超出 — upstream 審查'\n      description: Active\
+    \ connections {{ $value }} exceeds threshold\n      description_zh: 活動連線 {{ $value\
+    \ }} 超出閾值\n      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n  - alert: NginxHighConnectionsCritical\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:nginx_connections_active:max\\n  \
+    \    > on(tenant) group_left\\n      tenant:alert_threshold:nginx_connections_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:nginx_connections_active:max\\n     \
+    \ > on(tenant) group_left\\n      tenant:alert_threshold:nginx_connections_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 3m\n    labels:\n      severity: critical\n      metric_group: nginx_connections\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: NginxHighConnectionsCritical\
+    \ on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 上 Nginx 連線飽和嚴重'\n\
+    \      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: critical\
+    \ Nginx connection saturation — escalate'\n      platform_summary_zh: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}：嚴重 Nginx 連線飽和 — 需升級處理'\n      description: Active connections\
+    \ {{ $value }} exceeds critical threshold\n      description_zh: 活動連線 {{ $value\
+    \ }} 超出嚴重閾值\n      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{\
+    \ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert: NginxRequestRateSpike\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:nginx_requests:rate5m\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:nginx_request_rate\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:nginx_requests:rate5m\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:nginx_request_rate\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n\
+    \      severity: warning\n      metric_group: nginx_request_rate\n      tenant:\
+    \ '{{ $labels.tenant }}'\n    annotations:\n      summary: NginxRequestRateSpike\
+    \ on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 上 Nginx request\
+    \ 速率尖峰'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: request\
+    \ rate spike — traffic pattern review'\n      platform_summary_zh: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}：request 速率尖峰 — 流量模式審查'\n      description: Request\
+    \ rate {{ $value }} req/s exceeds threshold\n      description_zh: Request 速率\
+    \ {{ $value }} 請求/秒 超出閾值\n      runbook_url: '{{ $labels.runbook_url }}'\n   \
+    \   owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert:\
+    \ NginxRequestRateSpikeCritical\n    expr: \"(\\n  (\\n    (\\n      tenant:nginx_requests:rate5m\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:nginx_request_rate_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:nginx_requests:rate5m\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:nginx_request_rate_critical\\n   \
+    \ )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"\
+    } == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 3m\n\
+    \    labels:\n      severity: critical\n      metric_group: nginx_request_rate\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: NginxRequestRateSpikeCritical\
+    \ on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 上 Nginx request\
+    \ 速率尖峰嚴重'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}:\
+    \ critical request rate — possible DDoS or traffic surge, escalate'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}：嚴重 request 速率 — 可能 DDoS 或流量激增，需升級處理'\n\
+    \      description: Request rate {{ $value }} req/s exceeds critical threshold\n\
+    \      description_zh: Request 速率 {{ $value }} 請求/秒 超出嚴重閾值\n      runbook_url:\
+    \ '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n      tier:\
+    \ '{{ $labels.tier }}'\n  - alert: NginxConnectionBacklog\n    expr: \"(\\n  (\\\
+    n    (\\n      tenant:nginx_connections_waiting:max\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:nginx_waiting\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  * on(tenant)\
+    \ group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\\
+    n  (\\n    (\\n      tenant:nginx_connections_waiting:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:nginx_waiting\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n\
+    \      severity: warning\n      metric_group: nginx_waiting\n      tenant: '{{\
+    \ $labels.tenant }}'\n    annotations:\n      summary: NginxConnectionBacklog\
+    \ on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 上 Nginx 連線積壓'\n\
+    \      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: connection\
+    \ backlog building — upstream capacity review'\n      platform_summary_zh: '[{{\
+    \ $labels.tier }}] {{ $labels.tenant }}：連線積壓正在累積 — upstream 容量審查'\n      description:\
+    \ Waiting connections {{ $value }} exceeds threshold\n      description_zh: 等待中的連線\
+    \ {{ $value }} 超出閾值\n      runbook_url: '{{ $labels.runbook_url }}'\n      owner:\
+    \ '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert: NginxConnectionBacklogCritical\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:nginx_connections_waiting:max\\n \
+    \     > on(tenant) group_left\\n      tenant:alert_threshold:nginx_waiting_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:nginx_connections_waiting:max\\n    \
+    \  > on(tenant) group_left\\n      tenant:alert_threshold:nginx_waiting_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 3m\n    labels:\n      severity: critical\n      metric_group: nginx_waiting\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: NginxConnectionBacklogCritical\
+    \ on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 上 Nginx 連線積壓嚴重'\n\
+    \      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: critical\
+    \ connection backlog — service degradation likely'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}：嚴重連線積壓 — 服務降級可能性高'\n      description:\
+    \ Waiting connections {{ $value }} exceeds critical threshold\n      description_zh:\
+    \ 等待中的連線 {{ $value }} 超出嚴重閾值\n      runbook_url: '{{ $labels.runbook_url }}'\n\
+    \      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n"

--- a/k8s/03-monitoring/configmap-rules-operational.yaml
+++ b/k8s/03-monitoring/configmap-rules-operational.yaml
@@ -1,7 +1,8 @@
 # ============================================================
-# Operational Rule Pack — Sentinel Alerts for Alertmanager
-# Canonical source: rule-packs/rule-pack-operational.yaml
-# Maintained by: Platform Team
+# operational Rule Pack — Recording & Alert Rules (ConfigMap)
+# GENERATED from rule-packs/rule-pack-operational.yaml by
+# scripts/tools/dx/generate_rulepack_configmaps.py — DO NOT EDIT.
+# Run `make rulepack-configmaps` after editing the rule pack.
 # ============================================================
 apiVersion: v1
 kind: ConfigMap
@@ -12,72 +13,31 @@ metadata:
     app: prometheus
     rule-pack: operational
 data:
-  operational-alert.yml: |
-    # ============================================================
-    # Rule Pack: Operational Mode — Sentinel Alerts for Alertmanager
-    # 預設啟用 — 提供 Silent Mode + Severity Dedup 的 Alertmanager 聯動
-    #
-    # 不需要額外 exporter — 讀取 threshold-exporter 的指標:
-    #   - user_silent_mode     → Silent Mode sentinel
-    #   - user_severity_dedup  → Severity Dedup sentinel
-    #
-    # === Silent Mode ===
-    # alert 照常在 Prometheus 觸發 (TSDB 有 ALERTS 紀錄)，
-    # Alertmanager 透過 inhibit_rules 攔截通知。
-    # 與 Maintenance Mode 不同: maintenance 在 PromQL 層消滅 alert (無 TSDB 紀錄)。
-    #
-    # Tenant 配置:
-    #   _silent_mode: "warning" | "critical" | "all" | "disable"
-    #
-    # === Severity Dedup ===
-    # 當 critical 觸發時，選擇是否壓制同 metric_group 的 warning 通知。
-    # TSDB 永遠同時記錄 warning + critical，dedup 只控制通知行為。
-    #
-    # Tenant 配置:
-    #   _severity_dedup: "enable" (預設) | "disable"
-    #
-    # 搭配的 Alertmanager inhibit_rules:
-    #   - source: TenantSilentWarning         → target: severity="warning"
-    #   - source: TenantSilentCritical        → target: severity="critical"
-    #   - source: TenantSeverityDedupEnabled  → target: severity="warning" (同 metric_group)
-    # ============================================================
-    groups:
-      - name: operational-mode-sentinel
-        rules:
-          # Sentinel alert: fires when a tenant has silent mode active for warning.
-          # Used as inhibit_rules source to suppress warning notifications.
-          - alert: TenantSilentWarning
-            expr: user_silent_mode{target_severity="warning"} == 1
-            labels:
-              severity: none
-            annotations:
-              summary: "Silent mode (warning) active for {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 的靜默模式（警告級別）已啟用"
-              description: "Warning alerts for tenant {{ $labels.tenant }} will be recorded in TSDB but notifications suppressed."
-              description_zh: "{{ $labels.tenant }} 的警告等級告警將被記錄到 TSDB 但通知會被抑制。"
-
-          # Sentinel alert: fires when a tenant has silent mode active for critical.
-          # Used as inhibit_rules source to suppress critical notifications.
-          - alert: TenantSilentCritical
-            expr: user_silent_mode{target_severity="critical"} == 1
-            labels:
-              severity: none
-            annotations:
-              summary: "Silent mode (critical) active for {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 的靜默模式（嚴重級別）已啟用"
-              description: "Critical alerts for tenant {{ $labels.tenant }} will be recorded in TSDB but notifications suppressed."
-              description_zh: "{{ $labels.tenant }} 的嚴重等級告警將被記錄到 TSDB 但通知會被抑制。"
-
-          # Sentinel alert: fires when severity dedup is enabled for a tenant (default).
-          # Used by Alertmanager inhibit_rules to suppress warning notifications
-          # when critical fires for the same tenant+metric_group.
-          # Tenants with _severity_dedup: "disable" won't trigger this → both notifications sent.
-          - alert: TenantSeverityDedupEnabled
-            expr: user_severity_dedup{mode="enable"} == 1
-            labels:
-              severity: none
-            annotations:
-              summary: "Severity dedup enabled for {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 已啟用嚴重等級去重"
-              description: "Warning notifications for {{ $labels.tenant }} will be suppressed when critical fires for the same metric_group."
-              description_zh: "當相同指標群組的嚴重等級告警觸發時，{{ $labels.tenant }} 的警告通知會被抑制。"
+  operational-alert.yml: "groups:\n- name: operational-mode-sentinel\n  rules:\n \
+    \ - alert: TenantSilentWarning\n    expr: user_silent_mode{target_severity=\"\
+    warning\"} == 1\n    labels:\n      severity: none\n      tenant: '{{ $labels.tenant\
+    \ }}'\n    annotations:\n      summary: Silent mode (warning) active for {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 的靜默模式（警告級別）已啟用'\n      description:\
+    \ Warning alerts for tenant {{ $labels.tenant }} will be recorded in TSDB but\
+    \ notifications suppressed.\n      description_zh: '{{ $labels.tenant }} 的警告等級告警將被記錄到\
+    \ TSDB 但通知會被抑制。'\n  - alert: TenantSilentCritical\n    expr: user_silent_mode{target_severity=\"\
+    critical\"} == 1\n    labels:\n      severity: none\n      tenant: '{{ $labels.tenant\
+    \ }}'\n    annotations:\n      summary: Silent mode (critical) active for {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 的靜默模式（嚴重級別）已啟用'\n      description:\
+    \ Critical alerts for tenant {{ $labels.tenant }} will be recorded in TSDB but\
+    \ notifications suppressed.\n      description_zh: '{{ $labels.tenant }} 的嚴重等級告警將被記錄到\
+    \ TSDB 但通知會被抑制。'\n  - alert: TenantSeverityDedupEnabled\n    expr: user_severity_dedup{mode=\"\
+    enable\"} == 1\n    labels:\n      severity: none\n      tenant: '{{ $labels.tenant\
+    \ }}'\n    annotations:\n      summary: Severity dedup enabled for {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 已啟用嚴重等級去重'\n      description: Warning\
+    \ notifications for {{ $labels.tenant }} will be suppressed when critical fires\
+    \ for the same metric_group.\n      description_zh: 當相同指標群組的嚴重等級告警觸發時，{{ $labels.tenant\
+    \ }} 的警告通知會被抑制。\n  - alert: TenantConfigEvent\n    expr: da_config_event == 1\n\
+    \    for: 0s\n    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant\
+    \ }}'\n    annotations:\n      summary: 'Config expired for {{ $labels.tenant\
+    \ }}: {{ $labels.event }}'\n      summary_zh: '{{ $labels.tenant }} 的組態已過期：{{\
+    \ $labels.event }}'\n      description: 'Timed config for tenant {{ $labels.tenant\
+    \ }} has expired and auto-deactivated. Event: {{ $labels.event }}. Reason: {{\
+    \ $labels.reason }}. Please update or remove the expired config entry.'\n    \
+    \  description_zh: '{{ $labels.tenant }} 的定時組態已過期並自動停用。事件：{{ $labels.event }}。原因：{{\
+    \ $labels.reason }}。請更新或移除過期的組態項目。'\n"

--- a/k8s/03-monitoring/configmap-rules-oracle.yaml
+++ b/k8s/03-monitoring/configmap-rules-oracle.yaml
@@ -1,7 +1,8 @@
 # ============================================================
-# Oracle Rule Pack — Recording Rules & Alert Rules
-# Canonical source: rule-packs/rule-pack-oracle.yaml
-# Maintained by: DBA Team / Oracle Team
+# oracle Rule Pack — Recording & Alert Rules (ConfigMap)
+# GENERATED from rule-packs/rule-pack-oracle.yaml by
+# scripts/tools/dx/generate_rulepack_configmaps.py — DO NOT EDIT.
+# Run `make rulepack-configmaps` after editing the rule pack.
 # ============================================================
 apiVersion: v1
 kind: ConfigMap
@@ -12,149 +13,131 @@ metadata:
     app: prometheus
     rule-pack: oracle
 data:
-  oracle-recording.yml: |
-    groups:
-      - name: oracle-normalization
-        interval: 15s
-        rules:
-          - record: tenant:oracle_sessions_active:max
-            expr: max by(tenant) (oracledb_sessions_active)
-
-          - record: tenant:oracle_tablespace_used_percent:max
-            expr: max by(tenant) (oracledb_tablespace_used_percent)
-
-          - record: tenant:oracle_wait_time:rate5m
-            expr: sum by(tenant) (rate(oracledb_wait_time_seconds_total[5m]))
-
-          - record: tenant:oracle_process_count:max
-            expr: max by(tenant) (oracledb_process_count)
-
-          - record: tenant:oracle_pga_allocated_bytes:max
-            expr: max by(tenant) (oracledb_pga_allocated_bytes)
-
-          - record: tenant:oracle_session_utilization:ratio
-            expr: |
-              max by(tenant) (oracledb_sessions_active)
-              / max by(tenant) (oracledb_resource_limit{resource="sessions"} > 0)
-
-      - name: oracle-threshold-normalization
-        interval: 15s
-        rules:
-          - record: tenant:alert_threshold:oracle_sessions_active
-            expr: max by(tenant) (user_threshold{metric="oracle_sessions_active", severity="warning"})
-
-          - record: tenant:alert_threshold:oracle_tablespace_used_percent
-            expr: max by(tenant) (user_threshold{metric="oracle_tablespace_used_percent", severity="warning"})
-
-          - record: tenant:alert_threshold:oracle_wait_time_rate
-            expr: max by(tenant) (user_threshold{metric="oracle_wait_time_rate", severity="warning"})
-
-          - record: tenant:alert_threshold:oracle_process_count
-            expr: max by(tenant) (user_threshold{metric="oracle_process_count", severity="warning"})
-
-          - record: tenant:alert_threshold:oracle_pga_allocated_bytes
-            expr: max by(tenant) (user_threshold{metric="oracle_pga_allocated_bytes", severity="warning"})
-
-  oracle-alert.yml: |
-    groups:
-      - name: oracle-alerts
-        rules:
-          - alert: OracleDatabaseDown
-            expr: oracledb_up == 0
-            for: 15s
-            labels:
-              severity: critical
-            annotations:
-              summary: "Oracle instance {{ $labels.instance }} is DOWN"
-
-          - alert: OracleHighActiveSessions
-            expr: |
-              (
-                tenant:oracle_sessions_active:max
-                > on(tenant) group_left
-                tenant:alert_threshold:oracle_sessions_active
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Oracle high active sessions on {{ $labels.tenant }}"
-              description: "{{ $value | printf \"%.0f\" }} active sessions"
-
-          - alert: OracleTablespaceAlmostFull
-            expr: |
-              (
-                tenant:oracle_tablespace_used_percent:max
-                > on(tenant) group_left
-                tenant:alert_threshold:oracle_tablespace_used_percent
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Oracle tablespace nearing capacity on {{ $labels.tenant }}"
-              description: "Tablespace usage: {{ $value | printf \"%.1f\" }}%"
-
-          - alert: OracleHighWaitTime
-            expr: |
-              (
-                tenant:oracle_wait_time:rate5m
-                > on(tenant) group_left
-                tenant:alert_threshold:oracle_wait_time_rate
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Oracle high wait time on {{ $labels.tenant }}"
-              description: "Wait time rate: {{ $value | printf \"%.1f\" }}s/s"
-
-          - alert: OracleHighProcessCount
-            expr: |
-              (
-                tenant:oracle_process_count:max
-                > on(tenant) group_left
-                tenant:alert_threshold:oracle_process_count
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Oracle high process count on {{ $labels.tenant }}"
-              description: "{{ $value | printf \"%.0f\" }} active processes"
-
-          - alert: OracleHighPGAUsage
-            expr: |
-              (
-                tenant:oracle_pga_allocated_bytes:max
-                > on(tenant) group_left
-                tenant:alert_threshold:oracle_pga_allocated_bytes
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 10m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Oracle high PGA usage on {{ $labels.tenant }}"
-              description: "PGA allocated: {{ $value | humanize1024 }}B"
-
-          - alert: OracleHighSessionUtilization
-            expr: |
-              tenant:oracle_session_utilization:ratio > 0.85
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Oracle session limit approaching on {{ $labels.tenant }}"
-              description: "Session utilization: {{ $value | printf \"%.0f\" }}%"
+  oracle-recording.yml: "groups:\n- name: oracle-normalization\n  interval: 15s\n\
+    \  rules:\n  - record: tenant:oracle_sessions_active:max\n    expr: max by(tenant)\
+    \ (oracledb_sessions_active)\n  - record: tenant:oracle_tablespace_used_percent:max\n\
+    \    expr: max by(tenant) (oracledb_tablespace_used_percent)\n  - record: tenant:oracle_wait_time:rate5m\n\
+    \    expr: sum by(tenant) (rate(oracledb_wait_time_seconds_total[5m]))\n  - record:\
+    \ tenant:oracle_process_count:max\n    expr: max by(tenant) (oracledb_process_count)\n\
+    \  - record: tenant:oracle_pga_allocated_bytes:max\n    expr: max by(tenant) (oracledb_pga_allocated_bytes)\n\
+    \  - record: tenant:oracle_session_utilization:ratio\n    expr: 'max by(tenant)\
+    \ (oracledb_sessions_active)\n\n      / max by(tenant) (oracledb_resource_limit{resource=\"\
+    sessions\"} > 0)\n\n      '\n- name: oracle-threshold-normalization\n  interval:\
+    \ 15s\n  rules:\n  - record: tenant:alert_threshold:oracle_sessions_active\n \
+    \   expr: max by(tenant) (user_threshold{metric=\"oracle_sessions_active\", severity=\"\
+    warning\"})\n  - record: tenant:alert_threshold:oracle_tablespace_used_percent\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"oracle_tablespace_used_percent\"\
+    , severity=\"warning\"})\n  - record: tenant:alert_threshold:oracle_wait_time_rate\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"oracle_wait_time_rate\", severity=\"\
+    warning\"})\n  - record: tenant:alert_threshold:oracle_process_count\n    expr:\
+    \ max by(tenant) (user_threshold{metric=\"oracle_process_count\", severity=\"\
+    warning\"})\n  - record: tenant:alert_threshold:oracle_pga_allocated_bytes\n \
+    \   expr: max by(tenant) (user_threshold{metric=\"oracle_pga_allocated_bytes\"\
+    , severity=\"warning\"})\n"
+  oracle-alert.yml: "groups:\n- name: oracle-alerts\n  rules:\n  - alert: OracleDatabaseDown\n\
+    \    expr: oracledb_up == 0\n    for: 15s\n    labels:\n      severity: critical\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Oracle\
+    \ instance {{ $labels.instance }} is DOWN\n      summary_zh: Oracle 實例 {{ $labels.instance\
+    \ }} 已關閉\n      description: oracledb_up=0 for 15s on {{ $labels.instance }}\n\
+    \      description_zh: oracledb_up=0，持續 15 秒，實例：{{ $labels.instance }}\n  - alert:\
+    \ OracleHighActiveSessions\n    expr: \"(\\n  (\\n    (\\n      tenant:oracle_sessions_active:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:oracle_sessions_active\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:oracle_sessions_active:max\\n      >\
+    \ on(tenant) group_left\\n      tenant:alert_threshold:oracle_sessions_active\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 5m\n    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: Oracle high active sessions on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 上 Oracle 活動 session 數過高'\n     \
+    \ platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: Oracle active\
+    \ sessions elevated — connection pool review'\n      platform_summary_zh: '[{{\
+    \ $labels.tier }}] {{ $labels.tenant }}：Oracle 活動 session 數升高 — connection pool\
+    \ 審查'\n      description: '{{ $value | printf \"%.0f\" }} active sessions'\n \
+    \     description_zh: '{{ $value | printf \"%.0f\" }} 個活動 session'\n      runbook_url:\
+    \ '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n      tier:\
+    \ '{{ $labels.tier }}'\n  - alert: OracleTablespaceAlmostFull\n    expr: \"(\\\
+    n  (\\n    (\\n      tenant:oracle_tablespace_used_percent:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:oracle_tablespace_used_percent\\n\
+    \    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:oracle_tablespace_used_percent:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:oracle_tablespace_used_percent\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 5m\n    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: Oracle tablespace nearing capacity on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 上 Oracle tablespace 即將滿容'\n    \
+    \  platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: Oracle tablespace\
+    \ nearing capacity — storage review'\n      platform_summary_zh: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}：Oracle tablespace 即將滿容 — 儲存審查'\n      description:\
+    \ 'Tablespace usage: {{ $value | printf \"%.1f\" }}%'\n      description_zh: Tablespace\
+    \ 使用率：{{ $value | printf \"%.1f\" }}%\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: OracleHighWaitTime\n    expr: \"(\\n  (\\n    (\\n      tenant:oracle_wait_time:rate5m\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:oracle_wait_time_rate\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:oracle_wait_time:rate5m\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:oracle_wait_time_rate\\n    )\\n \
+    \   unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n\
+    \    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: Oracle high wait time on {{ $labels.tenant }}\n\
+    \      summary_zh: '{{ $labels.tenant }} 上 Oracle 等待時間過高'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: Oracle wait time elevated — performance\
+    \ bottleneck review'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}：Oracle 等待時間升高 — 效能瓶頸審查'\n      description: 'Wait time rate: {{ $value |\
+    \ printf \"%.1f\" }}s/s'\n      description_zh: 等待時間速率：{{ $value | printf \"%.1f\"\
+    \ }}秒/秒\n      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n  - alert: OracleHighProcessCount\n \
+    \   expr: \"(\\n  (\\n    (\\n      tenant:oracle_process_count:max\\n      >\
+    \ on(tenant) group_left\\n      tenant:alert_threshold:oracle_process_count\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:oracle_process_count:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:oracle_process_count\\n    )\\n  \
+    \  unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\\
+    n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n\
+    \      severity: warning\n      tenant: '{{ $labels.tenant }}'\n    annotations:\n\
+    \      summary: Oracle high process count on {{ $labels.tenant }}\n      summary_zh:\
+    \ '{{ $labels.tenant }} 上 Oracle process 數過高'\n      platform_summary: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}: Oracle process count high — resource review'\n   \
+    \   platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant }}：Oracle process\
+    \ 數過高 — 資源審查'\n      description: '{{ $value | printf \"%.0f\" }} active processes'\n\
+    \      description_zh: '{{ $value | printf \"%.0f\" }} 個活動 process'\n      runbook_url:\
+    \ '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n      tier:\
+    \ '{{ $labels.tier }}'\n  - alert: OracleHighPGAUsage\n    expr: \"(\\n  (\\n\
+    \    (\\n      tenant:oracle_pga_allocated_bytes:max\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:oracle_pga_allocated_bytes\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:oracle_pga_allocated_bytes:max\\n   \
+    \   > on(tenant) group_left\\n      tenant:alert_threshold:oracle_pga_allocated_bytes\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 10m\n    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant\
+    \ }}'\n    annotations:\n      summary: Oracle high PGA usage on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 上 Oracle PGA 使用率過高'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: Oracle PGA usage high — memory sizing\
+    \ review'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}：Oracle PGA 使用率過高 — 記憶體大小調整審查'\n      description: 'PGA allocated: {{ $value\
+    \ | humanize1024 }}B'\n      description_zh: 配置的 PGA：{{ $value | humanize1024\
+    \ }}B\n      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n  - alert: OracleHighSessionUtilization\n\
+    \    expr: \"(\\n  (\\n    tenant:oracle_session_utilization:ratio > 0.85\\n \
+    \   unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    tenant:oracle_session_utilization:ratio > 0.85\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n\
+    \      severity: warning\n      tenant: '{{ $labels.tenant }}'\n    annotations:\n\
+    \      summary: Oracle session limit approaching on {{ $labels.tenant }}\n   \
+    \   summary_zh: '{{ $labels.tenant }} 上 Oracle session 限制即將達到'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: Oracle session limit approaching\
+    \ — capacity action needed'\n      platform_summary_zh: '[{{ $labels.tier }}]\
+    \ {{ $labels.tenant }}：Oracle session 限制即將達到 — 需採取容量擴增行動'\n      description:\
+    \ 'Session utilization: {{ $value | printf \"%.0f\" }}%'\n      description_zh:\
+    \ Session 使用率：{{ $value | printf \"%.0f\" }}%\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n"

--- a/k8s/03-monitoring/configmap-rules-postgresql.yaml
+++ b/k8s/03-monitoring/configmap-rules-postgresql.yaml
@@ -1,7 +1,8 @@
 # ============================================================
-# PostgreSQL Rule Pack — Recording Rules & Alert Rules
-# Canonical source: rule-packs/rule-pack-postgresql.yaml
-# Maintained by: DBA Team
+# postgresql Rule Pack — Recording & Alert Rules (ConfigMap)
+# GENERATED from rule-packs/rule-pack-postgresql.yaml by
+# scripts/tools/dx/generate_rulepack_configmaps.py — DO NOT EDIT.
+# Run `make rulepack-configmaps` after editing the rule pack.
 # ============================================================
 apiVersion: v1
 kind: ConfigMap
@@ -12,198 +13,142 @@ metadata:
     app: prometheus
     rule-pack: postgresql
 data:
-  postgresql-recording.yml: |
-    groups:
-      - name: postgresql-normalization
-        interval: 15s
-        rules:
-          - record: tenant:pg_connection_usage:ratio
-            expr: |
-              100 * max by(tenant) (pg_stat_activity_count)
-              / on(tenant)
-              clamp_min(max by(tenant) (pg_settings_max_connections), 1)
-
-          - record: tenant:pg_connections:max
-            expr: max by(tenant) (pg_stat_activity_count)
-
-          - record: tenant:pg_replication_lag:max
-            expr: max by(tenant) (pg_replication_lag)
-
-          - record: tenant:pg_deadlocks:rate5m
-            expr: sum by(tenant) (rate(pg_stat_database_deadlocks[5m]))
-
-          - record: tenant:pg_transactions:rate5m
-            expr: |
-              sum by(tenant) (rate(pg_stat_database_xact_commit[5m]))
-              + sum by(tenant) (rate(pg_stat_database_xact_rollback[5m]))
-
-          - record: tenant:pg_rollback_ratio:rate5m
-            expr: |
-              sum by(tenant) (rate(pg_stat_database_xact_rollback[5m]))
-              / on(tenant)
-              clamp_min(
-                sum by(tenant) (rate(pg_stat_database_xact_commit[5m]))
-                + sum by(tenant) (rate(pg_stat_database_xact_rollback[5m])),
-                1
-              )
-
-          - record: tenant:pg_uptime:hours
-            expr: |
-              (time() - min by(tenant) (pg_postmaster_start_time_seconds)) / 3600
-
-      - name: postgresql-threshold-normalization
-        interval: 15s
-        rules:
-          - record: tenant:alert_threshold:pg_connections
-            expr: max by(tenant) (user_threshold{metric="pg_connections", severity="warning"})
-
-          - record: tenant:alert_threshold:pg_connections_critical
-            expr: max by(tenant) (user_threshold{metric="pg_connections", severity="critical"})
-
-          - record: tenant:alert_threshold:pg_replication_lag
-            expr: max by(tenant) (user_threshold{metric="pg_replication_lag", severity="warning"})
-
-          - record: tenant:alert_threshold:pg_replication_lag_critical
-            expr: max by(tenant) (user_threshold{metric="pg_replication_lag", severity="critical"})
-
-  postgresql-alert.yml: |
-    groups:
-      - name: postgresql-alerts
-        rules:
-          - alert: PostgreSQLDown
-            expr: pg_up == 0
-            for: 15s
-            labels:
-              severity: critical
-            annotations:
-              summary: "PostgreSQL instance {{ $labels.instance }} is DOWN"
-              summary_zh: "PostgreSQL 實例 {{ $labels.instance }} 已關閉"
-              description: "pg_up=0 for 15s on {{ $labels.instance }}"
-              description_zh: "pg_up=0，持續 15 秒，實例：{{ $labels.instance }}"
-
-          - alert: PostgreSQLExporterAbsent
-            expr: absent(pg_up{job="tenant-exporters"})
-            for: 30s
-            labels:
-              severity: critical
-            annotations:
-              summary: "postgres_exporter target missing"
-              summary_zh: "postgres_exporter 目標缺失"
-              description: "No pg_up metric found for 30s"
-              description_zh: "找不到 pg_up 指標，持續 30 秒"
-
-          - alert: PostgreSQLHighConnections
-            expr: |
-              (
-                tenant:pg_connection_usage:ratio
-                > on(tenant) group_left
-                tenant:alert_threshold:pg_connections
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: warning
-              metric_group: "pg_connections"
-            annotations:
-              summary: "High connection usage on {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 連線使用率過高"
-              description: "{{ $value | printf \"%.1f\" }}% of max_connections used (warning threshold exceeded)"
-              description_zh: "已使用 {{ $value | printf \"%.1f\" }}% 的 max_connections（超過警告閾值）"
-
-          - alert: PostgreSQLHighConnectionsCritical
-            expr: |
-              (
-                tenant:pg_connection_usage:ratio
-                > on(tenant) group_left
-                tenant:alert_threshold:pg_connections_critical
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: critical
-              metric_group: "pg_connections"
-            annotations:
-              summary: "Critical connection usage on {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 連線使用率嚴重過高"
-              description: "{{ $value | printf \"%.1f\" }}% of max_connections used (critical threshold exceeded)"
-              description_zh: "已使用 {{ $value | printf \"%.1f\" }}% 的 max_connections（超過嚴重閾值）"
-
-          - alert: PostgreSQLHighReplicationLag
-            expr: |
-              (
-                tenant:pg_replication_lag:max
-                > on(tenant) group_left
-                tenant:alert_threshold:pg_replication_lag
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: warning
-              metric_group: "pg_replication_lag"
-            annotations:
-              summary: "High replication lag on {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 複寫延遲過高"
-              description: "{{ $value | printf \"%.1f\" }}s replication lag (warning threshold exceeded)"
-              description_zh: "複寫延遲 {{ $value | printf \"%.1f\" }}s（超過警告閾值）"
-
-          - alert: PostgreSQLHighReplicationLagCritical
-            expr: |
-              (
-                tenant:pg_replication_lag:max
-                > on(tenant) group_left
-                tenant:alert_threshold:pg_replication_lag_critical
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: critical
-              metric_group: "pg_replication_lag"
-            annotations:
-              summary: "Critical replication lag on {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 複寫延遲嚴重"
-              description: "{{ $value | printf \"%.1f\" }}s replication lag (critical threshold exceeded)"
-              description_zh: "複寫延遲 {{ $value | printf \"%.1f\" }}s（超過嚴重閾值）"
-
-          - alert: PostgreSQLHighDeadlocks
-            expr: |
-              tenant:pg_deadlocks:rate5m > 0.1
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Deadlocks detected on {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 偵測到死鎖"
-              description: "{{ $value | printf \"%.2f\" }} deadlocks/sec over 5m"
-              description_zh: "{{ $value | printf \"%.2f\" }} 次死鎖／秒（5 分鐘內）"
-
-          - alert: PostgreSQLHighRollbackRatio
-            expr: |
-              tenant:pg_rollback_ratio:rate5m > 0.05
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "High rollback ratio on {{ $labels.tenant }}"
-              summary_zh: "{{ $labels.tenant }} 回滾比率過高"
-              description: "{{ $value | humanizePercentage }} of transactions are rollbacks"
-              description_zh: "{{ $value | humanizePercentage }} 的交易已回滾"
-
-          - alert: PostgreSQLRecentRestart
-            expr: |
-              (time() - pg_postmaster_start_time_seconds) < 300
-            for: 0s
-            labels:
-              severity: info
-            annotations:
-              summary: "{{ $labels.instance }} restarted recently"
-              summary_zh: "{{ $labels.instance }} 最近已重新啟動"
-              description: "PostgreSQL uptime is only {{ $value | printf \"%.0f\" }}s (< 5 min)"
-              description_zh: "PostgreSQL 運行時間僅 {{ $value | printf \"%.0f\" }}s（少於 5 分鐘）"
+  postgresql-recording.yml: "groups:\n- name: postgresql-normalization\n  interval:\
+    \ 15s\n  rules:\n  - record: tenant:pg_connection_usage:ratio\n    expr: '100\
+    \ * max by(tenant) (pg_stat_activity_count)\n\n      / on(tenant)\n\n      clamp_min(max\
+    \ by(tenant) (pg_settings_max_connections), 1)\n\n      '\n  - record: tenant:pg_connections:max\n\
+    \    expr: max by(tenant) (pg_stat_activity_count)\n  - record: tenant:pg_replication_lag:max\n\
+    \    expr: max by(tenant) (pg_replication_lag)\n  - record: tenant:pg_deadlocks:rate5m\n\
+    \    expr: sum by(tenant) (rate(pg_stat_database_deadlocks[5m]))\n  - record:\
+    \ tenant:pg_transactions:rate5m\n    expr: 'sum by(tenant) (rate(pg_stat_database_xact_commit[5m]))\n\
+    \n      + sum by(tenant) (rate(pg_stat_database_xact_rollback[5m]))\n\n      '\n\
+    \  - record: tenant:pg_rollback_ratio:rate5m\n    expr: \"sum by(tenant) (rate(pg_stat_database_xact_rollback[5m]))\\\
+    n/ on(tenant)\\nclamp_min(\\n  sum by(tenant) (rate(pg_stat_database_xact_commit[5m]))\\\
+    n  + sum by(tenant) (rate(pg_stat_database_xact_rollback[5m])),\\n  1\\n)\\n\"\
+    \n  - record: tenant:pg_uptime:hours\n    expr: '(time() - min by(tenant) (pg_postmaster_start_time_seconds))\
+    \ / 3600\n\n      '\n- name: postgresql-threshold-normalization\n  interval: 15s\n\
+    \  rules:\n  - record: tenant:alert_threshold:pg_connections\n    expr: max by(tenant)\
+    \ (user_threshold{metric=\"pg_connections\", severity=\"warning\"})\n  - record:\
+    \ tenant:alert_threshold:pg_connections_critical\n    expr: max by(tenant) (user_threshold{metric=\"\
+    pg_connections\", severity=\"critical\"})\n  - record: tenant:alert_threshold:pg_replication_lag\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"pg_replication_lag\", severity=\"\
+    warning\"})\n  - record: tenant:alert_threshold:pg_replication_lag_critical\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"pg_replication_lag\", severity=\"\
+    critical\"})\n"
+  postgresql-alert.yml: "groups:\n- name: postgresql-alerts\n  rules:\n  - alert:\
+    \ PostgreSQLDown\n    expr: pg_up == 0\n    for: 15s\n    labels:\n      severity:\
+    \ critical\n      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary:\
+    \ PostgreSQL instance {{ $labels.instance }} is DOWN\n      summary_zh: PostgreSQL\
+    \ 實例 {{ $labels.instance }} 已關閉\n      description: pg_up=0 for 15s on {{ $labels.instance\
+    \ }}\n      description_zh: pg_up=0，持續 15 秒，實例：{{ $labels.instance }}\n  - alert:\
+    \ PostgreSQLExporterAbsent\n    expr: absent(pg_up{job=\"tenant-exporters\"})\n\
+    \    for: 30s\n    labels:\n      severity: critical\n      tenant: '{{ $labels.tenant\
+    \ }}'\n    annotations:\n      summary: postgres_exporter target missing\n   \
+    \   summary_zh: postgres_exporter 目標缺失\n      description: No pg_up metric found\
+    \ for 30s\n      description_zh: 找不到 pg_up 指標，持續 30 秒\n  - alert: PostgreSQLHighConnections\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:pg_connection_usage:ratio\\n     \
+    \ > on(tenant) group_left\\n      tenant:alert_threshold:pg_connections\\n   \
+    \ )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"\
+    } == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:pg_connection_usage:ratio\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:pg_connections\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 30s\n    labels:\n\
+    \      severity: warning\n      metric_group: pg_connections\n      tenant: '{{\
+    \ $labels.tenant }}'\n    annotations:\n      summary: High connection usage on\
+    \ {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 連線使用率過高'\n   \
+    \   platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: connection usage\
+    \ high — review max_connections and pool sizing'\n      platform_summary_zh: '[{{\
+    \ $labels.tier }}] {{ $labels.tenant }}：連線使用率過高 — 檢查 max_connections 與連線集區大小設定'\n\
+    \      description: '{{ $value | printf \"%.1f\" }}% of max_connections used (warning\
+    \ threshold exceeded)'\n      description_zh: 已使用 {{ $value | printf \"%.1f\"\
+    \ }}% 的 max_connections（超過警告閾值）\n      runbook_url: '{{ $labels.runbook_url }}'\n\
+    \      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert:\
+    \ PostgreSQLHighConnectionsCritical\n    expr: \"(\\n  (\\n    (\\n      tenant:pg_connection_usage:ratio\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:pg_connections_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:pg_connection_usage:ratio\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:pg_connections_critical\\n    )\\\
+    n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 30s\n\
+    \    labels:\n      severity: critical\n      metric_group: pg_connections\n \
+    \     tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Critical\
+    \ connection usage on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 連線使用率嚴重過高'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: critical connection saturation — immediate action needed'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}：連線飽和 — 需立即採取行動'\n      description:\
+    \ '{{ $value | printf \"%.1f\" }}% of max_connections used (critical threshold\
+    \ exceeded)'\n      description_zh: 已使用 {{ $value | printf \"%.1f\" }}% 的 max_connections（超過嚴重閾值）\n\
+    \      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n  - alert: PostgreSQLHighReplicationLag\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:pg_replication_lag:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:pg_replication_lag\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:pg_replication_lag:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:pg_replication_lag\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 30s\n    labels:\n\
+    \      severity: warning\n      metric_group: pg_replication_lag\n      tenant:\
+    \ '{{ $labels.tenant }}'\n    annotations:\n      summary: High replication lag\
+    \ on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 複寫延遲過高'\n \
+    \     platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: replication\
+    \ lag elevated — check replica health'\n      platform_summary_zh: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}：複寫延遲升高 — 檢查副本健態'\n      description: '{{ $value | printf\
+    \ \"%.1f\" }}s replication lag (warning threshold exceeded)'\n      description_zh:\
+    \ 複寫延遲 {{ $value | printf \"%.1f\" }}s（超過警告閾值）\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: PostgreSQLHighReplicationLagCritical\n    expr: \"(\\n  (\\n    (\\\
+    n      tenant:pg_replication_lag:max\\n      > on(tenant) group_left\\n      tenant:alert_threshold:pg_replication_lag_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:pg_replication_lag:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:pg_replication_lag_critical\\n   \
+    \ )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"\
+    } == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 30s\n\
+    \    labels:\n      severity: critical\n      metric_group: pg_replication_lag\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Critical\
+    \ replication lag on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 複寫延遲嚴重'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: critical replication lag — failover risk, escalate'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}：複寫延遲嚴重 — 有容錯移轉風險，需升級處理'\n      description:\
+    \ '{{ $value | printf \"%.1f\" }}s replication lag (critical threshold exceeded)'\n\
+    \      description_zh: 複寫延遲 {{ $value | printf \"%.1f\" }}s（超過嚴重閾值）\n      runbook_url:\
+    \ '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n      tier:\
+    \ '{{ $labels.tier }}'\n  - alert: PostgreSQLHighDeadlocks\n    expr: \"(\\n \
+    \ (\\n    tenant:pg_deadlocks:rate5m > 0.1\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\
+    \"maintenance\\\"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner,\
+    \ tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\n  (\\n    tenant:pg_deadlocks:rate5m\
+    \ > 0.1\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 5m\n    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: Deadlocks detected on {{ $labels.tenant }}\n\
+    \      summary_zh: '{{ $labels.tenant }} 偵測到死鎖'\n      platform_summary: '[{{\
+    \ $labels.tier }}] {{ $labels.tenant }}: deadlocks detected — application-level\
+    \ lock contention'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}：偵測到死鎖 — 應用層鎖競爭'\n      description: '{{ $value | printf \"%.2f\" }} deadlocks/sec\
+    \ over 5m'\n      description_zh: '{{ $value | printf \"%.2f\" }} 次死鎖／秒（5 分鐘內）'\n\
+    \      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n  - alert: PostgreSQLHighRollbackRatio\n\
+    \    expr: \"(\\n  (\\n    tenant:pg_rollback_ratio:rate5m > 0.05\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    tenant:pg_rollback_ratio:rate5m > 0.05\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 5m\n    labels:\n      severity: warning\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: High rollback\
+    \ ratio on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 回滾比率過高'\n\
+    \      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}: high rollback\
+    \ ratio — application error pattern'\n      platform_summary_zh: '[{{ $labels.tier\
+    \ }}] {{ $labels.tenant }}：回滾比率過高 — 應用程式錯誤樣式'\n      description: '{{ $value |\
+    \ humanizePercentage }} of transactions are rollbacks'\n      description_zh:\
+    \ '{{ $value | humanizePercentage }} 的交易已回滾'\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: PostgreSQLRecentRestart\n    expr: '(time() - pg_postmaster_start_time_seconds)\
+    \ < 300\n\n      '\n    for: 0s\n    labels:\n      severity: info\n      tenant:\
+    \ '{{ $labels.tenant }}'\n    annotations:\n      summary: '{{ $labels.instance\
+    \ }} restarted recently'\n      summary_zh: '{{ $labels.instance }} 最近已重新啟動'\n\
+    \      description: PostgreSQL uptime is only {{ $value | printf \"%.0f\" }}s\
+    \ (< 5 min)\n      description_zh: PostgreSQL 運行時間僅 {{ $value | printf \"%.0f\"\
+    \ }}s（少於 5 分鐘）\n"

--- a/k8s/03-monitoring/configmap-rules-rabbitmq.yaml
+++ b/k8s/03-monitoring/configmap-rules-rabbitmq.yaml
@@ -1,7 +1,8 @@
 # ============================================================
-# RabbitMQ Rule Pack — Recording Rules & Alert Rules
-# Canonical source: rule-packs/rule-pack-rabbitmq.yaml
-# Maintained by: Platform Team
+# rabbitmq Rule Pack — Recording & Alert Rules (ConfigMap)
+# GENERATED from rule-packs/rule-pack-rabbitmq.yaml by
+# scripts/tools/dx/generate_rulepack_configmaps.py — DO NOT EDIT.
+# Run `make rulepack-configmaps` after editing the rule pack.
 # ============================================================
 apiVersion: v1
 kind: ConfigMap
@@ -12,181 +13,159 @@ metadata:
     app: prometheus
     rule-pack: rabbitmq
 data:
-  rabbitmq-recording.yml: |
-    groups:
-      - name: rabbitmq-normalization
-        interval: 15s
-        rules:
-          - record: tenant:rabbitmq_queue_messages:max
-            expr: max by(tenant) (rabbitmq_queue_messages_ready)
-
-          - record: tenant:rabbitmq_consumers:max
-            expr: max by(tenant) (rabbitmq_queue_consumers)
-
-          - record: tenant:rabbitmq_connections:max
-            expr: max by(tenant) (rabbitmq_connections)
-
-          - record: tenant:rabbitmq_node_mem_percent:ratio
-            expr: |
-              100 * max by(tenant) (rabbitmq_node_mem_used)
-              / on(tenant)
-              clamp_min(max by(tenant) (rabbitmq_node_mem_limit), 1)
-
-          - record: tenant:rabbitmq_unacked_messages:max
-            expr: max by(tenant) (rabbitmq_queue_messages_unacked)
-
-      - name: rabbitmq-threshold-normalization
-        interval: 15s
-        rules:
-          - record: tenant:alert_threshold:rabbitmq_queue_messages
-            expr: max by(tenant) (user_threshold{metric="rabbitmq_queue_messages", severity="warning"})
-
-          - record: tenant:alert_threshold:rabbitmq_queue_messages_critical
-            expr: max by(tenant) (user_threshold{metric="rabbitmq_queue_messages", severity="critical"})
-
-          - record: tenant:alert_threshold:rabbitmq_node_mem_percent
-            expr: max by(tenant) (user_threshold{metric="rabbitmq_node_mem_percent", severity="warning"})
-
-          - record: tenant:alert_threshold:rabbitmq_node_mem_percent_critical
-            expr: max by(tenant) (user_threshold{metric="rabbitmq_node_mem_percent", severity="critical"})
-
-          - record: tenant:alert_threshold:rabbitmq_connections
-            expr: max by(tenant) (user_threshold{metric="rabbitmq_connections", severity="warning"})
-
-          - record: tenant:alert_threshold:rabbitmq_consumers
-            expr: max by(tenant) (user_threshold{metric="rabbitmq_consumers", severity="warning"})
-
-          - record: tenant:alert_threshold:rabbitmq_unacked_messages
-            expr: max by(tenant) (user_threshold{metric="rabbitmq_unacked_messages", severity="warning"})
-
-  rabbitmq-alert.yml: |
-    groups:
-      - name: rabbitmq-alerts
-        rules:
-          - alert: RabbitMQExporterAbsent
-            expr: absent(rabbitmq_identity_info{job="tenant-exporters"})
-            for: 30s
-            labels:
-              severity: critical
-            annotations:
-              summary: "RabbitMQ exporter target missing"
-              description: "No rabbitmq_identity_info metric found for 30s"
-
-          - alert: RabbitMQHighQueueDepth
-            expr: |
-              (
-                tenant:rabbitmq_queue_messages:max
-                > on(tenant) group_left
-                tenant:alert_threshold:rabbitmq_queue_messages
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: warning
-              metric_group: "rabbitmq_queue_messages"
-            annotations:
-              summary: "High RabbitMQ queue depth on {{ $labels.tenant }}"
-              description: "Messages ready: {{ $value | printf \"%.0f\" }} (warning threshold exceeded)"
-
-          - alert: RabbitMQHighQueueDepthCritical
-            expr: |
-              (
-                tenant:rabbitmq_queue_messages:max
-                > on(tenant) group_left
-                tenant:alert_threshold:rabbitmq_queue_messages_critical
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: critical
-              metric_group: "rabbitmq_queue_messages"
-            annotations:
-              summary: "Critical RabbitMQ queue depth on {{ $labels.tenant }}"
-              description: "Messages ready: {{ $value | printf \"%.0f\" }} (critical threshold exceeded)"
-
-          - alert: RabbitMQHighMemory
-            expr: |
-              (
-                tenant:rabbitmq_node_mem_percent:ratio
-                > on(tenant) group_left
-                tenant:alert_threshold:rabbitmq_node_mem_percent
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: warning
-              metric_group: "rabbitmq_node_mem_percent"
-            annotations:
-              summary: "High RabbitMQ memory usage on {{ $labels.tenant }}"
-              description: "Memory used: {{ $value | printf \"%.1f\" }}% of limit (warning threshold exceeded)"
-
-          - alert: RabbitMQHighMemoryCritical
-            expr: |
-              (
-                tenant:rabbitmq_node_mem_percent:ratio
-                > on(tenant) group_left
-                tenant:alert_threshold:rabbitmq_node_mem_percent_critical
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: critical
-              metric_group: "rabbitmq_node_mem_percent"
-            annotations:
-              summary: "Critical RabbitMQ memory usage on {{ $labels.tenant }}"
-              description: "Memory used: {{ $value | printf \"%.1f\" }}% of limit (critical threshold exceeded)"
-
-          - alert: RabbitMQHighConnections
-            expr: |
-              (
-                tenant:rabbitmq_connections:max
-                > on(tenant) group_left
-                tenant:alert_threshold:rabbitmq_connections
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: warning
-              metric_group: "rabbitmq_connections"
-            annotations:
-              summary: "High RabbitMQ connection count on {{ $labels.tenant }}"
-              description: "Active connections: {{ $value | printf \"%.0f\" }} (warning threshold exceeded)"
-
-          - alert: RabbitMQLowConsumers
-            expr: |
-              (
-                tenant:rabbitmq_consumers:max
-                < on(tenant) group_left
-                tenant:alert_threshold:rabbitmq_consumers
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 30s
-            labels:
-              severity: warning
-              metric_group: "rabbitmq_consumers"
-            annotations:
-              summary: "Low RabbitMQ consumer count on {{ $labels.tenant }}"
-              description: "Active consumers: {{ $value | printf \"%.0f\" }} (below minimum threshold)"
-
-          - alert: RabbitMQHighUnackedMessages
-            expr: |
-              (
-                tenant:rabbitmq_unacked_messages:max
-                > on(tenant) group_left
-                tenant:alert_threshold:rabbitmq_unacked_messages
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-              metric_group: "rabbitmq_unacked_messages"
-            annotations:
-              summary: "High unacknowledged messages on {{ $labels.tenant }}"
-              description: "{{ $value | printf \"%.0f\" }} messages awaiting acknowledgment (consumer lag indicator)"
+  rabbitmq-recording.yml: "groups:\n- name: rabbitmq-normalization\n  interval: 15s\n\
+    \  rules:\n  - record: tenant:rabbitmq_queue_messages:max\n    expr: max by(tenant)\
+    \ (rabbitmq_queue_messages_ready)\n  - record: tenant:rabbitmq_consumers:max\n\
+    \    expr: max by(tenant) (rabbitmq_queue_consumers)\n  - record: tenant:rabbitmq_connections:max\n\
+    \    expr: max by(tenant) (rabbitmq_connections)\n  - record: tenant:rabbitmq_node_mem_percent:ratio\n\
+    \    expr: '100 * max by(tenant) (rabbitmq_node_mem_used)\n\n      / on(tenant)\n\
+    \n      clamp_min(max by(tenant) (rabbitmq_node_mem_limit), 1)\n\n      '\n  -\
+    \ record: tenant:rabbitmq_unacked_messages:max\n    expr: max by(tenant) (rabbitmq_queue_messages_unacked)\n\
+    - name: rabbitmq-threshold-normalization\n  interval: 15s\n  rules:\n  - record:\
+    \ tenant:alert_threshold:rabbitmq_queue_messages\n    expr: max by(tenant) (user_threshold{metric=\"\
+    rabbitmq_queue_messages\", severity=\"warning\"})\n  - record: tenant:alert_threshold:rabbitmq_queue_messages_critical\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"rabbitmq_queue_messages\",\
+    \ severity=\"critical\"})\n  - record: tenant:alert_threshold:rabbitmq_node_mem_percent\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"rabbitmq_node_mem_percent\"\
+    , severity=\"warning\"})\n  - record: tenant:alert_threshold:rabbitmq_node_mem_percent_critical\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"rabbitmq_node_mem_percent\"\
+    , severity=\"critical\"})\n  - record: tenant:alert_threshold:rabbitmq_connections\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"rabbitmq_connections\", severity=\"\
+    warning\"})\n  - record: tenant:alert_threshold:rabbitmq_consumers\n    expr:\
+    \ max by(tenant) (user_threshold{metric=\"rabbitmq_consumers\", severity=\"warning\"\
+    })\n  - record: tenant:alert_threshold:rabbitmq_unacked_messages\n    expr: max\
+    \ by(tenant) (user_threshold{metric=\"rabbitmq_unacked_messages\", severity=\"\
+    warning\"})\n"
+  rabbitmq-alert.yml: "groups:\n- name: rabbitmq-alerts\n  rules:\n  - alert: RabbitMQExporterAbsent\n\
+    \    expr: absent(rabbitmq_identity_info{job=\"tenant-exporters\"})\n    for:\
+    \ 30s\n    labels:\n      severity: critical\n      tenant: '{{ $labels.tenant\
+    \ }}'\n    annotations:\n      summary: RabbitMQ exporter target missing\n   \
+    \   summary_zh: RabbitMQ exporter 目標缺失\n      description: No rabbitmq_identity_info\
+    \ metric found for 30s\n      description_zh: 30 秒內未找到 rabbitmq_identity_info\
+    \ metric\n  - alert: RabbitMQHighQueueDepth\n    expr: \"(\\n  (\\n    (\\n  \
+    \    tenant:rabbitmq_queue_messages:max\\n      > on(tenant) group_left\\n   \
+    \   tenant:alert_threshold:rabbitmq_queue_messages\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  * on(tenant)\
+    \ group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\\
+    n  (\\n    (\\n      tenant:rabbitmq_queue_messages:max\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:rabbitmq_queue_messages\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 30s\n    labels:\n      severity: warning\n\
+    \      metric_group: rabbitmq_queue_messages\n      tenant: '{{ $labels.tenant\
+    \ }}'\n    annotations:\n      summary: High RabbitMQ queue depth on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 的 RabbitMQ 佇列深度過高'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: queue depth threshold exceeded —\
+    \ consumer capacity review'\n      platform_summary_zh: '[{{ $labels.tier }}]\
+    \ {{ $labels.tenant }}: 佇列深度超過閾值 — 請檢查消費者容量'\n      description: 'Messages ready:\
+    \ {{ $value | printf \"%.0f\" }} (warning threshold exceeded)'\n      description_zh:\
+    \ '待發送訊息: {{ $value | printf \"%.0f\" }} (超過警告閾值)'\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: RabbitMQHighQueueDepthCritical\n    expr: \"(\\n  (\\n    (\\n   \
+    \   tenant:rabbitmq_queue_messages:max\\n      > on(tenant) group_left\\n    \
+    \  tenant:alert_threshold:rabbitmq_queue_messages_critical\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:rabbitmq_queue_messages:max\\n      >\
+    \ on(tenant) group_left\\n      tenant:alert_threshold:rabbitmq_queue_messages_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 30s\n    labels:\n      severity: critical\n      metric_group: rabbitmq_queue_messages\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Critical\
+    \ RabbitMQ queue depth on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 的 RabbitMQ 佇列深度嚴重過高'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: critical queue depth — immediate consumer scaling needed'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: 佇列深度嚴重 — 需要立即擴展消費者'\n      description:\
+    \ 'Messages ready: {{ $value | printf \"%.0f\" }} (critical threshold exceeded)'\n\
+    \      description_zh: '待發送訊息: {{ $value | printf \"%.0f\" }} (超過嚴重閾值)'\n    \
+    \  runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n\
+    \      tier: '{{ $labels.tier }}'\n  - alert: RabbitMQHighMemory\n    expr: \"\
+    (\\n  (\\n    (\\n      tenant:rabbitmq_node_mem_percent:ratio\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:rabbitmq_node_mem_percent\\n    )\\\
+    n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:rabbitmq_node_mem_percent:ratio\\n  \
+    \    > on(tenant) group_left\\n      tenant:alert_threshold:rabbitmq_node_mem_percent\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 30s\n    labels:\n      severity: warning\n      metric_group: rabbitmq_node_mem_percent\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: High RabbitMQ\
+    \ memory usage on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }}\
+    \ 的 RabbitMQ 記憶體使用率過高'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: RabbitMQ memory usage high — broker sizing review'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ 記憶體使用率過高 — 請檢查 broker 大小'\n\
+    \      description: 'Memory used: {{ $value | printf \"%.1f\" }}% of limit (warning\
+    \ threshold exceeded)'\n      description_zh: '已使用記憶體: 限制的 {{ $value | printf\
+    \ \"%.1f\" }}% (超過警告閾值)'\n      runbook_url: '{{ $labels.runbook_url }}'\n   \
+    \   owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert:\
+    \ RabbitMQHighMemoryCritical\n    expr: \"(\\n  (\\n    (\\n      tenant:rabbitmq_node_mem_percent:ratio\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:rabbitmq_node_mem_percent_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:rabbitmq_node_mem_percent:ratio\\n  \
+    \    > on(tenant) group_left\\n      tenant:alert_threshold:rabbitmq_node_mem_percent_critical\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 30s\n    labels:\n      severity: critical\n      metric_group: rabbitmq_node_mem_percent\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Critical\
+    \ RabbitMQ memory usage on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 的 RabbitMQ 記憶體使用率嚴重過高'\n      platform_summary: '[{{ $labels.tier }}] {{\
+    \ $labels.tenant }}: critical RabbitMQ memory — broker at risk, escalate'\n  \
+    \    platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ\
+    \ 記憶體嚴重 — broker 有風險，請上報'\n      description: 'Memory used: {{ $value | printf\
+    \ \"%.1f\" }}% of limit (critical threshold exceeded)'\n      description_zh:\
+    \ '已使用記憶體: 限制的 {{ $value | printf \"%.1f\" }}% (超過嚴重閾值)'\n      runbook_url: '{{\
+    \ $labels.runbook_url }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{\
+    \ $labels.tier }}'\n  - alert: RabbitMQHighConnections\n    expr: \"(\\n  (\\\
+    n    (\\n      tenant:rabbitmq_connections:max\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:rabbitmq_connections\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  * on(tenant)\
+    \ group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\\
+    n  (\\n    (\\n      tenant:rabbitmq_connections:max\\n      > on(tenant) group_left\\\
+    n      tenant:alert_threshold:rabbitmq_connections\\n    )\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 30s\n    labels:\n      severity: warning\n\
+    \      metric_group: rabbitmq_connections\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: High RabbitMQ connection count on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 的 RabbitMQ 連線數過高'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ connection count high —\
+    \ client pool review'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: RabbitMQ 連線數過高 — 請檢查客戶端連線池'\n      description: 'Active connections: {{\
+    \ $value | printf \"%.0f\" }} (warning threshold exceeded)'\n      description_zh:\
+    \ '活躍連線: {{ $value | printf \"%.0f\" }} (超過警告閾值)'\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: RabbitMQLowConsumers\n    expr: \"(\\n  (\\n    (\\n      tenant:rabbitmq_consumers:max\\\
+    n      < on(tenant) group_left\\n      tenant:alert_threshold:rabbitmq_consumers\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:rabbitmq_consumers:max\\n      < on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:rabbitmq_consumers\\n    )\\n    unless\
+    \ on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\\
+    n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 30s\n    labels:\n\
+    \      severity: warning\n      metric_group: rabbitmq_consumers\n      tenant:\
+    \ '{{ $labels.tenant }}'\n    annotations:\n      summary: Low RabbitMQ consumer\
+    \ count on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 的 RabbitMQ\
+    \ 消費者數量過少'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant }}:\
+    \ RabbitMQ consumer count low — consumer health check'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: RabbitMQ 消費者數量過少 — 請檢查消費者狀態'\n \
+    \     description: 'Active consumers: {{ $value | printf \"%.0f\" }} (below minimum\
+    \ threshold)'\n      description_zh: '活躍的消費者: {{ $value | printf \"%.0f\" }} (低於最小閾值)'\n\
+    \      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n  - alert: RabbitMQHighUnackedMessages\n\
+    \    expr: \"(\\n  (\\n    (\\n      tenant:rabbitmq_unacked_messages:max\\n \
+    \     > on(tenant) group_left\\n      tenant:alert_threshold:rabbitmq_unacked_messages\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:rabbitmq_unacked_messages:max\\n    \
+    \  > on(tenant) group_left\\n      tenant:alert_threshold:rabbitmq_unacked_messages\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 5m\n    labels:\n      severity: warning\n      metric_group: rabbitmq_unacked_messages\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: High unacknowledged\
+    \ messages on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant }} 的\
+    \ RabbitMQ 未確認訊息過多'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: unacked messages piling up — consumer health check'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: 未確認訊息堆積 — 請檢查消費者狀態'\n      description:\
+    \ '{{ $value | printf \"%.0f\" }} messages awaiting acknowledgment (consumer lag\
+    \ indicator)'\n      description_zh: '{{ $value | printf \"%.0f\" }} 個訊息等待確認 (消費者延遲指標)'\n\
+    \      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n"

--- a/k8s/03-monitoring/configmap-rules-redis.yaml
+++ b/k8s/03-monitoring/configmap-rules-redis.yaml
@@ -1,7 +1,8 @@
 # ============================================================
-# Redis Rule Pack — Recording Rules & Alert Rules
-# Canonical source: rule-packs/rule-pack-redis.yaml
-# Maintained by: DBA Team / Cache Team
+# redis Rule Pack — Recording & Alert Rules (ConfigMap)
+# GENERATED from rule-packs/rule-pack-redis.yaml by
+# scripts/tools/dx/generate_rulepack_configmaps.py — DO NOT EDIT.
+# Run `make rulepack-configmaps` after editing the rule pack.
 # ============================================================
 apiVersion: v1
 kind: ConfigMap
@@ -12,138 +13,108 @@ metadata:
     app: prometheus
     rule-pack: redis
 data:
-  redis-recording.yml: |
-    groups:
-      - name: redis-normalization
-        interval: 15s
-        rules:
-          - record: tenant:redis_memory_used_bytes:max
-            expr: max by(tenant) (redis_memory_used_bytes)
-
-          - record: tenant:redis_memory_usage:ratio
-            expr: |
-              max by(tenant) (redis_memory_used_bytes)
-              / max by(tenant) (redis_memory_max_bytes > 0)
-
-          - record: tenant:redis_connected_clients:max
-            expr: max by(tenant) (redis_connected_clients)
-
-          - record: tenant:redis_evicted_keys:rate5m
-            expr: sum by(tenant) (rate(redis_evicted_keys_total[5m]))
-
-          - record: tenant:redis_keyspace_hit_ratio:avg
-            expr: |
-              sum by(tenant) (rate(redis_keyspace_hits_total[5m]))
-              / (
-                sum by(tenant) (rate(redis_keyspace_hits_total[5m]))
-                + sum by(tenant) (rate(redis_keyspace_misses_total[5m]))
-              )
-
-          - record: tenant:redis_replication_lag:max
-            expr: max by(tenant) (redis_connected_slave_lag_seconds)
-
-          - record: tenant:redis_commands:rate5m
-            expr: sum by(tenant) (rate(redis_commands_processed_total[5m]))
-
-      - name: redis-threshold-normalization
-        interval: 15s
-        rules:
-          - record: tenant:alert_threshold:redis_memory_used_bytes
-            expr: max by(tenant) (user_threshold{metric="redis_memory_used_bytes", severity="warning"})
-
-          - record: tenant:alert_threshold:redis_connected_clients
-            expr: max by(tenant) (user_threshold{metric="redis_connected_clients", severity="warning"})
-
-          - record: tenant:alert_threshold:redis_evicted_keys_rate
-            expr: max by(tenant) (user_threshold{metric="redis_evicted_keys_rate", severity="warning"})
-
-          - record: tenant:alert_threshold:redis_replication_lag
-            expr: max by(tenant) (user_threshold{metric="redis_replication_lag", severity="warning"})
-
-  redis-alert.yml: |
-    groups:
-      - name: redis-alerts
-        rules:
-          - alert: RedisDown
-            expr: redis_up == 0
-            for: 15s
-            labels:
-              severity: critical
-            annotations:
-              summary: "Redis instance {{ $labels.instance }} is DOWN"
-
-          - alert: RedisHighMemory
-            expr: |
-              (
-                tenant:redis_memory_used_bytes:max
-                > on(tenant) group_left
-                tenant:alert_threshold:redis_memory_used_bytes
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Redis high memory usage on {{ $labels.tenant }}"
-              description: "Memory usage: {{ $value | humanize1024 }}B"
-
-          - alert: RedisHighConnections
-            expr: |
-              (
-                tenant:redis_connected_clients:max
-                > on(tenant) group_left
-                tenant:alert_threshold:redis_connected_clients
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Redis high connection count on {{ $labels.tenant }}"
-              description: "{{ $value }} connected clients"
-
-          - alert: RedisHighKeyEvictions
-            expr: |
-              (
-                tenant:redis_evicted_keys:rate5m
-                > on(tenant) group_left
-                tenant:alert_threshold:redis_evicted_keys_rate
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 5m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Redis high key eviction rate on {{ $labels.tenant }}"
-              description: "{{ $value | printf \"%.1f\" }} evictions/sec — consider increasing maxmemory"
-
-          - alert: RedisReplicationLag
-            expr: |
-              (
-                tenant:redis_replication_lag:max
-                > on(tenant) group_left
-                tenant:alert_threshold:redis_replication_lag
-              )
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 2m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Redis replication lag on {{ $labels.tenant }}"
-              description: "Replication lag: {{ $value | printf \"%.1f\" }}s"
-
-          - alert: RedisLowHitRatio
-            expr: |
-              tenant:redis_keyspace_hit_ratio:avg < 0.9
-              unless on(tenant)
-              (user_state_filter{filter="maintenance"} == 1)
-            for: 10m
-            labels:
-              severity: warning
-            annotations:
-              summary: "Redis low hit ratio on {{ $labels.tenant }}"
-              description: "Hit ratio: {{ $value | printf \"%.2f\" }} — check cache strategy"
+  redis-recording.yml: "groups:\n- name: redis-normalization\n  interval: 15s\n  rules:\n\
+    \  - record: tenant:redis_memory_used_bytes:max\n    expr: max by(tenant) (redis_memory_used_bytes)\n\
+    \  - record: tenant:redis_memory_usage:ratio\n    expr: 'max by(tenant) (redis_memory_used_bytes)\n\
+    \n      / max by(tenant) (redis_memory_max_bytes > 0)\n\n      '\n  - record:\
+    \ tenant:redis_connected_clients:max\n    expr: max by(tenant) (redis_connected_clients)\n\
+    \  - record: tenant:redis_evicted_keys:rate5m\n    expr: sum by(tenant) (rate(redis_evicted_keys_total[5m]))\n\
+    \  - record: tenant:redis_keyspace_hit_ratio:avg\n    expr: \"sum by(tenant) (rate(redis_keyspace_hits_total[5m]))\\\
+    n/ (\\n  sum by(tenant) (rate(redis_keyspace_hits_total[5m]))\\n  + sum by(tenant)\
+    \ (rate(redis_keyspace_misses_total[5m]))\\n)\\n\"\n  - record: tenant:redis_replication_lag:max\n\
+    \    expr: max by(tenant) (redis_connected_slave_lag_seconds)\n  - record: tenant:redis_commands:rate5m\n\
+    \    expr: sum by(tenant) (rate(redis_commands_processed_total[5m]))\n- name:\
+    \ redis-threshold-normalization\n  interval: 15s\n  rules:\n  - record: tenant:alert_threshold:redis_memory_used_bytes\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"redis_memory_used_bytes\",\
+    \ severity=\"warning\"})\n  - record: tenant:alert_threshold:redis_connected_clients\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"redis_connected_clients\",\
+    \ severity=\"warning\"})\n  - record: tenant:alert_threshold:redis_evicted_keys_rate\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"redis_evicted_keys_rate\",\
+    \ severity=\"warning\"})\n  - record: tenant:alert_threshold:redis_replication_lag\n\
+    \    expr: max by(tenant) (user_threshold{metric=\"redis_replication_lag\", severity=\"\
+    warning\"})\n"
+  redis-alert.yml: "groups:\n- name: redis-alerts\n  rules:\n  - alert: RedisDown\n\
+    \    expr: redis_up == 0\n    for: 15s\n    labels:\n      severity: critical\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Redis\
+    \ instance {{ $labels.instance }} is DOWN\n      summary_zh: Redis 實例 {{ $labels.instance\
+    \ }} 已停機\n  - alert: RedisHighMemory\n    expr: \"(\\n  (\\n    (\\n      tenant:redis_memory_used_bytes:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:redis_memory_used_bytes\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:redis_memory_used_bytes:max\\n      >\
+    \ on(tenant) group_left\\n      tenant:alert_threshold:redis_memory_used_bytes\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 5m\n    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: Redis high memory usage on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 的 Redis 記憶體使用率過高'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: Redis memory threshold breached\
+    \ — evaluate maxmemory policy'\n      platform_summary_zh: '[{{ $labels.tier }}]\
+    \ {{ $labels.tenant }}: Redis 記憶體閾值超過 — 請評估 maxmemory 政策'\n      description:\
+    \ 'Memory usage: {{ $value | humanize1024 }}B'\n      description_zh: '記憶體使用量:\
+    \ {{ $value | humanize1024 }}B'\n      runbook_url: '{{ $labels.runbook_url }}'\n\
+    \      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n  - alert:\
+    \ RedisHighConnections\n    expr: \"(\\n  (\\n    (\\n      tenant:redis_connected_clients:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:redis_connected_clients\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:redis_connected_clients:max\\n      >\
+    \ on(tenant) group_left\\n      tenant:alert_threshold:redis_connected_clients\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for:\
+    \ 5m\n    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: Redis high connection count on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 的 Redis 連線數過高'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: Redis connection count high — client\
+    \ pool review'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: Redis 連線數過高 — 請檢查客戶端連線池'\n      description: '{{ $value }} connected clients'\n\
+    \      description_zh: '{{ $value }} 個已連線的客戶端'\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: RedisHighKeyEvictions\n    expr: \"(\\n  (\\n    (\\n      tenant:redis_evicted_keys:rate5m\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:redis_evicted_keys_rate\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:redis_evicted_keys:rate5m\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:redis_evicted_keys_rate\\n    )\\\
+    n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 5m\n\
+    \    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: Redis high key eviction rate on {{ $labels.tenant\
+    \ }}\n      summary_zh: '{{ $labels.tenant }} 的 Redis Key 驅逐率過高'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: key eviction rate elevated — capacity\
+    \ review needed'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: Key 驅逐率提升 — 需要檢查容量'\n      description: '{{ $value | printf \"%.1f\" }}\
+    \ evictions/sec — consider increasing maxmemory'\n      description_zh: '{{ $value\
+    \ | printf \"%.1f\" }} 驅逐次數/秒 — 請考慮增加 maxmemory'\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n\
+    \  - alert: RedisReplicationLag\n    expr: \"(\\n  (\\n    (\\n      tenant:redis_replication_lag:max\\\
+    n      > on(tenant) group_left\\n      tenant:alert_threshold:redis_replication_lag\\\
+    n    )\\n    unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\
+    \"} == 1)\\n  )\\n  * on(tenant) group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\\
+    n)\\nor\\n(\\n  (\\n    (\\n      tenant:redis_replication_lag:max\\n      > on(tenant)\
+    \ group_left\\n      tenant:alert_threshold:redis_replication_lag\\n    )\\n \
+    \   unless on(tenant)\\n    (user_state_filter{filter=\\\"maintenance\\\"} ==\
+    \ 1)\\n  )\\n  unless on(tenant) tenant_metadata_info\\n)\\n\"\n    for: 2m\n\
+    \    labels:\n      severity: warning\n      tenant: '{{ $labels.tenant }}'\n\
+    \    annotations:\n      summary: Redis replication lag on {{ $labels.tenant }}\n\
+    \      summary_zh: '{{ $labels.tenant }} 的 Redis 複製延遲'\n      platform_summary:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: Redis replication lag — check replica\
+    \ health'\n      platform_summary_zh: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: Redis 複製延遲 — 請檢查副本狀態'\n      description: 'Replication lag: {{ $value |\
+    \ printf \"%.1f\" }}s'\n      description_zh: '複製延遲: {{ $value | printf \"%.1f\"\
+    \ }}s'\n      runbook_url: '{{ $labels.runbook_url }}'\n      owner: '{{ $labels.owner\
+    \ }}'\n      tier: '{{ $labels.tier }}'\n  - alert: RedisLowHitRatio\n    expr:\
+    \ \"(\\n  (\\n    tenant:redis_keyspace_hit_ratio:avg < 0.9\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  * on(tenant)\
+    \ group_left(runbook_url, owner, tier)\\n    tenant_metadata_info\\n)\\nor\\n(\\\
+    n  (\\n    tenant:redis_keyspace_hit_ratio:avg < 0.9\\n    unless on(tenant)\\\
+    n    (user_state_filter{filter=\\\"maintenance\\\"} == 1)\\n  )\\n  unless on(tenant)\
+    \ tenant_metadata_info\\n)\\n\"\n    for: 10m\n    labels:\n      severity: warning\n\
+    \      tenant: '{{ $labels.tenant }}'\n    annotations:\n      summary: Redis\
+    \ low hit ratio on {{ $labels.tenant }}\n      summary_zh: '{{ $labels.tenant\
+    \ }} 的 Redis 快取命中率過低'\n      platform_summary: '[{{ $labels.tier }}] {{ $labels.tenant\
+    \ }}: low cache hit ratio — cache strategy review'\n      platform_summary_zh:\
+    \ '[{{ $labels.tier }}] {{ $labels.tenant }}: 快取命中率過低 — 請檢查快取策略'\n      description:\
+    \ 'Hit ratio: {{ $value | printf \"%.2f\" }} — check cache strategy'\n      description_zh:\
+    \ '命中率: {{ $value | printf \"%.2f\" }} — 請檢查快取策略'\n      runbook_url: '{{ $labels.runbook_url\
+    \ }}'\n      owner: '{{ $labels.owner }}'\n      tier: '{{ $labels.tier }}'\n"

--- a/rule-packs/rule-pack-clickhouse.yaml
+++ b/rule-packs/rule-pack-clickhouse.yaml
@@ -133,14 +133,28 @@ groups:
         expr: |
           (
             (
-              tenant:clickhouse_queries:rate5m
-              > on(tenant) group_left
-              tenant:alert_threshold:clickhouse_queries_rate
+              (
+                tenant:clickhouse_queries:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:clickhouse_queries_rate
+              )
+              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:clickhouse_queries:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:clickhouse_queries_rate
+              )
+              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -161,14 +175,28 @@ groups:
         expr: |
           (
             (
-              tenant:clickhouse_active_connections:max
-              > on(tenant) group_left
-              tenant:alert_threshold:clickhouse_active_connections
+              (
+                tenant:clickhouse_active_connections:max
+                > on(tenant) group_left
+                tenant:alert_threshold:clickhouse_active_connections
+              )
+              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:clickhouse_active_connections:max
+                > on(tenant) group_left
+                tenant:alert_threshold:clickhouse_active_connections
+              )
+              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -189,14 +217,28 @@ groups:
         expr: |
           (
             (
-              tenant:clickhouse_max_part_count:max
-              > on(tenant) group_left
-              tenant:alert_threshold:clickhouse_max_part_count
+              (
+                tenant:clickhouse_max_part_count:max
+                > on(tenant) group_left
+                tenant:alert_threshold:clickhouse_max_part_count
+              )
+              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:clickhouse_max_part_count:max
+                > on(tenant) group_left
+                tenant:alert_threshold:clickhouse_max_part_count
+              )
+              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 10m
         labels:
           severity: warning
@@ -217,14 +259,28 @@ groups:
         expr: |
           (
             (
-              tenant:clickhouse_replication_queue:max
-              > on(tenant) group_left
-              tenant:alert_threshold:clickhouse_replication_queue
+              (
+                tenant:clickhouse_replication_queue:max
+                > on(tenant) group_left
+                tenant:alert_threshold:clickhouse_replication_queue
+              )
+              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:clickhouse_replication_queue:max
+                > on(tenant) group_left
+                tenant:alert_threshold:clickhouse_replication_queue
+              )
+              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -245,14 +301,28 @@ groups:
         expr: |
           (
             (
-              tenant:clickhouse_memory_tracking:max
-              > on(tenant) group_left
-              tenant:alert_threshold:clickhouse_memory_tracking_bytes
+              (
+                tenant:clickhouse_memory_tracking:max
+                > on(tenant) group_left
+                tenant:alert_threshold:clickhouse_memory_tracking_bytes
+              )
+              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:clickhouse_memory_tracking:max
+                > on(tenant) group_left
+                tenant:alert_threshold:clickhouse_memory_tracking_bytes
+              )
+              unless on(tenant) (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning

--- a/rule-packs/rule-pack-db2.yaml
+++ b/rule-packs/rule-pack-db2.yaml
@@ -104,15 +104,30 @@ groups:
         expr: |
           (
             (
-              tenant:db2_connections_active:max
-              > on(tenant) group_left
-              tenant:alert_threshold:db2_connections_active
+              (
+                tenant:db2_connections_active:max
+                > on(tenant) group_left
+                tenant:alert_threshold:db2_connections_active
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:db2_connections_active:max
+                > on(tenant) group_left
+                tenant:alert_threshold:db2_connections_active
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -132,15 +147,30 @@ groups:
         expr: |
           (
             (
-              tenant:db2_bufferpool_hit_ratio:min
-              < on(tenant) group_left
-              tenant:alert_threshold:db2_bufferpool_hit_ratio
+              (
+                tenant:db2_bufferpool_hit_ratio:min
+                < on(tenant) group_left
+                tenant:alert_threshold:db2_bufferpool_hit_ratio
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:db2_bufferpool_hit_ratio:min
+                < on(tenant) group_left
+                tenant:alert_threshold:db2_bufferpool_hit_ratio
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 10m
         labels:
           severity: warning
@@ -160,15 +190,30 @@ groups:
         expr: |
           (
             (
-              tenant:db2_log_usage_percent:max
-              > on(tenant) group_left
-              tenant:alert_threshold:db2_log_usage_percent
+              (
+                tenant:db2_log_usage_percent:max
+                > on(tenant) group_left
+                tenant:alert_threshold:db2_log_usage_percent
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:db2_log_usage_percent:max
+                > on(tenant) group_left
+                tenant:alert_threshold:db2_log_usage_percent
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -188,15 +233,30 @@ groups:
         expr: |
           (
             (
-              tenant:db2_deadlocks:rate5m
-              > on(tenant) group_left
-              tenant:alert_threshold:db2_deadlock_rate
+              (
+                tenant:db2_deadlocks:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:db2_deadlock_rate
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:db2_deadlocks:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:db2_deadlock_rate
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -216,15 +276,30 @@ groups:
         expr: |
           (
             (
-              tenant:db2_tablespace_used_percent:max
-              > on(tenant) group_left
-              tenant:alert_threshold:db2_tablespace_used_percent
+              (
+                tenant:db2_tablespace_used_percent:max
+                > on(tenant) group_left
+                tenant:alert_threshold:db2_tablespace_used_percent
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:db2_tablespace_used_percent:max
+                > on(tenant) group_left
+                tenant:alert_threshold:db2_tablespace_used_percent
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -243,12 +318,23 @@ groups:
       - alert: DB2HighSortOverflow
         expr: |
           (
-            tenant:db2_sort_overflow_ratio:avg > 0.05
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            (
+              tenant:db2_sort_overflow_ratio:avg > 0.05
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              tenant:db2_sort_overflow_ratio:avg > 0.05
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 10m
         labels:
           severity: warning

--- a/rule-packs/rule-pack-elasticsearch.yaml
+++ b/rule-packs/rule-pack-elasticsearch.yaml
@@ -109,12 +109,23 @@ groups:
       - alert: ElasticsearchClusterYellow
         expr: |
           (
-            tenant:es_cluster_health:status == 1
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            (
+              tenant:es_cluster_health:status == 1
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              tenant:es_cluster_health:status == 1
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -134,15 +145,30 @@ groups:
         expr: |
           (
             (
-              tenant:es_heap_usage_percent:max
-              > on(tenant) group_left
-              tenant:alert_threshold:es_heap_usage_percent
+              (
+                tenant:es_heap_usage_percent:max
+                > on(tenant) group_left
+                tenant:alert_threshold:es_heap_usage_percent
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:es_heap_usage_percent:max
+                > on(tenant) group_left
+                tenant:alert_threshold:es_heap_usage_percent
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -162,15 +188,30 @@ groups:
         expr: |
           (
             (
-              tenant:es_disk_usage_percent:max
-              > on(tenant) group_left
-              tenant:alert_threshold:es_disk_usage_percent
+              (
+                tenant:es_disk_usage_percent:max
+                > on(tenant) group_left
+                tenant:alert_threshold:es_disk_usage_percent
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:es_disk_usage_percent:max
+                > on(tenant) group_left
+                tenant:alert_threshold:es_disk_usage_percent
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -190,15 +231,30 @@ groups:
         expr: |
           (
             (
-              tenant:es_search_latency_ms:avg
-              > on(tenant) group_left
-              tenant:alert_threshold:es_search_latency_ms
+              (
+                tenant:es_search_latency_ms:avg
+                > on(tenant) group_left
+                tenant:alert_threshold:es_search_latency_ms
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:es_search_latency_ms:avg
+                > on(tenant) group_left
+                tenant:alert_threshold:es_search_latency_ms
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -217,12 +273,23 @@ groups:
       - alert: ElasticsearchUnassignedShards
         expr: |
           (
-            tenant:es_unassigned_shards:count > 0
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            (
+              tenant:es_unassigned_shards:count > 0
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              tenant:es_unassigned_shards:count > 0
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 10m
         labels:
           severity: warning
@@ -242,15 +309,30 @@ groups:
         expr: |
           (
             (
-              tenant:es_pending_tasks:max
-              > on(tenant) group_left
-              tenant:alert_threshold:es_pending_tasks
+              (
+                tenant:es_pending_tasks:max
+                > on(tenant) group_left
+                tenant:alert_threshold:es_pending_tasks
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:es_pending_tasks:max
+                > on(tenant) group_left
+                tenant:alert_threshold:es_pending_tasks
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning

--- a/rule-packs/rule-pack-jvm.yaml
+++ b/rule-packs/rule-pack-jvm.yaml
@@ -81,15 +81,30 @@ groups:
         expr: |
           (
             (
-              tenant:jvm_gc_pause:rate5m
-              > on(tenant) group_left
-              tenant:alert_threshold:jvm_gc_pause
+              (
+                tenant:jvm_gc_pause:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:jvm_gc_pause
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:jvm_gc_pause:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:jvm_gc_pause
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -110,15 +125,30 @@ groups:
         expr: |
           (
             (
-              tenant:jvm_gc_pause:rate5m
-              > on(tenant) group_left
-              tenant:alert_threshold:jvm_gc_pause_critical
+              (
+                tenant:jvm_gc_pause:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:jvm_gc_pause_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:jvm_gc_pause:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:jvm_gc_pause_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 3m
         labels:
           severity: critical
@@ -140,15 +170,30 @@ groups:
         expr: |
           (
             (
-              tenant:jvm_memory_used:percent
-              > on(tenant) group_left
-              tenant:alert_threshold:jvm_memory
+              (
+                tenant:jvm_memory_used:percent
+                > on(tenant) group_left
+                tenant:alert_threshold:jvm_memory
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:jvm_memory_used:percent
+                > on(tenant) group_left
+                tenant:alert_threshold:jvm_memory
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -169,15 +214,30 @@ groups:
         expr: |
           (
             (
-              tenant:jvm_memory_used:percent
-              > on(tenant) group_left
-              tenant:alert_threshold:jvm_memory_critical
+              (
+                tenant:jvm_memory_used:percent
+                > on(tenant) group_left
+                tenant:alert_threshold:jvm_memory_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:jvm_memory_used:percent
+                > on(tenant) group_left
+                tenant:alert_threshold:jvm_memory_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 3m
         labels:
           severity: critical
@@ -199,15 +259,30 @@ groups:
         expr: |
           (
             (
-              tenant:jvm_threads:current
-              > on(tenant) group_left
-              tenant:alert_threshold:jvm_threads
+              (
+                tenant:jvm_threads:current
+                > on(tenant) group_left
+                tenant:alert_threshold:jvm_threads
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:jvm_threads:current
+                > on(tenant) group_left
+                tenant:alert_threshold:jvm_threads
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -228,15 +303,30 @@ groups:
         expr: |
           (
             (
-              tenant:jvm_threads:current
-              > on(tenant) group_left
-              tenant:alert_threshold:jvm_threads_critical
+              (
+                tenant:jvm_threads:current
+                > on(tenant) group_left
+                tenant:alert_threshold:jvm_threads_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:jvm_threads:current
+                > on(tenant) group_left
+                tenant:alert_threshold:jvm_threads_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 3m
         labels:
           severity: critical
@@ -258,15 +348,30 @@ groups:
         expr: |
           (
             (
-              tenant:jvm_gc_pause:rate5m > on(tenant) group_left tenant:alert_threshold:jvm_gc_pause
-              and on(tenant)
-              tenant:jvm_memory_used:percent > on(tenant) group_left tenant:alert_threshold:jvm_memory
+              (
+                tenant:jvm_gc_pause:rate5m > on(tenant) group_left tenant:alert_threshold:jvm_gc_pause
+                and on(tenant)
+                tenant:jvm_memory_used:percent > on(tenant) group_left tenant:alert_threshold:jvm_memory
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:jvm_gc_pause:rate5m > on(tenant) group_left tenant:alert_threshold:jvm_gc_pause
+                and on(tenant)
+                tenant:jvm_memory_used:percent > on(tenant) group_left tenant:alert_threshold:jvm_memory
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: critical

--- a/rule-packs/rule-pack-kafka.yaml
+++ b/rule-packs/rule-pack-kafka.yaml
@@ -99,15 +99,30 @@ groups:
         expr: |
           (
             (
-              tenant:kafka_consumer_lag:max
-              > on(tenant) group_left
-              tenant:alert_threshold:kafka_consumer_lag
+              (
+                tenant:kafka_consumer_lag:max
+                > on(tenant) group_left
+                tenant:alert_threshold:kafka_consumer_lag
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:kafka_consumer_lag:max
+                > on(tenant) group_left
+                tenant:alert_threshold:kafka_consumer_lag
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: warning
@@ -129,15 +144,30 @@ groups:
         expr: |
           (
             (
-              tenant:kafka_consumer_lag:max
-              > on(tenant) group_left
-              tenant:alert_threshold:kafka_consumer_lag_critical
+              (
+                tenant:kafka_consumer_lag:max
+                > on(tenant) group_left
+                tenant:alert_threshold:kafka_consumer_lag_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:kafka_consumer_lag:max
+                > on(tenant) group_left
+                tenant:alert_threshold:kafka_consumer_lag_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: critical
@@ -158,15 +188,30 @@ groups:
         expr: |
           (
             (
-              tenant:kafka_under_replicated_partitions:max
-              > on(tenant) group_left
-              tenant:alert_threshold:kafka_under_replicated_partitions
+              (
+                tenant:kafka_under_replicated_partitions:max
+                > on(tenant) group_left
+                tenant:alert_threshold:kafka_under_replicated_partitions
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:kafka_under_replicated_partitions:max
+                > on(tenant) group_left
+                tenant:alert_threshold:kafka_under_replicated_partitions
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: warning
@@ -188,15 +233,30 @@ groups:
         expr: |
           (
             (
-              tenant:kafka_under_replicated_partitions:max
-              > on(tenant) group_left
-              tenant:alert_threshold:kafka_under_replicated_partitions_critical
+              (
+                tenant:kafka_under_replicated_partitions:max
+                > on(tenant) group_left
+                tenant:alert_threshold:kafka_under_replicated_partitions_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:kafka_under_replicated_partitions:max
+                > on(tenant) group_left
+                tenant:alert_threshold:kafka_under_replicated_partitions_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: critical
@@ -217,15 +277,30 @@ groups:
         expr: |
           (
             (
-              tenant:kafka_active_controllers:max
-              < on(tenant) group_left
-              tenant:alert_threshold:kafka_active_controllers
+              (
+                tenant:kafka_active_controllers:max
+                < on(tenant) group_left
+                tenant:alert_threshold:kafka_active_controllers
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:kafka_active_controllers:max
+                < on(tenant) group_left
+                tenant:alert_threshold:kafka_active_controllers
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: critical
@@ -246,15 +321,30 @@ groups:
         expr: |
           (
             (
-              tenant:kafka_broker_count:max
-              < on(tenant) group_left
-              tenant:alert_threshold:kafka_broker_count
+              (
+                tenant:kafka_broker_count:max
+                < on(tenant) group_left
+                tenant:alert_threshold:kafka_broker_count
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:kafka_broker_count:max
+                < on(tenant) group_left
+                tenant:alert_threshold:kafka_broker_count
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: warning
@@ -275,15 +365,30 @@ groups:
         expr: |
           (
             (
-              tenant:kafka_request_rate:sum
-              > on(tenant) group_left
-              tenant:alert_threshold:kafka_request_rate
+              (
+                tenant:kafka_request_rate:sum
+                > on(tenant) group_left
+                tenant:alert_threshold:kafka_request_rate
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:kafka_request_rate:sum
+                > on(tenant) group_left
+                tenant:alert_threshold:kafka_request_rate
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: warning
@@ -305,15 +410,30 @@ groups:
         expr: |
           (
             (
-              tenant:kafka_request_rate:sum
-              > on(tenant) group_left
-              tenant:alert_threshold:kafka_request_rate_critical
+              (
+                tenant:kafka_request_rate:sum
+                > on(tenant) group_left
+                tenant:alert_threshold:kafka_request_rate_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:kafka_request_rate:sum
+                > on(tenant) group_left
+                tenant:alert_threshold:kafka_request_rate_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: critical

--- a/rule-packs/rule-pack-kubernetes.yaml
+++ b/rule-packs/rule-pack-kubernetes.yaml
@@ -395,16 +395,33 @@ groups:
           (
             (
               (
-                tenant:container_waiting_reason:count{reason="CrashLoopBackOff"}
-                * on(tenant) group_left
-                user_state_filter{filter="container_crashloop"}
-              ) > 0
+                (
+                  tenant:container_waiting_reason:count{reason="CrashLoopBackOff"}
+                  * on(tenant) group_left
+                  user_state_filter{filter="container_crashloop"}
+                ) > 0
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                (
+                  tenant:container_waiting_reason:count{reason="CrashLoopBackOff"}
+                  * on(tenant) group_left
+                  user_state_filter{filter="container_crashloop"}
+                ) > 0
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: critical
@@ -425,16 +442,33 @@ groups:
           (
             (
               (
-                tenant:container_waiting_reason:count{reason=~"ImagePullBackOff|InvalidImageName"}
-                * on(tenant) group_left
-                user_state_filter{filter="container_imagepull"}
-              ) > 0
+                (
+                  tenant:container_waiting_reason:count{reason=~"ImagePullBackOff|InvalidImageName"}
+                  * on(tenant) group_left
+                  user_state_filter{filter="container_imagepull"}
+                ) > 0
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                (
+                  tenant:container_waiting_reason:count{reason=~"ImagePullBackOff|InvalidImageName"}
+                  * on(tenant) group_left
+                  user_state_filter{filter="container_imagepull"}
+                ) > 0
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: warning

--- a/rule-packs/rule-pack-mariadb.yaml
+++ b/rule-packs/rule-pack-mariadb.yaml
@@ -102,15 +102,30 @@ groups:
         expr: |
           (
             (
-              tenant:mysql_threads_connected:max
-              > on(tenant) group_left
-              tenant:alert_threshold:connections
+              (
+                tenant:mysql_threads_connected:max
+                > on(tenant) group_left
+                tenant:alert_threshold:connections
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:mysql_threads_connected:max
+                > on(tenant) group_left
+                tenant:alert_threshold:connections
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: warning
@@ -132,15 +147,30 @@ groups:
         expr: |
           (
             (
-              tenant:mysql_threads_connected:max
-              > on(tenant) group_left
-              tenant:alert_threshold:connections_critical
+              (
+                tenant:mysql_threads_connected:max
+                > on(tenant) group_left
+                tenant:alert_threshold:connections_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:mysql_threads_connected:max
+                > on(tenant) group_left
+                tenant:alert_threshold:connections_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: critical
@@ -163,22 +193,45 @@ groups:
           (
             (
               (
-                tenant:mysql_threads_connected:max
-                > on(tenant) group_left
-                tenant:alert_threshold:connections
+                (
+                  tenant:mysql_threads_connected:max
+                  > on(tenant) group_left
+                  tenant:alert_threshold:connections
+                )
+                and on(tenant)
+                (
+                  tenant:mysql_cpu_usage:rate5m
+                  > on(tenant) group_left
+                  tenant:alert_threshold:cpu
+                )
               )
-              and on(tenant)
-              (
-                tenant:mysql_cpu_usage:rate5m
-                > on(tenant) group_left
-                tenant:alert_threshold:cpu
-              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                (
+                  tenant:mysql_threads_connected:max
+                  > on(tenant) group_left
+                  tenant:alert_threshold:connections
+                )
+                and on(tenant)
+                (
+                  tenant:mysql_cpu_usage:rate5m
+                  > on(tenant) group_left
+                  tenant:alert_threshold:cpu
+                )
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 60s
         labels:
           severity: critical
@@ -210,12 +263,23 @@ groups:
       - alert: MariaDBHighSlowQueries
         expr: |
           (
-            tenant:mysql_slow_queries:rate5m > 1
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            (
+              tenant:mysql_slow_queries:rate5m > 1
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              tenant:mysql_slow_queries:rate5m > 1
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -235,12 +299,23 @@ groups:
       - alert: MariaDBHighAbortedConnections
         expr: |
           (
-            tenant:mysql_aborted_connections:rate5m > 5
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            (
+              tenant:mysql_aborted_connections:rate5m > 5
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              tenant:mysql_aborted_connections:rate5m > 5
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning

--- a/rule-packs/rule-pack-mongodb.yaml
+++ b/rule-packs/rule-pack-mongodb.yaml
@@ -93,15 +93,30 @@ groups:
         expr: |
           (
             (
-              tenant:mongodb_connections_current:max
-              > on(tenant) group_left
-              tenant:alert_threshold:mongodb_connections_current
+              (
+                tenant:mongodb_connections_current:max
+                > on(tenant) group_left
+                tenant:alert_threshold:mongodb_connections_current
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:mongodb_connections_current:max
+                > on(tenant) group_left
+                tenant:alert_threshold:mongodb_connections_current
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -121,15 +136,30 @@ groups:
         expr: |
           (
             (
-              tenant:mongodb_replication_lag:max
-              > on(tenant) group_left
-              tenant:alert_threshold:mongodb_replication_lag
+              (
+                tenant:mongodb_replication_lag:max
+                > on(tenant) group_left
+                tenant:alert_threshold:mongodb_replication_lag
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:mongodb_replication_lag:max
+                > on(tenant) group_left
+                tenant:alert_threshold:mongodb_replication_lag
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 2m
         labels:
           severity: warning
@@ -149,15 +179,30 @@ groups:
         expr: |
           (
             (
-              tenant:mongodb_opcounters:rate5m
-              > on(tenant) group_left
-              tenant:alert_threshold:mongodb_opcounters_rate
+              (
+                tenant:mongodb_opcounters:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:mongodb_opcounters_rate
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:mongodb_opcounters:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:mongodb_opcounters_rate
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -176,12 +221,23 @@ groups:
       - alert: MongoDBHighPageFaults
         expr: |
           (
-            tenant:mongodb_page_faults:rate5m > 100
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            (
+              tenant:mongodb_page_faults:rate5m > 100
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              tenant:mongodb_page_faults:rate5m > 100
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -200,12 +256,23 @@ groups:
       - alert: MongoDBConnectionSaturation
         expr: |
           (
-            tenant:mongodb_connection_usage:ratio > 0.8
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            (
+              tenant:mongodb_connection_usage:ratio > 0.8
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              tenant:mongodb_connection_usage:ratio > 0.8
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning

--- a/rule-packs/rule-pack-nginx.yaml
+++ b/rule-packs/rule-pack-nginx.yaml
@@ -78,15 +78,30 @@ groups:
         expr: |
           (
             (
-              tenant:nginx_connections_active:max
-              > on(tenant) group_left
-              tenant:alert_threshold:nginx_connections
+              (
+                tenant:nginx_connections_active:max
+                > on(tenant) group_left
+                tenant:alert_threshold:nginx_connections
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:nginx_connections_active:max
+                > on(tenant) group_left
+                tenant:alert_threshold:nginx_connections
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -107,15 +122,30 @@ groups:
         expr: |
           (
             (
-              tenant:nginx_connections_active:max
-              > on(tenant) group_left
-              tenant:alert_threshold:nginx_connections_critical
+              (
+                tenant:nginx_connections_active:max
+                > on(tenant) group_left
+                tenant:alert_threshold:nginx_connections_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:nginx_connections_active:max
+                > on(tenant) group_left
+                tenant:alert_threshold:nginx_connections_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 3m
         labels:
           severity: critical
@@ -137,15 +167,30 @@ groups:
         expr: |
           (
             (
-              tenant:nginx_requests:rate5m
-              > on(tenant) group_left
-              tenant:alert_threshold:nginx_request_rate
+              (
+                tenant:nginx_requests:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:nginx_request_rate
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:nginx_requests:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:nginx_request_rate
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -166,15 +211,30 @@ groups:
         expr: |
           (
             (
-              tenant:nginx_requests:rate5m
-              > on(tenant) group_left
-              tenant:alert_threshold:nginx_request_rate_critical
+              (
+                tenant:nginx_requests:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:nginx_request_rate_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:nginx_requests:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:nginx_request_rate_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 3m
         labels:
           severity: critical
@@ -196,15 +256,30 @@ groups:
         expr: |
           (
             (
-              tenant:nginx_connections_waiting:max
-              > on(tenant) group_left
-              tenant:alert_threshold:nginx_waiting
+              (
+                tenant:nginx_connections_waiting:max
+                > on(tenant) group_left
+                tenant:alert_threshold:nginx_waiting
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:nginx_connections_waiting:max
+                > on(tenant) group_left
+                tenant:alert_threshold:nginx_waiting
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -225,15 +300,30 @@ groups:
         expr: |
           (
             (
-              tenant:nginx_connections_waiting:max
-              > on(tenant) group_left
-              tenant:alert_threshold:nginx_waiting_critical
+              (
+                tenant:nginx_connections_waiting:max
+                > on(tenant) group_left
+                tenant:alert_threshold:nginx_waiting_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:nginx_connections_waiting:max
+                > on(tenant) group_left
+                tenant:alert_threshold:nginx_waiting_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 3m
         labels:
           severity: critical

--- a/rule-packs/rule-pack-oracle.yaml
+++ b/rule-packs/rule-pack-oracle.yaml
@@ -100,15 +100,30 @@ groups:
         expr: |
           (
             (
-              tenant:oracle_sessions_active:max
-              > on(tenant) group_left
-              tenant:alert_threshold:oracle_sessions_active
+              (
+                tenant:oracle_sessions_active:max
+                > on(tenant) group_left
+                tenant:alert_threshold:oracle_sessions_active
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:oracle_sessions_active:max
+                > on(tenant) group_left
+                tenant:alert_threshold:oracle_sessions_active
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -128,15 +143,30 @@ groups:
         expr: |
           (
             (
-              tenant:oracle_tablespace_used_percent:max
-              > on(tenant) group_left
-              tenant:alert_threshold:oracle_tablespace_used_percent
+              (
+                tenant:oracle_tablespace_used_percent:max
+                > on(tenant) group_left
+                tenant:alert_threshold:oracle_tablespace_used_percent
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:oracle_tablespace_used_percent:max
+                > on(tenant) group_left
+                tenant:alert_threshold:oracle_tablespace_used_percent
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -156,15 +186,30 @@ groups:
         expr: |
           (
             (
-              tenant:oracle_wait_time:rate5m
-              > on(tenant) group_left
-              tenant:alert_threshold:oracle_wait_time_rate
+              (
+                tenant:oracle_wait_time:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:oracle_wait_time_rate
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:oracle_wait_time:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:oracle_wait_time_rate
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -184,15 +229,30 @@ groups:
         expr: |
           (
             (
-              tenant:oracle_process_count:max
-              > on(tenant) group_left
-              tenant:alert_threshold:oracle_process_count
+              (
+                tenant:oracle_process_count:max
+                > on(tenant) group_left
+                tenant:alert_threshold:oracle_process_count
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:oracle_process_count:max
+                > on(tenant) group_left
+                tenant:alert_threshold:oracle_process_count
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -212,15 +272,30 @@ groups:
         expr: |
           (
             (
-              tenant:oracle_pga_allocated_bytes:max
-              > on(tenant) group_left
-              tenant:alert_threshold:oracle_pga_allocated_bytes
+              (
+                tenant:oracle_pga_allocated_bytes:max
+                > on(tenant) group_left
+                tenant:alert_threshold:oracle_pga_allocated_bytes
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:oracle_pga_allocated_bytes:max
+                > on(tenant) group_left
+                tenant:alert_threshold:oracle_pga_allocated_bytes
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 10m
         labels:
           severity: warning
@@ -239,12 +314,23 @@ groups:
       - alert: OracleHighSessionUtilization
         expr: |
           (
-            tenant:oracle_session_utilization:ratio > 0.85
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            (
+              tenant:oracle_session_utilization:ratio > 0.85
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              tenant:oracle_session_utilization:ratio > 0.85
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning

--- a/rule-packs/rule-pack-postgresql.yaml
+++ b/rule-packs/rule-pack-postgresql.yaml
@@ -114,15 +114,30 @@ groups:
         expr: |
           (
             (
-              tenant:pg_connection_usage:ratio
-              > on(tenant) group_left
-              tenant:alert_threshold:pg_connections
+              (
+                tenant:pg_connection_usage:ratio
+                > on(tenant) group_left
+                tenant:alert_threshold:pg_connections
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:pg_connection_usage:ratio
+                > on(tenant) group_left
+                tenant:alert_threshold:pg_connections
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: warning
@@ -144,15 +159,30 @@ groups:
         expr: |
           (
             (
-              tenant:pg_connection_usage:ratio
-              > on(tenant) group_left
-              tenant:alert_threshold:pg_connections_critical
+              (
+                tenant:pg_connection_usage:ratio
+                > on(tenant) group_left
+                tenant:alert_threshold:pg_connections_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:pg_connection_usage:ratio
+                > on(tenant) group_left
+                tenant:alert_threshold:pg_connections_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: critical
@@ -173,15 +203,30 @@ groups:
         expr: |
           (
             (
-              tenant:pg_replication_lag:max
-              > on(tenant) group_left
-              tenant:alert_threshold:pg_replication_lag
+              (
+                tenant:pg_replication_lag:max
+                > on(tenant) group_left
+                tenant:alert_threshold:pg_replication_lag
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:pg_replication_lag:max
+                > on(tenant) group_left
+                tenant:alert_threshold:pg_replication_lag
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: warning
@@ -203,15 +248,30 @@ groups:
         expr: |
           (
             (
-              tenant:pg_replication_lag:max
-              > on(tenant) group_left
-              tenant:alert_threshold:pg_replication_lag_critical
+              (
+                tenant:pg_replication_lag:max
+                > on(tenant) group_left
+                tenant:alert_threshold:pg_replication_lag_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:pg_replication_lag:max
+                > on(tenant) group_left
+                tenant:alert_threshold:pg_replication_lag_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: critical
@@ -232,12 +292,23 @@ groups:
       - alert: PostgreSQLHighDeadlocks
         expr: |
           (
-            tenant:pg_deadlocks:rate5m > 0.1
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            (
+              tenant:pg_deadlocks:rate5m > 0.1
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              tenant:pg_deadlocks:rate5m > 0.1
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -257,12 +328,23 @@ groups:
       - alert: PostgreSQLHighRollbackRatio
         expr: |
           (
-            tenant:pg_rollback_ratio:rate5m > 0.05
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            (
+              tenant:pg_rollback_ratio:rate5m > 0.05
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              tenant:pg_rollback_ratio:rate5m > 0.05
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning

--- a/rule-packs/rule-pack-rabbitmq.yaml
+++ b/rule-packs/rule-pack-rabbitmq.yaml
@@ -98,15 +98,30 @@ groups:
         expr: |
           (
             (
-              tenant:rabbitmq_queue_messages:max
-              > on(tenant) group_left
-              tenant:alert_threshold:rabbitmq_queue_messages
+              (
+                tenant:rabbitmq_queue_messages:max
+                > on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_queue_messages
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:rabbitmq_queue_messages:max
+                > on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_queue_messages
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: warning
@@ -128,15 +143,30 @@ groups:
         expr: |
           (
             (
-              tenant:rabbitmq_queue_messages:max
-              > on(tenant) group_left
-              tenant:alert_threshold:rabbitmq_queue_messages_critical
+              (
+                tenant:rabbitmq_queue_messages:max
+                > on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_queue_messages_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:rabbitmq_queue_messages:max
+                > on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_queue_messages_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: critical
@@ -157,15 +187,30 @@ groups:
         expr: |
           (
             (
-              tenant:rabbitmq_node_mem_percent:ratio
-              > on(tenant) group_left
-              tenant:alert_threshold:rabbitmq_node_mem_percent
+              (
+                tenant:rabbitmq_node_mem_percent:ratio
+                > on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_node_mem_percent
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:rabbitmq_node_mem_percent:ratio
+                > on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_node_mem_percent
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: warning
@@ -187,15 +232,30 @@ groups:
         expr: |
           (
             (
-              tenant:rabbitmq_node_mem_percent:ratio
-              > on(tenant) group_left
-              tenant:alert_threshold:rabbitmq_node_mem_percent_critical
+              (
+                tenant:rabbitmq_node_mem_percent:ratio
+                > on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_node_mem_percent_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:rabbitmq_node_mem_percent:ratio
+                > on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_node_mem_percent_critical
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: critical
@@ -216,15 +276,30 @@ groups:
         expr: |
           (
             (
-              tenant:rabbitmq_connections:max
-              > on(tenant) group_left
-              tenant:alert_threshold:rabbitmq_connections
+              (
+                tenant:rabbitmq_connections:max
+                > on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_connections
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:rabbitmq_connections:max
+                > on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_connections
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: warning
@@ -245,15 +320,30 @@ groups:
         expr: |
           (
             (
-              tenant:rabbitmq_consumers:max
-              < on(tenant) group_left
-              tenant:alert_threshold:rabbitmq_consumers
+              (
+                tenant:rabbitmq_consumers:max
+                < on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_consumers
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:rabbitmq_consumers:max
+                < on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_consumers
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 30s
         labels:
           severity: warning
@@ -274,15 +364,30 @@ groups:
         expr: |
           (
             (
-              tenant:rabbitmq_unacked_messages:max
-              > on(tenant) group_left
-              tenant:alert_threshold:rabbitmq_unacked_messages
+              (
+                tenant:rabbitmq_unacked_messages:max
+                > on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_unacked_messages
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:rabbitmq_unacked_messages:max
+                > on(tenant) group_left
+                tenant:alert_threshold:rabbitmq_unacked_messages
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning

--- a/rule-packs/rule-pack-redis.yaml
+++ b/rule-packs/rule-pack-redis.yaml
@@ -102,15 +102,30 @@ groups:
         expr: |
           (
             (
-              tenant:redis_memory_used_bytes:max
-              > on(tenant) group_left
-              tenant:alert_threshold:redis_memory_used_bytes
+              (
+                tenant:redis_memory_used_bytes:max
+                > on(tenant) group_left
+                tenant:alert_threshold:redis_memory_used_bytes
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:redis_memory_used_bytes:max
+                > on(tenant) group_left
+                tenant:alert_threshold:redis_memory_used_bytes
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -130,15 +145,30 @@ groups:
         expr: |
           (
             (
-              tenant:redis_connected_clients:max
-              > on(tenant) group_left
-              tenant:alert_threshold:redis_connected_clients
+              (
+                tenant:redis_connected_clients:max
+                > on(tenant) group_left
+                tenant:alert_threshold:redis_connected_clients
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:redis_connected_clients:max
+                > on(tenant) group_left
+                tenant:alert_threshold:redis_connected_clients
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -158,15 +188,30 @@ groups:
         expr: |
           (
             (
-              tenant:redis_evicted_keys:rate5m
-              > on(tenant) group_left
-              tenant:alert_threshold:redis_evicted_keys_rate
+              (
+                tenant:redis_evicted_keys:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:redis_evicted_keys_rate
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:redis_evicted_keys:rate5m
+                > on(tenant) group_left
+                tenant:alert_threshold:redis_evicted_keys_rate
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 5m
         labels:
           severity: warning
@@ -186,15 +231,30 @@ groups:
         expr: |
           (
             (
-              tenant:redis_replication_lag:max
-              > on(tenant) group_left
-              tenant:alert_threshold:redis_replication_lag
+              (
+                tenant:redis_replication_lag:max
+                > on(tenant) group_left
+                tenant:alert_threshold:redis_replication_lag
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
             )
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              (
+                tenant:redis_replication_lag:max
+                > on(tenant) group_left
+                tenant:alert_threshold:redis_replication_lag
+              )
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 2m
         labels:
           severity: warning
@@ -213,12 +273,23 @@ groups:
       - alert: RedisLowHitRatio
         expr: |
           (
-            tenant:redis_keyspace_hit_ratio:avg < 0.9
-            unless on(tenant)
-            (user_state_filter{filter="maintenance"} == 1)
+            (
+              tenant:redis_keyspace_hit_ratio:avg < 0.9
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            * on(tenant) group_left(runbook_url, owner, tier)
+              tenant_metadata_info
           )
-          * on(tenant) group_left(runbook_url, owner, tier)
-            tenant_metadata_info
+          or
+          (
+            (
+              tenant:redis_keyspace_hit_ratio:avg < 0.9
+              unless on(tenant)
+              (user_state_filter{filter="maintenance"} == 1)
+            )
+            unless on(tenant) tenant_metadata_info
+          )
         for: 10m
         labels:
           severity: warning

--- a/scripts/tools/lint/check_leftouterjoin_enrichment.py
+++ b/scripts/tools/lint/check_leftouterjoin_enrichment.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Left-outer-join enrichment invariant lint (ADR-024 PR3-pre Commit 3).
+
+Codifies the onboarding-vacuum fix so it can't silently regress: every metadata
+enrichment in an alert must be a LEFT-outer join, not a bare inner join.
+
+WHY: `<firing> * on(tenant) group_left(runbook_url, owner, tier) tenant_metadata_info`
+is an INNER join — a tenant with metrics but no `tenant_metadata_info` row (an
+onboarding vacuum) is silently DROPPED and never alerts. The fix pairs every
+such enrichment with an `or (<firing> unless on(tenant) tenant_metadata_info)`
+branch so the bare firing vector still fires when metadata is absent.
+
+WHAT THIS CHECKS (a cheap structural proxy, per file): the number of enrichment
+markers `* on(tenant) group_left(runbook_url, owner, tier)` equals the number of
+void branches `unless on(tenant) tenant_metadata_info`. Every enriched alert
+across all 14 packs (kubernetes via :core, the other 12 via inline-duplicate)
+satisfies this 1:1 pairing. A new bare inner-join enrichment → markers > branches
+→ this lint fails. Semantic proof lives in tests/rulepacks/*-void_test.yaml.
+
+Exit codes: 0 ok / 1 unpaired enrichment (--ci) / 2 error.
+
+Usage:
+    python scripts/tools/lint/check_leftouterjoin_enrichment.py        # report
+    python scripts/tools/lint/check_leftouterjoin_enrichment.py --ci   # exit 1
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_THIS_DIR, ".."))
+try:
+    from _lib_compat import try_utf8_stdout  # noqa: E402
+except Exception:  # pragma: no cover
+    def try_utf8_stdout() -> None:  # type: ignore
+        pass
+
+ENRICH_MARKER = "* on(tenant) group_left(runbook_url, owner, tier)"
+VOID_BRANCH = "unless on(tenant) tenant_metadata_info"
+
+
+def _repo_root() -> Path:
+    p = Path(_THIS_DIR).resolve()
+    for parent in [p, *p.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return p.parent.parent.parent
+
+
+def count_pair(text: str) -> Tuple[int, int]:
+    """Pure core: (enrichment markers, void branches) in a rule/configmap file."""
+    return text.count(ENRICH_MARKER), text.count(VOID_BRANCH)
+
+
+def main() -> int:
+    try_utf8_stdout()
+    parser = argparse.ArgumentParser(
+        description="Left-outer-join enrichment invariant lint (ADR-024)")
+    parser.add_argument("--ci", action="store_true", help="exit 1 on violation")
+    args = parser.parse_args()
+
+    # SOURCE only. The generated configmaps re-serialize the expr (yaml.dump
+    # re-wraps lines), which perturbs the literal-substring count — and they are
+    # already guaranteed `== source` by generate_rulepack_configmaps.py --check.
+    # So source being left-outer-join + configmap == source ⇒ configmap correct.
+    repo = _repo_root()
+    targets: List[Path] = sorted((repo / "rule-packs").glob("rule-pack-*.yaml"))
+    targets = [t for t in targets if t.exists()]
+    if not targets:
+        print("ERROR: no rule-pack files found", file=sys.stderr)
+        return 2
+
+    violations = 0
+    for path in targets:
+        markers, branches = count_pair(path.read_text(encoding="utf-8"))
+        if markers != branches:
+            violations += 1
+            print(f"  ❌ {path.relative_to(repo)}: {markers} enrichment marker(s) "
+                  f"but {branches} void branch(es) — {markers - branches} bare "
+                  f"inner-join(s) would drop onboarding-vacuum tenants")
+
+    if violations:
+        print(f"\n❌ {violations} pack(s) have unpaired metadata enrichment. Every "
+              f"`{ENRICH_MARKER}` must be paired with an `or (… {VOID_BRANCH})` "
+              f"branch (ADR-024 PR3-pre Commit 3). See tests/rulepacks/*-void_test.yaml.",
+              file=sys.stderr)
+        return 1 if args.ci else 0
+    print(f"✅ All {len(targets)} rule pack(s): metadata enrichment is "
+          f"left-outer-join (no onboarding-vacuum drop).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/lint/test_check_leftouterjoin_enrichment.py
+++ b/tests/lint/test_check_leftouterjoin_enrichment.py
@@ -1,0 +1,71 @@
+"""Tests for check_leftouterjoin_enrichment.py — ADR-024 onboarding-vacuum guard.
+
+Pinned contracts
+----------------
+1. A left-outer-join enrichment (marker paired with a void branch) → markers ==
+   branches (compliant).
+2. A bare inner-join enrichment (marker without a void branch) → markers >
+   branches (flagged).
+3. Live dogfood: every committed rule pack pairs every enrichment with a void
+   branch (gates a regression of the PR3-pre Commit 3 sweep).
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_TOOLS_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "scripts", "tools", "lint"
+)
+sys.path.insert(0, _TOOLS_DIR)
+
+import check_leftouterjoin_enrichment as lint  # noqa: E402
+
+_BARE = (
+    "        expr: |\n"
+    "          (X)\n"
+    "          * on(tenant) group_left(runbook_url, owner, tier)\n"
+    "            tenant_metadata_info\n"
+)
+_LEFT_OUTER = (
+    "        expr: |\n"
+    "          (\n"
+    "            (X)\n"
+    "            * on(tenant) group_left(runbook_url, owner, tier)\n"
+    "              tenant_metadata_info\n"
+    "          )\n"
+    "          or\n"
+    "          (\n"
+    "            (X)\n"
+    "            unless on(tenant) tenant_metadata_info\n"
+    "          )\n"
+)
+
+
+def test_bare_inner_join_flagged():
+    markers, branches = lint.count_pair(_BARE)
+    assert markers == 1 and branches == 0
+    assert markers != branches  # the lint condition
+
+
+def test_left_outer_join_compliant():
+    markers, branches = lint.count_pair(_LEFT_OUTER)
+    assert markers == 1 and branches == 1
+    assert markers == branches
+
+
+def test_no_enrichment_compliant():
+    markers, branches = lint.count_pair("        expr: |\n          up == 0\n")
+    assert markers == 0 and branches == 0
+
+
+def test_live_repo_packs_all_paired():
+    repo = lint._repo_root()
+    packs = sorted((repo / "rule-packs").glob("rule-pack-*.yaml"))
+    assert packs, "expected rule packs under rule-packs/"
+    for p in packs:
+        markers, branches = lint.count_pair(p.read_text(encoding="utf-8"))
+        assert markers == branches, (
+            f"{p.name}: {markers} enrichment marker(s) but {branches} void "
+            f"branch(es) — a bare inner-join would drop onboarding-vacuum tenants"
+        )

--- a/tests/rulepacks/rule-pack-redis-void_test.yaml
+++ b/tests/rulepacks/rule-pack-redis-void_test.yaml
@@ -1,0 +1,86 @@
+# promtool unit test — ADR-024 PR3-pre Commit 3 left-outer-join sweep (redis).
+# Run: promtool test rules tests/rulepacks/rule-pack-redis-void_test.yaml
+#
+# Semantic oracle for the ADR-024 PR3-pre Commit 3 left-outer-join sweep: proves
+# the inner-join → left-outer-join conversion is SEMANTICALLY correct on redis
+# (representative of all swept packs — the enrichment suffix is byte-identical
+# everywhere; the conversion is a single uniform structural transform):
+#   - redis-a: metadata present  → fires ENRICHED (branch A, runbook/owner/tier).
+#   - redis-b: NO metadata (onboarding vacuum) → STILL fires BARE (branch B) —
+#     the inner-join would have silently dropped it. This is the fix.
+#   - redis-c: threshold exceeded but maintenance active → suppressed.
+#   - redis-d: below threshold → no alert.
+# Leaf series feed the full recording chain (max → threshold → alert).
+rule_files:
+  - ../../rule-packs/rule-pack-redis.yaml
+
+evaluation_interval: 15s
+
+tests:
+  - interval: 15s
+    input_series:
+      # redis-a: 600 clients > 500 threshold, metadata present → enriched fire.
+      - series: 'redis_connected_clients{tenant="redis-a"}'
+        values: '600x30'
+      - series: 'user_threshold{tenant="redis-a", metric="redis_connected_clients", severity="warning"}'
+        values: '500x30'
+      - series: 'tenant_metadata_info{tenant="redis-a", runbook_url="http://rb/a", owner="team-a", tier="gold"}'
+        values: '1x30'
+      # redis-b: 600 > 500, NO tenant_metadata_info → VACUUM-FIRE (branch B).
+      - series: 'redis_connected_clients{tenant="redis-b"}'
+        values: '600x30'
+      - series: 'user_threshold{tenant="redis-b", metric="redis_connected_clients", severity="warning"}'
+        values: '500x30'
+      # redis-c: 600 > 500, metadata present, BUT maintenance active → suppressed.
+      - series: 'redis_connected_clients{tenant="redis-c"}'
+        values: '600x30'
+      - series: 'user_threshold{tenant="redis-c", metric="redis_connected_clients", severity="warning"}'
+        values: '500x30'
+      - series: 'tenant_metadata_info{tenant="redis-c", runbook_url="http://rb/c", owner="team-c", tier="silver"}'
+        values: '1x30'
+      - series: 'user_state_filter{tenant="redis-c", filter="maintenance"}'
+        values: '1x30'
+      # redis-d: 400 < 500 threshold → no fire.
+      - series: 'redis_connected_clients{tenant="redis-d"}'
+        values: '400x30'
+      - series: 'user_threshold{tenant="redis-d", metric="redis_connected_clients", severity="warning"}'
+        values: '500x30'
+      - series: 'tenant_metadata_info{tenant="redis-d", runbook_url="http://rb/d", owner="team-d", tier="bronze"}'
+        values: '1x30'
+
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: RedisHighConnections
+        exp_alerts:
+          # redis-a: enriched (branch A) — carries runbook_url/owner/tier.
+          - exp_labels:
+              severity: warning
+              tenant: redis-a
+              runbook_url: "http://rb/a"
+              owner: team-a
+              tier: gold
+            exp_annotations:
+              summary: "Redis high connection count on redis-a"
+              summary_zh: "redis-a 的 Redis 連線數過高"
+              platform_summary: "[gold] redis-a: Redis connection count high — client pool review"
+              platform_summary_zh: "[gold] redis-a: Redis 連線數過高 — 請檢查客戶端連線池"
+              description: "600 connected clients"
+              description_zh: "600 個已連線的客戶端"
+              runbook_url: "http://rb/a"
+              owner: team-a
+              tier: gold
+          # redis-b: VACUUM-FIRE (branch B) — fires WITHOUT enrichment labels.
+          - exp_labels:
+              severity: warning
+              tenant: redis-b
+            exp_annotations:
+              summary: "Redis high connection count on redis-b"
+              summary_zh: "redis-b 的 Redis 連線數過高"
+              platform_summary: "[] redis-b: Redis connection count high — client pool review"
+              platform_summary_zh: "[] redis-b: Redis 連線數過高 — 請檢查客戶端連線池"
+              description: "600 connected clients"
+              description_zh: "600 個已連線的客戶端"
+              runbook_url: ""
+              owner: ""
+              tier: ""
+        # redis-c (maintenance) and redis-d (below threshold) produce NO alert.


### PR DESCRIPTION
## ADR-024 PR3-pre Commit 3 — left-outer-join the metadata enrichment across ALL packs

Closes the onboarding-vacuum bug everywhere. Every alert's
`(X) * on(tenant) group_left(runbook_url, owner, tier) tenant_metadata_info` was
an **inner** join — a tenant with metrics but **no `tenant_metadata_info` row**
(onboarding vacuum) was silently dropped and never alerted. #695 fixed only
kubernetes CPU/memory; this sweeps the remaining **74 enrichments** (12 packs'
alerts + kubernetes' 2 state alerts) to the left-outer-join form so the bare
firing vector still fires when metadata is absent:

```
(X * on(tenant) group_left(runbook_url, owner, tier) tenant_metadata_info)
or
(X unless on(tenant) tenant_metadata_info)
```

### How (execution method)
The enrichment suffix is **byte-identical across all packs** (surveyed: 72 + 2,
zero variants) → a single **deterministic, line-based transform** (inline-
duplicate of X), not 74 hand edits and not 12 LLM agents (which add variance to
a uniform mechanical change). Validated against a **promtool semantic oracle**
(redis) before applying everywhere; the one-time transformer is not committed —
the swept result + the permanent lint + the oracle are the durable artifacts.

### Verification
- **Semantic**: `rule-pack-redis-void_test.yaml` proves redis-b (no metadata)
  STILL fires bare, redis-a fires enriched, maintenance / below-threshold stay
  silent. Covers both X structural variants (single + double paren).
- **Syntax**: `promtool check rules` green on all 14 packs; all existing
  kubernetes promtool tests still pass.
- **Equivalence**: all 14 configmaps regenerated; `generate_rulepack_configmaps
  --check` confirms each == source (the big diff = left-outer-join + the
  ~2-month source drift the configmaps were already missing).
- **Regression guard (codify)**: `check_leftouterjoin_enrichment.py` + pre-commit
  hook + 4 self-tests assert every enrichment marker is paired with a void
  branch. **It caught kubernetes' 2 unconverted state alerts** that #695 missed.
- `validate_all` 8/8; HA-max + custom-rule lints green.

### Scope
13 packs swept (operational has no enrichment). Deferred follow-up: flip the
3-copy drift guard from warn-only to hard gate (Commit 4) — depends on the
operator-manifest leg, orthogonal to this fix.

Refs: #423
