### PR TITLE
fix(lint): repair stale JSX source roots in token gate + health scan (#444 Phase 0)

### DIFF
--- a/scripts/tools/dx/scan_component_health.py
+++ b/scripts/tools/dx/scan_component_health.py
@@ -55,7 +55,12 @@ def _find_repo_root(start: Path) -> Path:
 REPO = _find_repo_root(Path(__file__).resolve())
 REGISTRY = REPO / "docs/assets/tool-registry.yaml"
 E2E_DIR = REPO / "tests/e2e"
-JSX_ROOT = REPO / "docs"
+# TRK-242 monorepo restructure: portal source moved from docs/ to
+# tools/portal/src/. Registry `file:` paths (interactive/tools/... and
+# getting-started/...) are resolved relative to this root — matching the
+# convention already used by check_tool_registry_jsx_parity.py. (#444 Phase 0:
+# this default was left stale at REPO/"docs", silently reporting 0 active tools.)
+JSX_ROOT = REPO / "tools" / "portal" / "src"
 DEFAULT_OUTPUT = REPO / "docs/internal/component-health-snapshot.json"
 
 # --- Regex / 常數 ---

--- a/scripts/tools/lint/check_design_token_usage.py
+++ b/scripts/tools/lint/check_design_token_usage.py
@@ -58,8 +58,13 @@ from _lint_helpers import (  # noqa: E402
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
-JSX_TOOLS_DIR = REPO_ROOT / "docs" / "interactive" / "tools"
-WIZARD_DIR = REPO_ROOT / "docs" / "getting-started"
+# TRK-242 monorepo restructure: portal source moved from docs/ to
+# tools/portal/src/. These dirs were left stale at docs/interactive/tools +
+# docs/getting-started — neither holds .jsx anymore, so the lint silently
+# scanned ZERO files and always passed (#444 Phase 0 keystone fix). Aligns with
+# check_tool_registry_jsx_parity.py's JSX_ROOT = tools/portal/src.
+JSX_TOOLS_DIR = REPO_ROOT / "tools" / "portal" / "src" / "interactive" / "tools"
+WIZARD_DIR = REPO_ROOT / "tools" / "portal" / "src" / "getting-started"
 DESIGN_TOKENS = REPO_ROOT / "docs" / "assets" / "design-tokens.css"
 
 


### PR DESCRIPTION
## 摘要

修復 #444 **Phase 0**（measurement-infrastructure repair）。TRK-242 monorepo restructure 把 portal source 從 `docs/` 搬到 `tools/portal/src/` 後，兩支 lint/scan script 的來源目錄常數沒跟上，造成它們對著不存在的舊路徑掃描。

### 為什麼這是 keystone

**`check_design_token_usage.py` 是真正接在 pre-commit + `ci.yml:94` 的 px/hex design-token gate。** 它的 `JSX_TOOLS_DIR` 指向不存在的 `docs/interactive/tools/` → 掃到 **0 個檔案 → `--ci` 永遠 exit 0 → gate 形同虛設**。換言之，過去這段期間任何新增的 hardcoded px/hex 都不會被擋。

`scan_component_health.py`（snapshot 工具，未接 CI）同樣指向舊 `docs/` root，回報 0 active tools，component-health 訊號也是瞎的。

兩者改指 `tools/portal/src/`，對齊 `check_tool_registry_jsx_parity.py` 早已採用的 TRK-242 慣例。

## 變更

| 檔案 | 變更 |
|---|---|
| `scripts/tools/lint/check_design_token_usage.py` | `JSX_TOOLS_DIR` / `WIZARD_DIR` → `tools/portal/src/...` |
| `scripts/tools/dx/scan_component_health.py` | `JSX_ROOT` → `tools/portal/src` |

## 驗證（dev container + host）

- ✅ **gate 修復後** flag 出 **14 檔 / 70 violations**（先前 0）
- ✅ gate 是 **diff-only 預設** → 既有 70 violations 被 grandfather，**不會 red-wall 現有 PR**；但從此擋住**新增**的 px/hex
- ✅ `scan` 回報 **43 active tools / 13 px + 3 hex offenders**（先前 0）
- ✅ self-test `tests/dx/test_scan_component_health.py` **12 passed**
- ✅ `check_tool_registry_jsx_parity.py` 維持綠（未動 registry）

## Known follow-up（已記入 #444 Phase 0 後續）

self-test 用 `monkeypatch` 覆寫 `JSX_ROOT`，與模組預設常數解耦 —— 這正是此 bug 能長期潛伏的原因（測試抓不到「預設常數指向錯目錄」這類 drift）。下一個 Phase 0 commit 會補一個 regression test，斷言預設 root 存在且含 `.jsx`。

## Scope 修正（供 reviewer 參考）

原 issue 估「~330 sites / 24 檔 / ~2.4 週」。套用 gate 豁免規則（`#fff`/`#000`、`0/1/2px`、註解、`token-exempt`）後，實際待遷移為 **14 檔 / 70 violations**，約原估 1/4–1/5。Phase 1 遷移會依此真實清單分批進行。

Refs #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)
