### PR TITLE
docs(portal): refresh da-portal README + QUICKSTART to current architecture (+Dockerfile dist COPY)

### DIFF
--- a/components/da-portal/Dockerfile
+++ b/components/da-portal/Dockerfile
@@ -1,10 +1,12 @@
 # da-portal — Self-hosted Interactive Tools & Tenant Self-Service Portal
 #
-# Zero build step: all JSX files are transpiled in the browser via Babel standalone.
-# Vendor JS files are bundled for air-gapped / offline deployment.
+# Tools are pre-built into ESM bundles (esbuild, `make portal-build`) and served
+# as static files — no runtime build/transpile in the browser. Vendor JS
+# (React / Tailwind / Lucide) is bundled for air-gapped / offline deployment,
+# with CDN fallback otherwise.
 #
-# Build:  docker build -t da-portal:v2.5.0 -f components/da-portal/Dockerfile .
-# Run:    docker run -p 8080:80 da-portal:v2.5.0
+# Build:  make portal-build && docker build -t da-portal:v2.8.0 -f components/da-portal/Dockerfile .
+# Run:    docker run -p 8080:80 da-portal:v2.8.0
 #
 # Customisation via volume mounts:
 #   -v ./my-platform-data.json:/usr/share/nginx/html/assets/platform-data.json
@@ -45,8 +47,14 @@ RUN rm -rf /usr/share/nginx/html/*
 # ── Nginx config ──────────────────────────────────────────────
 COPY --chown=nginx:nginx components/da-portal/nginx.conf /etc/nginx/conf.d/default.conf
 
-# ── Interactive Tools Hub + 38 JSX tools ──────────────────────
+# ── Interactive Tools Hub (index + changelog) ─────────────────
 COPY --chown=nginx:nginx docs/interactive/ /usr/share/nginx/html/interactive/
+
+# ── Pre-built tool bundles (esbuild ESM output; `make portal-build`) ──
+# jsx-loader.html loads /assets/dist/<tool>.js at runtime; the legacy
+# in-browser Babel transpile path is gone, so these bundles MUST be in the
+# image or every tool 404s.
+COPY --chown=nginx:nginx docs/assets/dist/ /usr/share/nginx/html/assets/dist/
 
 # ── Getting Started Wizard ────────────────────────────────────
 # Path follows the portal monorepo restructure (PR #279, TD-042, 2026-05-07):

--- a/components/da-portal/QUICKSTART.md
+++ b/components/da-portal/QUICKSTART.md
@@ -1,39 +1,40 @@
-# da-portal — interactive alerting & ops tools, right in your browser
+# da-portal — 在瀏覽器裡玩的告警與維運互動工具
 
-> **把複雜的 PromQL 與告警配置封進一整套瀏覽器互動工具——打開就玩，零安裝。**
-> *Interactive alerting/ops tools in your browser — zero install.*
+> **把複雜的 PromQL 與告警配置，封成「打開瀏覽器就能玩」的一整套互動工具。**
+> *Interactive alerting/ops tools in your browser — open and play.*
 
 |  |  |
 |---|---|
-| **What / 是什麼** | self-service portal：alert builder / PromQL tester / threshold calculator / cost estimator / rule-pack selector…一整套互動工具（完整清單見 [Interactive Tools Hub](../../docs/interactive-tools.md)）。*A self-service portal of interactive tools.* |
-| **Why / 為什麼** | 把告警/維運能力封成**打開瀏覽器就能玩**的工具，零安裝、零 npm、零 build。*Complex PromQL & alert config, packaged as browser tools.* |
-| **Who / 給誰** | 任何想「先看看這平台能幹嘛」的人 |
-| **Try（≤2 min）** | `docker run --rm -p 8080:80 ghcr.io/vencil/da-portal:v2.8.0` → 開 http://localhost:8080 |
-| **→ You'll see** | 互動工具的儀表板，**立即可玩**。*A dashboard of interactive tools, instantly.* |
+| **是什麼** | 一個 self-service portal，內含 44 個互動工具：alert builder / PromQL tester / threshold calculator / cost estimator / routing trace / config lint…（完整清單見 [Interactive Tools Hub](../../docs/interactive-tools.md)） |
+| **解決什麼** | 不用先讀懂 PromQL、不用裝任何工具，就能試算閾值、預覽告警、驗證設定 |
+| **怎麼跑** | 一顆 nginx 靜態 image，`docker run` 一行即起；工具是**預先 build 好的**，你這端不需要 npm、不需要 build |
+| **打開會看到** | 一個互動工具的儀表板，**立即可玩** |
 
-> 🎯 **主要服務對象**：Tenant（瀏覽器自助調閾值 / Saved View，見 [Tenant 角色指南](../../docs/getting-started/for-tenants.md)）；Platform Engineer 為租戶除錯時亦常用。
+> 🎯 **這個 portal 服務誰？** 三種角色，各有專屬上手指南：
+> - **Tenant（租戶）** — 瀏覽器自助調閾值、存 Saved View → [Tenant 指南](../../docs/getting-started/for-tenants.md)
+> - **Platform Engineer / SRE** — 為租戶除錯、規劃容量、驗證路由 → [Platform 指南](../../docs/getting-started/for-platform-engineers.md)
+> - **Domain Expert** — 把監控知識落成 Rule Pack / 預算守則 → [Domain Expert 指南](../../docs/getting-started/for-domain-experts.md)
 
-**Prerequisite**：Docker 20.10+。
+**前置需求**：Docker 20.10+。
 
-## Try it
+## 馬上試（≤ 2 分鐘）
 
 ```sh
 docker run --rm -p 8080:80 ghcr.io/vencil/da-portal:v2.8.0
 #   → 開瀏覽器：http://localhost:8080
 ```
 
-**不需要 npm、不需要 `portal-build`、不需要任何後端**——這是 da-portal 的 packaging 優勢：published image 內含預先 build 好的 ESM bundle，`docker run` 一行即玩 ~34 個**純前端**工具（calculator / tester / selector / estimator…）。
+大多數工具是**純前端**（calculator / tester / selector / estimator…），單跑這顆 image 就能離線玩。
 
-> ⚠️ **旗艦 Tenant Manager / Saved Views / Simulate 需要 tenant-api 後端**——單跑 portal 時它們會顯示連線錯誤（這是預期的）。要看**活的** Tenant Manager（管理真實租戶、模擬變更），跑「核心雙星」：
+> ⚠️ **少數旗艦工具需要後端**——Tenant Manager / Saved Views / Simulate 會打 `tenant-api`，單跑 portal 時它們會顯示連線錯誤（這是預期的）。要看**活的** Tenant Manager（管理真實租戶、模擬變更、Save 落真實 git commit），在 [`try-local/`](../../try-local/) 起「核心雙星」：
 >
 > ```sh
-> # 在 try-local/ 目錄
-> docker compose up da-portal tenant-api
+> cd try-local
+> docker compose up da-portal tenant-api    # 約 10 秒，旗艦工具全活
 > ```
->
-> 約 10 秒，portal 後端有 tenant-api 撐腰，旗艦工具全活。
 
-## Next
-- ← **先玩整套**：[`try-local/`](../../try-local/)（Mode 0 核心雙星 + 完整監控網格與告警紅燈）
-- 📖 **深入配置 / 完整工具清單**：[`README.md`](README.md)（本元件的 reference）
-- → **上 production**：[`helm/da-portal/`](../../helm/da-portal/)（nginx 靜態服務 + ingress / oauth2-proxy 接 tenant-api）
+## 接下來
+
+- **先玩整套** → [`try-local/`](../../try-local/)：一鍵起完整監控網格 + 真實 critical 告警紅燈
+- **進階配置 / 完整參考** → [`README.md`](README.md)：build、部署、客製、troubleshooting
+- **上 production** → [`helm/da-portal/`](../../helm/da-portal/)：ingress + oauth2-proxy 接 tenant-api

--- a/components/da-portal/README.md
+++ b/components/da-portal/README.md
@@ -1,40 +1,52 @@
 # da-portal (v2.8.0)
 
-<!-- 標題版號 = 最後 released tag（目前 v2.8.0）；下一版 in-flight feature 在內文以 inline 版號標記。
-     Release wrap 切五線 tag 時，本標題 + 下方 helm --version 跟著批次同步 bump。 -->
+<!-- 標題版號 = 最後 released portal tag（目前 v2.8.0）。Release wrap 切五線 tag 時，
+     本標題 + 下方 helm --version 跟著批次同步 bump。 -->
 
-> 💡 **想快速把這個元件跑起來？** → **[QUICKSTART.md](QUICKSTART.md)**（`docker run` 一行、≤2 分鐘看到一整套互動工具）。本篇 README 是進階配置 / packaging **參考（Reference）**。
+> 💡 **只想把元件跑起來看看？** → **[QUICKSTART.md](QUICKSTART.md)**（`docker run` 一行、≤ 2 分鐘看到一整套互動工具）。本篇 README 是給**部署 / 維運 portal 的人**看的進階配置與 packaging **參考**。
 
-> **核心 component** — 把 Dynamic Alerting 的 43 個互動工具（Hub + Wizard + Tenant Manager + Self-Service Portal）封進一顆 ~12 MB nginx-alpine image，**zero build step**（瀏覽器端 Babel standalone 轉譯 JSX），給內網 / air-gapped 環境離線使用。
->
-> **Companion 文件：** [helm chart](../../helm/da-portal/) · [Interactive Tools Hub 文件](../../docs/interactive-tools.md) · [tool-registry.yaml SOT](../../docs/assets/tool-registry.yaml) · [architecture-and-design](../../docs/architecture-and-design.md)
+把 Dynamic Alerting 的 **44 個瀏覽器互動工具**（Hub + Wizard + Tenant Manager + Self-Service Portal）封進一顆 nginx-alpine image，供內網 / air-gapped 環境離線使用。工具在 CI 端用 **esbuild 預先 build 成 ESM bundle**，image 只負責靜態服務——不在 runtime 做任何 build。
+
+**Companion 文件：** [helm chart](../../helm/da-portal/) · [Interactive Tools Hub](../../docs/interactive-tools.md) · [tool-registry.yaml（工具 SSOT）](../../docs/assets/tool-registry.yaml) · [architecture-and-design](../../docs/architecture-and-design.md)
+
+---
+
+## 這個 portal 服務誰？
+
+da-portal 把告警/維運能力封成瀏覽器工具，給三種角色。**各角色的上手步驟都有專屬指南**，本 README 不重複（只負責部署 / packaging 參考）：
+
+| 角色 | 在 portal 做什麼 | 上手指南 |
+|------|------------------|----------|
+| **Tenant（租戶）** | 自助調閾值、存 / 套用 Saved View、預覽自己會收到的告警 | [for-tenants](../../docs/getting-started/for-tenants.md) |
+| **Platform Engineer / SRE** | 為租戶除錯、規劃容量、驗證四層路由、lint 設定 | [for-platform-engineers](../../docs/getting-started/for-platform-engineers.md) |
+| **Domain Expert** | 把監控知識落成 Rule Pack、在 CI 守 cardinality 預算 | [for-domain-experts](../../docs/getting-started/for-domain-experts.md) |
+
+> **誰會讀這份 README？** 是**部署 / 自架 portal** 的人（碰 Dockerfile、Helm、nginx.conf、`docker run`）。Tenant 等終端使用者用的是「已部署好的 portal UI」，請走上方角色指南。
 
 ---
 
 ## 1. What & Why
 
-- **Input** — `tools/portal/src/interactive/tools/*.jsx`（43 個工具，由 `tool-registry.yaml` 為 SSOT 列管）+ `tools/portal/src/getting-started/wizard.jsx` + `docs/assets/{platform-data.json, flows.json, design-tokens.css, tool-registry.yaml, vendor/}`，build 階段 `COPY` 進 image
-- **Output** — 一顆 nginx-alpine image，跑起來給瀏覽器讀靜態檔案；JSX 由 `jsx-loader.html` 用 Babel standalone 在瀏覽器端轉譯
-- **Why static + zero build** — 1) 內網 / air-gapped 場景不能跑 npm CI；2) 工具作者改 JSX 推 PR 即可，無 webpack / vite watch；3) image 純靜態 → 不需 secret，不需 runtime config
-- **Why bundled vendor** — `make vendor-download` 把 React 18.3 / Tailwind / Babel 7.26 / Lucide 抓進 `docs/assets/vendor/`，build 時一起塞進 image；瀏覽器啟動先 probe local，找不到才 fallback CDN
-- **不做的事** — 不執行 build pipeline；不持久化（無 state，所有資料來自 mount 進來的 JSON / Tenant API proxy）；不直連 Prometheus（CORS-free 查詢走 Tenant API 或自訂 nginx proxy）
+- **Source（輸入）** — `tools/portal/src/interactive/tools/*.jsx`（44 個工具；`tools/portal/manifest.json` 為 build entry SSOT、`docs/assets/tool-registry.yaml` 為工具 metadata SSOT）+ `tools/portal/src/getting-started/wizard.jsx`
+- **Build** — `make portal-build` 跑 [esbuild](../../tools/portal/build.mjs)，把每個工具 bundle 成 ESM 檔輸出到 `docs/assets/dist/<tool>.js`，**committed 進 repo**（CI 有 drift gate 確保 source 與 dist 同步）。測試走 `make test-portal`（Vitest）
+- **Image（輸出）** — 一顆 nginx-alpine，COPY 進 Hub（`docs/interactive/`）+ 預先 build 的 `docs/assets/dist/` + 共享 assets + vendor；瀏覽器直接載入 ESM bundle，**runtime 不做 build / transpile**
+- **為什麼是「預先 build + 靜態服務」** — 1) 內網 / air-gapped 場景不能在 runtime 跑 npm；2) build 在 CI 一次完成、結果 committed，部署端零依賴；3) image 純靜態 → 不需 secret、不需 runtime config
+- **vendor probe（離線優先）** — `make vendor-download` 把 React 18.3 / ReactDOM / Tailwind / Lucide 抓進 `docs/assets/vendor/`；瀏覽器啟動先 probe local，找不到才 fallback CDN（每個工具 bundle 透過頁面提供的這些 global 執行）
+- **不做的事** — 不在 runtime build；不持久化（無 state，資料來自 mount 的 JSON 或 tenant-api proxy）；不直連 Prometheus（CORS-free 查詢走 tenant-api 或自訂 nginx proxy）
 
-> **Hub UX 細節** — 43 工具的分類、journey-phase、related-tool 圖、search 行為見 [docs/interactive-tools.md](../../docs/interactive-tools.md)。本 README 只負責 operator quick-reference。
+> **Hub UX 細節**（44 工具的分類、journey-phase、related-tool 圖、search）見 [docs/interactive-tools.md](../../docs/interactive-tools.md)。本 README 只負責 operator quick-reference。
 
 ---
 
 ## 2. What's New in v2.8.0
 
-| # | 能力 | 影響 |
-|---|------|------|
-| 1 | **Tenant Manager API-First Mode + Saved Views frontend** — Tenant Manager UI 先打 `GET /api/v1/tenants/search`（live data，page_size 預設 50 / 上限 500，避過 500+ 租戶 DOM freeze），fallback 靜態 `platform-data.json`；新增 `SavedViewsPanel.jsx` 把 v2.5.0 已有的 Tenant API saved-views backend wire 起來（CRUD + demo-mode 404 graceful hide）。詳 [#148](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/148) / [#149](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/149) / [#100](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/100) | 千租戶可用；首次把 v2.5.0 backend 真正暴露給操作員 |
-| 2 | **Tenant Manager × Wizard deep links** — `TenantCard` footer 多兩個 anchor：🛠️ Alert (`?component=alert-builder&tenant_id=<name>`) + 🧭 Route (`?component=routing-trace&tenant_id=<name>`)；對應 `alert-builder.jsx` / `routing-trace.jsx` 讀 URL param seed `labels.tenant`。詳 [#94](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/94) | 把 Tenant Manager 從「viewer」變「launcher」，少 N 次 copy-paste tenant id |
-| 3 | **`tenant-manager.jsx` 兩階段拆分（1691 → 817 LOC, -52%）** — Phase 1 抽出 `fixtures/` `styles.js` `utils/yaml-generators.js` 與 `GroupSidebar`；Phase 2 抽出 `useTenantData` `useModalFocusTrap` `ApiNotificationToast` `OverflowBanner`。確立 **window-global 自我註冊** pattern（`window.__X = X;` at file tail），因 jsx-loader 用 indirect eval 不會 leak `const`/`let` 到 global。詳 [#153](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/153) | 為其他超過 1000 LOC 的工具（operator-setup-wizard 1252 LOC 等）建立可複製的 decomposition pattern |
-| 4 | **JSX 工具腳手架 `scaffold_jsx_dep.py` + line-count guard** — `scaffold_jsx_dep.py` 一行命令自動 wire 5 個 touch-point（front-matter `dependencies:` / 符號宣告 / `window.__X` 註冊 / orchestrator import / loader registry）；新 lint `check_jsx_line_count.py` soft cap 1500 / hard cap 2500 LOC，防止下個 monolith 偷偷長出來。詳 [#160](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/160) / [#152](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/152) | 把 tenant-manager 拆分學到的 pattern codify 成工具 + lint，下個拆分不用憑記憶 |
-| 5 | **Design-token 收斂 + drift 檢測** — `design-tokens.css` 補齊 4 個 token（`--da-color-link-on-dark` / `--da-color-accent-border-soft` / `--da-color-semantic-other` / `--da-color-hero-gradient`）；新 lint `check_undefined_tokens.py` 掃 JSX/JS/CSS 內所有 `var(--da-*)` 是否 defined，Tier B wizard.jsx hardcoded 色值收斂；同時抓出 `OverflowBanner.jsx:30` 用錯 token 的舊 bug。詳 [#142](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/142) / [#85](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/85) / [#86](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/86) | dark-mode / 主題切換不再有 hardcoded 色值漏洞 |
-| 6 | **oauth2-proxy v7.7.1 / v7.15.1 → v7.15.2（CVE 收斂）** — `helm/da-portal/values{,-tier1,-tier2}.yaml` 三檔同步 bump；清掉 CVE-2026-34457（CRITICAL，health-check User-Agent matching 繞 `auth_request` mode）/ CVE-2026-40575（CRITICAL，`X-Forwarded-Uri` header spoofing）/ GHSA-pxq7-h93f-9jrg（HIGH，fragment confusion in `skip_auth_routes`）。Trivy 0.70.0：v7.15.2 在 Debian 13.4 + go binary 為 0 HIGH / 0 CRITICAL。詳 [#92](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/92) of umbrella [#100](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/100) | Tier-1 / Tier-2 兩種 deployment profile 都 benefit |
+精簡重點（完整版本歷程見 [CHANGELOG.md](../../CHANGELOG.md)）：
 
-> **升級路徑** — 大多 v2.8.0 變更為 additive（新 lint / 新 hook / 新 sub-component）；唯一 breaking 風險是 **Tenant Manager 預設 hit `/api/v1/tenants/search`**：若 deploy 沒裝 Tenant API（單純丟 image + static JSON），會 fallback `platform-data.json` + 出現 demo-mode toast（非 fatal）。
+- **Tenant Manager API-First** — Tenant Manager 預設打 `GET /api/v1/tenants/search`（live data，分頁避過千租戶 DOM freeze），無後端時 fallback 靜態 `platform-data.json` + demo-mode 提示
+- **Tenant Manager → Wizard 深連結** — `TenantCard` 可一鍵帶著 tenant id 跳到 Alert Builder / Routing Trace，少掉反覆 copy-paste
+- **oauth2-proxy CVE 收斂** — Helm 三個 profile 同步升到無已知 CRITICAL/HIGH 的版本
+
+> **v2.8.0 之後（未 bump 版號）** — 工具的核心純邏輯（calculator / validator / parser / 路由演算法）已抽成可單元測試的模組並補上測試（behavior-preserving）；對部署 / 使用零影響。
 
 ---
 
@@ -46,16 +58,21 @@
 # 1. 抓 vendor 進 docs/assets/vendor/（air-gapped 必跑；CI build 自動跑）
 make vendor-download
 
-# 2. Build image（從 repo root，因為 COPY 來源是 docs/）
-make portal-image                                  # 預設 tag: ghcr.io/vencil/da-portal:latest
+# 2. Build 工具 bundle（esbuild → docs/assets/dist/）
+make portal-build
+
+# 3. Build image（從 repo root，因為 COPY 來源是 docs/ 與 tools/）
+make portal-image                                  # 預設 tag: ghcr.io/vencil/da-portal:v2.8.0
 # 或：docker build -t ghcr.io/vencil/da-portal:v2.8.0 -f components/da-portal/Dockerfile .
 
-# 3. Run
+# 4. Run
 docker run -p 8080:80 ghcr.io/vencil/da-portal:v2.8.0
 # 開瀏覽器：http://localhost:8080  →  Hub
 ```
 
-### Helm（K8s，含 oauth2-proxy 與 Tenant API integration）
+> `make portal-build` 在改過任何工具 source 後必跑（CI 有 drift gate）。只是要跑 published image，直接 `docker run` 即可，無需以上 build 步驟。
+
+### Helm（K8s，含 oauth2-proxy 與 tenant-api integration）
 
 ```bash
 helm install da-portal \
@@ -64,13 +81,11 @@ helm install da-portal \
   -f values-override.yaml
 ```
 
-Helm chart 三個 profile：
-
 | Profile | Values file | 適用場景 |
 |---------|-------------|----------|
-| Default | `values.yaml` | 純 portal + Tenant API proxy（無 IdP） |
-| Tier-1 | `values-tier1.yaml` | Git-Native：portal + Tenant API + GitOps writeback |
-| Tier-2 | `values-tier2.yaml` | Full Stack：Tier-1 + oauth2-proxy + Ingress + NetworkPolicy |
+| Default | `values.yaml` | 純 portal + tenant-api proxy（無 IdP） |
+| Tier-1 | `values-tier1.yaml` | portal + tenant-api + GitOps writeback |
+| Tier-2 | `values-tier2.yaml` | Tier-1 + oauth2-proxy + Ingress + NetworkPolicy |
 
 詳 [helm/da-portal/README.md](../../helm/da-portal/README.md)。
 
@@ -78,13 +93,24 @@ Helm chart 三個 profile：
 
 ## 4. Architecture
 
+### 兩條交付路徑
+
+| 路徑 | 服務內容 | 用途 |
+|------|----------|------|
+| **公開文件站**（mkdocs / GitHub Pages） | serve 整個 `docs/` 樹（Hub + `docs/assets/dist/` + assets） | 線上試玩 / 文件 |
+| **da-portal Docker image**（本元件） | nginx 把 Hub + dist + assets 封進 image | 自架 / air-gapped / Helm 部署 |
+
+兩者都載入同一份**預先 build 的 ESM bundle**（`docs/assets/dist/`），差別只在誰來做靜態服務。
+
+### 瀏覽器端載入流程
+
 ```
-┌────────────────────────────────────────────────────────────────────┐
-│ Browser                                                            │
-│  ├─ /interactive/index.html       ── Hub（43 工具卡片 + search）  │
-│  ├─ /interactive/tools/<x>.jsx    ── Babel standalone 端轉譯      │
-│  └─ /assets/jsx-loader.html       ── React + vendor probe + theme │
-└────────────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────────┐
+│ Browser                                                             │
+│  ├─ /interactive/index.html     ── Hub（44 工具卡片 + search）       │
+│  ├─ /assets/jsx-loader.html     ── 載入工具 + vendor probe + theme   │
+│  └─ /assets/dist/<tool>.js      ── 預先 build 的 ESM bundle（esbuild）│
+└─────────────────────────────────────────────────────────────────────┘
               │ static asset GET                  │ /api/v1/* (CORS-free)
               ▼                                   ▼
 ┌──────────────────────────┐         ┌────────────────────────────┐
@@ -99,16 +125,16 @@ Helm chart 三個 profile：
 
 關鍵點：
 
-- **Image 不含 build step** — `Dockerfile` 只 `COPY` + `apk del nginx-module-image-filter nginx-module-xslt`（移掉靜態 server 用不到的模組，cascade 拔 28 個 dep；image 從 72 → 44 packages，~23 MB 省）+ libavif 殘留檢查（CVE-2025-48174 mitigation）
-- **Vendor probe** — `jsx-loader.html` 啟動跑同源 sync XHR 試 `vendor/react.production.min.js`；HTTP 200 走 local，否則退 CDN（Tailwind / React 18.3.1 / Babel 7.26.4 / Lucide 0.436.0）
-- **Tool 之間共享狀態** — JSX 用 indirect eval 載入，`const`/`let` 不 leak global → 用 `window.__X = X;` 自我註冊 pattern（v2.8.0 由 `scaffold_jsx_dep.py` codify）
-- **Tenant API proxy** — `nginx.conf` 的 `/api/v1/` 預設 upstream 為 `tenant-api.monitoring.svc.cluster.local:8080`，自動轉 oauth2-proxy 注入的 `X-Forwarded-Email` / `X-Forwarded-User` / `X-Forwarded-Groups`
+- **Image 不含 build step** — `Dockerfile` 只 `COPY` 預先 build 的成品 + `apk del nginx-module-image-filter nginx-module-xslt`（移掉靜態 server 用不到的模組，cascade 拔 28 個 dep；image 從 72 → 44 packages）+ libavif 殘留檢查（CVE-2025-48174 mitigation）
+- **工具是 esbuild ESM bundle** — source 在 `tools/portal/src/`，`make portal-build` 產 `docs/assets/dist/`；瀏覽器直接 import，**不在瀏覽器端 transpile**
+- **vendor probe** — `jsx-loader.html` 啟動跑同源 sync XHR 試 `vendor/react.production.min.js`；HTTP 200 走 local，否則退 CDN（React 18.3.1 / ReactDOM / Tailwind / Lucide 0.436.0）
+- **tenant-api proxy** — `nginx.conf` 的 `/api/v1/` 預設 upstream 為 `tenant-api.monitoring.svc.cluster.local:8080`，自動轉 oauth2-proxy 注入的 `X-Forwarded-Email` / `X-Forwarded-User` / `X-Forwarded-Groups`
 
 ---
 
 ## 5. Customization（不重 build，只 mount）
 
-### 改 Tool 資料 / 引導流程
+### 改工具資料 / 引導流程
 
 ```bash
 docker run -p 8080:80 \
@@ -122,10 +148,10 @@ docker run -p 8080:80 \
 |----------|------|------|
 | `platform-data.json` | Rule Pack catalog（DB / 中介軟體 / runtime defaults） | `make platform-data` 產 |
 | `flows.json` | Guided Flows（onboarding 等順序步驟） | hand-edited |
-| `tool-registry.yaml` | 43 工具的 SSOT（title / audience / journey_phase / related） | hand-edited，CI 跑 `check_jsx_loader_compat.py` 比對 |
-| `design-tokens.css` | 100+ CSS 變數（色 / 間距 / 字 / 主題） | hand-edited，CI 跑 `check_undefined_tokens.py` |
+| `tool-registry.yaml` | 44 工具的 metadata SSOT（title / audience / journey_phase / related） | hand-edited |
+| `design-tokens.css` | 主題 CSS 變數（色 / 間距 / 字 / 明暗主題） | hand-edited，CI 跑 `check_undefined_tokens.py` |
 
-### 改 nginx.conf（換 Tenant API upstream / 加 Prometheus proxy）
+### 改 nginx.conf（換 tenant-api upstream / 加 Prometheus proxy）
 
 ```bash
 docker run -p 8080:80 \
@@ -133,7 +159,7 @@ docker run -p 8080:80 \
   ghcr.io/vencil/da-portal:v2.8.0
 ```
 
-預設 `nginx.conf` 把 `/api/v1/` proxy 給 `tenant-api.monitoring.svc.cluster.local:8080`。要改 upstream（指向你環境的 Tenant API）或加 Prometheus reverse proxy 給 alert preview 直查 PromQL，editable 範本見 [`nginx.conf`](nginx.conf)。
+預設 `nginx.conf` 把 `/api/v1/` proxy 給 `tenant-api.monitoring.svc.cluster.local:8080`。要改 upstream，或加 Prometheus reverse proxy 給 alert preview 直查 PromQL，editable 範本見 [`nginx.conf`](nginx.conf)。
 
 ---
 
@@ -142,11 +168,11 @@ docker run -p 8080:80 \
 | Property | Value |
 |----------|-------|
 | Base image | `nginx:1.28-alpine3.23` |
-| Image size | ~12 MB（含 vendor），~9 MB（CDN-only） |
-| Health check | `GET /healthz`（`HEALTHCHECK --interval=30s --timeout=3s`） |
+| Image size | ~15 MB（含 dist + vendor），~12 MB（CDN-only，不含 vendor） |
+| Health check | `GET /healthz`（`HEALTHCHECK --interval=30s --timeout=3s`，probe 走 127.0.0.1） |
 | Listen port | 80 |
 | User | `nginx`（non-root；K8s `securityContext.runAsNonRoot: true` 友好） |
-| Build step | 無（純 `COPY`；瀏覽器端 Babel transpile） |
+| Build step | 無（純 `COPY` 預先 build 的成品） |
 | Vendor mode | local（`docs/assets/vendor/` 存在）→ CDN fallback |
 
 ### Security headers（`nginx.conf` 內 baked）
@@ -160,7 +186,7 @@ docker run -p 8080:80 \
 | Referrer-Policy | `strict-origin-when-cross-origin` |
 | Permissions-Policy | `camera=(), microphone=(), geolocation=()` |
 
-> CDN fallback 需要 `script-src` 含 `cdnjs.cloudflare.com`；air-gapped 部署可移掉這條，只留 `'self'`。
+> CDN fallback 需要 `script-src` 含 `cdnjs.cloudflare.com`；air-gapped 部署（vendor 已 baked）可移掉這條，只留 `'self'`。
 
 ---
 
@@ -171,26 +197,26 @@ docker run -p 8080:80 \
 | `NGINX_PORT` | `80` | container 內 listen port |
 | `NGINX_WORKER_PROCESSES` | `auto` | nginx worker 數 |
 
-> Portal **不靠 env 設定行為**；所有可變項（Tenant API upstream、tool 列表、theme tokens）走 volume mount。
+> Portal **不靠 env 設定行為**；所有可變項（tenant-api upstream、工具列表、theme tokens）走 volume mount。
 
 ---
 
 ## 8. Develop（加 / 改一個工具）
 
-| 步驟 | 命令 |
-|------|------|
-| 1. Scaffold 新工具的 dep 檔 | `python3 scripts/tools/dx/scaffold_jsx_dep.py --tool foo --kind hook --name useFoo` |
-| 2. 編寫工具 JSX | `tools/portal/src/interactive/tools/foo.jsx` |
-| 3. 註冊到 SSOT | 編 `docs/assets/tool-registry.yaml` 加 `- key: foo` block |
-| 4. 重新產 platform-data | `make platform-data` |
-| 5. Lint（auto-stage） | `pre-commit run --all-files` |
-| 6. 本機 smoke | `make portal-image && docker run -p 8080:80 ghcr.io/vencil/da-portal:latest` |
-| 7. E2E（Playwright） | `make e2e-portal`（spec 在 `tests/e2e/portal-*.spec.ts`） |
+| 步驟 | 命令 / 動作 |
+|------|-------------|
+| 1. 寫工具 JSX（ESM imports） | `tools/portal/src/interactive/tools/foo.jsx` |
+| 2. 加 build entry | `tools/portal/entries/foo.entry.jsx`，並把 `foo` 加進 `tools/portal/manifest.json` |
+| 3. 註冊 metadata SSOT | 編 `docs/assets/tool-registry.yaml` 加 `foo` block（title / audience / related） |
+| 4. Build + 測試 | `make portal-build`（esbuild → dist）+ `make test-portal`（Vitest） |
+| 5. 重新產 platform-data（如有動到 Rule Pack） | `make platform-data` |
+| 6. Lint（auto-stage） | `pre-commit run --all-files` |
+| 7. E2E（Playwright） | spec 在 `tests/e2e/portal-*.spec.ts` |
 
-**JSX 寫作三守則：**
-1. **檔尾自我註冊** — 任何 dep 檔（hook / sub-component / util）結尾必有 `window.__X = X;`，orchestrator 端 `const X = window.__X;`（jsx-loader 用 indirect eval，不會 leak `const` 到 global）
-2. **front-matter `dependencies:`** — orchestrator 列出所有 dep 路徑，loader 依序 fetch + eval
-3. **Design tokens not hardcoded colors** — `var(--da-color-accent)` 而非 `bg-blue-500`；CI lint 會抓
+**JSX 寫作守則：**
+1. **ESM imports** — 工具與其 sibling 模組用標準 `import` / `export`；`make portal-build` 由 esbuild bundle 成 dist。改過 source 後必跑 `portal-build`（CI 有 source↔dist drift gate）
+2. **Design tokens not hardcoded colors** — 用 `var(--da-color-accent)` 而非 `bg-blue-500`；CI lint（`check_undefined_tokens.py`）會抓未定義 token
+3. **重邏輯抽成可測模組** — calculator / validator / parser 等純邏輯抽到 tool-local `<tool>/<engine>.js` + 補 Vitest，別讓單檔長成 monolith
 
 完整守則見 [`docs/internal/dev-rules.md`](../../docs/internal/dev-rules.md)。
 
@@ -200,24 +226,24 @@ docker run -p 8080:80 \
 
 | 症狀 | 可能原因 | 解法 |
 |------|---------|------|
-| Hub 載入後白屏 | 某 JSX parse 失敗 + 沒 ErrorBoundary | 開 DevTools console 找出 parse 失敗的 JSX 單檔修復；ErrorBoundary 為已知缺口，未來版本補強 |
+| Hub 載入後工具白屏 / 404 | image 沒含 `docs/assets/dist/`（舊 / 自建 image） | 確認 `make portal-build` 跑過且 `docs/assets/dist/` 有進 image；重 build |
 | 404 on `/healthz` | 舊 image（< v2.3.0） | 重 build：`make portal-image` |
-| CORS error on Tenant API | nginx proxy upstream 錯 | 改 `nginx.conf` 的 `proxy_pass`，或在 K8s 確認 `tenant-api` Service 存在於 `monitoring` namespace |
-| Tenant Manager 顯示 demo-mode toast | `/api/v1/tenants/search` 回 404 / 5xx | 確認 Tenant API 跑著且 RBAC 有 read 權限；也可能是純靜態部署（無 backend），demo mode 為 expected |
-| Tools 顯示舊資料 | 掛載的 `platform-data.json` 過舊 | `make platform-data` 重產 + 重 mount |
-| Air-gapped 環境 vendor probe 失敗 | `make vendor-download` 沒跑 / `docs/assets/vendor/` 沒進 image | 確認 `docs/assets/vendor/react.production.min.js` 存在；重 build |
-| `var(--da-*)` 顯示為 fallback 色 | 用了 undefined token | 跑 `python3 scripts/tools/lint/check_undefined_tokens.py`，補 `design-tokens.css` |
+| CORS error on tenant-api | nginx proxy upstream 錯 | 改 `nginx.conf` 的 `proxy_pass`，或在 K8s 確認 `tenant-api` Service 存在於 `monitoring` namespace |
+| Tenant Manager 顯示 demo-mode 提示 | `/api/v1/tenants/search` 回 404 / 5xx | 確認 tenant-api 跑著且 RBAC 有 read 權限；也可能是純靜態部署（無後端），demo mode 為 expected |
+| 工具顯示舊資料 | 掛載的 `platform-data.json` 過舊 | `make platform-data` 重產 + 重 mount |
+| air-gapped 環境 vendor probe 失敗 | `make vendor-download` 沒跑 / `docs/assets/vendor/` 沒進 image | 確認 `docs/assets/vendor/react.production.min.js` 存在；重 build |
+| `var(--da-*)` 顯示為 fallback 色 | 用了未定義的 token | 跑 `python3 scripts/tools/lint/check_undefined_tokens.py`，補 `design-tokens.css` |
 
 ---
 
 ## 10. Related Documentation
 
 - [Interactive Tools Hub 使用指南](../../docs/interactive-tools.md)
-- [Tool Registry SOT](../../docs/assets/tool-registry.yaml) — 43 工具元資料
-- [Design Tokens](../../docs/assets/design-tokens.css) — 主題系統 100+ CSS 變數
+- [Tool Registry SSOT](../../docs/assets/tool-registry.yaml) — 44 工具 metadata
+- [Design Tokens](../../docs/assets/design-tokens.css) — 主題系統 CSS 變數
 - [Helm Chart README](../../helm/da-portal/README.md) — 三個 profile 細節
 - [架構深度](../../docs/architecture-and-design.md) — 9 個核心設計概念
-- [Dev Rules](../../docs/internal/dev-rules.md) — JSX 寫作守則 + 13 條開發規範
+- [Dev Rules](../../docs/internal/dev-rules.md) — JSX 寫作守則 + 開發規範
 
 ---
 
@@ -229,8 +255,8 @@ docker run -p 8080:80 \
 | `exporter/v*` | threshold-exporter + Helm chart |
 | `tools/v*` | da-tools CLI image |
 | `tenant-api/v*` | tenant-api REST API |
-| `v*` | Platform tag (GitHub Release，不觸發 build) |
+| `v*` | Platform tag（GitHub Release，不觸發 build） |
 
 ---
 
-> **回報問題** — Issue tracker：https://github.com/vencil/Dynamic-Alerting-Integrations/issues。若是 JSX 載入 / vendor probe / Tenant API proxy 問題，請附 (1) 瀏覽器 console log，(2) `curl -I http://<portal>/assets/vendor/react.production.min.js` 結果，(3) `kubectl logs -l app=da-portal -c oauth2-proxy --tail 50`（如果是 Tier-2 deploy）。
+> **回報問題** — Issue tracker：<https://github.com/vencil/Dynamic-Alerting-Integrations/issues>。若是工具載入 / vendor probe / tenant-api proxy 問題，請附 (1) 瀏覽器 console log，(2) `curl -I http://<portal>/assets/dist/<tool>.js` 與 `/assets/vendor/react.production.min.js` 結果，(3) `kubectl logs -l app=da-portal -c oauth2-proxy --tail 50`（如果是 Tier-2 deploy）。


### PR DESCRIPTION
## 摘要

把 `components/da-portal` 的 **README + QUICKSTART 更新到現況**,並補完一個未完成的架構遷移。

## 為什麼

兩份文件描述的是**舊的「瀏覽器端 Babel / zero build step」模型**,與現況不符 —— 工具現在是 **esbuild 預先 build 的 ESM bundle**(`docs/assets/dist/`，`make portal-build`)，image 只做靜態服務、runtime 不 transpile。連帶發現 **Dockerfile 沒 `COPY docs/assets/dist/`**:在現況下 build 出來的 image 每個工具都會 404(瀏覽器 Babel 路徑已移除)。

## 改了什麼

**文件**
- **README**:架構段重寫為 esbuild dist-only + 新增「兩條交付路徑」(mkdocs/Pages vs Docker image);頂部加「這個 portal 服務誰？」表，**連結既有角色指南**（for-tenants / for-platform-engineers / for-domain-experts）**而非重造**；工具數 43 → **44**（registry/manifest SSOT）;`What's New` 由 6 列 PR-dump 瘦身為 3 條 + 連 CHANGELOG;Develop 段改為 esbuild ESM 實況。
- **QUICKSTART**:修「零 build」措辭矛盾;工具數 → 44;加三角色導引。

**Dockerfile（補完遷移）**
- **`+ COPY docs/assets/dist/`** — 沒這行新 image 工具全 404。
- 修開頭過時的 Babel 註解。vendor COPY **保留**（jsx-loader runtime 仍載 React/Tailwind/Lucide globals）。

## 受眾決策（對抗式 review）

採「**連結而非拆分**」:受眾拆分已是現用 SoT（`docs/getting-started/for-*.md`），元件 README 的真實讀者是 **operator**，且與剛重整的 sibling README（da-tools / tenant-api）一致 —— 故用一個導引表路由到既有指南，不在 README 內複製三段 audience how-to。

## 驗證
- codename 乾淨;所有連結目標存在;`bump_docs --check` 一致;全 pre-commit hooks 過。
- 註:published `:v2.8.0` image 為舊 Babel 版（仍能跑）；本 PR 合併並出新 image 後，自架 image 才與現況一致。

## 不在此 PR 範圍（已 flag）
- `vendor_download.sh` 仍抓 `babel.min.js`（runtime 已不用，死重），建議另案清理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
