### PR TITLE
refactor(portal): design token migration B1-B3 + gate %/exempt fixes (#444 Phase 1)

### DIFF
--- a/scripts/tools/lint/check_design_token_usage.py
+++ b/scripts/tools/lint/check_design_token_usage.py
@@ -72,6 +72,18 @@ DESIGN_TOKENS = REPO_ROOT / "docs" / "assets" / "design-tokens.css"
 # Scanners
 # ---------------------------------------------------------------------------
 
+# A line is exempt if it carries /* token-exempt */ OR the reasoned form
+# /* token-exempt: <reason> */. Requiring the bare string only (the old
+# behaviour) silently dropped reasoned markers — every "/* token-exempt:
+# category colors */" was ignored and the finding still fired. Accepting the
+# reasoned form *encourages* authors to document WHY a value is exempt.
+_EXEMPT_RE = re.compile(r"/\*\s*token-exempt\b")
+
+
+def _is_exempt(line: str) -> bool:
+    return bool(_EXEMPT_RE.search(line))
+
+
 def check_hardcoded_hex_colors(content: str, filename: str) -> List[Dict]:
     """Scan for hardcoded hex colors that should use --da-color-* tokens.
 
@@ -86,8 +98,8 @@ def check_hardcoded_hex_colors(content: str, filename: str) -> List[Dict]:
 
     lines = content.splitlines()
     for i, line in enumerate(lines, 1):
-        # Skip lines with exempt marker
-        if "/* token-exempt */" in line:
+        # Skip lines with exempt marker (bare or reasoned)
+        if _is_exempt(line):
             continue
 
         # Skip pure comment lines
@@ -130,8 +142,8 @@ def check_hardcoded_px_values(content: str, filename: str) -> List[Dict]:
 
     lines = content.splitlines()
     for i, line in enumerate(lines, 1):
-        # Skip lines with exempt marker
-        if "/* token-exempt */" in line:
+        # Skip lines with exempt marker (bare or reasoned)
+        if _is_exempt(line):
             continue
 
         # Skip pure comment lines
@@ -148,13 +160,23 @@ def check_hardcoded_px_values(content: str, filename: str) -> List[Dict]:
 
         # Find style property patterns
         # Match patterns like: fontSize: '14px', padding: 12, margin: "8px"
+        # Group 3 captures the trailing unit (if any) so percentage/viewport/
+        # em values are NOT misread as px. A bare number (no unit) is treated
+        # as px because React maps unitless numeric style values to px.
         prop_pattern = re.compile(
-            r'(\w+)\s*:\s*[\'"]?(\d+)(?:px)?[\'"]?'
+            r'(\w+)\s*:\s*[\'"]?(\d+)(px|%|vh|vw|em|rem|fr|s|ms)?[\'"]?'
         )
 
         for m in prop_pattern.finditer(code_part):
             prop_name = m.group(1)
             px_value = m.group(2)
+            unit = m.group(3)
+
+            # Only px (or unitless → React defaults to px) is a violation.
+            # %, vh/vw, em/rem, fr, s/ms are legitimately not px (e.g.
+            # width: '100%' must not be flagged as 100px).
+            if unit not in (None, "px"):
+                continue
 
             # Exceptions: 0, 1, 2 (borders/hairlines)
             if int(px_value) in (0, 1, 2):

--- a/scripts/tools/lint/check_design_token_usage.py
+++ b/scripts/tools/lint/check_design_token_usage.py
@@ -136,10 +136,6 @@ def check_hardcoded_px_values(content: str, filename: str) -> List[Dict]:
     """
     issues = []
 
-    # Pattern for style properties with px values
-    # Matches: property: 'XXpx' or property: XXpx or property: 'XX' (numeric)
-    style_pattern = re.compile(r''':\s*(?:['"])?(\d+)(?:px)?['"]?\s*[,}]''')
-
     lines = content.splitlines()
     for i, line in enumerate(lines, 1):
         # Skip lines with exempt marker (bare or reasoned)
@@ -182,16 +178,9 @@ def check_hardcoded_px_values(content: str, filename: str) -> List[Dict]:
             if int(px_value) in (0, 1, 2):
                 continue
 
-            # Reconstruct the matched text with px suffix
-            matched_text = line[m.start():m.end()]
-            if "px" not in matched_text:
-                px_text = f"{px_value}px"
-            else:
-                px_text = f"{px_value}px"
-
             issues.append({
                 "line": i,
-                "px": px_text,
+                "px": f"{px_value}px",
                 "property": prop_name,
                 "context": line.strip()[:80],
             })

--- a/tests/lint/test_check_design_token_usage.py
+++ b/tests/lint/test_check_design_token_usage.py
@@ -159,6 +159,15 @@ class TestHexColors:
         issues = dtu.check_hardcoded_hex_colors(content, jsx_file_hex_in_comment.name)
         assert issues == []
 
+    def test_hex_reasoned_token_exempt_honored(self):
+        """/* token-exempt: <reason> */ suppresses hex findings too (#444 B3).
+        The old exact-string check only honored the bare /* token-exempt */."""
+        issues = dtu.check_hardcoded_hex_colors(
+            "<div style={{ color: '#ff0000' /* token-exempt: brand red */ }} />",
+            "x.jsx",
+        )
+        assert issues == []
+
     def test_hex_white_and_black_exempt(self, tmp_path):
         """#fff and #000 should be exempt (too common)."""
         content = textwrap.dedent("""\
@@ -207,6 +216,40 @@ class TestPxValues:
         p.write_text(content, encoding="utf-8")
         issues = dtu.check_hardcoded_px_values(content, "test.jsx")
         # Should not flag since no style= present
+        assert issues == []
+
+    # --- #444 Phase 1 B3: non-px units must not be misread as px ---
+    def test_percent_not_flagged_as_px(self):
+        """width: '100%' must NOT be reported as 100px (the regex used to drop
+        the unit and treat the bare number as px)."""
+        issues = dtu.check_hardcoded_px_values(
+            "<div style={{ width: '100%', maxWidth: '60px' }} />", "x.jsx"
+        )
+        pxes = [i["px"] for i in issues]
+        assert "100px" not in pxes
+        assert pxes == ["60px"]
+
+    def test_other_css_units_not_flagged(self):
+        """vh/vw/em/rem/fr/ms are legitimate non-px units, never flagged."""
+        for val in ("100vh", "50vw", "2em", "300ms", "1fr"):
+            issues = dtu.check_hardcoded_px_values(
+                f"<div style={{{{ x: '{val}' }}}} />", "x.jsx"
+            )
+            assert issues == [], f"{val} should not be flagged as px"
+
+    def test_unitless_number_still_px(self):
+        """React maps a unitless numeric style value to px, so it IS a finding."""
+        issues = dtu.check_hardcoded_px_values(
+            "<div style={{ fontSize: 24 }} />", "x.jsx"
+        )
+        assert any(i["px"] == "24px" for i in issues)
+
+    def test_px_reasoned_token_exempt_honored(self):
+        """/* token-exempt: <reason> */ suppresses px findings (#444 B3)."""
+        issues = dtu.check_hardcoded_px_values(
+            "<div style={{ maxWidth: '900px' /* token-exempt: page width */ }} />",
+            "x.jsx",
+        )
         assert issues == []
 
 

--- a/tools/portal/src/interactive/tools/_common/components/EmptyState.jsx
+++ b/tools/portal/src/interactive/tools/_common/components/EmptyState.jsx
@@ -43,19 +43,19 @@ const WRAPPER_STYLE = {
   gap: 'var(--da-space-3, 12px)',
   padding: 'var(--da-space-6, 32px) var(--da-space-4, 16px)',
   textAlign: 'center',
-  color: 'var(--da-color-fg, #6b7280)',
+  color: 'var(--da-color-muted)',
 };
 const ICON_STYLE = { fontSize: '32px', lineHeight: 1 };
 const TITLE_STYLE = {
   fontSize: '16px',
   fontWeight: 600,
-  color: 'var(--da-color-fg, #111827)',
+  color: 'var(--da-color-fg)',
 };
 const DESC_STYLE = { fontSize: '14px', maxWidth: '480px' };
 const BUTTON_STYLE = {
   marginTop: 'var(--da-space-2, 8px)',
   padding: '6px 14px',
-  background: 'var(--da-color-accent, #2563eb)',
+  background: 'var(--da-color-accent)',
   color: 'var(--da-color-accent-fg, #fff)',
   border: 'none',
   borderRadius: 'var(--da-radius-sm, 4px)',

--- a/tools/portal/src/interactive/tools/_common/components/ErrorBoundary.jsx
+++ b/tools/portal/src/interactive/tools/_common/components/ErrorBoundary.jsx
@@ -47,7 +47,7 @@ import { Component } from "react";  // TRK-233 ESM import
 const FALLBACK_BOX_STYLE = {
   padding: '24px',
   margin: '16px',
-  border: '1px solid var(--da-color-error, #dc2626)',
+  border: '1px solid var(--da-color-error)',
   borderRadius: 'var(--da-radius-sm, 6px)',
   background: 'var(--da-color-surface, #fff)',
   fontFamily: 'system-ui, -apple-system, sans-serif',
@@ -57,12 +57,12 @@ const FALLBACK_TITLE_STYLE = {
 };
 const FALLBACK_HINT_STYLE = {
   fontSize: '14px',
-  color: 'var(--da-color-fg, #6b7280)',
+  color: 'var(--da-color-muted)',
   marginBottom: '12px',
 };
 const FALLBACK_PRE_STYLE = {
   fontSize: '12px',
-  background: 'var(--da-color-surface-hover, #f3f4f6)',
+  background: 'var(--da-color-surface-hover)',
   padding: '8px',
   borderRadius: 'var(--da-radius-sm, 4px)',
   overflowX: 'auto',
@@ -70,7 +70,7 @@ const FALLBACK_PRE_STYLE = {
 };
 const FALLBACK_BUTTON_STYLE = {
   padding: '6px 12px',
-  background: 'var(--da-color-accent, #2563eb)',
+  background: 'var(--da-color-accent)',
   color: 'var(--da-color-accent-fg, #fff)',
   border: 'none',
   borderRadius: 'var(--da-radius-sm, 4px)',

--- a/tools/portal/src/interactive/tools/_common/components/Loading.jsx
+++ b/tools/portal/src/interactive/tools/_common/components/Loading.jsx
@@ -45,7 +45,7 @@ const WRAPPER_STYLE = {
   justifyContent: 'center',
   gap: 'var(--da-space-3, 12px)',
   padding: 'var(--da-space-4, 16px)',
-  color: 'var(--da-color-fg, #6b7280)',
+  color: 'var(--da-color-muted)',
 };
 const TEXT_STYLE = { fontSize: '14px' };
 
@@ -61,8 +61,8 @@ function buildSpinnerStyle(dim) {
   return {
     width: dim + 'px',
     height: dim + 'px',
-    border: '3px solid var(--da-color-surface-hover, #e5e7eb)',
-    borderTopColor: 'var(--da-color-accent, #2563eb)',
+    border: '3px solid var(--da-color-surface-border)',
+    borderTopColor: 'var(--da-color-accent)',
     borderRadius: '50%',
     animation: 'daSpin 0.8s linear infinite',
   };

--- a/tools/portal/src/interactive/tools/component-health.jsx
+++ b/tools/portal/src/interactive/tools/component-health.jsx
@@ -255,7 +255,7 @@ function ProgressCell({ ratio }) {
       <div style={styles.progressBar} role="progressbar" aria-valuenow={pct} aria-valuemin={0} aria-valuemax={100} aria-label={`i18n coverage ${pct}%`}>
         <div style={{ ...styles.progressFill, width: `${pct}%`, background: color }} />
       </div>
-      <span style={{ fontSize: 'var(--da-font-size-xs)', minWidth: '36px', color }}>{pct}%</span>
+      <span style={{ fontSize: 'var(--da-font-size-xs)', minWidth: '36px' /* token-exempt: fixed label width */, color }}>{pct}%</span>
     </div>
   );
 }
@@ -268,7 +268,7 @@ function SimpleBar({ items, maxVal, colorFn }) {
         return (
           <div key={label} style={styles.barGroup}>
             <div style={styles.barValue}>{value}</div>
-            <div style={{ width: '100%', maxWidth: '60px', height: `${h}px`, borderRadius: 'var(--da-radius-sm)', background: colorFn(label), transition: 'height 0.3s ease' }} />
+            <div style={{ width: '100%', maxWidth: '60px' /* token-exempt: bar width cap */, height: `${h}px`, borderRadius: 'var(--da-radius-sm)', background: colorFn(label), transition: 'height 0.3s ease' }} />
             <div style={styles.barLabel}>{label}</div>
           </div>
         );
@@ -441,7 +441,7 @@ export default function ComponentHealth() {
                       {tool.palette}
                     </span>
                   </td>
-                  <td style={{ ...styles.td, minWidth: '120px' }}>
+                  <td style={{ ...styles.td, minWidth: '120px' /* token-exempt: table column min width */ }}>
                     <ProgressCell ratio={tool.i18n} />
                   </td>
                   <td style={styles.td}>

--- a/tools/portal/src/interactive/tools/multi-tenant-comparison.jsx
+++ b/tools/portal/src/interactive/tools/multi-tenant-comparison.jsx
@@ -11,11 +11,11 @@ import React, { useState, useMemo } from 'react';
 
 const t = window.__t || ((zh, en) => en);
 
-// Style tokens (v2.7.0 Phase .a0 migration):
-// - Colors mapped to var(--da-color-*) tokens where exact hex match exists (9 unique colors replaced, 23 occurrences).
-// - Remaining hex literals (#1e293b primary text ×5; #dc2626/#fecaca/#f0fdf4/#cbd5e1/#8b5cf6/#3b82f6/#16a34a one-offs) kept —
-//   no exact semantic token; pending design:design-system audit to decide: add tokens, normalize, or remove.
-// - px values embedded in CSS shorthand strings (e.g., padding: '6px 12px') intentionally left for v2.7.0 Phase .a0 batch 2.
+// Style tokens: all colors mapped to var(--da-color-*) tokens (#444 Phase 1 B2).
+// Semantic-first mapping: primary text -> --da-color-fg, outlier/error -> --da-color-error,
+// common-settings -> --da-color-success(-soft), silent-mode icon -> --da-color-mode-silent
+// (matches the sibling maintenance icon's --da-color-warning; the old hardcoded #8b5cf6
+// purple was off-system). px values in CSS shorthand strings remain (layout, token-exempt).
 
 // ── Sample Data ───────────────────────────────────────────────────
 // Simulates multiple tenant YAML configs with threshold overrides.
@@ -129,7 +129,7 @@ function findDivergent(tenants) {
 function MetricCard({ label, value, sub }) {
   const containerStyle = { background: 'var(--da-color-surface-hover)', border: '1px solid var(--da-color-section-border)', borderRadius: 8, padding: '12px 16px', textAlign: 'center', minWidth: 100 };
   const labelStyle = { fontSize: 12, color: 'var(--da-color-muted)', marginBottom: 4 };
-  const valueStyle = { fontSize: 24, fontWeight: 700, color: '#1e293b' };
+  const valueStyle = { fontSize: 24, fontWeight: 700, color: 'var(--da-color-fg)' };
   const subStyle = { fontSize: 11, color: 'var(--da-color-hero-muted)', marginTop: 2 };
   return (
     <div style={containerStyle}>
@@ -154,7 +154,7 @@ function BarChart({ data, maxVal, label }) {
         const barContainerStyle = { flex: 1, background: 'var(--da-color-tag-bg)', borderRadius: 4, height: 20, position: 'relative' };
         const barStyle = {
           width: `${Math.min(pct, 100)}%`, height: '100%', borderRadius: 4,
-          background: isOutlier ? 'var(--da-color-error)' : '#3b82f6',
+          background: isOutlier ? 'var(--da-color-error)' : 'var(--da-color-accent)',
           transition: 'width 0.3s',
         };
         const valueSpanStyle = { width: 45, fontSize: 11, color: isOutlier ? 'var(--da-color-error)' : 'var(--da-color-tag-fg)', textAlign: 'right', marginLeft: 8, fontWeight: isOutlier ? 700 : 400 };
@@ -189,7 +189,7 @@ function HeatmapRow({ metric, tenants, stats }) {
           padding: '6px 12px', textAlign: 'center', fontSize: 13,
           background: bg, borderBottom: '1px solid var(--da-color-section-border)',
           fontWeight: isDefault ? 400 : 700,
-          color: isDefault ? 'var(--da-color-muted)' : '#1e293b',
+          color: isDefault ? 'var(--da-color-muted)' : 'var(--da-color-fg)',
         };
         const defaultBadgeStyle = { fontSize: 10, color: 'var(--da-color-tile-muted)' };
         return (
@@ -246,7 +246,7 @@ function MultiTenantComparison() {
   const silentCount = tenants.filter(t => t.silentMode !== 'none').length;
 
   const mainContainerStyle = { fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif', maxWidth: 960, margin: '0 auto', padding: 24 };
-  const titleStyle = { fontSize: 22, fontWeight: 700, color: '#1e293b', marginBottom: 4 };
+  const titleStyle = { fontSize: 22, fontWeight: 700, color: 'var(--da-color-fg)', marginBottom: 4 };
   const descriptionStyle = { fontSize: 14, color: 'var(--da-color-muted)', marginBottom: 24 };
   const summaryCardsStyle = { display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' };
   const heatmapContainerStyle = { border: '1px solid var(--da-color-section-border)', borderRadius: 8, overflow: 'auto', marginBottom: 24 };
@@ -258,20 +258,20 @@ function MultiTenantComparison() {
   const drilldownContainerStyle = { display: 'flex', gap: 24, marginBottom: 24, flexWrap: 'wrap' };
   const drilldownLeftStyle = { flex: 1, minWidth: 300 };
   const drilldownRightStyle = { flex: 1, minWidth: 300 };
-  const drilldownTitleStyle = { fontSize: 16, fontWeight: 600, color: '#1e293b', marginBottom: 12 };
+  const drilldownTitleStyle = { fontSize: 16, fontWeight: 600, color: 'var(--da-color-fg)', marginBottom: 12 };
   const controlsStyle = { display: 'flex', gap: 12, marginBottom: 12, alignItems: 'center' };
-  const selectStyle = { padding: '6px 10px', borderRadius: 6, border: '1px solid #cbd5e1', fontSize: 13 };
+  const selectStyle = { padding: '6px 10px', borderRadius: 6, border: '1px solid var(--da-color-surface-border)', fontSize: 13 };
   const labelStyle = { fontSize: 12, color: 'var(--da-color-muted)' };
   const inputRangeStyle = { width: 80, marginLeft: 6 };
   const sigmaTextStyle = { marginLeft: 4 };
-  const outlierBoxStyle = { marginTop: 8, padding: '8px 12px', background: 'var(--da-color-error-soft)', borderRadius: 6, border: '1px solid #fecaca' };
-  const outlierLabelStyle = { fontSize: 12, fontWeight: 600, color: '#dc2626' };
-  const outlierValueStyle = { fontSize: 12, color: '#dc2626', marginLeft: 8 };
+  const outlierBoxStyle = { marginTop: 8, padding: '8px 12px', background: 'var(--da-color-error-soft)', borderRadius: 6, border: '1px solid var(--da-color-error)' };
+  const outlierLabelStyle = { fontSize: 12, fontWeight: 600, color: 'var(--da-color-error)' };
+  const outlierValueStyle = { fontSize: 12, color: 'var(--da-color-error)', marginLeft: 8 };
   const divergenceBoxStyle = { border: '1px solid var(--da-color-section-border)', borderRadius: 8, overflow: 'hidden' };
-  const commonSettingsBoxStyle = { padding: '8px 12px', background: '#f0fdf4', borderTop: '1px solid var(--da-color-section-border)' };
-  const commonSettingsTextStyle = { fontSize: 12, color: '#16a34a' };
+  const commonSettingsBoxStyle = { padding: '8px 12px', background: 'var(--da-color-success-soft)', borderTop: '1px solid var(--da-color-section-border)' };
+  const commonSettingsTextStyle = { fontSize: 12, color: 'var(--da-color-success)' };
   const recommendationsStyle = { border: '1px solid var(--da-color-section-border)', borderRadius: 8, padding: 16, background: 'var(--da-color-surface-hover)' };
-  const recommendationsHeadingStyle = { fontSize: 16, fontWeight: 600, color: '#1e293b', marginBottom: 8 };
+  const recommendationsHeadingStyle = { fontSize: 16, fontWeight: 600, color: 'var(--da-color-fg)', marginBottom: 8 };
   const recommendationsListStyle = { margin: 0, paddingLeft: 20, fontSize: 13, color: 'var(--da-color-tag-fg)', lineHeight: 1.8 };
 
   return (
@@ -306,7 +306,7 @@ function MultiTenantComparison() {
               </th>
               {tenants.map((tenant, i) => {
                 const maintenanceIconStyle = { color: 'var(--da-color-warning)' };
-                const silentIconStyle = { color: '#8b5cf6' };
+                const silentIconStyle = { color: 'var(--da-color-mode-silent)' };
                 return (
                 <th key={i} style={tenantHeaderStyle}>
                   {tenant.name}

--- a/tools/portal/src/interactive/tools/operator-setup-wizard.jsx
+++ b/tools/portal/src/interactive/tools/operator-setup-wizard.jsx
@@ -736,7 +736,7 @@ export default function OperatorSetupWizard() {
       background: 'var(--da-color-bg)',
       padding: 'var(--da-space-8)',
     }}>
-      <div style={{ maxWidth: '900px', margin: '0 auto' }}>
+      <div style={{ maxWidth: '900px' /* token-exempt: page content max width */, margin: '0 auto' }}>
         {/* Header */}
         <div style={{ marginBottom: 'var(--da-space-8)' }}>
           <h1 style={{


### PR DESCRIPTION
## #444 Phase 1 — design token 遷移（non-VR 批次 B1–B3）

把 portal JSX 工具裡硬編碼的 hex/px 遷移到 `var(--da-*)` design token。這是 Phase 1 中**不觸及 Playwright visual-regression baseline** 的批次；觸及 VR 的 tenant-manager cluster（B4）另開 PR。

### 批次內容

**B1 — `_common` 共用元件**（ErrorBoundary / EmptyState / Loading，10 處）
移除 `var(--token, #fallback)` 的冗餘 CSS fallback（design-tokens.css 是 SSOT + `check_undefined_tokens` lint 護著），並修正 2 處語意誤用：
- `var(--da-color-fg, #6b7280)` 在 hint/muted 語境 → `--da-color-muted`（原本錯套主前景 token）
- spinner border 的 `surface-hover` → `--da-color-surface-border`（border 語意）

**B2 — multi-tenant-comparison**（13 處 naked hex）
語意優先映射：主文字→`fg`、outlier→`error`、common-settings→`success(-soft)`、bar→`accent`。silent-mode icon 的 off-system 紫 `#8b5cf6` → `--da-color-mode-silent`（與並列的 maintenance icon 的 `--da-color-warning` 對稱）。

**B3 — layout px 豁免 + 兩個 gate bug 修復**（component-health / operator-setup-wizard）
真 layout 尺寸（minWidth/maxWidth 36/60/120/900px，無語意 token）標 `token-exempt`。遷移中發現並根治 gate 兩個 bug：
1. **`width: '100%'` 被誤判為 100px** — px regex 丟棄單位、把百分比數字當 px。修正為捕獲單位，只有 px / unitless（React 預設 px）才算違規。消除 4 個 false positive。
2. **reasoned token-exempt 失效** — gate 只認精確 `/* token-exempt */`，帶理由的 `/* token-exempt: <reason> */` 被靜默忽略。改用 prefix 比對，鼓勵寫豁免原因。
+ 6 個 regression test（% / vh/vw/em/rem/fr/ms 不報、unitless 仍報、reasoned exempt 生效）。

### 不在本 PR
- **dependency-graph 分類配色**：已由 #726 用真 design token 解決（本 PR rebase 後該檔 0 violations）。
- **tenant-manager cluster（B4，6 檔 22 violations）**：含 VR baseline（tenant-manager.jsx + SavedViewsPanel），需跑 visual-baseline workflow，另開 PR。

### 驗證
- gate full-scan：B1–B3 涵蓋檔全部 0 violations；repo 違規 70 → 22（其餘全為 B4）
- `pytest tests/lint/test_check_design_token_usage.py`：25 passed（含 6 個新 regression test）
- 所有新用 token 均在 design-tokens.css 定義（light + dark）
- Design token compliance pre-commit hook：Passed
- Preflight READY；rebase 至最新 origin/main，零檔案衝突

Refs #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **New Features**
  * 支持带理由的设计 token 豁免注释，相关检查可识别并跳过这些豁免行

* **Bug Fixes**
  * 改进对 CSS/样式单位的识别，仅对 px 或无单位数值触发告警，忽略其他单位，减少误报

* **Tests**
  * 新增多项测试覆盖豁免注释与不同单位的检测场景

* **Style**
  * 多处组件样式改为使用设计 token，移除硬编码回退色值
<!-- end of auto-generated comment: release notes by coderabbit.ai -->