### PR TITLE
fix(ops): de-flake git_check_lock — scope active-git scan to this repo

### DIFF
--- a/scripts/session-guards/git_check_lock.sh
+++ b/scripts/session-guards/git_check_lock.sh
@@ -227,9 +227,14 @@ filter_to_this_repo() {
         return
     fi
     while IFS= read -r line; do
-        # argv 顯式引用本 repo（git -C <repo> / --git-dir=<repo>/.git）→ 計入
+        # argv 顯式引用本 repo（git -C <repo> / --git-dir=<repo>/.git）→ 計入。
+        # 須帶 path boundary（行尾 / 空白 / `/`），否則 sibling 前綴路徑
+        # （如 <repo>-other）會被誤配 → 又把無關 git 算成活躍。
         case "$line" in
-            *"$REPO_ROOT_ABS"*) echo "$line"; continue ;;
+            *"$REPO_ROOT_ABS" | *"$REPO_ROOT_ABS "* | *"$REPO_ROOT_ABS"/*)
+                echo "$line"
+                continue
+                ;;
         esac
         local pid cwd
         pid="${line%% *}"

--- a/scripts/session-guards/git_check_lock.sh
+++ b/scripts/session-guards/git_check_lock.sh
@@ -207,13 +207,46 @@ echo ""
 #   3. 濾掉 pgrep 自己（argv 含 "git" 來自「搜尋 git」的 pattern）
 #
 # 剩下的才可能是真的活 git 程序（git commit / fetch / push 等）。
+#
+#   4. Repo-scope filter (主要正確性 + 去 flake)：原本 host-global `pgrep`
+#      會把「跟本 repo 無關」的 git 程序也算進來（例如平行 CI 下其他
+#      pytest-xdist worker 跑的 git），造成 --clean 誤判「有活躍 git」而
+#      跳過清理 → flaky test（test_clean_mode_removes_stale_locks）。
+#      改為只計入「cwd 落在本 repo 內」或「argv 顯式指向本 repo」的程序。
+#      無 /proc 的平台（如 Windows Git Bash）退回保守的 host-global 行為。
 echo "--- 活躍的 Git 程序 ---"
 SELF_PIDS="^($$|$PPID|${BASHPID:-$$})$"
+REPO_ROOT_ABS="$(cd "$REPO_ROOT" 2>/dev/null && pwd || echo "$REPO_ROOT")"
+
+# stdin: self/name-filtered pgrep lines（格式 "<pid> <argv...>"）
+# stdout: 只保留真正在操作「本 repo」的行
+filter_to_this_repo() {
+    if [ ! -d /proc ]; then
+        # 無 /proc：無法依 cwd scope，退回保守 host-global 行為
+        cat
+        return
+    fi
+    while IFS= read -r line; do
+        # argv 顯式引用本 repo（git -C <repo> / --git-dir=<repo>/.git）→ 計入
+        case "$line" in
+            *"$REPO_ROOT_ABS"*) echo "$line"; continue ;;
+        esac
+        local pid cwd
+        pid="${line%% *}"
+        # 讀不到 cwd（程序已結束 / 非本 repo）→ 排除（不誤判為活躍）
+        cwd="$(readlink "/proc/$pid/cwd" 2>/dev/null)" || continue
+        case "$cwd" in
+            "$REPO_ROOT_ABS" | "$REPO_ROOT_ABS"/*) echo "$line" ;;
+        esac
+    done
+}
+
 ACTIVE_LINES=$(
     pgrep -af "git" 2>/dev/null \
         | grep -v "git_check_lock" \
         | grep -v "pgrep" \
         | awk -v selfre="$SELF_PIDS" '$1 !~ selfre' \
+        | filter_to_this_repo \
         | head -5 \
         || true
 )


### PR DESCRIPTION
## 問題

`tests/ops/test_git_check_lock.py::TestLockDiagnosis::test_clean_mode_removes_stale_locks` 在 `Python Tests (3.13)` (Linux, `pytest -n auto`) 間歇性失敗：

```
AssertionError: stale lock should have been removed
```

它一度卡住一支純文件 PR (#796)（套件 `-x` 連坐）。

## 真因（非 mtime/timing）

lock 被 aged 到 **60s**，遠超 `git_check_lock.sh` 的 **30s** staleness 門檻，granularity/clock 不可能是因。真因是 active-git 偵測用 **host-global** 掃描：

```bash
pgrep -af "git"   # 比對整台機器所有 argv 含 git 的程序
```

`pytest -n auto` 下其他 xdist worker 會 spawn 真實 `git` 子程序。某個剛好活著時，本測試的 `--clean` 把它算成「有活躍 git」→ 走「⛔ 跳過清理」分支 → lock 未刪 → assertion 失敗。腳本仍 `exit 0`，故 `returncode == 0` 通過、只有 lock assertion 爆——正好對上觀察到的特徵。

> 補充：Windows dev host 無 `pgrep` → 本機永遠 false → 一律過（解釋「本機 3/3 綠」）。flake 是 Linux-CI + 平行套件專屬。

## 修法

把 active-git 偵測收斂到「真正在操作本 repo」的程序：只計入 `/proc/<pid>/cwd` 落在 `REPO_ROOT` 內、或 argv 顯式指向本 repo（`git -C` / `--git-dir`）的程序。無 `/proc` 的平台（Windows Git Bash）退回原本保守的 host-global 行為。

這也修掉一個真實（雖小）的 production 缺陷：別的 checkout 在跑 `git fetch` 不該擋住本 repo 的 `make git-preflight` 清 lock。連帶修好同樣依賴此判斷的 sibling 測試 `test_no_false_positive_when_invoked_normally`。

**權衡（誠實揭露）**：若有人用 `git -C <repo>` 從 repo 外、且 argv 未含絕對路徑操作本 repo，偵測會漏掉它。本 repo 工作流 git 一律從 repo 內啟動（dev container / make / hooks，cwd 在 repo 內），此情境罕見；argv 比對也覆蓋常見的 `-C`/`--git-dir` 寫法。

## 驗證（dev-container, Linux + pgrep + /proc）

| 項目 | 結果 |
|---|---|
| 行為重現（修前）— foreign git 在別處 | `LOCK STILL EXISTS`（bug 重現）|
| 行為重現（修後）— foreign git 在別處 | lock **REMOVED**（flake 消失）|
| 行為重現（修後）— 真實 git 在本 repo | lock **KEPT**（safety 保留）|
| `pytest tests/ops/test_git_check_lock.py -n auto` ×5 | 14 passed ×5 |
| 同上 + 背景持續 churn foreign git ×8 | 全綠 |

與 #796（docs refresh）、#794（entrypoint hardening）無關，獨立維護修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
