### PR TITLE
test: testing-suite refactor (idioms, helpers, coverage, dedup)

### DIFF
--- a/components/threshold-exporter/app/config_debounce_test.go
+++ b/components/threshold-exporter/app/config_debounce_test.go
@@ -9,6 +9,7 @@ package main
 // running in CI as in production, just with a faster clock.
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -599,5 +600,68 @@ func TestTriggerDebouncedReload_Concurrent(t *testing.T) {
 	})
 	if !ok {
 		t.Errorf("debounce never fired under concurrent load (count=%d)", m.DebounceFiredCount())
+	}
+}
+
+// TestEmitParseFailureSignal pins parse-failure attribution at the unit level.
+// A defaults-chain failure must bump the offending _defaults file's basename
+// counter AND emit an ERROR log; a tenant-file failure must bump the tenant
+// file's basename counter and stay silent here (the tenant path is logged
+// upstream via logMergeSkip, not in emitParseFailureSignal).
+//
+// The tenant-file branch (config_debounce.go ~659) previously had no direct
+// coverage — integration tests only drove the defaults-chain path. If it
+// regressed, ops would lose the "this tenant file is persistently broken"
+// signal the docstring promises. Parallel-safe via per-test fresh metrics +
+// captured logger (#4a + #4b).
+func TestEmitParseFailureSignal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		tenantFile    string
+		defaultsChain []string
+		mergeErr      error
+		wantBasename  string // counter label expected to read 1
+		wantLog       string // substring expected in log output ("" = none)
+	}{
+		{
+			name:          "defaults-chain failure attributes to defaults basename",
+			tenantFile:    "team-a/tenant-x.yaml",
+			defaultsChain: []string{"/conf.d/db/_defaults.yaml"},
+			mergeErr:      errors.New("parse defaults[0]: yaml: line 3: did not find expected key"),
+			wantBasename:  "_defaults.yaml",
+			wantLog:       "ERROR: skip unparseable defaults/profiles file",
+		},
+		{
+			name:       "tenant-file failure attributes to tenant basename",
+			tenantFile: "team-a/broken-tenant.yaml",
+			// chain present but NOT the culprit — must not be mis-attributed.
+			defaultsChain: []string{"/conf.d/db/_defaults.yaml"},
+			mergeErr:      errors.New("parse tenant: yaml: line 2: mapping values are not allowed in this context"),
+			wantBasename:  "broken-tenant.yaml",
+			wantLog:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fresh, _ := freshMetrics(t)
+			testLogger, logBuf := newTestLogger()
+
+			emitParseFailureSignal(fresh, testLogger, "tenant-x", tt.tenantFile, tt.defaultsChain, tt.mergeErr)
+
+			if got := testutil.ToFloat64(fresh.parseFailures.WithLabelValues(tt.wantBasename)); got != 1 {
+				t.Errorf("parseFailures{file_basename=%s} = %v, want 1", tt.wantBasename, got)
+			}
+			if tt.wantLog == "" {
+				if logBuf.Len() != 0 {
+					t.Errorf("expected no log output for tenant-file path, got: %s", logBuf.String())
+				}
+			} else if !strings.Contains(logBuf.String(), tt.wantLog) {
+				t.Errorf("log missing %q; got: %s", tt.wantLog, logBuf.String())
+			}
+		})
 	}
 }

--- a/components/threshold-exporter/app/config_hierarchy_test.go
+++ b/components/threshold-exporter/app/config_hierarchy_test.go
@@ -16,8 +16,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/vencil/threshold-exporter/internal/testutil"
 )
 
@@ -491,20 +490,8 @@ func TestScanDirHierarchical_MixedValidInvalid(t *testing.T) {
 	}
 
 	// Invariant #4: parse-failure metric incremented exactly once for
-	// the broken file's basename. Pulls counter value via the test-only
-	// collector API.
-	ch := make(chan prometheus.Metric, 1)
-	fresh.parseFailures.WithLabelValues("broken.yaml").Collect(ch)
-	close(ch)
-	var count float64
-	for m := range ch {
-		var dto dto.Metric
-		if err := m.Write(&dto); err != nil {
-			t.Fatalf("metric.Write: %v", err)
-		}
-		count = dto.GetCounter().GetValue()
-	}
-	if count != 1 {
+	// the broken file's basename. Reads the counter via testutil.ToFloat64.
+	if count := promtest.ToFloat64(fresh.parseFailures.WithLabelValues("broken.yaml")); count != 1 {
 		t.Errorf("da_config_parse_failure_total{file_basename=broken.yaml} = %v, want 1", count)
 	}
 }
@@ -571,18 +558,7 @@ func TestRecomputeMergedHash_DefaultsParseFailureEmitsErrorAndMetric(t *testing.
 	// basename. At least once (the test fires per-tenant, so we expect
 	// >= 2 for two tenants — but the metric API quirk makes >= 1 the
 	// safe assertion across both initial-scan and debounced-reload paths).
-	ch := make(chan prometheus.Metric, 1)
-	fresh.parseFailures.WithLabelValues("_defaults.yaml").Collect(ch)
-	close(ch)
-	var count float64
-	for m := range ch {
-		var d dto.Metric
-		if err := m.Write(&d); err != nil {
-			t.Fatalf("metric.Write: %v", err)
-		}
-		count = d.GetCounter().GetValue()
-	}
-	if count < 1 {
+	if count := promtest.ToFloat64(fresh.parseFailures.WithLabelValues("_defaults.yaml")); count < 1 {
 		t.Errorf(
 			"da_config_parse_failure_total{file_basename=_defaults.yaml} = %v, want >= 1 (hierarchical recompute path)",
 			count,

--- a/components/threshold-exporter/app/config_hierarchy_test.go
+++ b/components/threshold-exporter/app/config_hierarchy_test.go
@@ -6,8 +6,6 @@ package main
 // parity test — see config_golden_parity_test.go).
 
 import (
-	"bytes"
-	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -521,8 +519,7 @@ func TestRecomputeMergedHash_DefaultsParseFailureEmitsErrorAndMetric(t *testing.
 	// + mgr.SetLogger so observations land on `fresh`/`logBuf` instead
 	// of the package singletons (#4a + #4b; parallel-safe).
 	fresh, _ := freshMetrics(t)
-	var logBuf bytes.Buffer
-	testLogger := log.New(&logBuf, "", 0)
+	testLogger, logBuf := newTestLogger()
 
 	// Poison-pill root _defaults.yaml.
 	writeFile(t, filepath.Join(root, "_defaults.yaml"),

--- a/components/threshold-exporter/app/config_loaddir_test.go
+++ b/components/threshold-exporter/app/config_loaddir_test.go
@@ -14,8 +14,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/vencil/threshold-exporter/internal/testutil"
 )
 
@@ -283,18 +282,7 @@ tenants:
 	// Invariant #2: parse-failure metric incremented for `_defaults.yaml`
 	// basename. This may run via loadDir (initial scan) — the counter
 	// pattern matches A-8d.
-	ch := make(chan prometheus.Metric, 1)
-	fresh.parseFailures.WithLabelValues("_defaults.yaml").Collect(ch)
-	close(ch)
-	var count float64
-	for m := range ch {
-		var d dto.Metric
-		if err := m.Write(&d); err != nil {
-			t.Fatalf("metric.Write: %v", err)
-		}
-		count = d.GetCounter().GetValue()
-	}
-	if count < 1 {
+	if count := promtest.ToFloat64(fresh.parseFailures.WithLabelValues("_defaults.yaml")); count < 1 {
 		t.Errorf("da_config_parse_failure_total{file_basename=_defaults.yaml} = %v, want >= 1", count)
 	}
 }

--- a/components/threshold-exporter/app/config_loaddir_test.go
+++ b/components/threshold-exporter/app/config_loaddir_test.go
@@ -6,8 +6,6 @@ package main
 // config_test.go.
 
 import (
-	"bytes"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -242,8 +240,7 @@ func TestConfigManager_LoadDir_UnparseableDefaultsErrorAndMetric(t *testing.T) {
 	// + mgr.SetLogger so scanner observations land on `fresh`/`logBuf`
 	// instead of the package singletons (#4a + #4b; parallel-safe).
 	fresh, _ := freshMetrics(t)
-	var logBuf bytes.Buffer
-	testLogger := log.New(&logBuf, "", 0)
+	testLogger, logBuf := newTestLogger()
 
 	// Poison-pill `_defaults.yaml`. Use a structurally broken YAML
 	// (unclosed brace) so yaml.Unmarshal definitively errors regardless

--- a/components/threshold-exporter/app/config_mixed_mode_test.go
+++ b/components/threshold-exporter/app/config_mixed_mode_test.go
@@ -34,9 +34,7 @@ package main
 // + `populateHierarchyState`) so production hot paths are covered.
 
 import (
-	"bytes"
 	"errors"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -188,8 +186,7 @@ tenants:
 	// appear) is observed against THIS test's log output, not the
 	// global stdlib logger that sibling parallel tests would race on
 	// (#4b).
-	var logBuf bytes.Buffer
-	testLogger := log.New(&logBuf, "", 0)
+	testLogger, logBuf := newTestLogger()
 
 	mgr := NewConfigManager(root)
 	mgr.SetLogger(testLogger)

--- a/components/threshold-exporter/app/config_test.go
+++ b/components/threshold-exporter/app/config_test.go
@@ -44,6 +44,15 @@ func SVScheduled(def string, overrides ...TimeWindowOverride) ScheduledValue {
 	return ScheduledValue{Default: def, Overrides: overrides}
 }
 
+// newTestLogger returns a logger that writes into the returned buffer with no
+// prefix or flags. Per-test capture keeps parallel tests from racing on the
+// global stdlib logger (#4b); pair it with mgr.SetLogger to route the code
+// under test's log output onto the buffer for assertion.
+func newTestLogger() (*log.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	return log.New(buf, "", 0), buf
+}
+
 // region ConfigManagerBasics — single-file and directory loading
 
 func TestConfigManager_LoadFile(t *testing.T) {
@@ -111,8 +120,7 @@ func TestLogConfigStats_Format(t *testing.T) {
 	// Per-test logger writing to a captured buffer — no global stdlib
 	// state mutation, so other parallel tests never observe our log
 	// stream and we never observe theirs (#4b).
-	var buf bytes.Buffer
-	testLogger := log.New(&buf, "", 0)
+	testLogger, buf := newTestLogger()
 
 	logConfigStats(testLogger, cfg, "Test prefix")
 
@@ -385,8 +393,7 @@ tenants:
 	// Per-test logger so any log lines emitted during the failing
 	// reload land on our buffer (not the global stdlib logger),
 	// keeping this test parallel-safe (#4b).
-	var buf bytes.Buffer
-	testLogger := log.New(&buf, "", 0)
+	testLogger, buf := newTestLogger()
 
 	// Load initial valid config
 	mgr := NewConfigManager(configPath)

--- a/tests/ops/test_config_diff.py
+++ b/tests/ops/test_config_diff.py
@@ -36,33 +36,27 @@ class TestFlattenTenantConfig:
 
 class TestClassifyChange:
 
-    def test_added(self):
-        assert cd.classify_change(None, 50) == "added"
-
-    def test_removed(self):
-        assert cd.classify_change(50, None) == "removed"
-
-    def test_tighter(self):
-        assert cd.classify_change(80, 50) == "tighter"
-
-    def test_looser(self):
-        assert cd.classify_change(50, 80) == "looser"
-
-    def test_toggled_disable(self):
-        assert cd.classify_change(50, "disable") == "toggled"
-
-    def test_toggled_enable(self):
-        assert cd.classify_change("disable", 50) == "toggled"
-
-    def test_modified_dict(self):
-        old = {"default": 50, "schedule": []}
-        new = {"default": 70, "schedule": []}
-        # Different dicts → modified (can't do simple numeric compare)
-        result = cd.classify_change(old, new)
-        assert result == "modified"
-
-    def test_same_value_unchanged(self):
-        assert cd.classify_change(50, 50) == "unchanged"
+    @pytest.mark.parametrize(
+        "old, new, expected",
+        [
+            (None, 50, "added"),
+            (50, None, "removed"),
+            (80, 50, "tighter"),
+            (50, 80, "looser"),
+            (50, "disable", "toggled"),
+            ("disable", 50, "toggled"),
+            # dict vs dict → no numeric compare possible → modified
+            ({"default": 50, "schedule": []}, {"default": 70, "schedule": []}, "modified"),
+            (50, 50, "unchanged"),
+        ],
+        ids=[
+            "added", "removed", "tighter", "looser",
+            "toggled_disable", "toggled_enable", "modified_dict",
+            "same_value_unchanged",
+        ],
+    )
+    def test_classify_change(self, old, new, expected):
+        assert cd.classify_change(old, new) == expected
 
 
 # ── 3. Compute Diff ──────────────────────────────────────────────────

--- a/tests/ops/test_config_diff.py
+++ b/tests/ops/test_config_diff.py
@@ -189,6 +189,51 @@ class TestRenderMarkdown:
         assert cd._format_value(50) == "50"
         assert cd._format_value({"schedule": []}) == "(scheduled)"
 
+    def test_with_profile_changes(self):
+        """The '## Profile Changes' section renders all three pd shapes:
+        a modified profile with a key-diff table and >10 affected tenants
+        (truncation), an added profile, and a profile with no key diffs.
+        """
+        profile_diffs = [
+            {
+                "profile": "mysql-prod",
+                "change": "modified",
+                "affected_count": 12,
+                "affected_tenants": [f"t{i}" for i in range(12)],
+                "key_diffs": [
+                    {"key": "mysql_connections", "old": 80, "new": 50,
+                     "change": "tighter"},
+                ],
+            },
+            {
+                "profile": "redis-new",
+                "change": "added",
+                "affected_count": 1,
+                "affected_tenants": ["t-redis"],
+                "key_diffs": [],
+            },
+            {
+                "profile": "empty-prof",
+                "change": "modified",
+                "affected_count": 0,
+                "affected_tenants": [],
+                "key_diffs": [],
+            },
+        ]
+        md = cd.render_markdown({}, "old", "new", profile_diffs=profile_diffs)
+
+        assert "## Profile Changes" in md
+        # modified profile: header + truncated tenant list + key-diff table
+        assert "Profile: mysql-prod (modified) — 12 tenant(s) affected" in md
+        assert "(+2 more)" in md          # 12 affected, first 10 shown
+        assert "Tenants:" in md
+        assert "| mysql_connections |" in md
+        assert "tighter" in md
+        # added profile with no key diffs → "New profile with N keys" line
+        assert "New profile with 0 keys" in md
+        # third profile (modified, no key diffs, no tenants) still renders
+        assert "empty-prof" in md
+
 
 # ── 7. CLI ───────────────────────────────────────────────────────────
 

--- a/tests/ops/test_gitops_check.py
+++ b/tests/ops/test_gitops_check.py
@@ -64,6 +64,18 @@ import gitops_check as gc
 from _lib_exitcodes import EXIT_CALLER_ERROR  # noqa: E402
 
 
+def run_main(argv):
+    """Run gc.main() under the given sys.argv and return the pytest
+    ExceptionInfo for the expected SystemExit. Callers assert on
+    exc_info.value.code and read capsys themselves, so assertion order
+    (code-first vs output-first) stays explicit at the call site.
+    """
+    with patch("sys.argv", argv):
+        with pytest.raises(SystemExit) as exc_info:
+            gc.main()
+    return exc_info
+
+
 # ── Fixtures ──────────────────────────────────────────────────────────────
 
 @pytest.fixture
@@ -624,9 +636,7 @@ class TestMainRepo:
             }
         )
 
-        with patch("sys.argv", ["gitops-check", "repo", "--url", "https://github.com/test/repo.git"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "repo", "--url", "https://github.com/test/repo.git"])
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -643,9 +653,7 @@ class TestMainRepo:
             details={"url": "https://github.com/test/repo.git"}
         )
 
-        with patch("sys.argv", ["gitops-check", "repo", "--url", "https://github.com/test/repo.git", "--json"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "repo", "--url", "https://github.com/test/repo.git", "--json"])
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -663,9 +671,7 @@ class TestMainRepo:
             details={}
         )
 
-        with patch("sys.argv", ["gitops-check", "repo", "--url", "https://github.com/test/repo.git"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "repo", "--url", "https://github.com/test/repo.git"])
 
         assert exc_info.value.code == 1
 
@@ -679,9 +685,7 @@ class TestMainRepo:
             details={}
         )
 
-        with patch("sys.argv", ["gitops-check", "repo", "--url", "https://github.com/test/repo.git"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "repo", "--url", "https://github.com/test/repo.git"])
 
         assert exc_info.value.code == 1
 
@@ -695,9 +699,7 @@ class TestMainRepo:
             details={}
         )
 
-        with patch("sys.argv", ["gitops-check", "repo", "--url", "https://github.com/test/repo.git", "--ci"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "repo", "--url", "https://github.com/test/repo.git", "--ci"])
 
         assert exc_info.value.code == 0
 
@@ -711,9 +713,7 @@ class TestMainRepo:
             details={}
         )
 
-        with patch("sys.argv", ["gitops-check", "repo", "--url", "https://github.com/test/repo.git", "--ci"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "repo", "--url", "https://github.com/test/repo.git", "--ci"])
 
         assert exc_info.value.code == 1
 
@@ -736,9 +736,7 @@ class TestMainLocal:
             }
         )
 
-        with patch("sys.argv", ["gitops-check", "local", "--dir", "/tmp/config"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "local", "--dir", "/tmp/config"])
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -754,9 +752,7 @@ class TestMainLocal:
             details={"directory": "/tmp/config"}
         )
 
-        with patch("sys.argv", ["gitops-check", "local", "--dir", "/tmp/config", "--json"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "local", "--dir", "/tmp/config", "--json"])
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -779,9 +775,7 @@ class TestMainLocal:
             }
         )
 
-        with patch("sys.argv", ["gitops-check", "local", "--dir", "/tmp/config"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "local", "--dir", "/tmp/config"])
 
         assert exc_info.value.code == 1
         captured = capsys.readouterr()
@@ -805,9 +799,7 @@ class TestMainSidecar:
             }
         )
 
-        with patch("sys.argv", ["gitops-check", "sidecar"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "sidecar"])
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -827,9 +819,7 @@ class TestMainSidecar:
             }
         )
 
-        with patch("sys.argv", ["gitops-check", "sidecar", "--json"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "sidecar", "--json"])
 
         assert exc_info.value.code == 1
         captured = capsys.readouterr()
@@ -846,9 +836,7 @@ class TestMainSidecar:
             details={"namespace": "custom-ns"}
         )
 
-        with patch("sys.argv", ["gitops-check", "sidecar", "--namespace", "custom-ns"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "sidecar", "--namespace", "custom-ns"])
 
         # Verify check_sidecar was called with custom namespace
         mock_check_sidecar.assert_called_once_with("custom-ns")
@@ -859,29 +847,21 @@ class TestMainEdgeCases:
 
     def test_no_subcommand(self, capsys):
         """No subcommand → print help and exit caller error."""
-        with patch("sys.argv", ["gitops-check"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check"])
 
         assert exc_info.value.code == EXIT_CALLER_ERROR
 
     def test_invalid_subcommand(self, capsys):
         """Invalid subcommand → argparse error."""
-        with patch("sys.argv", ["gitops-check", "invalid"]):
-            with pytest.raises(SystemExit):
-                gc.main()
+        run_main(["gitops-check", "invalid"])
 
     def test_repo_missing_required_url(self):
         """repo subcommand without --url → error."""
-        with patch("sys.argv", ["gitops-check", "repo"]):
-            with pytest.raises(SystemExit):
-                gc.main()
+        run_main(["gitops-check", "repo"])
 
     def test_local_missing_required_dir(self):
         """local subcommand without --dir → error."""
-        with patch("sys.argv", ["gitops-check", "local"]):
-            with pytest.raises(SystemExit):
-                gc.main()
+        run_main(["gitops-check", "local"])
 
 
 # ── 8. Output Format Tests ─────────────────────────────────────────────────
@@ -899,9 +879,7 @@ class TestOutputFormatting:
             details={}
         )
 
-        with patch("sys.argv", ["gitops-check", "repo", "--url", "test"]):
-            with pytest.raises(SystemExit):
-                gc.main()
+        run_main(["gitops-check", "repo", "--url", "test"])
 
         captured = capsys.readouterr()
         assert "✓" in captured.out
@@ -916,9 +894,7 @@ class TestOutputFormatting:
             details={}
         )
 
-        with patch("sys.argv", ["gitops-check", "repo", "--url", "test"]):
-            with pytest.raises(SystemExit):
-                gc.main()
+        run_main(["gitops-check", "repo", "--url", "test"])
 
         captured = capsys.readouterr()
         assert "⚠" in captured.out
@@ -933,9 +909,7 @@ class TestOutputFormatting:
             details={}
         )
 
-        with patch("sys.argv", ["gitops-check", "repo", "--url", "test"]):
-            with pytest.raises(SystemExit):
-                gc.main()
+        run_main(["gitops-check", "repo", "--url", "test"])
 
         captured = capsys.readouterr()
         assert "✗" in captured.out
@@ -955,9 +929,7 @@ class TestOutputFormatting:
             }
         )
 
-        with patch("sys.argv", ["gitops-check", "local", "--dir", "/path/to/config"]):
-            with pytest.raises(SystemExit):
-                gc.main()
+        run_main(["gitops-check", "local", "--dir", "/path/to/config"])
 
         captured = capsys.readouterr()
         assert "directory" in captured.out
@@ -972,9 +944,7 @@ class TestIntegration:
 
     def test_local_check_end_to_end(self, valid_config_dir, capsys):
         """Full local check without mocks."""
-        with patch("sys.argv", ["gitops-check", "local", "--dir", valid_config_dir]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "local", "--dir", valid_config_dir])
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -984,9 +954,7 @@ class TestIntegration:
 
     def test_local_check_json_output_valid(self, valid_config_dir, capsys):
         """Local check with JSON output."""
-        with patch("sys.argv", ["gitops-check", "local", "--dir", valid_config_dir, "--json"]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "local", "--dir", valid_config_dir, "--json"])
 
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
@@ -1000,14 +968,7 @@ class TestIntegration:
         """Repo check with custom branch and path."""
         mock_run_cmd.return_value = (True, "abc\trefs/heads/develop\n", "")
 
-        with patch("sys.argv", [
-            "gitops-check", "repo",
-            "--url", "git@github.com:test/repo.git",
-            "--branch", "develop",
-            "--path", "config/",
-        ]):
-            with pytest.raises(SystemExit) as exc_info:
-                gc.main()
+        exc_info = run_main(["gitops-check", "repo", "--url", "git@github.com:test/repo.git", "--branch", "develop", "--path", "config/"])
 
         assert exc_info.value.code == 0
 
@@ -1083,9 +1044,7 @@ class TestTimestamps:
             details={}
         )
 
-        with patch("sys.argv", ["gitops-check", "local", "--dir", "/tmp", "--json"]):
-            with pytest.raises(SystemExit):
-                gc.main()
+        run_main(["gitops-check", "local", "--dir", "/tmp", "--json"])
 
         captured = capsys.readouterr()
         data = json.loads(captured.out)

--- a/tests/ops/test_gitops_check.py
+++ b/tests/ops/test_gitops_check.py
@@ -78,13 +78,8 @@ def run_main(argv):
 
 # ── Fixtures ──────────────────────────────────────────────────────────────
 
-@pytest.fixture
-def config_dir():
-    """Temporary directory for config testing."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        yield tmpdir
-
-
+# config_dir (a bare temp dir) is provided by the shared tests/conftest.py
+# fixture of the same name; only the seeded valid_config_dir is file-local.
 @pytest.fixture
 def valid_config_dir():
     """Temporary directory with valid _defaults.yaml and tenant files."""


### PR DESCRIPTION
## 概述

8 個循環的 **testing 專屬 refactor**（`/loop` 自我節奏執行），全部為**行為保持的測試碼變更**，無任何 production source 異動。每輪流程：發想 → 對抗式 review 挑 ROI → 塑型 → 實作 → self review → 對抗式 review → 驗證 → commit。

範圍涵蓋使用者要求的四面向：覆蓋率 / 測試方法 / 測試碼去重 / 更好的測試作法。

## 各循環

| # | Commit | 內容 | 技法 |
|---|---|---|---|
| 1 | `e7fdba51` | 用套件自身既有的 `testutil.ToFloat64` 取代 3 處冗長手動 prometheus counter 讀取（−36 行） | idiom 統一 |
| 2 | `109d2b3e` | 抽 `newTestLogger()` helper，集中 #4b 並行安全的 buffer-logger pattern（5 site） | helper 抽取 |
| 3 | `f073f5b0` | 補測 `emitParseFailureSignal` 的 tenant-file parse-failure 分支（真實 ops 告警契約；69.2%→84.6%） | 覆蓋率 |
| 4 | `6d789170` | 抽 `run_main(argv)` helper，收斂 `test_gitops_check` 24 處 `patch(sys.argv)+raises(SystemExit)+main()`（−41 行） | helper 抽取 |
| 5 | `956354a3` | 將 `TestClassifyChange` 8 個單形方法 parametrize（`ids=` 保留案名） | parametrize |
| 6 | `bbbd0361` | 補測 `config_diff.render_markdown` 的 "Profile Changes" 渲染區段（83.0%→90.2%） | 覆蓋率 |
| 7 | `7aa86545` | 移除 `test_gitops_check` 與 conftest 完全相同的本地 `config_dir` fixture shadow | fixture 去重 |

## 驗證

- **Go (threshold-exporter)**：312 PASS、0 個非 golden-parity 失敗、`go vet` 乾淨（於 dev container 隔離副本跑；golden-parity 在 app-only 副本中因缺 repo-root fixtures 而 fail，屬預期環境假象）。
- **Python**：觸及檔（`test_gitops_check.py` + `test_config_diff.py`）124 passed / 1 skipped。
- 真實 delta = 7 個檔，**全部為測試檔**（無 source 變更）。

## 對抗式 review 擋下的假目標（過程要點）

- Explore agent 的「高 ROI」清單多為虛構/過時：`run_scaffold` 三份複製（實際 1 份）、subprocess-coverage-trap（早已修掉）。
- `tenant-api` 的 `federation/testhelpers_test.go` 重複是 **maintainer 刻意且有註解**的設計 → 未合併。
- collector.go 未覆蓋處全是難觸發的防禦死碼（`prometheus.NewConstMetric` label 不符）→ 拒絕 coverage-padding。

核心結論：此測試套件已相當成熟，價值在於「驗證優先、不硬塞 churn」。

## 備註

- CI 會在 main + 本分支的虛擬 merge 上跑；本分支落後 main 1 commit 但 merge-tree 驗證**無衝突**（變更為隔離的測試檔）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
