### PR TITLE
refactor(exporter): decompose god-functions + dedup loader paths

### DIFF
--- a/components/threshold-exporter/app/collector.go
+++ b/components/threshold-exporter/app/collector.go
@@ -60,6 +60,23 @@ func (c *ThresholdCollector) Collect(ch chan<- prometheus.Metric) {
 	// here would break that test-isolation contract.
 	resolved, stats := cfg.ResolveAtWithStats(time.Now())
 	c.manager.getMetrics().PublishTenantMetricsOverLimit(stats.PerTenantOverLimit)
+
+	// Each metric family is emitted by a focused collector method; order is
+	// irrelevant (Prometheus sorts on Gather) but kept stable for diff clarity.
+	c.collectThresholds(ch, resolved)
+	c.collectCustomAlertErrors(ch, stats.PerTenantCustomAlertErrors)
+	c.collectStateFilters(ch, cfg)
+	c.collectSilentModes(ch, cfg)
+	c.collectMaintenanceExpiries(ch, cfg)
+	c.collectSeverityDedup(ch, cfg)
+	c.collectConfigInfo(ch)
+	c.collectMetadata(ch, cfg)
+}
+
+// collectThresholds emits the user_threshold gauge for every resolved
+// threshold (Scenario A numeric + Phase 2B dimensional). Custom labels are
+// appended sorted; regex labels get the _re suffix for PromQL matching.
+func (c *ThresholdCollector) collectThresholds(ch chan<- prometheus.Metric, resolved []ResolvedThreshold) {
 	for _, t := range resolved {
 		labelNames := []string{"tenant", "metric", "component", "severity"}
 		labelValues := []string{t.Tenant, t.Metric, t.Component, t.Severity}
@@ -105,20 +122,19 @@ func (c *ThresholdCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		ch <- m
 	}
+}
 
-	// #741 S3a: per-tenant malformed _custom_alerts count (fail-loud). Emitted as
-	// a ConstMetric here (same idiom as user_threshold / user_state_filter) rather
-	// than a Reset()+Set() GaugeVec mutated during Collect — Registry.Gather runs
-	// collectors concurrently, so a separately-registered GaugeVec could observe a
-	// partial Reset+Set snapshot. ConstMetric is computed per scrape, so a tenant
-	// that fixed/removed its declarations simply stops emitting (no stale series).
+// collectCustomAlertErrors emits da_custom_alert_parse_errors (#741 S3a,
+// fail-loud) per tenant. ConstMetric per scrape so a fixed tenant stops
+// emitting rather than leaving a stale GaugeVec series.
+func (c *ThresholdCollector) collectCustomAlertErrors(ch chan<- prometheus.Metric, caErrors map[string]int) {
 	caErrDesc := prometheus.NewDesc(
 		"da_custom_alert_parse_errors",
 		"Per-tenant count of malformed _custom_alerts entries dropped at resolve time (ADR-024 能力 B, #741). 0 = all parsed+validated. Fail-loud: a silently-skipped custom alert surfaces here. Alert: > 0 (warning). Upstream hard-gates (CI compiler, tenant-api preflight) catch these first; this is the defense-in-depth last line for a direct-push bypass.",
 		[]string{"tenant"},
 		nil,
 	)
-	for tenant, n := range stats.PerTenantCustomAlertErrors {
+	for tenant, n := range caErrors {
 		m, err := prometheus.NewConstMetric(caErrDesc, prometheus.GaugeValue, float64(n), tenant)
 		if err != nil {
 			log.Printf("WARN: failed to create da_custom_alert_parse_errors metric for tenant=%s: %v", tenant, err)
@@ -126,8 +142,10 @@ func (c *ThresholdCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		ch <- m
 	}
+}
 
-	// Scenario C: state filter flags
+// collectStateFilters emits user_state_filter flags (Scenario C).
+func (c *ThresholdCollector) collectStateFilters(ch chan<- prometheus.Metric, cfg *ThresholdConfig) {
 	stateDesc := prometheus.NewDesc(
 		"user_state_filter",
 		"State-based monitoring filter flag (1=enabled, absent=disabled). Scenario C: state/string matching.",
@@ -142,15 +160,12 @@ func (c *ThresholdCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		ch <- m
 	}
+}
 
-	// Silent mode: per-tenant notification suppression flags.
-	// Alerts still fire in Prometheus (TSDB records exist), but Alertmanager
-	// uses sentinel alerts + inhibit_rules to suppress notifications.
-	// Distinct from maintenance mode which suppresses at PromQL level (no TSDB records).
-	//
-	// v1.7.0: expired entries (Expired=true) do NOT emit user_silent_mode —
-	// sentinel metric disappears → Alertmanager inhibit stops → notifications resume.
-	// Instead, expired entries emit da_config_event for notification purposes.
+// collectSilentModes emits user_silent_mode for active silences; expired
+// silences emit da_config_event instead (v1.7.0) so Alertmanager inhibit
+// stops and notifications resume.
+func (c *ThresholdCollector) collectSilentModes(ch chan<- prometheus.Metric, cfg *ThresholdConfig) {
 	silentDesc := prometheus.NewDesc(
 		"user_silent_mode",
 		"Silent mode flag (1=active). Alerts fire (TSDB records) but notifications suppressed via Alertmanager inhibit.",
@@ -190,11 +205,18 @@ func (c *ThresholdCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		ch <- m
 	}
+}
 
-	// Maintenance mode expiry events (v1.7.0).
-	// When structured _state_maintenance with expires is past, the state filter
-	// metric already stops emitting (handled in ResolveStateFiltersAt).
-	// Here we emit da_config_event to notify that maintenance auto-deactivated.
+// collectMaintenanceExpiries emits da_config_event when a maintenance window
+// has auto-deactivated (v1.7.0). Active windows need no event (their state
+// filter simply keeps emitting).
+func (c *ThresholdCollector) collectMaintenanceExpiries(ch chan<- prometheus.Metric, cfg *ThresholdConfig) {
+	configEventDesc := prometheus.NewDesc(
+		"da_config_event",
+		"Config lifecycle event (1=event active). Emitted when timed config expires. Labels identify event type and tenant.",
+		[]string{"tenant", "event", "reason"},
+		nil,
+	)
 	for _, me := range cfg.ResolveMaintenanceExpiries() {
 		if !me.Expired {
 			continue // Still active, no event needed
@@ -211,11 +233,10 @@ func (c *ThresholdCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		ch <- m
 	}
+}
 
-	// Severity dedup: per-tenant warning↔critical notification deduplication.
-	// When enabled (default), Alertmanager inhibit rules suppress warning notifications
-	// when critical fires for the same tenant+metric_group.
-	// Both alerts ALWAYS fire in TSDB regardless of this setting — dedup only controls notifications.
+// collectSeverityDedup emits user_severity_dedup flags (v1.2.0+).
+func (c *ThresholdCollector) collectSeverityDedup(ch chan<- prometheus.Metric, cfg *ThresholdConfig) {
 	dedupDesc := prometheus.NewDesc(
 		"user_severity_dedup",
 		"Severity dedup flag (1=enabled). Warning notifications suppressed when critical fires for same metric_group. v1.2.0+",
@@ -230,10 +251,11 @@ func (c *ThresholdCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 		ch <- m
 	}
+}
 
-	// Config info metric (v2.3.0): exposes config source metadata for GitOps observability.
-	// Labels: config_source ("configmap"|"operator"|"git-sync"), git_commit (hash or "").
-	// Portal's Config Drift detection compares this against platform-data.json last_config_commit.
+// collectConfigInfo emits threshold_exporter_config_info (v2.3.0): config
+// source + git revision for GitOps drift observability.
+func (c *ThresholdCollector) collectConfigInfo(ch chan<- prometheus.Metric) {
 	configInfoDesc := prometheus.NewDesc(
 		"threshold_exporter_config_info",
 		"Config source metadata (info metric, always 1). Labels identify deployment mode and git revision. v2.3.0+",
@@ -245,11 +267,11 @@ func (c *ThresholdCollector) Collect(ch chan<- prometheus.Metric) {
 		info.ConfigSource, info.GitCommit); err == nil {
 		ch <- m
 	}
+}
 
-	// Tenant metadata info metric (v1.11.0): unconditionally emitted for ALL tenants.
-	// Carries runbook_url, owner, tier as labels. Unset fields default to empty string.
-	// Rule Pack Part 3 alert rules use group_left(runbook_url, owner, tier) to inherit
-	// these labels, enabling dynamic runbook injection in Alertmanager notifications.
+// collectMetadata emits tenant_metadata_info (v1.11.0): unconditional per-tenant
+// runbook_url/owner/tier labels for Alertmanager group_left joins.
+func (c *ThresholdCollector) collectMetadata(ch chan<- prometheus.Metric, cfg *ThresholdConfig) {
 	metadataDesc := prometheus.NewDesc(
 		"tenant_metadata_info",
 		"Tenant metadata labels (info metric, always 1). Unconditional output for group_left joins. v1.11.0+",

--- a/components/threshold-exporter/app/config.go
+++ b/components/threshold-exporter/app/config.go
@@ -415,24 +415,7 @@ func (m *ConfigManager) IncrementalLoad() error {
 	oldConfigs := m.flat.configs
 	m.mu.RUnlock()
 
-	var changed, added, removed []string
-
-	// Detect changed and added files
-	for name, newHash := range newHashes {
-		oldHash, exists := oldHashes[name]
-		if !exists {
-			added = append(added, name)
-		} else if newHash != oldHash {
-			changed = append(changed, name)
-		}
-	}
-
-	// Detect removed files
-	for name := range oldHashes {
-		if _, exists := newHashes[name]; !exists {
-			removed = append(removed, name)
-		}
-	}
+	changed, added, removed := diffFileHashes(oldHashes, newHashes)
 
 	// Copy cache for mutation — deferred until after diff to avoid
 	// unnecessary allocation when the per-file diff shows no changes
@@ -482,56 +465,17 @@ func (m *ConfigManager) IncrementalLoad() error {
 		delete(newConfigs, name)
 	}
 
-	// Phase 4: merge — use incremental patch when only tenant files changed,
-	// full rebuild when _defaults.yaml, _profiles.yaml, or _state_filters changed.
-	tenantOnly := true
-	for _, name := range append(changed, added...) {
-		if name == "_defaults.yaml" || name == "_profiles.yaml" || strings.HasPrefix(name, "_") {
-			tenantOnly = false
-			break
-		}
-	}
-	for _, name := range removed {
-		if strings.HasPrefix(name, "_") {
-			tenantOnly = false
-			break
-		}
-	}
+	// Phase 4: merge — incremental tenant patch when only tenant files changed,
+	// full rebuild when a _defaults/_profiles/_state_filters file changed.
 	var merged ThresholdConfig
-	if tenantOnly && m.config != nil {
-		// Incremental patch: copy existing merged config, patch only affected tenants.
-		// This avoids O(N) merge for the common "1 tenant file changed" case.
+	if isTenantOnlyChange(changed, added, removed) && m.config != nil {
+		// Incremental patch: copy existing merged config, patch only affected
+		// tenants. Avoids the O(N) merge for the common "1 tenant file changed"
+		// case. prev is read under the lock; patchTenants is otherwise pure.
 		m.mu.RLock()
 		prev := m.config
 		m.mu.RUnlock()
-
-		merged = ThresholdConfig{
-			Defaults:     prev.Defaults,     // shared (immutable between patches)
-			StateFilters: prev.StateFilters, // shared
-			Profiles:     prev.Profiles,     // shared
-			Tenants:      make(map[string]map[string]ScheduledValue, len(prev.Tenants)),
-		}
-		// Shallow-copy tenants map (keys only, values are immutable per-tenant maps)
-		for k, v := range prev.Tenants {
-			merged.Tenants[k] = v
-		}
-		// Apply changes: overwrite tenants from re-parsed files
-		for _, name := range append(changed, added...) {
-			if partial, ok := newConfigs[name]; ok {
-				for tenant, overrides := range partial.Tenants {
-					merged.Tenants[tenant] = overrides
-				}
-			}
-		}
-		// Remove tenants from deleted files
-		for _, name := range removed {
-			if partial, ok := oldConfigs[name]; ok {
-				for tenant := range partial.Tenants {
-					delete(merged.Tenants, tenant)
-				}
-			}
-		}
-		// Profiles unchanged → no need to re-apply
+		merged = patchTenants(prev, newConfigs, oldConfigs, changed, added, removed)
 	} else {
 		// Full rebuild: _defaults or _profiles changed, must re-merge everything
 		merged = mergePartialConfigs(newConfigs)
@@ -544,6 +488,81 @@ func (m *ConfigManager) IncrementalLoad() error {
 		mtimes:  newMtimes,
 	}, fmt.Sprintf("Config reloaded (incremental, %d changed, %d added, %d removed)", len(changed), len(added), len(removed)))
 	return nil
+}
+
+// diffFileHashes compares the previous and current per-file hash maps and
+// classifies each file as changed (hash differs), added (new), or removed
+// (gone from the new scan). Pure helper extracted from IncrementalLoad Phase 2.
+func diffFileHashes(oldHashes, newHashes map[string]string) (changed, added, removed []string) {
+	for name, newHash := range newHashes {
+		oldHash, exists := oldHashes[name]
+		if !exists {
+			added = append(added, name)
+		} else if newHash != oldHash {
+			changed = append(changed, name)
+		}
+	}
+	for name := range oldHashes {
+		if _, exists := newHashes[name]; !exists {
+			removed = append(removed, name)
+		}
+	}
+	return changed, added, removed
+}
+
+// isTenantOnlyChange reports whether an incremental reload touched only tenant
+// files — i.e. no underscore-prefixed file (_defaults.yaml / _profiles.yaml /
+// _state_filters). When true, IncrementalLoad can patch just the affected
+// tenants instead of re-merging the whole tree. Extracted from Phase 4.
+//
+// An underscore prefix already subsumes the specific _defaults.yaml /
+// _profiles.yaml names, so the prefix test alone is sufficient.
+func isTenantOnlyChange(changed, added, removed []string) bool {
+	for _, group := range [][]string{changed, added, removed} {
+		for _, name := range group {
+			if strings.HasPrefix(name, "_") {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// patchTenants builds a merged config from the tenant-only incremental fast
+// path: it shallow-copies prev (Defaults/StateFilters/Profiles shared, Tenants
+// map cloned) then overwrites tenants from changed/added files and drops
+// tenants from removed files. Extracted from IncrementalLoad Phase 4; the
+// caller reads prev under the lock, this function is otherwise pure.
+func patchTenants(prev *ThresholdConfig, newConfigs, oldConfigs map[string]ThresholdConfig, changed, added, removed []string) ThresholdConfig {
+	merged := ThresholdConfig{
+		Defaults:     prev.Defaults,     // shared (immutable between patches)
+		StateFilters: prev.StateFilters, // shared
+		Profiles:     prev.Profiles,     // shared
+		Tenants:      make(map[string]map[string]ScheduledValue, len(prev.Tenants)),
+	}
+	// Shallow-copy tenants map (keys only, values are immutable per-tenant maps)
+	for k, v := range prev.Tenants {
+		merged.Tenants[k] = v
+	}
+	// Overwrite tenants from re-parsed (changed + added) files
+	for _, group := range [][]string{changed, added} {
+		for _, name := range group {
+			if partial, ok := newConfigs[name]; ok {
+				for tenant, overrides := range partial.Tenants {
+					merged.Tenants[tenant] = overrides
+				}
+			}
+		}
+	}
+	// Remove tenants from deleted files
+	for _, name := range removed {
+		if partial, ok := oldConfigs[name]; ok {
+			for tenant := range partial.Tenants {
+				delete(merged.Tenants, tenant)
+			}
+		}
+	}
+	return merged
 }
 
 // fullDirLoad performs a full directory load and initializes the per-file cache.

--- a/components/threshold-exporter/app/config.go
+++ b/components/threshold-exporter/app/config.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
-	"gopkg.in/yaml.v3"
 )
 
 // ============================================================
@@ -442,16 +441,8 @@ func (m *ConfigManager) IncrementalLoad() error {
 				continue
 			}
 		}
-		var partial ThresholdConfig
-		if err := yaml.Unmarshal(data, &partial); err != nil {
-			// See loadDir — defaults parse failure silently nullifies the
-			// block; promote to ERROR + emit metric (cycle-6 RCA, archive §S#37d).
-			m.getMetrics().IncParseFailure(filepath.Base(fullPath))
-			if strings.HasPrefix(name, "_") {
-				m.getLogger().Printf("ERROR: skip unparseable defaults/profiles file %s: %v (entire block dropped — fix file or remove)", fullPath, err)
-			} else {
-				m.getLogger().Printf("WARN: skip unparseable file %s: %v", fullPath, err)
-			}
+		partial, ok := parsePartialConfig(name, fullPath, data, m.getMetrics(), m.getLogger())
+		if !ok {
 			delete(newConfigs, name)
 			continue
 		}
@@ -598,16 +589,8 @@ func (m *ConfigManager) fullDirLoad() error {
 				continue
 			}
 		}
-		var partial ThresholdConfig
-		if err := yaml.Unmarshal(data, &partial); err != nil {
-			// See loadDir — defaults parse failure silently nullifies the
-			// block; promote to ERROR + emit metric (cycle-6 RCA, archive §S#37d).
-			m.getMetrics().IncParseFailure(filepath.Base(fullPath))
-			if strings.HasPrefix(name, "_") {
-				m.getLogger().Printf("ERROR: skip unparseable defaults/profiles file %s: %v (entire block dropped — fix file or remove)", fullPath, err)
-			} else {
-				m.getLogger().Printf("WARN: skip unparseable file %s: %v", fullPath, err)
-			}
+		partial, ok := parsePartialConfig(name, fullPath, data, m.getMetrics(), m.getLogger())
+		if !ok {
 			continue
 		}
 		applyBoundaryRules(name, &partial, m.getLogger())

--- a/components/threshold-exporter/app/config_debounce.go
+++ b/components/threshold-exporter/app/config_debounce.go
@@ -318,6 +318,130 @@ func (m *ConfigManager) scanAndCheckHierarchical(prior reloadPriorState) (reload
 	}, false, nil
 }
 
+// reloadEmissionKey is the group-by key for the per-tick blast-radius
+// histogram: each tenant contributes one increment to exactly one
+// (reason, scope, effect) bucket, and classifyAndCount emits a single
+// Observe(N=count) per non-empty bucket afterwards. Preserves dimensional
+// detail (a tick can fire applied/shadowed/cosmetic concurrently) without
+// conflating distinct events into one sample.
+type reloadEmissionKey struct{ reason, scope, effect string }
+
+// rebuildParsedDefaults rebuilds the parsedDefaults cache for a reload tick
+// (Issue #61): it reuses the prior parse for any defaults file whose hash did
+// not move and re-parses the rest. Read/parse failures are log-and-skip (same
+// policy as populateHierarchyState cold start). Extracted from classifyAndCount.
+func (m *ConfigManager) rebuildParsedDefaults(prior reloadPriorState, scan reloadScanState) map[string]map[string]any {
+	out := make(map[string]map[string]any, len(scan.defaults))
+	for dp := range scan.defaults {
+		if scan.hashes[dp] == prior.hashes[dp] {
+			if cached, ok := prior.parsedDefaults[dp]; ok && cached != nil {
+				out[dp] = cached
+				continue
+			}
+		}
+		b, rerr := os.ReadFile(dp)
+		if rerr != nil {
+			m.getLogger().Printf("WARN: parsedDefaults: read %s: %v", dp, rerr)
+			continue
+		}
+		parsed, perr := parseDefaultsBytes(b)
+		if perr != nil {
+			m.getLogger().Printf("WARN: parsedDefaults: parse %s: %v", dp, perr)
+			continue
+		}
+		out[dp] = parsed
+	}
+	return out
+}
+
+// classifyTenant classifies one tenant during a reload tick into its
+// reload/no-op category, updating res (merged_hash, reloaded/noOp counters) and
+// the per-tick emission buckets, and emitting the trigger/shadowed/noop
+// counters. Extracted verbatim from the classifyAndCount per-tenant loop body;
+// res is mutated through the pointer, buckets through the shared map.
+func (m *ConfigManager) classifyTenant(tid, srcPath string, prior reloadPriorState, scan reloadScanState, res *reloadResult, buckets map[reloadEmissionKey]int) {
+	prevSrc, wasKnown := prior.tenantSources[tid]
+	sourceChanged := !wasKnown || prevSrc != srcPath || scan.hashes[srcPath] != prior.hashes[srcPath]
+
+	defaultsChain := scan.graph.TenantDefaults[tid]
+	defaultsChanged := false
+	for _, dp := range defaultsChain {
+		if scan.hashes[dp] != prior.hashes[dp] {
+			defaultsChanged = true
+			break
+		}
+	}
+
+	if !sourceChanged && !defaultsChanged {
+		// Reuse cached merged_hash — nothing that feeds this tenant moved.
+		if prev, ok := prior.mergedHashes[tid]; ok {
+			res.newMergedHashes[tid] = prev
+			return
+		}
+		// No cached value (first scan after enabling hierarchical mode).
+		// Fall through to compute.
+	}
+
+	mh, mergeErr := m.recomputeMergedHash(tid, srcPath, defaultsChain)
+	if mergeErr != nil {
+		logMergeSkip(m.getLogger(), tid, "debounced-reload", mergeErr)
+		// Preserve any prior merged_hash we had so the /effective
+		// endpoint still serves the last-known-good value. Absent prior
+		// → mark empty (tenant will read as merge-failing).
+		if prev, ok := prior.mergedHashes[tid]; ok {
+			res.newMergedHashes[tid] = prev
+		}
+		return
+	}
+	res.newMergedHashes[tid] = mh
+
+	if sourceChanged {
+		res.reloaded++
+		if wasKnown {
+			m.getMetrics().IncReloadTrigger(ReloadReasonSource)
+			buckets[reloadEmissionKey{ReloadReasonSource, "tenant", "applied"}]++
+		} else {
+			m.getMetrics().IncReloadTrigger(ReloadReasonNewTenant)
+			buckets[reloadEmissionKey{ReloadReasonNewTenant, "tenant", "applied"}]++
+		}
+	} else if defaultsChanged {
+		scope := widestChangedScope(defaultsChain, scan.hashes, prior.hashes, m.path)
+		if scope == "" {
+			// Defensive: defaultsChanged was true but no chain entry
+			// differs by hash. Shouldn't happen (defaultsChanged is
+			// derived from the same comparison) — fall back to unknown.
+			scope = "unknown"
+		}
+		if prev, ok := prior.mergedHashes[tid]; ok && prev == mh {
+			// Defaults file changed but the resulting merged_hash
+			// didn't — "quiet defaults edit". v2.8.0 Issue #61 splits
+			// this into shadowed (tenant override blocked the change)
+			// vs cosmetic (comment/reorder/whitespace).
+			res.noOp++
+			tenantBytes, terr := os.ReadFile(srcPath)
+			effect := "cosmetic"
+			if terr == nil {
+				effect = classifyDefaultsNoOpEffect(
+					tenantBytes, tid, defaultsChain,
+					prior.parsedDefaults, res.newParsedDefaults,
+					scan.hashes, prior.hashes,
+				)
+			}
+			switch effect {
+			case "shadowed":
+				m.getMetrics().IncDefaultsShadowed()
+			default:
+				m.getMetrics().IncDefaultsNoop()
+			}
+			buckets[reloadEmissionKey{ReloadReasonDefaults, scope, effect}]++
+		} else {
+			res.reloaded++
+			m.getMetrics().IncReloadTrigger(ReloadReasonDefaults)
+			buckets[reloadEmissionKey{ReloadReasonDefaults, scope, "applied"}]++
+		}
+	}
+}
+
 // classifyAndCount is the heart of the reload pipeline:
 //
 //  1. Maintain parsedDefaults cache incrementally — reuse prior parse for
@@ -338,126 +462,21 @@ func (m *ConfigManager) scanAndCheckHierarchical(prior reloadPriorState) (reload
 // — installNewHierarchyState only does the atomic swap.
 func (m *ConfigManager) classifyAndCount(prior reloadPriorState, scan reloadScanState) reloadResult {
 	res := reloadResult{
-		newMergedHashes:   make(map[string]string, len(scan.tenants)),
-		newParsedDefaults: make(map[string]map[string]any, len(scan.defaults)),
+		newMergedHashes: make(map[string]string, len(scan.tenants)),
 	}
 	for tid := range scan.tenants {
 		res.newMergedHashes[tid] = "" // filled below
 	}
 
-	// Issue #61: parsedDefaults cache rebuild. Reuse prior parse where
-	// the hash didn't move; re-parse the rest. Parse failures are
-	// log-and-skip (same policy as populateHierarchyState cold start).
-	for dp := range scan.defaults {
-		if scan.hashes[dp] == prior.hashes[dp] {
-			if cached, ok := prior.parsedDefaults[dp]; ok && cached != nil {
-				res.newParsedDefaults[dp] = cached
-				continue
-			}
-		}
-		b, rerr := os.ReadFile(dp)
-		if rerr != nil {
-			m.getLogger().Printf("WARN: parsedDefaults: read %s: %v", dp, rerr)
-			continue
-		}
-		parsed, perr := parseDefaultsBytes(b)
-		if perr != nil {
-			m.getLogger().Printf("WARN: parsedDefaults: parse %s: %v", dp, perr)
-			continue
-		}
-		res.newParsedDefaults[dp] = parsed
-	}
+	// Issue #61: rebuild the parsedDefaults cache, reusing unchanged parses.
+	res.newParsedDefaults = m.rebuildParsedDefaults(prior, scan)
 
-	// Per-tick group-by emission for the blast-radius histogram. Each
-	// tenant contributes one increment to exactly one (reason, scope,
-	// effect) bucket; after the loop each non-empty bucket emits a single
-	// Observe(N=count). Preserves dimensional detail (a tick can fire
-	// applied/shadowed/cosmetic concurrently) without conflating distinct
-	// events into a single sample.
-	type emissionKey struct{ reason, scope, effect string }
-	buckets := make(map[emissionKey]int)
+	// Per-tick group-by buckets for the blast-radius histogram (see
+	// reloadEmissionKey); each tenant increments exactly one bucket.
+	buckets := make(map[reloadEmissionKey]int)
 
 	for tid, srcPath := range scan.tenants {
-		prevSrc, wasKnown := prior.tenantSources[tid]
-		sourceChanged := !wasKnown || prevSrc != srcPath || scan.hashes[srcPath] != prior.hashes[srcPath]
-
-		defaultsChain := scan.graph.TenantDefaults[tid]
-		defaultsChanged := false
-		for _, dp := range defaultsChain {
-			if scan.hashes[dp] != prior.hashes[dp] {
-				defaultsChanged = true
-				break
-			}
-		}
-
-		if !sourceChanged && !defaultsChanged {
-			// Reuse cached merged_hash — nothing that feeds this tenant moved.
-			if prev, ok := prior.mergedHashes[tid]; ok {
-				res.newMergedHashes[tid] = prev
-				continue
-			}
-			// No cached value (first scan after enabling hierarchical mode).
-			// Fall through to compute.
-		}
-
-		mh, mergeErr := m.recomputeMergedHash(tid, srcPath, defaultsChain)
-		if mergeErr != nil {
-			logMergeSkip(m.getLogger(), tid, "debounced-reload", mergeErr)
-			// Preserve any prior merged_hash we had so the /effective
-			// endpoint still serves the last-known-good value. Absent prior
-			// → mark empty (tenant will read as merge-failing).
-			if prev, ok := prior.mergedHashes[tid]; ok {
-				res.newMergedHashes[tid] = prev
-			}
-			continue
-		}
-		res.newMergedHashes[tid] = mh
-
-		if sourceChanged {
-			res.reloaded++
-			if wasKnown {
-				m.getMetrics().IncReloadTrigger(ReloadReasonSource)
-				buckets[emissionKey{ReloadReasonSource, "tenant", "applied"}]++
-			} else {
-				m.getMetrics().IncReloadTrigger(ReloadReasonNewTenant)
-				buckets[emissionKey{ReloadReasonNewTenant, "tenant", "applied"}]++
-			}
-		} else if defaultsChanged {
-			scope := widestChangedScope(defaultsChain, scan.hashes, prior.hashes, m.path)
-			if scope == "" {
-				// Defensive: defaultsChanged was true but no chain entry
-				// differs by hash. Shouldn't happen (defaultsChanged is
-				// derived from the same comparison) — fall back to unknown.
-				scope = "unknown"
-			}
-			if prev, ok := prior.mergedHashes[tid]; ok && prev == mh {
-				// Defaults file changed but the resulting merged_hash
-				// didn't — "quiet defaults edit". v2.8.0 Issue #61 splits
-				// this into shadowed (tenant override blocked the change)
-				// vs cosmetic (comment/reorder/whitespace).
-				res.noOp++
-				tenantBytes, terr := os.ReadFile(srcPath)
-				effect := "cosmetic"
-				if terr == nil {
-					effect = classifyDefaultsNoOpEffect(
-						tenantBytes, tid, defaultsChain,
-						prior.parsedDefaults, res.newParsedDefaults,
-						scan.hashes, prior.hashes,
-					)
-				}
-				switch effect {
-				case "shadowed":
-					m.getMetrics().IncDefaultsShadowed()
-				default:
-					m.getMetrics().IncDefaultsNoop()
-				}
-				buckets[emissionKey{ReloadReasonDefaults, scope, effect}]++
-			} else {
-				res.reloaded++
-				m.getMetrics().IncReloadTrigger(ReloadReasonDefaults)
-				buckets[emissionKey{ReloadReasonDefaults, scope, "applied"}]++
-			}
-		}
+		m.classifyTenant(tid, srcPath, prior, scan, &res, buckets)
 	}
 
 	// Detect deleted tenants — previously known, absent now. Deletions
@@ -467,7 +486,7 @@ func (m *ConfigManager) classifyAndCount(prior reloadPriorState, scan reloadScan
 		if _, stillKnown := scan.tenants[tid]; !stillKnown {
 			res.reloaded++
 			m.getMetrics().IncReloadTrigger(ReloadReasonDelete)
-			buckets[emissionKey{ReloadReasonDelete, "tenant", "applied"}]++
+			buckets[reloadEmissionKey{ReloadReasonDelete, "tenant", "applied"}]++
 		}
 	}
 

--- a/components/threshold-exporter/app/flat_scanner.go
+++ b/components/threshold-exporter/app/flat_scanner.go
@@ -57,6 +57,29 @@ func loadFile(path string) (ThresholdConfig, string, error) {
 	return cfg, hash, nil
 }
 
+// parsePartialConfig unmarshals one config file's bytes into a ThresholdConfig.
+// On parse failure it records the parse_failure metric and logs — ERROR for
+// underscore-prefixed files (a broken _defaults/_profiles silently nullifies an
+// entire block → every dependent tenant override breaks; cycle-6 RCA, planning
+// archive §S#37d, cost 5+ hours at WARN) or WARN for tenant files — then
+// returns ok=false so the caller can skip the file. `name` is the base filename
+// (drives the underscore severity choice); `path` is the display path used for
+// logs and the metric basename. Shared by loadDirWithMetrics, IncrementalLoad,
+// and fullDirLoad so the three flat-mode parse paths report failures identically.
+func parsePartialConfig(name, path string, data []byte, metrics *configMetrics, logger *log.Logger) (ThresholdConfig, bool) {
+	var partial ThresholdConfig
+	if err := yaml.Unmarshal(data, &partial); err != nil {
+		metrics.IncParseFailure(filepath.Base(path))
+		if strings.HasPrefix(name, "_") {
+			logger.Printf("ERROR: skip unparseable defaults/profiles file %s: %v (entire block dropped — fix file or remove)", path, err)
+		} else {
+			logger.Printf("WARN: skip unparseable file %s: %v", path, err)
+		}
+		return partial, false
+	}
+	return partial, true
+}
+
 // loadDir scans a directory for *.yaml files, parses and deep-merges them.
 //
 // File naming convention:
@@ -135,20 +158,8 @@ func loadDirWithMetrics(dir string, metrics *configMetrics, logger *log.Logger) 
 		}
 		hasher.Write(data)
 
-		var partial ThresholdConfig
-		if err := yaml.Unmarshal(data, &partial); err != nil {
-			// _defaults.yaml parse failure silently nullifies the entire
-			// defaults block → every dependent tenant override breaks
-			// (`unknown key not in defaults`). Cycle-6 RCA (planning archive
-			// §S#37d) cost 5+ hours wall-clock because this signal lived at
-			// WARN. Promote to ERROR for `_*` files; emit parse_failure_total
-			// (v2.8.0 A-8d metric) so ops can alert.
-			metrics.IncParseFailure(filepath.Base(path))
-			if strings.HasPrefix(name, "_") {
-				logger.Printf("ERROR: skip unparseable defaults/profiles file %s: %v (entire block dropped — fix file or remove)", path, err)
-			} else {
-				logger.Printf("WARN: skip unparseable file %s: %v", path, err)
-			}
+		partial, ok := parsePartialConfig(name, path, data, metrics, logger)
+		if !ok {
 			continue
 		}
 

--- a/components/threshold-exporter/app/flat_scanner.go
+++ b/components/threshold-exporter/app/flat_scanner.go
@@ -152,26 +152,10 @@ func loadDirWithMetrics(dir string, metrics *configMetrics, logger *log.Logger) 
 			continue
 		}
 
-		isDefaultsFile := strings.HasPrefix(name, "_")
-		isProfilesFile := name == "_profiles.yaml" || name == "_profiles.yml"
-
-		// Boundary enforcement: warn if tenant file contains state_filters, defaults, or profiles
-		if !isDefaultsFile {
-			if len(partial.StateFilters) > 0 {
-				logger.Printf("WARN: state_filters found in %s — should only be in _defaults.yaml, ignoring", name)
-				partial.StateFilters = nil
-			}
-			if len(partial.Defaults) > 0 {
-				logger.Printf("WARN: defaults found in %s — should only be in _defaults.yaml, ignoring", name)
-				partial.Defaults = nil
-			}
-		}
-		if !isProfilesFile && !isDefaultsFile {
-			if len(partial.Profiles) > 0 {
-				logger.Printf("WARN: profiles found in %s — should only be in _profiles.yaml, ignoring", name)
-				partial.Profiles = nil
-			}
-		}
+		// Boundary enforcement: warn if tenant file contains state_filters,
+		// defaults, or profiles (shared with the incremental path via
+		// applyBoundaryRules — keep the two call sites byte-identical).
+		applyBoundaryRules(name, &partial, logger)
 
 		// Merge defaults
 		for k, v := range partial.Defaults {

--- a/components/threshold-exporter/app/flat_scanner.go
+++ b/components/threshold-exporter/app/flat_scanner.go
@@ -157,35 +157,9 @@ func loadDirWithMetrics(dir string, metrics *configMetrics, logger *log.Logger) 
 		// applyBoundaryRules — keep the two call sites byte-identical).
 		applyBoundaryRules(name, &partial, logger)
 
-		// Merge defaults
-		for k, v := range partial.Defaults {
-			merged.Defaults[k] = v
-		}
-
-		// Merge state_filters
-		for k, v := range partial.StateFilters {
-			merged.StateFilters[k] = v
-		}
-
-		// Merge profiles (v1.12.0)
-		for profileName, profileValues := range partial.Profiles {
-			if merged.Profiles[profileName] == nil {
-				merged.Profiles[profileName] = make(map[string]ScheduledValue)
-			}
-			for k, v := range profileValues {
-				merged.Profiles[profileName][k] = v
-			}
-		}
-
-		// Merge tenants (deep merge per tenant)
-		for tenant, overrides := range partial.Tenants {
-			if merged.Tenants[tenant] == nil {
-				merged.Tenants[tenant] = make(map[string]ScheduledValue)
-			}
-			for k, v := range overrides {
-				merged.Tenants[tenant][k] = v
-			}
-		}
+		// Deep-merge this file's partial into the running result (shared
+		// flat-mode merge semantics — see mergePartialInto).
+		mergePartialInto(&merged, partial)
 	}
 
 	hash := fmt.Sprintf("%x", hasher.Sum(nil))
@@ -344,33 +318,41 @@ func mergePartialConfigs(configs map[string]ThresholdConfig) ThresholdConfig {
 	sort.Strings(names)
 
 	for _, name := range names {
-		partial := configs[name]
-
-		for k, v := range partial.Defaults {
-			merged.Defaults[k] = v
-		}
-		for k, v := range partial.StateFilters {
-			merged.StateFilters[k] = v
-		}
-		for profileName, profileValues := range partial.Profiles {
-			if merged.Profiles[profileName] == nil {
-				merged.Profiles[profileName] = make(map[string]ScheduledValue)
-			}
-			for k, v := range profileValues {
-				merged.Profiles[profileName][k] = v
-			}
-		}
-		for tenant, overrides := range partial.Tenants {
-			if merged.Tenants[tenant] == nil {
-				merged.Tenants[tenant] = make(map[string]ScheduledValue, len(overrides))
-			}
-			for k, v := range overrides {
-				merged.Tenants[tenant][k] = v
-			}
-		}
+		mergePartialInto(&merged, configs[name])
 	}
 
 	return merged
+}
+
+// mergePartialInto deep-merges one partial config into merged using the
+// flat-mode merge semantics shared by loadDirWithMetrics and
+// mergePartialConfigs: defaults and state_filters overwrite by key; profiles
+// and tenants deep-merge per name (later values win). Keeping this in one place
+// guarantees the eager (loadDir) and incremental (mergePartialConfigs) paths
+// can never drift in merge precedence.
+func mergePartialInto(merged *ThresholdConfig, partial ThresholdConfig) {
+	for k, v := range partial.Defaults {
+		merged.Defaults[k] = v
+	}
+	for k, v := range partial.StateFilters {
+		merged.StateFilters[k] = v
+	}
+	for profileName, profileValues := range partial.Profiles {
+		if merged.Profiles[profileName] == nil {
+			merged.Profiles[profileName] = make(map[string]ScheduledValue)
+		}
+		for k, v := range profileValues {
+			merged.Profiles[profileName][k] = v
+		}
+	}
+	for tenant, overrides := range partial.Tenants {
+		if merged.Tenants[tenant] == nil {
+			merged.Tenants[tenant] = make(map[string]ScheduledValue, len(overrides))
+		}
+		for k, v := range overrides {
+			merged.Tenants[tenant][k] = v
+		}
+	}
 }
 
 // WatchLoop periodically checks for config changes and reloads.

--- a/components/threshold-exporter/app/internal/profile/decisions.go
+++ b/components/threshold-exporter/app/internal/profile/decisions.go
@@ -298,10 +298,28 @@ func applyDecisions(props []ExtractionProposal, decisions *ProposalDecisions) (e
 		policy = UndecidedEmit
 	}
 
-	// Index decisions by key for O(1) lookup. Duplicate keys are
-	// surfaced as a warning — silently letting the last entry win
-	// would mask a misedit (reviewer copy-pasted a row and only
-	// changed the verdict, not the key).
+	// Index decisions by key (surfacing duplicates), then warn on decisions
+	// whose key no longer matches any live proposal (cluster shape shifted
+	// between scaffold time and emission time).
+	byKey, idxWarnings := indexDecisionsByKey(decisions)
+	warnings = append(warnings, idxWarnings...)
+	warnings = append(warnings, staleDecisionWarnings(byKey, props)...)
+
+	for i, p := range props {
+		emit, w := resolveProposalVerdict(i, p, byKey, policy)
+		warnings = append(warnings, w...)
+		if emit {
+			emitIdx = append(emitIdx, i)
+		}
+	}
+	return emitIdx, warnings
+}
+
+// indexDecisionsByKey indexes a decisions file by cluster key for O(1) lookup,
+// returning the map plus warnings for duplicate keys (silently letting the last
+// entry win would mask a misedit — reviewer copy-pasted a row and only changed
+// the verdict, not the key). Extracted from applyDecisions.
+func indexDecisionsByKey(decisions *ProposalDecisions) (map[string]ProposalDecision, []string) {
 	byKey := make(map[string]ProposalDecision, len(decisions.Proposals))
 	dupes := make([]string, 0)
 	for _, d := range decisions.Proposals {
@@ -314,15 +332,18 @@ func applyDecisions(props []ExtractionProposal, decisions *ProposalDecisions) (e
 		byKey[d.Key] = d
 	}
 	sort.Strings(dupes)
+	var warnings []string
 	for _, k := range dupes {
 		warnings = append(warnings, fmt.Sprintf(
 			"decisions: duplicate key %q in decisions file (last entry wins; check for misedit)", k))
 	}
+	return byKey, warnings
+}
 
-	// Warn on decisions that reference clusters not present in the
-	// current ProposalSet (cluster shape shifted between scaffold
-	// time and emission time). Detected as decisions whose Key
-	// doesn't appear in any current proposal.
+// staleDecisionWarnings warns for each decision whose key references a cluster
+// not present in the current ProposalSet (the cluster shape shifted). Extracted
+// from applyDecisions.
+func staleDecisionWarnings(byKey map[string]ProposalDecision, props []ExtractionProposal) []string {
 	livKeys := make(map[string]struct{}, len(props))
 	for _, p := range props {
 		livKeys[p.Key()] = struct{}{}
@@ -334,71 +355,78 @@ func applyDecisions(props []ExtractionProposal, decisions *ProposalDecisions) (e
 		}
 	}
 	sort.Strings(stale)
+	var warnings []string
 	for _, k := range stale {
 		warnings = append(warnings, fmt.Sprintf(
 			"decisions: key %q references a proposal not present in the current ProposalSet (cluster shape may have shifted; verdict=%q ignored)",
 			k, byKey[k].Decision))
 	}
+	return warnings
+}
 
-	for i, p := range props {
-		key := p.Key()
-		dec, ok := byKey[key]
-		if !ok {
-			// No decision recorded for this proposal at all.
-			if policy == UndecidedSkip {
-				warnings = append(warnings, fmt.Sprintf(
-					"proposal[%d]: no decision recorded; undecided_policy=skip → emission skipped",
-					i))
-				continue
-			}
-			emitIdx = append(emitIdx, i)
+// resolveProposalVerdict decides whether proposal i should emit, given the
+// indexed decisions and the undecided-policy. Returns (emit, warnings). A
+// recorded verdict is honoured even when the member list drifted (the drift
+// surfaces as a warning but does not override the reviewer's intent). Extracted
+// verbatim from the applyDecisions per-proposal loop.
+func resolveProposalVerdict(i int, p ExtractionProposal, byKey map[string]ProposalDecision, policy UndecidedPolicy) (bool, []string) {
+	var warnings []string
+	key := p.Key()
+	dec, ok := byKey[key]
+	if !ok {
+		// No decision recorded for this proposal at all.
+		if policy == UndecidedSkip {
 			warnings = append(warnings, fmt.Sprintf(
-				"proposal[%d]: no decision recorded; undecided_policy=emit → emitted by default",
+				"proposal[%d]: no decision recorded; undecided_policy=skip → emission skipped",
 				i))
-			continue
+			return false, warnings
 		}
-
-		// Member-list cross-check: warn if recorded != live, but
-		// still honour the verdict (the reviewer's intent is to
-		// accept/reject the cluster identified by Key; member drift
-		// surfaces but doesn't override the verdict).
-		if !sameStringSlice(dec.MemberRuleIDs, p.MemberRuleIDs) {
-			warnings = append(warnings, fmt.Sprintf(
-				"proposal[%d] (key=%s): decision was recorded against %d members; cluster now has %d members — re-review recommended",
-				i, key, len(dec.MemberRuleIDs), len(p.MemberRuleIDs)))
-		}
-
-		switch dec.Decision {
-		case DecisionAccept:
-			emitIdx = append(emitIdx, i)
-		case DecisionReject:
-			// Drop silently — explicit reject doesn't need a
-			// warning; the reviewer wanted this.
-		case DecisionPending, "":
-			if policy == UndecidedSkip {
-				warnings = append(warnings, fmt.Sprintf(
-					"proposal[%d]: decision=pending; undecided_policy=skip → emission skipped",
-					i))
-				continue
-			}
-			emitIdx = append(emitIdx, i)
-			warnings = append(warnings, fmt.Sprintf(
-				"proposal[%d]: decision=pending; undecided_policy=emit → emitted by default",
-				i))
-		default:
-			// Unknown verdict — treat as pending + warn so typos
-			// surface. Keeps the door open for future verdicts
-			// without breaking deployed callers.
-			warnings = append(warnings, fmt.Sprintf(
-				"proposal[%d]: unknown decision verdict %q; treating as pending",
-				i, dec.Decision))
-			if policy == UndecidedSkip {
-				continue
-			}
-			emitIdx = append(emitIdx, i)
-		}
+		warnings = append(warnings, fmt.Sprintf(
+			"proposal[%d]: no decision recorded; undecided_policy=emit → emitted by default",
+			i))
+		return true, warnings
 	}
-	return emitIdx, warnings
+
+	// Member-list cross-check: warn if recorded != live, but
+	// still honour the verdict (the reviewer's intent is to
+	// accept/reject the cluster identified by Key; member drift
+	// surfaces but doesn't override the verdict).
+	if !sameStringSlice(dec.MemberRuleIDs, p.MemberRuleIDs) {
+		warnings = append(warnings, fmt.Sprintf(
+			"proposal[%d] (key=%s): decision was recorded against %d members; cluster now has %d members — re-review recommended",
+			i, key, len(dec.MemberRuleIDs), len(p.MemberRuleIDs)))
+	}
+
+	switch dec.Decision {
+	case DecisionAccept:
+		return true, warnings
+	case DecisionReject:
+		// Drop silently — explicit reject doesn't need a
+		// warning; the reviewer wanted this.
+		return false, warnings
+	case DecisionPending, "":
+		if policy == UndecidedSkip {
+			warnings = append(warnings, fmt.Sprintf(
+				"proposal[%d]: decision=pending; undecided_policy=skip → emission skipped",
+				i))
+			return false, warnings
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			"proposal[%d]: decision=pending; undecided_policy=emit → emitted by default",
+			i))
+		return true, warnings
+	default:
+		// Unknown verdict — treat as pending + warn so typos
+		// surface. Keeps the door open for future verdicts
+		// without breaking deployed callers.
+		warnings = append(warnings, fmt.Sprintf(
+			"proposal[%d]: unknown decision verdict %q; treating as pending",
+			i, dec.Decision))
+		if policy == UndecidedSkip {
+			return false, warnings
+		}
+		return true, warnings
+	}
 }
 
 // sameStringSlice returns true iff a and b have identical elements

--- a/components/threshold-exporter/app/internal/profile/emit.go
+++ b/components/threshold-exporter/app/internal/profile/emit.go
@@ -288,6 +288,27 @@ func emitOneProposal(
 		}
 	}
 
+	// Intermediate (PR-2) shape: _defaults.yaml + per-tenant overrides +
+	// PROPOSAL.md. Used directly when translation is off, and as the fallback
+	// when a cluster can't be translated.
+	warnings = append(warnings, emitIntermediateProposal(files, pathFor, prop, ruleIndex, tenantKey, propIdx)...)
+	return warnings
+}
+
+// emitIntermediateProposal writes the PR-2 intermediate artifact shape for one
+// proposal: _defaults.yaml (shared structure), one override file per member
+// tenant, and a human-readable PROPOSAL.md. Returns per-proposal warnings.
+// Extracted from emitOneProposal (the non-translated / fallback path).
+func emitIntermediateProposal(
+	files map[string][]byte,
+	pathFor func(string) string,
+	prop ExtractionProposal,
+	ruleIndex map[string]parser.ParsedRule,
+	tenantKey string,
+	propIdx int,
+) []string {
+	var warnings []string
+
 	// 1. _defaults.yaml — shared structure across all members.
 	defaultsBytes, err := marshalDefaults(prop)
 	if err != nil {

--- a/components/threshold-exporter/app/internal/profile/translate.go
+++ b/components/threshold-exporter/app/internal/profile/translate.go
@@ -562,6 +562,67 @@ type ProposalTranslation struct {
 	Warnings           []string           `json:"warnings,omitempty"`
 }
 
+// proposalTenantValue pairs a tenant id with its translated threshold, used to
+// derive per-tenant overrides that differ from the cluster default.
+type proposalTenantValue struct {
+	tenant string
+	value  float64
+}
+
+// proposalTally accumulates the per-member translation votes and values that
+// TranslateProposal folds into the cluster-level summary. Built by
+// tallyProposalMembers.
+type proposalTally struct {
+	keyVotes        map[string]int
+	opVotes         map[string]int
+	severityVotes   map[string]int
+	thresholds      []float64
+	tenantValues    []proposalTenantValue
+	translatedCount int
+}
+
+// tallyProposalMembers translates each member rule, appends its per-member
+// status to out.MemberStatuses, and accumulates the votes/thresholds/per-tenant
+// values needed for the cluster summary. It returns an error only on a
+// translator contract violation (empty Expr); skipped members are recorded but
+// do not contribute votes. Extracted verbatim from TranslateProposal.
+func tallyProposalMembers(members []parser.ParsedRule, tenantKey string, out *ProposalTranslation) (proposalTally, error) {
+	tally := proposalTally{
+		keyVotes:      make(map[string]int),
+		opVotes:       make(map[string]int),
+		severityVotes: make(map[string]int),
+	}
+	for _, m := range members {
+		t, err := TranslateRule(m)
+		if err != nil {
+			// Translator only errors on empty Expr — propagate so
+			// the caller sees a contract violation, rather than
+			// silently treating it like a TranslationSkipped.
+			return tally, fmt.Errorf("translate member %q: %w", m.SourceRuleID, err)
+		}
+		out.MemberStatuses = append(out.MemberStatuses, t)
+		if t.Status == TranslationSkipped {
+			continue
+		}
+		tally.translatedCount++
+		tally.keyVotes[t.MetricKey]++
+		tally.opVotes[t.Operator]++
+		if t.Severity != "" {
+			tally.severityVotes[t.Severity]++
+		}
+		tally.thresholds = append(tally.thresholds, t.Threshold)
+
+		tenantID := ""
+		if tenantKey != "" {
+			tenantID = m.Labels[tenantKey]
+		}
+		if tenantID != "" {
+			tally.tenantValues = append(tally.tenantValues, proposalTenantValue{tenant: tenantID, value: t.Threshold})
+		}
+	}
+	return tally, nil
+}
+
 // TranslateProposal applies TranslateRule to every member of a
 // proposal and produces the cluster-level summary. tenantKey is
 // the label pickTenantLabelKey resolved (so tenant-id is read off
@@ -582,48 +643,13 @@ func TranslateProposal(prop ExtractionProposal, members []parser.ParsedRule, ten
 	}
 	out.MemberStatuses = make([]RuleTranslation, 0, len(members))
 
-	// Per-member translation.
-	keyVotes := make(map[string]int)
-	severityVotes := make(map[string]int)
-	opVotes := make(map[string]int)
-	var thresholds []float64
-	type tenantValue struct {
-		tenant string
-		value  float64
-	}
-	var tenantValues []tenantValue
-
-	translatedCount := 0
-	for _, m := range members {
-		t, err := TranslateRule(m)
-		if err != nil {
-			// Translator only errors on empty Expr — propagate so
-			// the caller sees a contract violation, rather than
-			// silently treating it like a TranslationSkipped.
-			return nil, fmt.Errorf("translate member %q: %w", m.SourceRuleID, err)
-		}
-		out.MemberStatuses = append(out.MemberStatuses, t)
-		if t.Status == TranslationSkipped {
-			continue
-		}
-		translatedCount++
-		keyVotes[t.MetricKey]++
-		opVotes[t.Operator]++
-		if t.Severity != "" {
-			severityVotes[t.Severity]++
-		}
-		thresholds = append(thresholds, t.Threshold)
-
-		tenantID := ""
-		if tenantKey != "" {
-			tenantID = m.Labels[tenantKey]
-		}
-		if tenantID != "" {
-			tenantValues = append(tenantValues, tenantValue{tenant: tenantID, value: t.Threshold})
-		}
+	// Per-member translation + vote/threshold accumulation.
+	tally, err := tallyProposalMembers(members, tenantKey, out)
+	if err != nil {
+		return nil, err
 	}
 
-	if translatedCount == 0 {
+	if tally.translatedCount == 0 {
 		out.Status = TranslationSkipped
 		out.Warnings = append(out.Warnings,
 			"no member rule translated successfully; proposal falls back to intermediate emission")
@@ -631,32 +657,32 @@ func TranslateProposal(prop ExtractionProposal, members []parser.ParsedRule, ten
 	}
 
 	// Pick winner (and detect dissent) for each axis.
-	out.MetricKey = pickMajority(keyVotes)
-	out.Operator = pickMajority(opVotes)
-	out.Severity = pickMajority(severityVotes)
+	out.MetricKey = pickMajority(tally.keyVotes)
+	out.Operator = pickMajority(tally.opVotes)
+	out.Severity = pickMajority(tally.severityVotes)
 
-	if len(keyVotes) > 1 {
+	if len(tally.keyVotes) > 1 {
 		out.Warnings = append(out.Warnings, fmt.Sprintf(
 			"metric_key not unanimous across %d translated members: %s; using majority %q",
-			translatedCount, formatVotes(keyVotes), out.MetricKey))
+			tally.translatedCount, formatVotes(tally.keyVotes), out.MetricKey))
 	}
-	if len(opVotes) > 1 {
+	if len(tally.opVotes) > 1 {
 		out.Warnings = append(out.Warnings, fmt.Sprintf(
 			"comparison operator not unanimous: %s; using majority %q",
-			formatVotes(opVotes), out.Operator))
+			formatVotes(tally.opVotes), out.Operator))
 	}
-	if len(severityVotes) > 1 {
+	if len(tally.severityVotes) > 1 {
 		out.Warnings = append(out.Warnings, fmt.Sprintf(
 			"severity not unanimous: %s; using majority %q",
-			formatVotes(severityVotes), out.Severity))
+			formatVotes(tally.severityVotes), out.Severity))
 	}
 
 	// Default threshold = median (stable against single-tenant
 	// extreme values).
-	out.DefaultThreshold = median(thresholds)
+	out.DefaultThreshold = median(tally.thresholds)
 
 	// Per-tenant overrides — only when value differs from default.
-	for _, tv := range tenantValues {
+	for _, tv := range tally.tenantValues {
 		if tv.value != out.DefaultThreshold {
 			out.PerTenantOverrides[tv.tenant] = tv.value
 		}
@@ -665,7 +691,7 @@ func TranslateProposal(prop ExtractionProposal, members []parser.ParsedRule, ten
 	// Final status: OK if every translated member returned OK and
 	// no axis required majority resolution; Partial otherwise.
 	out.Status = TranslationOK
-	if len(keyVotes) > 1 || len(opVotes) > 1 || len(severityVotes) > 1 {
+	if len(tally.keyVotes) > 1 || len(tally.opVotes) > 1 || len(tally.severityVotes) > 1 {
 		out.Status = TranslationPartial
 	}
 	for _, m := range out.MemberStatuses {
@@ -674,11 +700,11 @@ func TranslateProposal(prop ExtractionProposal, members []parser.ParsedRule, ten
 			break
 		}
 	}
-	if translatedCount < len(members) {
+	if tally.translatedCount < len(members) {
 		out.Status = TranslationPartial
 		out.Warnings = append(out.Warnings, fmt.Sprintf(
 			"%d of %d members were skipped (see MemberStatuses for individual SkipReason)",
-			len(members)-translatedCount, len(members)))
+			len(members)-tally.translatedCount, len(members)))
 	}
 
 	return out, nil

--- a/components/threshold-exporter/app/pkg/config/resolve.go
+++ b/components/threshold-exporter/app/pkg/config/resolve.go
@@ -113,148 +113,15 @@ func (c *ThresholdConfig) ResolveAtWithStats(now time.Time) ([]ResolvedThreshold
 	for tenant, overrides := range c.Tenants {
 		startIdx := len(result) // track where this tenant's metrics start
 
-		for metricKey, defaultValue := range c.Defaults {
-			// Skip _state_ prefixed keys — handled by ResolveStateFilters()
-			// Skip _silent_ prefixed keys — handled by ResolveSilentModes()
-			// Skip _severity_dedup — handled by ResolveSeverityDedup()
-			// Skip _routing — handled by ResolveRouting() (Phase 4)
-			if strings.HasPrefix(metricKey, "_state_") || strings.HasPrefix(metricKey, "_silent_") ||
-				metricKey == "_severity_dedup" || strings.HasPrefix(metricKey, "_routing") {
-				continue
-			}
-
-			// Parse metric key: "mysql_connections" → component="mysql", metric="connections"
-			component, metric := parseMetricKey(metricKey)
-			severity := "warning" // default severity
-
-			// Check tenant override (skip _state_ overrides)
-			if sv, exists := overrides[metricKey]; exists {
-				override := sv.ResolveValue(now)
-				lower := strings.TrimSpace(strings.ToLower(override))
-
-				// State 3: disable
-				if isDisabled(lower) {
-					continue
-				}
-
-				// Check if it has severity suffix: "70:critical"
-				parts := strings.SplitN(override, ":", 2)
-				valueStr := strings.TrimSpace(parts[0])
-				if len(parts) == 2 {
-					severity = strings.TrimSpace(parts[1])
-				}
-
-				// State 1: custom value
-				if v, err := strconv.ParseFloat(valueStr, 64); err == nil {
-					result = append(result, ResolvedThreshold{
-						Tenant:    tenant,
-						Metric:    metric,
-						Value:     v,
-						Severity:  severity,
-						Component: component,
-					})
-					continue
-				}
-
-				// Unknown value — log warning, use default
-				log.Printf("WARN: unknown value %q for tenant=%s metric=%s, using default", override, tenant, metricKey)
-			}
-
-			// State 2: use default
-			result = append(result, ResolvedThreshold{
-				Tenant:    tenant,
-				Metric:    metric,
-				Value:     defaultValue,
-				Severity:  severity,
-				Component: component,
-			})
-		}
-
-		// Multi-tier severity: scan for <metricKey>_critical overrides.
-		// These produce an additional threshold with severity=critical.
-		for key, sv := range overrides {
-			if !strings.HasSuffix(key, "_critical") || strings.HasPrefix(key, "_state_") || strings.HasPrefix(key, "_silent_") {
-				continue
-			}
-
-			override := sv.ResolveValue(now)
-			lower := strings.TrimSpace(strings.ToLower(override))
-			if isDisabled(lower) {
-				continue
-			}
-
-			// Derive the base metric key: "mysql_connections_critical" → "mysql_connections"
-			baseKey := strings.TrimSuffix(key, "_critical")
-			// Verify that the base metric exists in defaults (otherwise ignore)
-			if _, exists := c.Defaults[baseKey]; !exists {
-				log.Printf("WARN: _critical key %q has no matching default %q, skipping", key, baseKey)
-				continue
-			}
-
-			component, metric := parseMetricKey(baseKey)
-			if v, err := strconv.ParseFloat(strings.TrimSpace(override), 64); err == nil {
-				result = append(result, ResolvedThreshold{
-					Tenant:    tenant,
-					Metric:    metric,
-					Value:     v,
-					Severity:  "critical",
-					Component: component,
-				})
-			} else {
-				log.Printf("WARN: invalid critical threshold %q for tenant=%s key=%s", override, tenant, key)
-			}
-		}
-
-		// Phase 2B: dimensional keys — tenant overrides with {label="value"} syntax.
-		// Phase 11 B1: also supports {label=~"pattern"} regex matchers.
-		// These are tenant-only (no default inheritance) and don't support _critical suffix.
-		// Severity override uses the "value:severity" syntax (e.g., "500:critical").
-		for key, sv := range overrides {
-			if !strings.Contains(key, "{") {
-				continue // not a dimensional key
-			}
-			if strings.HasPrefix(key, "_state_") || strings.HasPrefix(key, "_silent_") ||
-				key == "_severity_dedup" || strings.HasPrefix(key, "_routing") {
-				continue
-			}
-
-			baseKey, customLabels, regexLabels := parseKeyWithLabels(key)
-			if len(customLabels) == 0 && len(regexLabels) == 0 {
-				log.Printf("WARN: failed to parse dimensional key %q for tenant=%s, skipping", key, tenant)
-				continue
-			}
-
-			valStr := sv.ResolveValue(now)
-			lower := strings.TrimSpace(strings.ToLower(valStr))
-			if isDisabled(lower) {
-				continue
-			}
-
-			component, metric := parseMetricKey(baseKey)
-			severity := "warning"
-
-			parts := strings.SplitN(valStr, ":", 2)
-			valueStr := strings.TrimSpace(parts[0])
-			if len(parts) == 2 {
-				severity = strings.TrimSpace(parts[1])
-			}
-
-			v, err := strconv.ParseFloat(valueStr, 64)
-			if err != nil {
-				log.Printf("WARN: invalid dimensional threshold %q for tenant=%s key=%s, skipping", valStr, tenant, key)
-				continue
-			}
-
-			result = append(result, ResolvedThreshold{
-				Tenant:       tenant,
-				Metric:       metric,
-				Value:        v,
-				Severity:     severity,
-				Component:    component,
-				CustomLabels: customLabels,
-				RegexLabels:  regexLabels,
-			})
-		}
+		// Phase 2A: base thresholds (three-state + inline severity suffix),
+		// Phase 2A-crit: <metric>_critical variants, Phase 2B: dimensional
+		// {label="v"}/{label=~"re"} overrides. Each phase is a verbatim
+		// extraction appended in the original order; intra-segment order is
+		// otherwise governed by Go map iteration (non-deterministic, as before)
+		// and the cardinality sort below.
+		result = append(result, c.resolveBaseRows(tenant, overrides, now)...)
+		result = append(result, c.resolveCriticalRows(tenant, overrides, now)...)
+		result = append(result, c.resolveDimensionalRows(tenant, overrides, now)...)
 
 		// #741 S3a: tenant-authored custom alerts → user_threshold{component="custom",
 		// recipe_id,name,mode}. Appended into this tenant's segment BEFORE the
@@ -304,6 +171,168 @@ func (c *ThresholdConfig) ResolveAtWithStats(now time.Time) ([]ResolvedThreshold
 		PerTenantOverLimit:         perTenantOverLimit,
 		PerTenantCustomAlertErrors: perTenantCustomAlertErrors,
 	}
+}
+
+// resolveBaseRows resolves a tenant's base thresholds from c.Defaults using the
+// three-state contract (custom value / omitted→default / disable) plus the
+// inline "value:severity" suffix. Extracted verbatim from the
+// ResolveAtWithStats per-tenant loop (Phase 2A) — see that method for the
+// full contract; behavior is unchanged.
+func (c *ThresholdConfig) resolveBaseRows(tenant string, overrides map[string]ScheduledValue, now time.Time) []ResolvedThreshold {
+	var rows []ResolvedThreshold
+	for metricKey, defaultValue := range c.Defaults {
+		// Skip _state_ / _silent_ / _severity_dedup / _routing keys — handled
+		// by ResolveStateFilters() / ResolveSilentModes() / ResolveSeverityDedup()
+		// / ResolveRouting() respectively.
+		if strings.HasPrefix(metricKey, "_state_") || strings.HasPrefix(metricKey, "_silent_") ||
+			metricKey == "_severity_dedup" || strings.HasPrefix(metricKey, "_routing") {
+			continue
+		}
+
+		// Parse metric key: "mysql_connections" → component="mysql", metric="connections"
+		component, metric := parseMetricKey(metricKey)
+		severity := "warning" // default severity
+
+		// Check tenant override (skip _state_ overrides)
+		if sv, exists := overrides[metricKey]; exists {
+			override := sv.ResolveValue(now)
+			lower := strings.TrimSpace(strings.ToLower(override))
+
+			// State 3: disable
+			if isDisabled(lower) {
+				continue
+			}
+
+			// Check if it has severity suffix: "70:critical"
+			parts := strings.SplitN(override, ":", 2)
+			valueStr := strings.TrimSpace(parts[0])
+			if len(parts) == 2 {
+				severity = strings.TrimSpace(parts[1])
+			}
+
+			// State 1: custom value
+			if v, err := strconv.ParseFloat(valueStr, 64); err == nil {
+				rows = append(rows, ResolvedThreshold{
+					Tenant:    tenant,
+					Metric:    metric,
+					Value:     v,
+					Severity:  severity,
+					Component: component,
+				})
+				continue
+			}
+
+			// Unknown value — log warning, use default
+			log.Printf("WARN: unknown value %q for tenant=%s metric=%s, using default", override, tenant, metricKey)
+		}
+
+		// State 2: use default
+		rows = append(rows, ResolvedThreshold{
+			Tenant:    tenant,
+			Metric:    metric,
+			Value:     defaultValue,
+			Severity:  severity,
+			Component: component,
+		})
+	}
+	return rows
+}
+
+// resolveCriticalRows resolves a tenant's <metric>_critical override variants,
+// each producing an additional severity=critical threshold for an existing
+// default metric. Extracted verbatim from the ResolveAtWithStats per-tenant
+// loop (multi-tier severity scan); behavior is unchanged.
+func (c *ThresholdConfig) resolveCriticalRows(tenant string, overrides map[string]ScheduledValue, now time.Time) []ResolvedThreshold {
+	var rows []ResolvedThreshold
+	for key, sv := range overrides {
+		if !strings.HasSuffix(key, "_critical") || strings.HasPrefix(key, "_state_") || strings.HasPrefix(key, "_silent_") {
+			continue
+		}
+
+		override := sv.ResolveValue(now)
+		lower := strings.TrimSpace(strings.ToLower(override))
+		if isDisabled(lower) {
+			continue
+		}
+
+		// Derive the base metric key: "mysql_connections_critical" → "mysql_connections"
+		baseKey := strings.TrimSuffix(key, "_critical")
+		// Verify that the base metric exists in defaults (otherwise ignore)
+		if _, exists := c.Defaults[baseKey]; !exists {
+			log.Printf("WARN: _critical key %q has no matching default %q, skipping", key, baseKey)
+			continue
+		}
+
+		component, metric := parseMetricKey(baseKey)
+		if v, err := strconv.ParseFloat(strings.TrimSpace(override), 64); err == nil {
+			rows = append(rows, ResolvedThreshold{
+				Tenant:    tenant,
+				Metric:    metric,
+				Value:     v,
+				Severity:  "critical",
+				Component: component,
+			})
+		} else {
+			log.Printf("WARN: invalid critical threshold %q for tenant=%s key=%s", override, tenant, key)
+		}
+	}
+	return rows
+}
+
+// resolveDimensionalRows resolves a tenant's dimensional overrides using the
+// `metric{label="v"}` / `{label=~"re"}` syntax. These are tenant-only (no
+// default inheritance) and use the "value:severity" suffix for severity.
+// Extracted verbatim from the ResolveAtWithStats per-tenant loop
+// (Phase 2B / Phase 11 B1); behavior is unchanged.
+func (c *ThresholdConfig) resolveDimensionalRows(tenant string, overrides map[string]ScheduledValue, now time.Time) []ResolvedThreshold {
+	var rows []ResolvedThreshold
+	for key, sv := range overrides {
+		if !strings.Contains(key, "{") {
+			continue // not a dimensional key
+		}
+		if strings.HasPrefix(key, "_state_") || strings.HasPrefix(key, "_silent_") ||
+			key == "_severity_dedup" || strings.HasPrefix(key, "_routing") {
+			continue
+		}
+
+		baseKey, customLabels, regexLabels := parseKeyWithLabels(key)
+		if len(customLabels) == 0 && len(regexLabels) == 0 {
+			log.Printf("WARN: failed to parse dimensional key %q for tenant=%s, skipping", key, tenant)
+			continue
+		}
+
+		valStr := sv.ResolveValue(now)
+		lower := strings.TrimSpace(strings.ToLower(valStr))
+		if isDisabled(lower) {
+			continue
+		}
+
+		component, metric := parseMetricKey(baseKey)
+		severity := "warning"
+
+		parts := strings.SplitN(valStr, ":", 2)
+		valueStr := strings.TrimSpace(parts[0])
+		if len(parts) == 2 {
+			severity = strings.TrimSpace(parts[1])
+		}
+
+		v, err := strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			log.Printf("WARN: invalid dimensional threshold %q for tenant=%s key=%s, skipping", valStr, tenant, key)
+			continue
+		}
+
+		rows = append(rows, ResolvedThreshold{
+			Tenant:       tenant,
+			Metric:       metric,
+			Value:        v,
+			Severity:     severity,
+			Component:    component,
+			CustomLabels: customLabels,
+			RegexLabels:  regexLabels,
+		})
+	}
+	return rows
 }
 
 // truncationSortKey produces a deterministic ordering key for one tenant's


### PR DESCRIPTION
## 目的

對 `components/threshold-exporter` 進行 **10 輪行為保留（behavior-preserving）refactor**，每輪流程為：發想 → 對抗式 ROI review → 計畫 → 實作 → self-review → 對抗式 review → build/vet/對應測試全綠 → commit。全程**零行為變更、零弱化測試、零新增 export**。

## 10 個 commit

| # | Commit | 主題 | 效果 |
|---|---|---|---|
| 1 | `52a3037` | 邊界規則去重 → 收斂回既有 `applyBoundaryRules` | −16 dup |
| 2 | `48fadef` | 合併迴圈去重 → `mergePartialInto`（eager/incremental 共用） | −28 dup |
| 3 | `d86b839` | `ResolveAtWithStats` 拆三相位 helper（base/critical/dimensional） | 226→70 |
| 4 | `f25b42b` | `IncrementalLoad` 拆純函式 `diffFileHashes`/`isTenantOnlyChange`/`patchTenants` + 清死碼 | 170→95 |
| 5 | `0964e92` | parse-error 處理去重 → `parsePartialConfig`（3 處共用）+ 移除失效 yaml import | −36 dup |
| 6 | `ea4fd5e` | `classifyAndCount`（154，最大 reload 函式）拆 `rebuildParsedDefaults`/`classifyTenant` | 154→40 |
| 7 | `014c177` | `TranslateProposal` 抽 `tallyProposalMembers` 累加器 | 114→62 |
| 8 | `d46f316` | `Collect`（232，全元件最長）拆 8 個 per-family `collect*` 方法 | 232→30 |
| 9 | `94a8ab4` | `emitOneProposal` 抽 `emitIntermediateProposal` | 101→50 |
| 10 | `de4b6ad` | `applyDecisions`（120）拆 `indexDecisionsByKey`/`staleDecisionWarnings`/`resolveProposalVerdict` | 120→30 |

主軸：把元件最複雜的幾個 god-function（`Collect` 232、`classifyAndCount` 154、`applyDecisions` 120、`ResolveAtWithStats` 226）拆成可單獨測試的小單元；並收斂 config-loader 三條路徑（flat/incremental/fullDir）的重複邊界規則、合併、parse-error 處理。

## 對抗式 review 擋下的「假 ROI」（皆先讀檔頭/grep 驗證才下判斷）

- ❌ **移除 `config_inheritance.go` shim** — 檔頭明載是刻意的 v2.8.0 PR-4 相容層（lowercase 人因 + 8 個語意陷阱單一文件家 + app-only `logMergeSkip`），移除＝跨 4 檔 churn、負 ROI。
- ❌ **`ReloadReason` 改 typed enum** — 原始碼註解明說「刻意保持 untyped 讓 metric label 與 log line 字串一致」。
- ❌ **config source 偵測去重** — 根本無重複（`GetConfigInfo` 只是讀快取欄位、`detectConfigSource` 負責填）。

## 驗證

- `go build ./...` / `go vet ./...` / `gofmt -l`：全綠、無未格式化檔。
- 全模組 `go test ./...`：10 packages 全 `ok`、0 failures。
- 每輪皆由對應既有測試把關，含 **golden-parity（cross-impl merged_hash）**、72 reload/debounce/blast-radius、66 collector/metric、49 translate、38 decisions、16 incremental 等。

## Review 重點建議

每個 commit 都是獨立、原子的單一 refactor，**建議逐 commit review**。所有抽出的 helper 皆為原邏輯的 verbatim lift（commit message 內已逐項標註等價性論證，如 `continue`→`return`、map 迭代序本就非決定性、append 順序保留等）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
