### PR TITLE
chore(portal): drop dead babel-standalone from vendor download

### DIFF
--- a/scripts/tools/vendor_download.sh
+++ b/scripts/tools/vendor_download.sh
@@ -10,11 +10,12 @@ if [[ "${1:-}" == "--check" ]]; then
   CHECK_ONLY=true
 fi
 
-# CDN resources used by jsx-loader.html and interactive/index.html
+# Runtime globals loaded by jsx-loader.html (vendor probe → local, else CDN).
+# Babel-standalone was dropped: tools are pre-built ESM bundles (esbuild), so
+# there is no in-browser transpile and babel.min.js is no longer loaded.
 declare -A RESOURCES=(
   ["react.production.min.js"]="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.production.min.js"
   ["react-dom.production.min.js"]="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.production.min.js"
-  ["babel.min.js"]="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.26.4/babel.min.js"
   ["lucide-react.min.js"]="https://unpkg.com/lucide-react@0.436.0/dist/umd/lucide-react.min.js"
   ["tailwindcss.js"]="https://cdn.tailwindcss.com"
 )


### PR DESCRIPTION
## 摘要

移除 `vendor_download.sh` 仍在抓、但 runtime 已不用的 **babel-standalone**（~1.5 MB 死重）。這是 #800/#801 那條「esbuild dist-only 遷移」的最後一塊收尾。

## 為什麼

自從瀏覽器端 Babel transpile 路徑被移除、工具改為 **esbuild 預先 build 的 ESM bundle** 後，`jsx-loader.html` 的 vendor probe 只載 **React / ReactDOM / Tailwind / Lucide** —— **不再載 `babel.min.js`**。但 `vendor_download.sh` 仍把它抓下來，且 Dockerfile COPY 整個 `vendor/` → 死重也跟著進 image。

## 改了什麼

- `scripts/tools/vendor_download.sh`：移除 `babel.min.js` 下載項，並加註說明為何移除。

## 驗證（對抗式 review）

- **grep 全 repo**：`babel.min.js` 僅出現在這一行；其餘 "babel" 引用都是 **`lint_jsx_babel.py`**（用 npm `@babel` 做 JSX parse-check 的 dev lint，與此 runtime vendor 檔無關）或歷史註解。
- 無任何 test / vendor-completeness 檢查斷言 `babel.min.js` 存在。
- `bash -n` 語法通過；vendor probe 行為不受影響（array 其餘 4 項正是 runtime 實際載入的）。
- 連帶效果：da-portal image 少 ~1.5 MB。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
