### PR TITLE
fix(release): seed skopeo authfile + align tenant-api image label

### DIFF
--- a/components/tenant-api/Dockerfile
+++ b/components/tenant-api/Dockerfile
@@ -66,4 +66,4 @@ EXPOSE 8080
 LABEL org.opencontainers.image.title="tenant-api" \
       org.opencontainers.image.description="Tenant Management API — Dynamic Alerting Platform" \
       org.opencontainers.image.source="https://github.com/vencil/vibe-k8s-lab" \
-      org.opencontainers.image.version="2.9.0"
+      org.opencontainers.image.version="2.9.7"

--- a/scripts/ops/verify_release_digest.sh
+++ b/scripts/ops/verify_release_digest.sh
@@ -62,6 +62,11 @@ CHART_YAML="${2:-}"
 SKOPEO_ERR=$(mktemp)
 SKOPEO_AUTH=$(mktemp)
 trap 'rm -f "${SKOPEO_ERR}" "${SKOPEO_AUTH}"' EXIT
+# mktemp leaves a 0-byte file; `skopeo login --authfile` reads it as JSON to
+# merge new creds, and an empty file fails with "unexpected end of JSON input".
+# Seed a minimal valid auth doc so the merge-read succeeds (skopeo then writes
+# the real ghcr.io credentials into it).
+printf '{"auths":{}}' > "${SKOPEO_AUTH}"
 
 # --- Env var validation ---
 for var in REGISTRY IMAGE_OWNER VERSION GITHUB_ACTOR GITHUB_TOKEN; do


### PR DESCRIPTION
## 背景

v2.9.0 五線 release 推出 4 個 component tag 後，全部 release.yaml run fail，卡在兩個**首次浮現**的 release-infra bug（皆確定性、非 transient）。

## Bug 1 — digest-verify skopeo login 空 authfile（擋 exporter/tools/portal）

`scripts/ops/verify_release_digest.sh` 用 `mktemp` 建出 0-byte authfile，`skopeo login --authfile` 會先讀它做 creds merge → 空檔 → `unexpected end of JSON input`。

此 #445 L3 digest-verify step **史上第一次在真實 component release 跑**（v2.8.1 platform-only、v2.8.0 早於 #445），latent bug 首發。

**修法**：login 前 seed `{"auths":{}}`，merge-read 成功後 skopeo 寫入真 ghcr.io creds。

## Bug 2 — tenant-api image label 對齊 chart 版號（擋 tenant-api）

release.yaml 硬要求 `chart version == tag`。tenant-api chart 是 per-change（現 2.9.7）、以自己的版號發版、與平台 2.9.0 線解耦。Dockerfile OCI version label 從 2.9.0 → **2.9.7** 對齊 chart（tenant-api 將以 `tenant-api/v2.9.7` 發版）。

## 影響範圍

- 純 release-infra（CI script + image metadata label），無 runtime / API / schema 行為變更。
- `bash -n` clean；seed 在 login 前；label 對齊 chart 2.9.7。

Refs: #445
