### PR TITLE
fix(dx): dist-source-consistency hook — accept whole tools/portal/src/ subtree

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -914,7 +914,7 @@ repos:
         always_run: true
         # Auto-stage, FATAL on findings. Triggers when staged files include
         # docs/assets/dist/*.js but no matching source-of-rebuild signal
-        # (entries / build.mjs / manifest / interactive / getting-started).
+        # (entries / build.mjs / manifest / shims / tools/portal/src/**).
         # Codifies the PR-E (#269) regression pattern: dist drift hidden
         # behind a single visible source change. Escape: BYPASS_DIST_CHECK=1
         # for legitimate dist-only commits (e.g. CI bot regen).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the **Dynamic Alerting Integrations** project will be doc
 ### Fixed
 
 - **Threshold Backtest workflow 從未被 PR 觸發（latent dead filter）**：`.github/workflows/backtest.yaml` 的 paths filter 寫 `conf.d/**`（repo-root-relative，但本 repo 的 conf.d 實際在 `components/threshold-exporter/config/conf.d/`）→ 修正路徑；連帶修復兩個觸發後仍會 silent no-op 的斷點 — script `--git-diff` 的客戶契約 pathspec 改以 `working-directory` 錨定（不動 `da-tools backtest` CLI 行為）、PR comment gate 由 `hashFiles('/tmp/...')`（workspace 外恆空）改為 step output（同 `config-diff.yaml` 模式）。
+- **portal dist 一致性 hook 誤擋合法的 src 資產變更（TRK-239 樣式漏配）**：`dist-source-consistency-check` 的 source-of-rebuild 樣式只認 `tools/portal/src/**` 的 `.jsx`/`.js`，但 esbuild `bundle: true` 也會把 import 的 `.json` 資料檔打進 dist bundle → 改 `recipe-enums.json` + 重建 dist 的正當 commit 被誤擋、被迫 `BYPASS_DIST_CHECK=1`。改為認整棵 `tools/portal/src/**` 子樹，並修掉 docstring / 錯誤訊息中殘留的 TRK-242 搬遷前舊路徑（`docs/interactive/` / `docs/getting-started/`）。
 - **`CHANGELOG.md` 變更不觸發任何文件驗證（同類 CI-paths 漏配）**：`CHANGELOG.md` 在 mkdocs nav（渲染進站台）卻不在 `.github/workflows/docs-ci.yaml` 的 `paths` filter 內 → 只改 CHANGELOG 的 PR 不跑 Check Documentation Links / Front Matter / MkDocs Build / Line Count 等（多個是 required check）。把 `CHANGELOG.md` 補進 docs-ci paths，與既有的 `README.md` / `CLAUDE.md` 一致。
 
 ## [v2.9.0] — 租戶自助告警 (Custom Alerts) + 租戶聯邦 + 寫入平面韌性 (2026-06-06)

--- a/scripts/tools/lint/check_dist_source_consistency.py
+++ b/scripts/tools/lint/check_dist_source_consistency.py
@@ -30,8 +30,7 @@ match one of:
   - tools/portal/build.mjs                 (esbuild config)
   - tools/portal/manifest.json             (entry list)
   - tools/portal/shims/*.js                (build-time shims)
-  - docs/interactive/tools/**/*.{jsx,js}   (component sources)
-  - docs/getting-started/**/*.{jsx,js}     (wizard sources)
+  - tools/portal/src/**                    (component sources + bundled assets)
 
 Otherwise it's "dist drift without source intent" — the exact pattern
 that broke main in PR-E. Block the commit.
@@ -82,8 +81,12 @@ SOURCE_PATTERNS = [
     lambda p: p == "tools/portal/build.mjs",
     lambda p: p == "tools/portal/manifest.json",
     lambda p: p.startswith("tools/portal/shims/") and p.endswith(".js"),
-    # JSX/JS source files (post-TRK-242)
-    lambda p: p.startswith("tools/portal/src/") and (p.endswith(".jsx") or p.endswith(".js")),
+    # Portal source tree (post-TRK-242) — whole subtree, not just .jsx/.js:
+    # esbuild `bundle: true` also pulls imported non-JS assets (e.g. .json
+    # data files) into the dist bundle, so any change under src/ is a
+    # plausible rebuild trigger (PR #819: recipe-enums.json edit + rebuilt
+    # dist was falsely blocked by the old extension filter).
+    lambda p: p.startswith("tools/portal/src/"),
 ]
 
 # Dist-side patterns — staging any of these is what triggers the check.
@@ -169,8 +172,7 @@ def main() -> int:
     print("    - tools/portal/build.mjs")
     print("    - tools/portal/manifest.json")
     print("    - tools/portal/shims/*.js")
-    print("    - docs/interactive/tools/**/*.{jsx,js}")
-    print("    - docs/getting-started/**/*.{jsx,js}")
+    print("    - tools/portal/src/**")
     print()
     print("  Why: PR-E (#269) committed regenerated dist on a chunk reshuffle")
     print("  triggered by ONE source change. Reviewer attention was on the")


### PR DESCRIPTION
## 問題

`dist-source-consistency-check` hook（TRK-239）的 source-of-rebuild 樣式清單對 `tools/portal/src/**` 只認 `.jsx`/`.js`，但 esbuild `bundle: true` 也會把 import 的非 JS 資產（如 `.json` 資料檔）打進 `docs/assets/dist` bundle。

實際踩雷：#819 改 `tools/portal/src/interactive/tools/_common/data/recipe-enums.json` + 重建 dist 的正當 commit 被誤擋，被迫 `BYPASS_DIST_CHECK=1`。

## 修正

- `SOURCE_PATTERNS` 改認整棵 `tools/portal/src/` 子樹（不限副檔名）— src/ 下任何變更都是合理的 rebuild trigger
- 連帶修掉 docstring / 錯誤訊息 / `.pre-commit-config.yaml` 註解中殘留的 TRK-242 搬遷前舊路徑（`docs/interactive/tools/**`、`docs/getting-started/**` — 這些路徑已不存在，error message 卻還在引導使用者去看）
- CHANGELOG Unreleased 補一筆 Fixed

## 驗證

用 script 的 explicit-args 測試模式跑三情境矩陣：

| 情境 | 期望 | 結果 |
|---|---|---|
| dist + `src/**/*.json`（#819 情境） | 通過 | ✅ exit 0 |
| dist-only | 擋下 | ✅ exit 1 |
| 無 dist | 不觸發 | ✅ exit 0 |

`grep tests/` 確認無測試 caller 引用此 lint；commit 時 68 個 pre-commit hooks 全綠（含本 hook 自身）。

Refs TRK-239, #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)