### PR TITLE
fix(release): bump Go 1.26.4 + nginx 1.30 base to clear release-gate CVEs

### DIFF
--- a/components/da-portal/Dockerfile
+++ b/components/da-portal/Dockerfile
@@ -13,7 +13,7 @@
 #   -v ./my-flows.json:/usr/share/nginx/html/assets/flows.json
 #   -v ./my-nginx.conf:/etc/nginx/conf.d/default.conf
 
-FROM nginx:1.28-alpine3.23
+FROM nginx:1.30-alpine3.23
 
 LABEL org.opencontainers.image.title="da-portal" \
       org.opencontainers.image.description="Dynamic Alerting Interactive Tools Portal" \

--- a/components/tenant-api/Dockerfile
+++ b/components/tenant-api/Dockerfile
@@ -14,7 +14,7 @@
 # #463 multi-arch: builder pinned to the native BUILDPLATFORM, cross-compiles
 # to TARGETARCH below (CGO_ENABLED=0 → no cross-toolchain, no QEMU for the Go
 # compile). The final alpine stage's `apk add` still runs under QEMU for arm64.
-FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine3.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS builder
 
 WORKDIR /src
 

--- a/components/tenant-api/go.mod
+++ b/components/tenant-api/go.mod
@@ -1,6 +1,6 @@
 module github.com/vencil/tenant-api
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/components/threshold-exporter/app/Dockerfile
+++ b/components/threshold-exporter/app/Dockerfile
@@ -1,7 +1,7 @@
 # #463 multi-arch: pin the builder to the native BUILDPLATFORM and
 # cross-compile to TARGETARCH below — far faster than emulating the Go
 # compile under QEMU.
-FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine3.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./

--- a/components/threshold-exporter/app/go.mod
+++ b/components/threshold-exporter/app/go.mod
@@ -1,6 +1,6 @@
 module github.com/vencil/threshold-exporter
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/VictoriaMetrics/metricsql v0.87.0


### PR DESCRIPTION
## 背景

v2.9.0 五線 release 的 4 個 component image 過了 build/push/digest-verify（#813 修好那兩關）後，**統一卡在 release.yaml 的 `Scan image with Trivy` 硬 gate**（`severity HIGH,CRITICAL` + `ignore-unfixed` + `exit-code 1`）。掃出 3 個**今天剛揭露**的 HIGH CVE——v2.8.0 GA 當時 Trivy 是過的，純粹是上次乾淨掃描後 CVE 才落地的例行 base-image 衛生。

## 修復

| Image | CVE | 修法 |
|---|---|---|
| exporter / da-tools / tenant-api | `CVE-2026-42504`（Go stdlib MIME DoS） | go.mod `go 1.26.3→1.26.4` ×2 + golang builder Dockerfile ×2 |
| da-portal | `CVE-2026-9256`（nginx rewrite **RCE**）+ `CVE-2026-49975`（nginx HTTP/2 DoS） | base `nginx:1.28-alpine3.23`(1.28.3-r1) → `nginx:1.30-alpine3.23`(1.30.2-r1, stable 線) |

- da-portal 既有 hardening（`apk --no-cache upgrade` + 移除 `nginx-module-xslt`→連帶拔 libxml2）清掉 base bump 後的殘留 libxml2 finding。
- da-tools 的 Go binary 由 `build.sh` 從 threshold-exporter module 編，go.mod bump + GOTOOLCHAIN auto 一併涵蓋。

## 本地實證（Trivy 同 gate 設定）

- exporter on Go 1.26.4 → **0 HIGH/CRITICAL fixable**（CVE-2026-42504 消失）
- da-portal base+hardening on nginx:1.30 → **0 HIGH/CRITICAL fixable**

純 base-image / toolchain bump，無 runtime / API / schema 變更。

Refs: #445
