### PR TITLE
docs(e2e): align regression-naming SOP to TRK-1NN (REG-NNN frozen legacy)

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -14,7 +14,7 @@ lang: zh
 
 # tests/e2e — Playwright E2E 起手式（深入版）
 
-父 README：[`tests/README.md`](../README.md)。先看父檔的決策樹（測試擺哪、CI 對應、跑法 cheat sheet）；本檔處理進到 `tests/e2e/` 之後的細節：tag 語意、fixture 契約、新 spec 模板、REG 編號制度。
+父 README：[`tests/README.md`](../README.md)。先看父檔的決策樹（測試擺哪、CI 對應、跑法 cheat sheet）；本檔處理進到 `tests/e2e/` 之後的細節：tag 語意、fixture 契約、新 spec 模板、TRK 回歸編號制度。
 
 ## 目前規模（最新 snapshot）
 
@@ -29,7 +29,7 @@ lang: zh
 
 | Tag | 語意 | 使用時機 | 跑的指令 |
 |-----|------|---------|---------|
-| `@critical` | smoke + sanity 主要互動 + REG 防線；CI 必跑 | 工具的「載入 + 主要互動鏈路 + 回歸防線」 | `npm run test:critical` 或預設 `npm test` |
+| `@critical` | smoke + sanity 主要互動 + regression 防線；CI 必跑 | 工具的「載入 + 主要互動鏈路 + 回歸防線」 | `npm run test:critical` 或預設 `npm test` |
 | `@visual` | pixel-diff baseline | `toHaveScreenshot()` 比對；只能在 Linux baseline 平台跑 | `npm run test:visual`（基線更新 `test:visual:update`） |
 
 **沒被掛 tag 的 spec**會被 `npm test`（`--grep-invert @visual`）跑到，但不被 `test:critical` 篩到。寫新 spec 時：
@@ -85,9 +85,9 @@ test.describe('<Tool Display Name> @critical', () => {
 
 加互動測試（fill / click）時繼續放在同一個 `describe` 內，新 `test()` block。**不要**為了單一互動 spec 另開 file。
 
-## REG-NNN regression-guard 命名
+## TRK-1NN regression-guard 命名
 
-明確的回歸防線 test 用 `REG-NNN` 編號標記在 test 名稱或 fixture docstring：
+明確的回歸防線 test 用 `TRK-1NN` 編號標記在 test 名稱或 fixture docstring。`TRK-100~199` 是 [`planning-id-mapping.md`](../../docs/internal/planning-id-mapping.md) 定義的「產品 / portal regression registry」分區（ADR-019 planning-SSOT 將舊 `REG-NNN` 凍結、遷移為此區段 — 例如 `REG-004` → `TRK-104`）。**`REG-NNN` 為 frozen legacy namespace，新編號一律用 `TRK-1NN`**；舊 commit / playbook 裡的 `REG-NNN` 仍可 grep，對應關係查 mapping 表。
 
 | 編號 | 防的是 |
 |------|--------|
@@ -95,10 +95,10 @@ test.describe('<Tool Display Name> @critical', () => {
 | TRK-104 | **portal-safe hrefs**：絕對根路徑 `href="/foo"` 在 portal sub-path 部署會 404；`assertNoAbsoluteRootHrefs` helper 防守此類 |
 
 **新 regression test 的 SOP**：
-1. 找下一個沒用過的 `REG-NNN`（`grep -rhoE "REG-[0-9]+" tests/ docs/interactive/` 確認）
-2. test 名稱寫 `'<behavior> (REG-NNN regression guard)'`
-3. spec / fixture 內若有專用 helper，docstring 寫 `(see REG-NNN)`
-4. 在這個表格新增一行說明
+1. 在 [`planning-id-mapping.md`](../../docs/internal/planning-id-mapping.md) §REG-NNN→TRK-101~199 表找下一個沒用過的 `TRK-1NN`（`grep -rhoE "TRK-1[0-9]{2}" tests/ docs/` 交叉確認）
+2. test 名稱寫 `'<behavior> (TRK-1NN regression guard)'`
+3. spec / fixture 內若有專用 helper，docstring 寫 `(see TRK-1NN)`
+4. 在這個表格新增一行說明，並回填 mapping 表
 
 ## Mocking 慣例
 


### PR DESCRIPTION
## 背景

`tests/e2e/README.md` 的「regression-guard 命名」章節仍在宣導已凍結的 legacy `REG-NNN` namespace（標題 / prose / SOP grep），但表格與全部 50+ 個 test 名稱、fixture docstring 都已用 ADR-019 planning-SSOT 遷移後的 `TRK-1NN`（`REG-004`→`TRK-104`、`REG-001`→`TRK-101`）。照舊 SOP 走的 contributor 會去鑄一個**死 namespace** 的 `REG-NNN`。

這正是先前 docs-only refactor 刻意未動 test/source 而留下的 doc↔code 不一致缺口。

## 為何不改 test 名 / 不寫豁免

`TRK-104` / `TRK-101` **不是 internal codename**，而是受認可的 planning ID：

- [`planning-id-mapping.md`](../blob/main/docs/internal/planning-id-mapping.md) 定義 `TRK-100~199` 為「產品 / portal regression registry」分區（[ADR-019](../blob/main/docs/adr/019-planning-ssot.md) 遷移 `REG-NNN`）。
- codename gate 只攔 decision-tag：`check_codename_leak.py` 為 `\bDEC-[A-Z]\b`，且 `.ts` 的 `//` 註解被 skip → `tests/` 內不被 gate 攔。

故無違規可修、無物可豁免；改 test 名只會砍掉 SSOT-traceable 的 canonical ID、製造對 planning-SSOT 的 drift。

## 改了什麼（僅 `tests/e2e/README.md`，+8/−8）

- §標題 `REG-NNN` → `TRK-1NN`；prose 改 `TRK-1NN` 並加註分區來源 + 「`REG-NNN` 為 frozen legacy」說明
- SOP grep 改 `TRK-1[0-9]{2}`、改從 `planning-id-mapping.md` §表分配；test 名稱 / docstring 範式改 `TRK-1NN`
- 導言「REG 編號制度」、tag 表「REG 防線」一併對齊
- 保留少量 `REG-` 字樣僅用於說明 frozen legacy + 指向 mapping 表

## 驗證

- **零 `.ts` 變更、零 spec / test 計數變更**（24 specs / 136 tests 不動）→ e2e 套件行為不受影響，無需重跑
- 68 個 pre-commit hook 全 Passed；`pr-preflight` 通過（marker `0deb34b1`）
- contributor-facing，無 `.en.md` mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)