### PR TITLE
ci(rule-packs): flip configmap↔source drift to hard gate (ADR-024 Commit 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,20 +174,22 @@ jobs:
             echo "::endgroup::"
           done
 
-      # ADR-024 PR3-pre-2 Commit 2: rule-pack 3-copy drift — AUDIT-ONLY.
-      # continue-on-error makes the ~2-month stale-configmap drift VISIBLE in
-      # CI logs without blocking, until the left-outer-join source hardening
-      # (PR3-pre-3) + configmap regeneration (Commit 3) land. Commit 4 removes
-      # continue-on-error to flip this to a hard gate.
-      - name: "Rule-pack copy drift (audit-only — ADR-024 PR3-pre-2)"
+      # ADR-024 PR3-pre Commit 4: the configmap↔source copy is now a HARD gate.
+      # The DEPLOYED configmaps (k8s/03-monitoring/configmap-rules-*.yaml, the
+      # production source of truth via ADR-005 projected volume) must never drift
+      # from rule-packs/ source again — that ~2-month silent drift is exactly what
+      # caused the onboarding-vacuum bug (#709). Edit a rule pack → run
+      # `make rulepack-configmaps` (or generate_rulepack_configmaps.py) → commit
+      # both. The pre-commit `rulepack-configmap-drift` hook catches this locally.
+      - name: "Rule-pack configmap drift (HARD gate — ADR-024 Commit 4)"
+        run: python scripts/tools/dx/generate_rulepack_configmaps.py --check
+
+      # The 3rd copy (operator-manifests/) stays AUDIT-ONLY: those CRD reference
+      # samples are owned by the operator epic (#692) and not yet regenerated to
+      # the left-outer-join source. Flip to hard when the operator epic syncs them.
+      - name: "Rule-pack 3-copy sync incl. operator (audit-only — operator epic #692)"
         continue-on-error: true
-        run: |
-          echo "::group::configmap-rules-*.yaml ↔ rule-packs/ source (semantic)"
-          python scripts/tools/dx/generate_rulepack_configmaps.py --check
-          echo "::endgroup::"
-          echo "::group::3-copy sync (rule-packs ↔ configmap ↔ operator)"
-          python scripts/tools/lint/check_rulepack_sync.py --ci
-          echo "::endgroup::"
+        run: python scripts/tools/lint/check_rulepack_sync.py --ci
 
   iac-helm-sast:
     # Container/k8s SAST Layers 2 + 4 (#448 / TRK-312 + TRK-314).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -750,6 +750,18 @@ repos:
         # branch. Source-only: configmaps are sync-checked against source
         # separately. Semantic proof: tests/rulepacks/*-void_test.yaml.
 
+      - id: rulepack-configmap-drift
+        name: "ADR-024: configmap-rules-*.yaml must match rule-packs/ source (Commit 4 hard gate)"
+        entry: python3 -X utf8 scripts/tools/dx/generate_rulepack_configmaps.py --check
+        language: python
+        additional_dependencies: ['pyyaml']
+        pass_filenames: false
+        files: ^(rule-packs/rule-pack-.*\.yaml|k8s/03-monitoring/configmap-rules-.*\.yaml)$
+        # The deployed configmaps must never silently drift from source (the
+        # ~2-month drift caused the onboarding-vacuum bug, #709). Edit a rule pack
+        # but forget to regenerate its configmap → this fails locally before the
+        # CI hard gate does. Fix: `make rulepack-configmaps`, then commit both.
+
       - id: ksm-version-allowlist
         name: "ADR-024: kube-state-metrics must allowlist app.kubernetes.io/version (test/rulepack-e2e)"
         entry: python3 -X utf8 scripts/tools/lint/check_ksm_version_allowlist.py --ci


### PR DESCRIPTION
## ADR-024 PR3-pre Commit 4 — flip the configmap↔source drift check to a HARD gate

Completes the PR3-pre series. The deployed configmaps (`k8s/03-monitoring/configmap-rules-*.yaml`, the production source of truth via ADR-005 projected volume) were drifting silently from `rule-packs/` source for ~2 months — exactly what caused the onboarding-vacuum bug fixed in #709. Now that #709 brought all 14 configmaps in sync, this locks them there:

- **CI**: removes `continue-on-error` from the `configmap-rules-*.yaml ↔ rule-packs/` check → a **HARD gate**. Edit a rule pack without regenerating its configmap → CI fails.
- **pre-commit**: new `rulepack-configmap-drift` hook runs the same `--check` locally (scoped to rule-pack / configmap changes) so a forgotten regen fails **before** push, not as a first-CI-red.
- **Mutation-proven load-bearing**: tweaking a configmap rule makes `--check` report the drift (missing/extra rule) and exit non-zero.

### Scope — the 3rd copy stays audit-only
The `check_rulepack_sync.py` 3-copy check (incl. `operator-manifests/`) **keeps** `continue-on-error`. Those CRD reference samples are owned by the operator epic (#692) and not yet regenerated to the left-outer-join source — flipping that leg to hard belongs with the operator epic, not here (avoids coupling this gate to unrelated operator drift).

Refs: #423
