### PR TITLE
docs: sync JSX 互動工具 count 43→44 to match SOT

### DIFF
--- a/docs/internal/dev-rules.md
+++ b/docs/internal/dev-rules.md
@@ -188,7 +188,7 @@ Status 處理 / hotfix 例外 / A vs B CI 分類細節見 [`github-release-playb
 
 ## 互動工具變更 SOP
 
-專案有 **43 個 JSX 互動工具**（v2.8.0 Phase .c 期間自 39 增至 43：master-onboarding / alert-builder / routing-trace / simulate-preview），Source of Truth 檔案：
+專案有 **44 個 JSX 互動工具**（v2.8.0 Phase .c 期間自 39 增至 43：master-onboarding / alert-builder / routing-trace / simulate-preview），Source of Truth 檔案：
 
 | 檔案 | 用途 |
 |------|------|


### PR DESCRIPTION
## What

修正 [`docs/internal/dev-rules.md`](docs/internal/dev-rules.md) §互動工具變更 SOP headline 的 latent count drift：headline 寫「**43** 個 JSX 互動工具」，但 SOT [`docs/assets/tool-registry.yaml`](docs/assets/tool-registry.yaml) 實際已有 **44** 個（44 個 `- key:` entry）。

## Why

某個近期加 JSX 工具的 PR（疑似 [#782](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/782) RecipeBuilder lifecycle UX）漏跑 `bump_docs.py --sync-counts`，留下 headline 與 SOT 不一致。與當前其他 in-flight 工作無關，獨立修。

## How

- `py scripts/tools/dx/bump_docs.py --sync-counts` 自動把 headline `43→44`（regex 只配 `**N 個 JSX 互動工具**`）。
- 只 stage 那一行；括號內歷史敘事「v2.8.0 Phase .c 期間自 39 增至 43」是歷史記述，**不動**。
- `bump_docs --check` 仍綠（counts 非 version gate，確認過）。
- sync-counts 順帶偵測到另一處 CLAUDE.md pre-commit hook 數（65→67）drift，**不在本 PR 範圍**，已 revert。

## Scope

單行 docs-only 變更，無 API / schema / CLI / behavior 影響。

🤖 Generated with [Claude Code](https://claude.com/claude-code)