### PR TITLE
docs: add cross-tier rule lifecycle governance view (§7) + entry anchors

### DIFF
--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -71,6 +71,7 @@ Real-world common scenarios and corresponding solutions.
 | Shadow Monitoring one-click cutover | [scenarios/shadow-monitoring-cutover.en.md](scenarios/shadow-monitoring-cutover.en.md) | Platform Engineer, DevOps |
 | Multi-cluster Federation | [scenarios/multi-cluster-federation.en.md](scenarios/multi-cluster-federation.en.md) | Platform Engineer |
 | Tenant lifecycle (onboarding, modification, offboarding) | [scenarios/tenant-lifecycle.en.md](scenarios/tenant-lifecycle.en.md) | Platform Engineer, DevOps |
+| Rule lifecycle governance (define → version-cut → fix → retire) + maturity limits | [custom-rule-governance.en.md §7](custom-rule-governance.en.md) | Platform Engineer, Domain Expert |
 | Advanced scenarios & test coverage | [internal/test-coverage-matrix.md](internal/test-coverage-matrix.md) | Platform Engineer, SRE |
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,7 @@ Dynamic Alerting 平台的完整文件導覽。根據你的角色快速找到所
 | Shadow Monitoring 一鍵切換 | [scenarios/shadow-monitoring-cutover.md](scenarios/shadow-monitoring-cutover.md) | Platform Engineer、DevOps |
 | 多叢集 Federation | [scenarios/multi-cluster-federation.md](scenarios/multi-cluster-federation.md) | Platform Engineer |
 | Tenant 生命週期（新增、修改、下架） | [scenarios/tenant-lifecycle.md](scenarios/tenant-lifecycle.md) | Platform Engineer、DevOps |
+| Rule 生命週期治理（訂定 → 切版 → 修錯 → 退役）+ 成熟度限制 | [custom-rule-governance.md §7](custom-rule-governance.md) | Platform Engineer、Domain Expert |
 | 進階場景 & 測試覆蓋 | [internal/test-coverage-matrix.md](internal/test-coverage-matrix.md) | Platform Engineer、SRE |
 
 ---

--- a/docs/custom-rule-governance.en.md
+++ b/docs/custom-rule-governance.en.md
@@ -261,6 +261,28 @@ flowchart TD
 | **CI checks** | Automatic (three-state validation) | Rule Pack CI | Deny-list linting |
 | **Lifecycle** | Permanent | Permanent | Expiry date required |
 
+## 7. Rule Lifecycle Governance (cross-tier lifecycle view)
+
+> **For whom**: platform / domain owners migrating from an existing system, evaluating whether "a rule can be governed across its whole life". §1–§6 are organized by **governance tier**; this section cuts across by **the rule's life**. Each stage gives: platform guarantees, ⚠️ known limits, and a how-to link.
+
+A rule here is not a single entity — its lifecycle mechanism differs by tier (platform Rule Pack / tenant threshold Tier 1 / Tier 3 Custom). The table cuts across "born → aging → sick → retired":
+
+| Stage | Platform Rule Pack | Tenant threshold (Tier 1) | Tier 3 Custom | how-to |
+|---|---|---|---|---|
+| **Born** (define) | platform writes the PromQL pack | `tenant.yaml` sets a plain number | Domain Expert ghost-writes + deny-list lint | [Domain Expert guide](getting-started/for-domain-experts.en.md) · §2 |
+| **Aging** (cut to V2) | edit the pack (CI gate) | **version-aware thresholds**: multiple versions coexist per tenant, emergent cutover on upgrade, dynamic fallback | evolves with the pack | [Version-Aware guide](scenarios/version-aware-thresholds.en.md) · [ADR-024](adr/024-version-aware-threshold-via-dimensional-label.en.md) |
+| **Sick** (fix) | edit pack + promtool | edit the number + shadow value-diff validation | edit PromQL + lint | [Troubleshooting](troubleshooting.en.md) · [Shadow Monitoring cutover](scenarios/shadow-monitoring-cutover.en.md) |
+| **Retired** (offboard) | remove the pack rule (Projected Volume `optional`, zero PR conflict) | remove the key → series disappears; an undeclared-version threshold = orphan, detected by the `version_orphaned` sentinel (7d/30d) | deprecate + expiry + auto-disable after 14d no-reply + force-decommission after 30d (see §5) | §5 · [ADR-024](adr/024-version-aware-threshold-via-dimensional-label.en.md) |
+
+**⚠️ Honest maturity & limits (read before a migration evaluation)**:
+
+- **Aging**: version-aware thresholds are currently the **kubernetes pilot only (container_cpu / memory)**; a `version` key on other packs is rejected by da-guard (non-k8s version alignment is Future).
+- **Retirement**: retiring a tenant threshold / version is **detect-only today** (`version_orphaned` sentinel + portal yellow + CLI); an **auto-GC PR bot is not yet implemented** (manual cleanup); only Tier 3 custom has expiry-based auto-decommission (§5).
+- **Tenant custom alerts**: a custom-alert recipe (letting tenants / domains author non-pack alerts, with a recipe `status: active / deprecated / eol` lifecycle) is **design-converged, not yet implemented** ([ADR-024 §Custom Alerts](adr/024-version-aware-threshold-via-dimensional-label.en.md), epic #741).
+- **Blast radius**: platform rules rely on O(M) vectorization (one rule covers all tenants, editing one place affects all) → CI promtool gate + shadow value-diff are the safety net; per-tenant / version dimensions are capped by the Cardinality Guard (500 per tenant).
+
+**Access governance** (who can change what at each stage, audit, break-glass) is in [governance-security.md](governance-security.en.md); the **tier model & assimilation** are in §2 / §5.
+
 ## Related Resources
 
 | Resource | Relevance |

--- a/docs/custom-rule-governance.md
+++ b/docs/custom-rule-governance.md
@@ -299,6 +299,28 @@ flowchart TD
 | **生命週期** | 永久 | 永久 | 帶 expiry date |
 | **工具** | `scaffold` / `patch_config` | Rule Pack YAML | `lint` / `validate-config` |
 
+## 7. 規則生命週期治理（全 tier 生命週期視圖）
+
+> **給誰**：從既有系統遷入、要評估「一條規則能不能被管一輩子」的 platform / domain 負責人。§1–§6 按**治理層級**組織；本節按**規則的一生**橫切。每階段給：平台保證、⚠️ 已知限制、how-to 連結。
+
+規則在本平台不是單一實體——依 tier（平台 Rule Pack / 租戶閾值 Tier 1 / Tier 3 Custom）不同，生命週期機制不同。下表按「生 → 老 → 病 → 死」橫切：
+
+| 階段 | 平台 Rule Pack | 租戶閾值（Tier 1） | Tier 3 Custom | how-to |
+|---|---|---|---|---|
+| **生** 訂定 | 平台寫 PromQL pack | `tenant.yaml` 填純數字 | Domain Expert 代寫 + deny-list lint | [Domain Expert 入門](getting-started/for-domain-experts.md) · 本文 §2 |
+| **老** 切版（V2） | 改 pack（CI gate） | **version-aware 閾值**：同租戶多版本並存、升版 emergent cutover、動態降級 | 隨 pack 演進 | [Version-Aware 使用攻略](scenarios/version-aware-thresholds.md) · [ADR-024](adr/024-version-aware-threshold-via-dimensional-label.md) |
+| **病** 修錯 | 改 pack + promtool | 改數字 + shadow 數值 diff 驗證 | 改 PromQL + lint | [故障排查](troubleshooting.md) · [Shadow Monitoring 切換](scenarios/shadow-monitoring-cutover.md) |
+| **死** 退役 | 移除 pack rule（Projected Volume `optional`，零 PR 衝突） | 移除 key → series 消失；未宣告版本的閾值 = 孤兒，由 `version_orphaned` sentinel（7d/30d）偵測 | deprecate + expiry + 14d 未回應自動停用 + 30d 強制下架（見本文 §5） | 本文 §5 · [ADR-024](adr/024-version-aware-threshold-via-dimensional-label.md) |
+
+**⚠️ 誠實的成熟度與限制（遷入評估前必讀）**：
+
+- **切版**：version-aware 閾值目前僅 **kubernetes pilot（container_cpu / memory）**；其餘 pack 寫 `version` key 會被 da-guard 拒（非-k8s 版本對齊列 future）。
+- **退役**：租戶閾值 / 版本的退役今天是 **detect-only**（`version_orphaned` sentinel + portal 黃燈 + CLI），**auto-GC PR bot 尚未實作**（需人工清）；只有 Tier 3 custom 有 expiry-based 自動下架（§5）。
+- **租戶自訂告警**：讓租戶 / domain 自訂非-pack 告警的 custom alert recipe（含 recipe `status: active / deprecated / eol` 生命週期）為**設計收斂、實作未起**（[ADR-024 §Custom Alerts](adr/024-version-aware-threshold-via-dimensional-label.md)，epic #741）。
+- **爆炸半徑**：平台規則靠 O(M) 向量化（一條規則蓋全租戶，改一處影響全部）→ CI promtool gate + shadow 數值 diff 為安全網；per-tenant / version 維度受 Cardinality Guard（per-tenant 500）封頂。
+
+**存取治理**（誰能在各階段改什麼、稽核、break-glass）見 [governance-security.md](governance-security.md)；**Tier 模型與晉升機制**見本文 §2 / §5。
+
 ## 相關資源
 
 | 資源 | 相關性 |

--- a/docs/governance-security.en.md
+++ b/docs/governance-security.en.md
@@ -228,5 +228,6 @@ Default deny-all (Ingress + Egress) + per-component whitelist:
 | Resource | Relevance |
 |----------|-----------|
 | [Governance, Audit & Security Compliance](./governance-security.md) | Full Chinese version |
+| [Rule Lifecycle Governance (§7 cross-tier view)](./custom-rule-governance.en.md) | Born→aging→sick→retired governance + maturity limits (read before a migration evaluation) |
 | [GitOps Deployment](integration/gitops-deployment.en.md) | Deployment security, RBAC |
 | [Testing Playbook](./internal/testing-playbook.md) | SAST test execution |

--- a/docs/governance-security.md
+++ b/docs/governance-security.md
@@ -228,5 +228,6 @@ Default deny-all（Ingress + Egress）+ 逐元件白名單：
 | 資源 | 相關性 |
 |------|--------|
 | [Custom Rule Governance](./custom-rule-governance.md) | 規則治理模型 |
+| [規則生命週期治理（§7 全 tier 視圖）](./custom-rule-governance.md) | 規則生→老→病→死的橫切治理 + 成熟度限制（遷入評估必讀） |
 | [GitOps Deployment](integration/gitops-deployment.md) | 部署安全、RBAC |
 | [Testing Playbook](./internal/testing-playbook.md) | SAST 測試執行 |


### PR DESCRIPTION
## What & why

Docs-only. Fixes a **rule-lifecycle discoverability gap** found by tracing a real persona's journey: a platform/domain owner migrating from a large project who wants to know how a rule is governed across its whole life (born → aging/V2 → sick/fix → retired).

The audit found the knowledge exists but the **journey doesn't**: the repo's governance docs are organized by *concern* (access/RBAC in `governance-security`, custom-tier in `custom-rule-governance`, security), not by a rule's *life* — so the lifecycle question fell between docs, and `version-aware-thresholds` was an island reachable only via the ADR index.

## Change

Adds a **cross-tier rule-lifecycle governance view** as `custom-rule-governance.md` §7 (the doc that already has lifecycle DNA — §5 assimilation cycle, the Tier-table lifecycle row). It is a *router*, not duplicated content: a born→aging→sick→retired table that, per stage × tier (platform pack / tenant threshold / Tier-3 custom), states the guarantee + ⚠️ honest limit + a link to the owning doc (version-aware/ADR-024, troubleshooting, shadow-monitoring, §5).

**Honest maturity limits stated up front** (the highest-value part for an evaluator): version-aware is k8s-pilot-only; threshold retirement is detect-only with no auto-GC; custom-alert recipes are design-only (#741).

**Entry anchors** (placed simultaneously so it isn't a new island): docs/README scenario table (sibling row to Tenant lifecycle) + governance-security related-resources (platform path).

## Placement decision

Landed as a **section, not a new doc**: the architecturally-pure "new axis doc" would add a doc-map count + bump_docs count + mkdocs nav + new bilingual pair cascade with no content gain. A section in the lifecycle-DNA governance doc delivers identical persona value at near-zero cascade.

## Verification
- All pre-commit hooks green (bilingual ZH/EN structure sync, codename gate, doc-map — no drift since no new doc); pre-push **mkdocs strict PASS** (links validated, fragment-free); preflight READY, 0 behind / no conflict.
- Built in an isolated worktree off `origin/main` (a concurrent session is on `feat/741-custom-alerts-compiler`).

Refs: #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)
