### PR TITLE
fix(ci): backtest workflow never triggered — fix dead paths filter + two no-op gates

### DIFF
--- a/.github/workflows/backtest.yaml
+++ b/.github/workflows/backtest.yaml
@@ -2,7 +2,7 @@ name: Threshold Backtest
 on:
   pull_request:
     paths:
-      - 'conf.d/**'
+      - 'components/threshold-exporter/config/conf.d/**'
 
 permissions:
   contents: read
@@ -28,8 +28,11 @@ jobs:
         id: backtest
         env:
           PROMETHEUS_URL: ${{ secrets.PROMETHEUS_URL }}
+        # backtest_threshold.py 的 --git-diff 用客戶 repo 契約 `git diff -- conf.d/`
+        # （conf.d 在客戶 repo root）；本 repo 以 cwd 錨定到實際 conf.d 位置。
+        working-directory: components/threshold-exporter/config
         run: |
-          python3 scripts/tools/ops/backtest_threshold.py \
+          python3 "$GITHUB_WORKSPACE/scripts/tools/ops/backtest_threshold.py" \
             --git-diff \
             --prometheus "${PROMETHEUS_URL:-http://localhost:9090}" \
             --skip-if-unavailable \
@@ -37,8 +40,17 @@ jobs:
             --output /tmp/backtest-report.json
         continue-on-error: true
 
+      - name: Check for report
+        id: report
+        # hashFiles() 只能讀 GITHUB_WORKSPACE 內的檔案（/tmp 恆回空字串），
+        # 改用 step output gate（同 config-diff.yaml 的 has_changes 模式）。
+        run: |
+          if [ -s /tmp/backtest-comment.md ]; then
+            echo "has_comment=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Comment PR
-        if: hashFiles('/tmp/backtest-comment.md') != ''
+        if: steps.report.outputs.has_comment == 'true'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           path: /tmp/backtest-comment.md

--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -24,6 +24,7 @@ on:
       - "README.md"
       - "README.en.md"
       - "CLAUDE.md"
+      - "CHANGELOG.md"
       - "mkdocs.yml"
       - "scripts/tools/**/*.py"
       - "scripts/tools/lint/**/*.sh"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the **Dynamic Alerting Integrations** project will be doc
 ### Fixed
 
 - **Threshold Backtest workflow 從未被 PR 觸發（latent dead filter）**：`.github/workflows/backtest.yaml` 的 paths filter 寫 `conf.d/**`（repo-root-relative，但本 repo 的 conf.d 實際在 `components/threshold-exporter/config/conf.d/`）→ 修正路徑；連帶修復兩個觸發後仍會 silent no-op 的斷點 — script `--git-diff` 的客戶契約 pathspec 改以 `working-directory` 錨定（不動 `da-tools backtest` CLI 行為）、PR comment gate 由 `hashFiles('/tmp/...')`（workspace 外恆空）改為 step output（同 `config-diff.yaml` 模式）。
+- **`CHANGELOG.md` 變更不觸發任何文件驗證（同類 CI-paths 漏配）**：`CHANGELOG.md` 在 mkdocs nav（渲染進站台）卻不在 `.github/workflows/docs-ci.yaml` 的 `paths` filter 內 → 只改 CHANGELOG 的 PR 不跑 Check Documentation Links / Front Matter / MkDocs Build / Line Count 等（多個是 required check）。把 `CHANGELOG.md` 補進 docs-ci paths，與既有的 `README.md` / `CLAUDE.md` 一致。
 
 ## [v2.9.0] — 租戶自助告警 (Custom Alerts) + 租戶聯邦 + 寫入平面韌性 (2026-06-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to the **Dynamic Alerting Integrations** project will be doc
 
 <!-- 下一版 in-flight 工作暫存區。每筆 entry 目標 3-6 行使用者重點 + 一行指回內部 artifact；session 過程 / FUSE trap / 完整 commit list 不入此處。release 收尾時做最終 condensation 並切正式 `## [vX.Y.Z]` heading。 -->
 
+### Fixed
+
+- **Threshold Backtest workflow 從未被 PR 觸發（latent dead filter）**：`.github/workflows/backtest.yaml` 的 paths filter 寫 `conf.d/**`（repo-root-relative，但本 repo 的 conf.d 實際在 `components/threshold-exporter/config/conf.d/`）→ 修正路徑；連帶修復兩個觸發後仍會 silent no-op 的斷點 — script `--git-diff` 的客戶契約 pathspec 改以 `working-directory` 錨定（不動 `da-tools backtest` CLI 行為）、PR comment gate 由 `hashFiles('/tmp/...')`（workspace 外恆空）改為 step output（同 `config-diff.yaml` 模式）。
+
 ## [v2.9.0] — 租戶自助告警 (Custom Alerts) + 租戶聯邦 + 寫入平面韌性 (2026-06-06)
 
 v2.9.0 把平台從「平台 authored 告警」推進為**租戶自助的宣告式告警引擎**，並讓 v2.8.0 outline 的多項深水區能力落地。戰略主題是**從第一個客戶的實際使用去 harden — reactive > predictive**：三條主線是 (1) **Custom Alerts**（租戶用平台 authored 的參數化 recipe 自訂告警、**不寫 PromQL**，ADR-024 能力 B）、(2) **Tenant Federation**（ADR-020 token endpoint + gateway + policy + offboarding 從 outline 走到可部署）、(3) **寫入平面 single-writer 韌性**（ADR-023 把 GitOps 寫入路徑的幽靈寫者 / 孤兒寫入 / rate-limit / 優雅關機系統性補強）。同時平台日誌彙整、IaC SAST 四層、與一輪 silent-failure 反應式硬化（含一個燒了兩個月的 P0 prod drift）一併收斂。


### PR DESCRIPTION
## 問題

`Threshold Backtest` workflow（`.github/workflows/backtest.yaml`）自建立以來**從未被 PR 觸發**：GitHub Actions 的 `paths` filter 是 repo-root-relative，filter 寫 `conf.d/**`，但 repo root 沒有 `conf.d/`——真實位置在 `components/threshold-exporter/config/conf.d/`（latent dead filter）。

修正 filter 後逐步驗證其餘步驟，發現**即使觸發了，後面還有兩個 silent no-op 斷點**，本 PR 一併修復：

## 三項修復

1. **paths filter** → `components/threshold-exporter/config/conf.d/**`（與姊妹 workflow `config-diff.yaml` 同路徑）。
2. **script pathspec**：`backtest_threshold.py --git-diff` 內部跑 `git diff HEAD~1 -- conf.d/`，從 repo root 起算同樣 diff 不到任何東西。但這個 pathspec 是**客戶 repo 契約**（`da-tools backtest` 子命令；客戶 repo 的 `conf.d/` 在 root），不能改 script——改在 workflow 用 `working-directory: components/threshold-exporter/config` 錨定 cwd（git pathspec 相對 cwd 解析）。diff header 仍為 root-relative，但 parser 用 `Path(fname).name` 取 basename 提取 tenant，不受目錄深度影響。
3. **comment gate**：`hashFiles('/tmp/backtest-comment.md')` **恆為空字串**——官方文件明載 hashFiles「can only include files inside of the GITHUB_WORKSPACE」，`/tmp` 在 workspace 外。改為 step output gate（`[ -s ... ] && has_comment=true`），同 `config-diff.yaml` 既有的 `has_changes` 模式。

## 其餘步驟驗證（仍成立）

- `fetch-depth: 2` + `HEAD~1`：PR event checkout 的是虛擬 merge commit，`HEAD~1` = base branch tip → diff 涵蓋整個 PR 變更（非只有最後一個 commit）✅
- HIGH-risk 變更時 script 以非零 exit 退出（markdown 已先寫出）；step-level `continue-on-error: true` 吸收後，report-check step 與 comment step 照常執行 ✅
- `tests/ops/test_backtest_threshold.py` 全程 mock `subprocess.run` 且不 assert pathspec 參數，無測試連動 ✅
- Prometheus secret 未設定時 `--skip-if-unavailable` 優雅跳過、不產 comment（既有設計，不變）✅

## 範圍外（觀察，未動）

- `blast-radius.yml` 同時列 `components/.../conf.d/**` 與冗餘的 `conf.d/**`——後者同樣 dead 但無害（正確路徑已並列），未納入本次。
- `init_project.py` / portal generators 產生的客戶側 workflow 用 `conf.d/**` 是**正確的**（客戶 repo 的 conf.d 在 root），不需改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追加修補（同類 CI-paths-漏配）— commit `1fe1f66`

收尾本 PR 時發現 `docs-ci.yaml` 有**完全同類**的 bug：`CHANGELOG.md` 在 mkdocs nav（[mkdocs.yml:281](mkdocs.yml#L281)，渲染進站台）卻不在任何 workflow 的 `paths` filter 內。後果與 backtest 同形：

- 只改 `CHANGELOG.md` 的 PR **不觸發任何文件驗證 workflow**——Check Documentation Links / Front Matter / Coverage / MkDocs Build Verification / Documentation Line Count Monitor / HEAD Blob Hygiene / Drift Detection 全來自 `docs-ci.yaml`，其中多個是 required status check。
- 一個破壞 link 或 mkdocs `--strict` 的 CHANGELOG 編輯會躲過 CI（只有 bypassable 的本地 pre-push hook 擋得到）。

修補：把 `CHANGELOG.md` 加進 `docs-ci.yaml` 的 `paths`，與既有的 `README.md` / `README.en.md` / `CLAUDE.md` root-doc 條目並列。因 docs-ci paths 本就含 `.github/workflows/docs-ci.yaml`，編輯它自身使這些 doc check **在本 PR 真的執行並回報**（不再僅靠 admin bypass）。

> 註：首推時 CodeQL `Analyze (javascript-typescript)` 的 red 是 SARIF 上傳的 transient auth flake（分析本身完成；本 PR 零 JS/TS 變更），非必需 check；GitHub default-setup run 無法手動重跩，已由本次 push 在新 commit 上重觸發。
