### PR TITLE
fix(tenant-api): bump golang-jwt/jwt v5.2.2 to clear CVE-2025-30204

### DIFF
--- a/components/tenant-api/go.mod
+++ b/components/tenant-api/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-playground/validator/v10 v10.30.2
-	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/sony/gobreaker/v2 v2.4.0
 	github.com/swaggo/swag v1.16.6

--- a/components/tenant-api/go.sum
+++ b/components/tenant-api/go.sum
@@ -40,8 +40,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.30.2 h1:JiFIMtSSHb2/XBUbWM4i/MpeQm9ZK2xqPNk8vgvu5JQ=
 github.com/go-playground/validator/v10 v10.30.2/go.mod h1:mAf2pIOVXjTEBrwUMGKkCWKKPs9NheYGabeB04txQSc=
-github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
-github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=


### PR DESCRIPTION
## 背景

v2.9.0 五線 release 的 3 個 component（exporter/tools/portal）已在重打 tag 後 release 成功；**tenant-api 是最後一個 release-gate blocker**。

#814 修好了 Go stdlib + base image CVE，但 tenant-api 還多一個 **Go 依賴** CVE（exporter 等是 scratch base 故無此依賴）：

```
github.com/golang-jwt/jwt/v5  CVE-2025-30204  HIGH  fixed
  installed v5.2.1 → fixed v5.2.2   (malformed token 過量記憶體配置)
```

## 修復

`go get github.com/golang-jwt/jwt/v5@v5.2.2` + `go mod tidy`（go.mod + go.sum，3 行）。tenant-api auth 路徑用的 JWT library bump 到修補版。

## 本地實證（Trivy 同 gate 設定）

tenant-api image with jwt v5.2.2 → **0 HIGH/CRITICAL fixable**。

純依賴 bump，無 API / schema / 行為變更。

Refs: #445
