### PR TITLE
fix(tenant-api): harden PR-mode errors + strict env parsing

### DIFF
--- a/components/tenant-api/internal/gitops/writer.go
+++ b/components/tenant-api/internal/gitops/writer.go
@@ -40,6 +40,14 @@ var ErrPendingPR = errors.New("pending PR exists for this tenant")
 // file another tenant already merged remotely — the whole TRK-318 hazard).
 var ErrForgeDegraded = errors.New("forge degradation: base fetch timed out — write lock released")
 
+// ErrValidation wraps a schema/structural validation failure of the incoming
+// YAML. It lets handlers distinguish a CLIENT error (malformed body → HTTP 400)
+// from a server-side write failure (500): the direct-write path already returned
+// 400 for these, but the PR-mode path previously mapped every non-retryable
+// write error to 500 (#795 F1). Returned by Write / WritePR / WritePRBatch via
+// fmt.Errorf("%w: …", ErrValidation, …), so errors.Is(err, ErrValidation) holds.
+var ErrValidation = errors.New("validation failed")
+
 // OnWriteFunc is called after a successful config write.
 // tenantID is the tenant or entity that was written (tenant ID, "groups", "views", etc.)
 type OnWriteFunc func(tenantID string)
@@ -257,7 +265,7 @@ func (w *Writer) Write(ctx context.Context, tenantID, authorEmail, yamlContent s
 	// admission slot — validation is cheap, CPU-only, and must not consume the
 	// single-writer token).
 	if errs := validate(w.configDir, tenantID, yamlContent); len(errs) > 0 {
-		return fmt.Errorf("validation failed: %s", strings.Join(errs, "; "))
+		return fmt.Errorf("%w: %s", ErrValidation, strings.Join(errs, "; "))
 	}
 
 	// Step 2: load-shedding admission (TRK-320) before w.mu.

--- a/components/tenant-api/internal/gitops/writer_extra_test.go
+++ b/components/tenant-api/internal/gitops/writer_extra_test.go
@@ -2,6 +2,7 @@ package gitops
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -141,6 +142,30 @@ func TestWrite_MissingTenantSection(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "validation failed") {
 		t.Errorf("expected 'validation failed' in error, got: %v", err)
+	}
+}
+
+// TestValidationFailuresWrapErrValidation is the #795 F1 guard at the gitops
+// layer: Write / WritePR / WritePRBatch must wrap validation failures so callers
+// can errors.Is(err, ErrValidation) and map them to HTTP 400 (not 500). All three
+// validate BEFORE any git/disk work, so a plain temp dir (no git repo) suffices.
+// Notably covers the WritePRBatch path that backs the batch handler's
+// ErrValidation→400 branch (tenant_batch.go).
+func TestValidationFailuresWrapErrValidation(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	w := NewWriter(dir, dir)
+	ctx := context.Background()
+	const bad = "{{invalid yaml"
+
+	if err := w.Write(ctx, "db-a", "e@x.com", bad); !errors.Is(err, ErrValidation) {
+		t.Errorf("Write: errors.Is(err, ErrValidation) = false; err = %v", err)
+	}
+	if _, err := w.WritePR(ctx, "db-a", "e@x.com", bad); !errors.Is(err, ErrValidation) {
+		t.Errorf("WritePR: errors.Is(err, ErrValidation) = false; err = %v", err)
+	}
+	if _, err := w.WritePRBatch(ctx, []PRBatchOp{{TenantID: "db-a", YAMLContent: bad}}, "e@x.com"); !errors.Is(err, ErrValidation) {
+		t.Errorf("WritePRBatch: errors.Is(err, ErrValidation) = false; err = %v", err)
 	}
 }
 

--- a/components/tenant-api/internal/gitops/writer_pr.go
+++ b/components/tenant-api/internal/gitops/writer_pr.go
@@ -36,7 +36,7 @@ type PRWriteResult struct {
 func (w *Writer) WritePR(ctx context.Context, tenantID, authorEmail, yamlContent string) (*PRWriteResult, error) {
 	// Step 1: validate schema before anything
 	if errs := validate(w.configDir, tenantID, yamlContent); len(errs) > 0 {
-		return nil, fmt.Errorf("validation failed: %s", strings.Join(errs, "; "))
+		return nil, fmt.Errorf("%w: %s", ErrValidation, strings.Join(errs, "; "))
 	}
 
 	// Step 1b: load-shedding admission (TRK-320) before w.mu.
@@ -145,7 +145,7 @@ func (w *Writer) WritePRBatch(ctx context.Context, ops []PRBatchOp, authorEmail 
 	// Validate all operations first
 	for _, op := range ops {
 		if errs := validate(w.configDir, op.TenantID, op.YAMLContent); len(errs) > 0 {
-			return nil, fmt.Errorf("validation failed for %s: %s", op.TenantID, strings.Join(errs, "; "))
+			return nil, fmt.Errorf("%w for %s: %s", ErrValidation, op.TenantID, strings.Join(errs, "; "))
 		}
 	}
 

--- a/components/tenant-api/internal/handler/errors.go
+++ b/components/tenant-api/internal/handler/errors.go
@@ -35,6 +35,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -310,7 +311,10 @@ func writeWriteFlowError(w http.ResponseWriter, r *http.Request, err error) bool
 //     through to the 503 below (TRK-319).
 //   - platform.ErrCircuitOpen → 503 CodeForgeUnavailable: forge degraded and
 //     fast-failed (#632/#645); never leaks the internal "circuit breaker open".
-//   - anything else           → 503 with the sanitized provider message.
+//   - anything else           → 503 with a FIXED provider-scoped message; the
+//     underlying error is logged server-side, never echoed to the client
+//     (#795 F2 — keeps the no-leak contract; err here is the already-sanitized
+//     APIError but we don't surface even its method/path/status).
 func writeForgeCreateError(w http.ResponseWriter, r *http.Request, provider string, err error) {
 	switch {
 	case errors.Is(err, platform.ErrForbidden):
@@ -320,7 +324,8 @@ func writeForgeCreateError(w http.ResponseWriter, r *http.Request, provider stri
 		WriteJSONErrorWithCode(w, r, http.StatusServiceUnavailable, CodeForgeUnavailable,
 			fmt.Sprintf("%s is currently unavailable — please retry shortly", provider))
 	default:
+		slog.Warn("forge PR/MR creation failed", "provider", provider, "error", err)
 		WriteJSONError(w, r, http.StatusServiceUnavailable,
-			fmt.Sprintf("%s PR/MR creation failed: %s", provider, err.Error()))
+			fmt.Sprintf("%s PR/MR creation failed — please retry shortly", provider))
 	}
 }

--- a/components/tenant-api/internal/handler/middleware.go
+++ b/components/tenant-api/internal/handler/middleware.go
@@ -18,9 +18,9 @@ package handler
 // ============================================================
 
 import (
-	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -120,8 +120,10 @@ func MaxBodyBytesFromEnv(envValue string) (n int64, malformed bool) {
 	if v == "" {
 		return DefaultMaxBodyBytes, false
 	}
-	var parsed int64
-	if _, err := fmt.Sscanf(v, "%d", &parsed); err != nil || parsed <= 0 {
+	// #795 F4: strict full-string parse (see RateLimitConfigFromEnv) — Sscanf
+	// accepted numeric prefixes like "1048576x", silently using a wrong cap.
+	parsed, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || parsed <= 0 {
 		return DefaultMaxBodyBytes, true
 	}
 	return parsed, false

--- a/components/tenant-api/internal/handler/middleware_test.go
+++ b/components/tenant-api/internal/handler/middleware_test.go
@@ -440,6 +440,58 @@ func TestMaxBodyBytesFromEnv_Negative(t *testing.T) {
 	}
 }
 
+// TestRateLimitConfigFromEnv_NumericPrefixRejected is the #795 F4 guard: strict
+// strconv.Atoi parsing must reject a numeric-prefixed value. The old fmt.Sscanf
+// silently accepted "100rpm" → 100, shipping a typo'd cap instead of warning.
+func TestRateLimitConfigFromEnv_NumericPrefixRejected(t *testing.T) {
+	t.Parallel()
+	cfg, malformed := RateLimitConfigFromEnv("100rpm")
+	if cfg.RequestsPerMinute != 100 {
+		t.Errorf("prefixed env: RequestsPerMinute = %d, want 100 (fallback default)", cfg.RequestsPerMinute)
+	}
+	if !malformed {
+		t.Error("'100rpm' must be flagged malformed (strict parse), not silently parsed as 100")
+	}
+}
+
+// TestMaxBodyBytesFromEnv_NumericPrefixRejected mirrors the above for the body cap.
+func TestMaxBodyBytesFromEnv_NumericPrefixRejected(t *testing.T) {
+	t.Parallel()
+	n, malformed := MaxBodyBytesFromEnv("1048576x")
+	if n != DefaultMaxBodyBytes {
+		t.Errorf("prefixed env: bytes = %d, want default %d (fallback)", n, DefaultMaxBodyBytes)
+	}
+	if !malformed {
+		t.Error("'1048576x' must be flagged malformed (strict parse), not silently parsed as 1048576")
+	}
+}
+
+// TestRateLimit_DisabledClearsActiveLimiter is the #795 F3 guard: rebuilding the
+// limiter as disabled (RequestsPerMinute<=0) must clear the package-level
+// activeLimiter so RateLimitMetrics() honors its (0,0) contract instead of
+// reporting the previously-installed limiter. NOT t.Parallel() — it mutates the
+// package-level activeLimiter that RateLimitMetrics() reads.
+func TestRateLimit_DisabledClearsActiveLimiter(t *testing.T) {
+	stop := make(chan struct{})
+	defer close(stop)
+	// Install an enabled limiter and drive a rejection so its counters are non-zero.
+	_, lim := RateLimit(RateLimitConfig{RequestsPerMinute: 1}, stop)
+	if lim == nil {
+		t.Fatal("enabled RateLimit returned a nil limiter")
+	}
+	now := time.Now()
+	lim.allow("c", now)
+	lim.allow("c", now) // second within the window → rejection (cap 1)
+	if rej, _ := RateLimitMetrics(); rej == 0 {
+		t.Fatal("precondition: expected non-zero rejections from the enabled limiter")
+	}
+	// Rebuild disabled → must clear activeLimiter.
+	RateLimit(RateLimitConfig{RequestsPerMinute: 0}, stop)
+	if rej, active := RateLimitMetrics(); rej != 0 || active != 0 {
+		t.Errorf("after disabled rebuild: RateLimitMetrics() = (%d, %d), want (0, 0) — activeLimiter not cleared (#795 F3)", rej, active)
+	}
+}
+
 // Deps.MaxBody fallback: tests that build Deps without wiring
 // MaxBodyBytes must still get a non-zero limit so existing
 // fixtures keep working.

--- a/components/tenant-api/internal/handler/pr_test.go
+++ b/components/tenant-api/internal/handler/pr_test.go
@@ -718,6 +718,70 @@ func TestPutTenant_PRMode_ForgeForbidden(t *testing.T) {
 	}
 }
 
+// TestPutTenant_PRMode_MalformedYAMLReturns400 is the #795 F1 guard: in PR mode a
+// malformed/invalid tenant body is a CLIENT error → HTTP 400 (matching the
+// direct-write path), not a 500. Before the fix WritePR's validation failure was
+// mapped to 500 by the PR handler. The body declares the wrong tenant section so
+// validate() fails (gitops.ErrValidation) before any forge call.
+func TestPutTenant_PRMode_MalformedYAMLReturns400(t *testing.T) {
+	t.Parallel()
+	configDir := initGitConfigDir(t)
+	writer := newTestWriter(configDir)
+	rbacMgr := adminRBAC(t)
+	mockClient := &mockPlatformClient{providerName: "github"}
+	mockTracker := &mockPlatformTracker{}
+
+	h := PutTenant(&Deps{Writer: writer, WriteMode: WriteModePR, PRClient: mockClient, PRTracker: mockTracker, RBAC: rbacMgr})
+	// tenants.db-a is absent → validate() returns "must contain tenants.db-a".
+	body := bytes.NewBufferString("tenants:\n  other-tenant:\n    _silent_mode: \"warning\"\n")
+	req := newRequestWithChiParam("PUT", "/api/v1/tenants/db-a", "id", "db-a", body)
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+	req.Header.Set("X-Forwarded-Groups", "admins")
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(h, rbacMgr, rbac.PermWrite, TenantIDFromPath).ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("malformed PR-mode body: status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+	// Claim released on the client-error exit so a corrected retry isn't blocked.
+	if !mockTracker.ClaimTenant("db-a") {
+		t.Error("claim should be released after a validation-failed PR write")
+	}
+}
+
+// TestPutTenant_PRMode_GenericForgeErrorNoLeak is the #795 F2 guard: a generic
+// (non-forbidden, non-circuit) forge creation error maps to a fixed 503 message;
+// the underlying error text is NOT echoed in the response body.
+func TestPutTenant_PRMode_GenericForgeErrorNoLeak(t *testing.T) {
+	t.Parallel()
+	configDir := initGitConfigDir(t)
+	writer := newTestWriter(configDir)
+	rbacMgr := adminRBAC(t)
+	const secret = "super-secret-internal-detail-/repos/o/r"
+	mockClient := &mockPlatformClient{
+		providerName: "github",
+		createPRFunc: func(title, body, headBranch string, labels []string) (*platform.PRInfo, error) {
+			return nil, fmt.Errorf("%s", secret)
+		},
+	}
+	mockTracker := &mockPlatformTracker{}
+
+	h := PutTenant(&Deps{Writer: writer, WriteMode: WriteModePR, PRClient: mockClient, PRTracker: mockTracker, RBAC: rbacMgr})
+	body := bytes.NewBufferString("tenants:\n  db-a:\n    _silent_mode: \"critical\"\n")
+	req := newRequestWithChiParam("PUT", "/api/v1/tenants/db-a", "id", "db-a", body)
+	req.Header.Set("X-Forwarded-Email", "alice@example.com")
+	req.Header.Set("X-Forwarded-Groups", "admins")
+	w := httptest.NewRecorder()
+	wrapWithRBACMiddleware(h, rbacMgr, rbac.PermWrite, TenantIDFromPath).ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("generic forge error: status = %d, want 503; body=%s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), secret) {
+		t.Errorf("503 body leaked internal error detail: %s", w.Body.String())
+	}
+}
+
 // TestPutTenant_PRMode_RateLimited403MapsTo503 is the TRK-319 end-to-end guard:
 // a forge 403 that is a SECONDARY RATE LIMIT (not a permission error) must NOT
 // map to a clean HTTP 403 (which would tell the operator "fix your token" for a

--- a/components/tenant-api/internal/handler/rate_limiter.go
+++ b/components/tenant-api/internal/handler/rate_limiter.go
@@ -12,6 +12,7 @@ package handler
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -306,8 +307,10 @@ func RateLimitMetrics() (rejections int64, activeCallers int) {
 // else's limiter.
 func RateLimit(cfg RateLimitConfig, stopCh <-chan struct{}) (func(http.Handler) http.Handler, *rateLimiter) {
 	if cfg.RequestsPerMinute <= 0 {
-		// Limiter disabled: hand back the identity middleware so
-		// the chain composes cleanly.
+		// Limiter disabled: clear any previously-installed limiter so
+		// RateLimitMetrics() honors its (0, 0) contract (#795 F3), then hand
+		// back the identity middleware so the chain composes cleanly.
+		activeLimiter.Store(nil)
 		return func(next http.Handler) http.Handler { return next }, nil
 	}
 	// Production limiters get the sweeper; the activeLimiter
@@ -366,8 +369,11 @@ func RateLimitConfigFromEnv(envValue string) (cfg RateLimitConfig, malformed boo
 	if v == "" {
 		return cfg, false
 	}
-	var n int
-	if _, err := fmt.Sscanf(v, "%d", &n); err != nil || n < 0 {
+	// #795 F4: strict full-string parse. fmt.Sscanf("%d") accepted numeric
+	// prefixes (e.g. "100rpm" → 100), silently shipping a typo'd cap; strconv.Atoi
+	// rejects any non-integer so malformed input takes the warn+default path.
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
 		return cfg, true
 	}
 	cfg.RequestsPerMinute = n

--- a/components/tenant-api/internal/handler/tenant_batch.go
+++ b/components/tenant-api/internal/handler/tenant_batch.go
@@ -148,11 +148,16 @@ func BatchTenants(d *Deps) http.HandlerFunc {
 			result, err := d.Writer.WritePRBatch(r.Context(), batchOps, email)
 			if err != nil {
 				// TRK-320 ErrWriteOverloaded / TRK-318 ErrForgeDegraded → canonical
-				// retry-hinting 503s (shared with the single-write path). Anything else
-				// is an unexpected git failure → generic 500 with the batch message.
+				// retry-hinting 503s (shared with the single-write path).
 				if writeWriteFlowError(rw, r, err) {
 					return
 				}
+				// #795 F1: a malformed op body is a CLIENT error → 400, not a 500.
+				if errors.Is(err, gitops.ErrValidation) {
+					WriteJSONError(rw, r, http.StatusBadRequest, err.Error())
+					return
+				}
+				// Anything else is an unexpected git failure → generic 500.
 				WriteJSONError(rw, r, http.StatusInternalServerError, "PR/MR batch write failed: "+err.Error())
 				return
 			}

--- a/components/tenant-api/internal/handler/tenant_put.go
+++ b/components/tenant-api/internal/handler/tenant_put.go
@@ -167,11 +167,17 @@ func putTenantPRMode(d *Deps, rw http.ResponseWriter, r *http.Request, tenantID,
 	result, err := d.Writer.WritePR(r.Context(), tenantID, email, yamlContent)
 	if err != nil {
 		// TRK-320 ErrWriteOverloaded / TRK-318 ErrForgeDegraded → canonical
-		// retry-hinting 503s (shared with the batch path). Anything else is an
-		// unexpected git failure → generic 500 with the single-write message.
+		// retry-hinting 503s (shared with the batch path).
 		if writeWriteFlowError(rw, r, err) {
 			return
 		}
+		// #795 F1: malformed body is a CLIENT error → 400 (matches the
+		// direct-write path), not a server 500.
+		if errors.Is(err, gitops.ErrValidation) {
+			WriteJSONError(rw, r, http.StatusBadRequest, err.Error())
+			return
+		}
+		// Anything else is an unexpected git failure → generic 500.
 		WriteJSONError(rw, r, http.StatusInternalServerError, "PR write failed: "+err.Error())
 		return
 	}


### PR DESCRIPTION
## 摘要

#793(tenant-api 11-cycle 重構)merge 後的 hardening follow-up,修掉 CodeRabbit 在 #793 提出、經查全為 **main 既有、被 #793 逐字搬移**的 4 項(當時刻意 defer 以保持 #793 純重構)。Resolves #795。

## 內容

| # | 修正 | 變更 |
|---|------|------|
| **F1** | PR-mode 驗證失敗回 500 → **400** | 新增 gitops `ErrValidation` sentinel;`Write`/`WritePR`/`WritePRBatch` 以 `%w` 包裝 `validate()` 失敗;PR-mode handler(`PutTenant`、`BatchTenants`)以 `errors.Is(err, ErrValidation)` 對映 **400**,與 direct-write 路徑一致。**順序保留**:`ErrWriteOverloaded`/`ErrForgeDegraded` 仍優先回各自的 503。 |
| **F2** | forge 建立失敗的 503 body 不再夾 `err.Error()` | default 分支改固定訊息 `"<provider> PR/MR creation failed — please retry shortly"`,底層 err 改 `slog.Warn` server-side。 |
| **F3** | `RateLimit` 停用時清 `activeLimiter` | `RequestsPerMinute<=0` 分支 `activeLimiter.Store(nil)`,使 `RateLimitMetrics()` 守住 (0,0) 契約。 |
| **F4** | env 整數解析改嚴格全字串 | `RateLimitConfigFromEnv` + `MaxBodyBytesFromEnv` 以 `strconv.Atoi`/`ParseInt` 取代 `fmt.Sscanf("%d")`(後者會吃 `100rpm`→100 前綴、靜默採用錯值)。 |

唯一行為變更即 F1(500→400);F2 訊息收斂;F3/F4 為硬化。**無功能新增**。

## 測試(+6 regression)

- `TestPutTenant_PRMode_MalformedYAMLReturns400`(F1 單租戶)
- `TestPutTenant_PRMode_GenericForgeErrorNoLeak`(F2 不洩漏)
- `TestRateLimitConfigFromEnv_NumericPrefixRejected` / `TestMaxBodyBytesFromEnv_NumericPrefixRejected`(F4)
- `TestRateLimit_DisabledClearsActiveLimiter`(F3)
- `TestValidationFailuresWrapErrValidation`(gitops 單元;斷言三個 writer 都包 `ErrValidation`,**涵蓋 batch 路徑**)

## 驗證

- `go build ./...`、`go vet ./...`、`gofmt`(改動檔)全乾淨;全測試套件 **GREEN**(除 host-flaky `internal/ws`,本 PR 未動)。
- 對抗式 review:**correct-and-complete** —— 確認 (a) `ErrValidation` 不會把非驗證類的 500 誤降為 400(只包 3 個 `validate()` 分支),(b) F1 順序保留 503,(c) F2 零洩漏,(d) F4 不會誤拒任何原本合法的 env 值(`+5`/`007`/前後空白/overflow 皆與舊行為一致)。

## ⚠️ 合併提醒

與 #793 相同:本 PR 純 Go(`components/tenant-api/**`),不觸發 path-filtered 的 `docs-ci.yaml`,故其 8 個 required doc context 不會 report → `mergeStateStatus` 會是 **BLOCKED**。`enforce_admins=false`,請 **admin-merge**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
