### PR TITLE
docs: #692 P0③ disk/PVC alert design — 3 ADR amends + kubelet spike

### DIFF
--- a/docs/adr/006-tenant-mapping-topologies.en.md
+++ b/docs/adr/006-tenant-mapping-topologies.en.md
@@ -159,18 +159,18 @@ groups:
 
 ## Addendum: Tenant Attribution for Infrastructure Metrics (v2.10.0)
 
-ADR-024's self-service recipes now consume **platform infrastructure metrics** (kubelet `kubelet_volume_stats_*`, cAdvisor `container_fs_*`) for the first time — previously recipes consumed only tenant-owned exporter metrics. These metrics natively carry `namespace` but not `tenant`, so this topology ADR needs an explicit rule for them.
+**Decision: disk, PVC, and node metrics support 1:1 tenant attribution only (one namespace = one tenant).**
 
-**Policy: infrastructure-metric tenant attribution is 1:1 only.** Attribution follows the **recipe-path idiom** — a `metric_relabel` on the kubelet / cAdvisor scrape jobs maps `namespace → tenant` (1:1, identical to the tenant-exporters job, see §Decision). This is equivalent to but distinct from the platform-pack idiom (recording-rule `label_replace(namespace→tenant)`, e.g. #809 node-health, the version-aware container rules): **recipe-consumed metrics go via scrape-relabel; platform-pack rules go via recording-rule.**
+ADR-024's self-service alerts now let tenants set conditions on platform infrastructure metrics (e.g. kubelet's `kubelet_volume_stats_*`). These metrics natively carry only `namespace`, not `tenant`, so at scrape time the `namespace` is used directly as the `tenant` — the 1:1 approach this ADR already uses.
 
-**N:1 / 1:N infrastructure attribution: deferred-with-trigger, and fail-loud.**
+**Why N:1 and 1:N are out of scope here.** This ADR's N:1 (several namespaces aggregated into one tenant) and 1:N (one instance split into several logical tenants) rely on an extra mapping layer; infrastructure metrics are attributed by a plain rename at scrape time and never reach that layer:
 
-- **N:1** (multiple namespaces → one tenant): this ADR's N:1 uses a scrape `relabel_configs` regex (`scaffold_tenant.py --namespaces`) and produces **no joinable namespace→tenant series**, so infrastructure metrics cannot reuse it. **Key risk**: a per-tenant threshold recipe under N:1 **fails silently** — the metric carries `tenant="db-a-read"` but the tenant's config key is `db-a` → the `on(tenant)` join matches nothing and the alert silently never fires; unlike platform-pack alerts whose N:1 failure is fail-loud (over-alert).
-- **1:N** (one instance, many logical tenants): a single PVC cannot be split per schema / tablespace → structurally unservable.
-- **Backstop**: ADR-024's per-tenant runtime sentinel (`CustomRecipeDiskInert{tenant}`) turns the above fail-silent into **fail-loud** — if a tenant declared an infrastructure recipe but the attributed metric is not flowing, it fires.
-- **Trigger**: when an N:1 customer (e.g. a read/write-split estate) concretely needs infrastructure (disk / node) attribution, evaluate applying the N:1 mapping to the kubelet `metric_relabel` (generated from the same SSOT as the exporter relabel, to avoid a second drifting copy).
+- **N:1 would silently miss alerts.** The metric is labeled `tenant="db-a-read"`, but the tenant's config uses the name `db-a` — they don't match, so the alert never fires.
+- **1:N is structurally impossible.** A single PVC cannot be split per schema / tablespace across tenants.
 
-Related: [ADR-024](024-version-aware-threshold-via-dimensional-label.md) (self-service recipes + disk recipe class + sentinel), #809 (node-health, same 1:1 idiom), #692 (epic).
+**Keeping "unsupported" from becoming "silently broken."** ADR-024 ships a per-tenant watchdog alert, `CustomRecipeDiskInert`: if a tenant declared a disk alert and its pods are running but the attributed metric never appears, it fires. So an N:1 customer gets a clear "this alert isn't working" signal on migration day instead of a silent miss. When an N:1 customer (e.g. a read/write-split database) actually needs infrastructure alerts, the mapping can be added then.
+
+Related: [ADR-024](024-version-aware-threshold-via-dimensional-label.md), node-health alerting (#809, which uses the same 1:1 attribution), the epic (#692).
 
 ## Related Decisions
 

--- a/docs/adr/006-tenant-mapping-topologies.en.md
+++ b/docs/adr/006-tenant-mapping-topologies.en.md
@@ -13,6 +13,7 @@ lang: en
 ## Status
 
 ✅ **Accepted** (v2.1.0) — Toolchain completed, 1:N end-to-end integration pending production validation
+📎 **Addendum** (v2.10.0) — Tenant-attribution policy for infrastructure metrics (disk/PVC/node), see §Addendum below
 
 ## Background
 
@@ -155,6 +156,21 @@ groups:
 **Remaining**:
 - End-to-end validation in real multi-schema Oracle environments (pending production feedback)
 - Schema validation (`_instance_mapping.yaml` JSON Schema) deferred to next cycle
+
+## Addendum: Tenant Attribution for Infrastructure Metrics (v2.10.0)
+
+ADR-024's self-service recipes now consume **platform infrastructure metrics** (kubelet `kubelet_volume_stats_*`, cAdvisor `container_fs_*`) for the first time — previously recipes consumed only tenant-owned exporter metrics. These metrics natively carry `namespace` but not `tenant`, so this topology ADR needs an explicit rule for them.
+
+**Policy: infrastructure-metric tenant attribution is 1:1 only.** Attribution follows the **recipe-path idiom** — a `metric_relabel` on the kubelet / cAdvisor scrape jobs maps `namespace → tenant` (1:1, identical to the tenant-exporters job, see §Decision). This is equivalent to but distinct from the platform-pack idiom (recording-rule `label_replace(namespace→tenant)`, e.g. #809 node-health, the version-aware container rules): **recipe-consumed metrics go via scrape-relabel; platform-pack rules go via recording-rule.**
+
+**N:1 / 1:N infrastructure attribution: deferred-with-trigger, and fail-loud.**
+
+- **N:1** (multiple namespaces → one tenant): this ADR's N:1 uses a scrape `relabel_configs` regex (`scaffold_tenant.py --namespaces`) and produces **no joinable namespace→tenant series**, so infrastructure metrics cannot reuse it. **Key risk**: a per-tenant threshold recipe under N:1 **fails silently** — the metric carries `tenant="db-a-read"` but the tenant's config key is `db-a` → the `on(tenant)` join matches nothing and the alert silently never fires; unlike platform-pack alerts whose N:1 failure is fail-loud (over-alert).
+- **1:N** (one instance, many logical tenants): a single PVC cannot be split per schema / tablespace → structurally unservable.
+- **Backstop**: ADR-024's per-tenant runtime sentinel (`CustomRecipeDiskInert{tenant}`) turns the above fail-silent into **fail-loud** — if a tenant declared an infrastructure recipe but the attributed metric is not flowing, it fires.
+- **Trigger**: when an N:1 customer (e.g. a read/write-split estate) concretely needs infrastructure (disk / node) attribution, evaluate applying the N:1 mapping to the kubelet `metric_relabel` (generated from the same SSOT as the exporter relabel, to avoid a second drifting copy).
+
+Related: [ADR-024](024-version-aware-threshold-via-dimensional-label.md) (self-service recipes + disk recipe class + sentinel), #809 (node-health, same 1:1 idiom), #692 (epic).
 
 ## Related Decisions
 

--- a/docs/adr/006-tenant-mapping-topologies.md
+++ b/docs/adr/006-tenant-mapping-topologies.md
@@ -164,18 +164,18 @@ groups:
 
 ## Addendum：基礎設施指標的租戶歸屬 (v2.10.0)
 
-ADR-024 的自助 recipe 首次消費**平台基礎設施指標**（kubelet `kubelet_volume_stats_*`、cAdvisor `container_fs_*`）——過去 recipe 只消費租戶自帶 exporter 指標。這類指標原生帶 `namespace` 但不帶 `tenant`，須在本 ADR 的拓撲政策下補一條明確規範。
+**決策：磁碟、PVC、節點這類基礎設施指標，只支援 1:1 的租戶歸屬（一個 namespace = 一個租戶）。**
 
-**政策：基礎設施指標的租戶歸屬僅支援 1:1。** 歸屬走 **recipe-path 慣例**——在 kubelet / cAdvisor scrape job 上以 `metric_relabel` 將 `namespace → tenant`（1:1，與 tenant-exporters job 一致，見 §決策）。這與另一條 platform-pack 慣例（recording-rule `label_replace(namespace→tenant)`，如 #809 node-health、版本感知容器規則）等價但分屬不同路徑：**recipe 消費的指標走 scrape-relabel、platform-pack 規則走 recording-rule**。
+ADR-024 的自助告警開始讓租戶對平台的基礎設施指標（例如 kubelet 的 `kubelet_volume_stats_*`）設條件。這些指標原生只帶 `namespace`、不帶 `tenant`，所以在抓取階段直接把 `namespace` 當成 `tenant`——沿用本 ADR 既有的 1:1 做法。
 
-**N:1 / 1:N 基礎設施歸屬：defer-with-trigger，且 fail-loud。**
+**為什麼 N:1 與 1:N 不在這次的支援範圍。** 本 ADR 的 N:1（多個 namespace 聚合成一個租戶）和 1:N（一個實例切成多個邏輯租戶）靠的是額外的映射規則，而基礎設施指標走的是抓取階段的直接改名、拿不到那層映射：
 
-- **N:1**（多 namespace → 一租戶）：本 ADR 的 N:1 走 scrape `relabel_configs` regex（`scaffold_tenant.py --namespaces`），**不產生可 join 的 namespace→tenant series**，故基礎設施指標無法沿用。**關鍵風險**：per-tenant 閾值 recipe 在 N:1 下會 **fail-silent**——指標帶 `tenant="db-a-read"`，但租戶 config 的 key 是 `db-a` → `on(tenant)` join 命中零、靜默漏告警；有別於 platform-pack 告警 N:1 的 fail-loud（over-alert）。
-- **1:N**（一實例多邏輯租戶）：單一 PVC 無法按 schema / tablespace 切分 → 結構性不可服務。
-- **兜底**：ADR-024 amend 的 per-tenant runtime sentinel（`CustomRecipeDiskInert{tenant}`）把上述 fail-silent 轉為 **fail-loud**——租戶宣告了基礎設施 recipe 但歸屬後的指標沒流，即告警。
-- **Trigger**：N:1 客戶（如讀寫分離 estate）明確需要基礎設施（disk / node）歸屬時，再評估把 N:1 mapping 套到 kubelet `metric_relabel`（須與 exporter relabel 共用同一 SSOT 生成，避免第二份副本漂移）。
+- **N:1 會靜默漏告警。** 指標被標成 `tenant="db-a-read"`，但租戶的設定用的是 `db-a` 這個名字——兩者對不上，告警永遠不觸發。
+- **1:N 本質上做不到。** 一顆 PVC 無法按 schema / tablespace 拆給不同租戶。
 
-相關：[ADR-024](024-version-aware-threshold-via-dimensional-label.md)（自助 recipe + disk recipe class + sentinel）、#809（node-health，同 1:1 idiom）、#692（epic）。
+**怎麼讓「不支援」不變成「悄悄壞掉」。** ADR-024 有一條對每個租戶的看門告警 `CustomRecipeDiskInert`：租戶設了磁碟告警、相關 Pod 也在跑，但歸屬後的指標一直沒出現，它就會響。於是 N:1 客戶在遷移當天就會收到「這條告警沒生效」的明確訊號，而不是無聲漏報。等真有 N:1 客戶（例如讀寫分離的資料庫）需要基礎設施告警，再把映射補上。
+
+相關：[ADR-024](024-version-aware-threshold-via-dimensional-label.md)、節點健康告警（#809，也用同一套 1:1 歸屬）、本 epic（#692）。
 
 ## 相關決策
 

--- a/docs/adr/006-tenant-mapping-topologies.md
+++ b/docs/adr/006-tenant-mapping-topologies.md
@@ -18,6 +18,7 @@ updated_at: 2026-05-13
 ## 狀態
 
 ✅ **Accepted** (v2.1.0) — 工具鏈已完成，1:N 端到端整合待生產驗證
+📎 **Addendum** (v2.10.0) — 基礎設施指標（disk/PVC/node）的租戶歸屬政策，見下方 §Addendum
 
 ## 背景
 
@@ -160,6 +161,21 @@ groups:
 **殘留**：
 - 在實際多 schema Oracle 環境驗證端到端流程（待生產環境回饋）
 - Schema validation（`_instance_mapping.yaml` JSON Schema）排入後續
+
+## Addendum：基礎設施指標的租戶歸屬 (v2.10.0)
+
+ADR-024 的自助 recipe 首次消費**平台基礎設施指標**（kubelet `kubelet_volume_stats_*`、cAdvisor `container_fs_*`）——過去 recipe 只消費租戶自帶 exporter 指標。這類指標原生帶 `namespace` 但不帶 `tenant`，須在本 ADR 的拓撲政策下補一條明確規範。
+
+**政策：基礎設施指標的租戶歸屬僅支援 1:1。** 歸屬走 **recipe-path 慣例**——在 kubelet / cAdvisor scrape job 上以 `metric_relabel` 將 `namespace → tenant`（1:1，與 tenant-exporters job 一致，見 §決策）。這與另一條 platform-pack 慣例（recording-rule `label_replace(namespace→tenant)`，如 #809 node-health、版本感知容器規則）等價但分屬不同路徑：**recipe 消費的指標走 scrape-relabel、platform-pack 規則走 recording-rule**。
+
+**N:1 / 1:N 基礎設施歸屬：defer-with-trigger，且 fail-loud。**
+
+- **N:1**（多 namespace → 一租戶）：本 ADR 的 N:1 走 scrape `relabel_configs` regex（`scaffold_tenant.py --namespaces`），**不產生可 join 的 namespace→tenant series**，故基礎設施指標無法沿用。**關鍵風險**：per-tenant 閾值 recipe 在 N:1 下會 **fail-silent**——指標帶 `tenant="db-a-read"`，但租戶 config 的 key 是 `db-a` → `on(tenant)` join 命中零、靜默漏告警；有別於 platform-pack 告警 N:1 的 fail-loud（over-alert）。
+- **1:N**（一實例多邏輯租戶）：單一 PVC 無法按 schema / tablespace 切分 → 結構性不可服務。
+- **兜底**：ADR-024 amend 的 per-tenant runtime sentinel（`CustomRecipeDiskInert{tenant}`）把上述 fail-silent 轉為 **fail-loud**——租戶宣告了基礎設施 recipe 但歸屬後的指標沒流，即告警。
+- **Trigger**：N:1 客戶（如讀寫分離 estate）明確需要基礎設施（disk / node）歸屬時，再評估把 N:1 mapping 套到 kubelet `metric_relabel`（須與 exporter relabel 共用同一 SSOT 生成，避免第二份副本漂移）。
+
+相關：[ADR-024](024-version-aware-threshold-via-dimensional-label.md)（自助 recipe + disk recipe class + sentinel）、#809（node-health，同 1:1 idiom）、#692（epic）。
 
 ## 相關決策
 

--- a/docs/adr/008-operator-native-integration-path.en.md
+++ b/docs/adr/008-operator-native-integration-path.en.md
@@ -13,7 +13,8 @@ lang: en
 ## Status
 
 ✅ **Accepted** (v2.3.0) — Platform supports both ConfigMap and Operator CRD paths; detection logic auto-selects
-📎 **Addendum** (v2.6.0) — Architecture boundary declaration added, see §Addendum below
+📎 **Addendum** (v2.6.0) — Architecture boundary declaration added, see §Addendum: Architecture Boundary Declaration
+📎 **Addendum** (v2.10.0) — da-assembler direct-render retired + Operator path decision (Option E), see §Addendum (v2.10.0)
 
 ## Context
 
@@ -188,13 +189,23 @@ Any new Operator-related tool or feature must pass these three questions:
 2. **Does it require the exporter to connect to the K8s API?** → If yes, boundary violation — delegate to external tools
 3. **Is it purely "read → transform → output"?** → If yes, falls within toolchain scope — proceed
 
+## Addendum (v2.10.0): da-assembler direct-render retired + Operator path decision
+
+When the [#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692) epic expanded "rule-pack drift → compiler operator" into an implementation plan, the three organs of the original idea each found a better home: **the compile brain → CI** (pure build-time, zero runtime); **the write heart → tenant-api's existing single-writer plane** ([ADR-023](023-write-plane-single-writer-invariant.md)); **the replay validation → a PR-comment backtest**. So the da-assembler-controller "long-term exploration" item in §Evolution Status above gets three decisions:
+
+1. **`da_assembler` direct-render → hard-deprecated (debug-only).** With compile-in-CI settled, the only legal production-actuation path is the GitOps CI pipeline (recipe → compile → promtool → PR → ConfigMap). Direct-render bypasses the generator-of-record: a CR-declared `_custom_alerts` emits a `user_threshold` series, but CI compiles no matching rule = a **structural silent alert**. Kept for local debugging only.
+2. **`ThresholdConfig` CRD → dormant, not installed by default.** With direct-render retired the CRD has no consumer; not installing it means `kubectl apply` errors immediately = a **natural fail-loud form**, better than a description warning (nobody reads it) or an always-deny webhook (a runtime component for a zombie CRD). The schema is kept for CI validation; it is reinstalled together with the pre-decision below when the trigger fires.
+3. **"Future Operator mode" → Option E pre-decision (no standalone operator).** The da-assembler-controller / standalone compiler operator is cancelled. If a CR-native self-service interface is ever needed (**trigger = a customer RFP explicitly requiring a kubectl-native interface**), implement it as an **optional watch mode embedded in tenant-api** (flag-gated, reusing the existing client-go + `ClaimTenant` single-writer pattern) — **never a standalone operator, never a sixth version line**. Rationale: the watch layer's only value is the thin skin that translates `kubectl apply` into a write request; building a state machine / retries / auth / version-line registration for that skin has negative ROI, so defer-with-trigger plus a pre-sketched shape avoids re-diverging later.
+
+Shipping narrative: **"Zero-Runtime, Pure-GitOps PromQL Compiler"** — multi-tenant / HA-correct / version-aware alert compilation with no new controller installed in the production cluster.
+
 ## Evolution Status
 
 - **v2.3.0** (completed): `operator-generate` / `operator-check` toolchain, PrometheusRule + AlertmanagerConfig + ServiceMonitor CRD output
 - **v2.6.0** (completed): Architecture boundary declaration (see §Addendum above), `operator-generate --kustomize` multi-cluster deployment, `drift_detect.py --mode operator` cross-cluster CRD drift detection
 
 **Remaining**:
-- **da-assembler-controller** (long-term exploration): external Operator watches `ThresholdConfig` CRD → renders `conf.d/`. Note: this component lives outside threshold-exporter, does not violate the architecture boundary declaration
+- ~~**da-assembler-controller** (long-term exploration): external Operator watches `ThresholdConfig` CRD → renders `conf.d/`~~ → **retired in v2.10.0** (see §Addendum (v2.10.0)): direct-render hard-deprecated, CRD dormant, a future CR-native interface becomes an embedded tenant-api watch mode
 - **Helm Chart kube-prometheus-stack values examples**: provide values.yaml reference for common Operator deployments
 - **ArgoCD ApplicationSet integration**: multi-cluster Federation CRD deployment automation
 

--- a/docs/adr/008-operator-native-integration-path.en.md
+++ b/docs/adr/008-operator-native-integration-path.en.md
@@ -14,7 +14,7 @@ lang: en
 
 ✅ **Accepted** (v2.3.0) — Platform supports both ConfigMap and Operator CRD paths; detection logic auto-selects
 📎 **Addendum** (v2.6.0) — Architecture boundary declaration added, see §Addendum: Architecture Boundary Declaration
-📎 **Addendum** (v2.10.0) — da-assembler direct-render retired + Operator path decision (Option E), see §Addendum (v2.10.0)
+📎 **Addendum** (v2.10.0) — da-assembler direct-render retired + Operator path decision, see §Addendum (v2.10.0)
 
 ## Context
 
@@ -191,13 +191,15 @@ Any new Operator-related tool or feature must pass these three questions:
 
 ## Addendum (v2.10.0): da-assembler direct-render retired + Operator path decision
 
-When the [#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692) epic expanded "rule-pack drift → compiler operator" into an implementation plan, the three organs of the original idea each found a better home: **the compile brain → CI** (pure build-time, zero runtime); **the write heart → tenant-api's existing single-writer plane** ([ADR-023](023-write-plane-single-writer-invariant.md)); **the replay validation → a PR-comment backtest**. So the da-assembler-controller "long-term exploration" item in §Evolution Status above gets three decisions:
+When the [#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692) epic took the originally-imagined "operator that watches a CRD and compiles rules on the fly" and pulled it apart, its three jobs each found a better home: **the compile logic stays in CI** (pure build-time, no new runtime component); **the write goes through tenant-api's existing single-writer plane** ([ADR-023](023-write-plane-single-writer-invariant.md)); **the pre-deploy replay check becomes a backtest posted as a PR comment**. All that's left is the thin skin that translates a CRD into one write request — and there is no demand for it yet. So the da-assembler-controller exploration item in §Evolution Status above gets three decisions:
 
-1. **`da_assembler` direct-render → hard-deprecated (debug-only).** With compile-in-CI settled, the only legal production-actuation path is the GitOps CI pipeline (recipe → compile → promtool → PR → ConfigMap). Direct-render bypasses the generator-of-record: a CR-declared `_custom_alerts` emits a `user_threshold` series, but CI compiles no matching rule = a **structural silent alert**. Kept for local debugging only.
-2. **`ThresholdConfig` CRD → dormant, not installed by default.** With direct-render retired the CRD has no consumer; not installing it means `kubectl apply` errors immediately = a **natural fail-loud form**, better than a description warning (nobody reads it) or an always-deny webhook (a runtime component for a zombie CRD). The schema is kept for CI validation; it is reinstalled together with the pre-decision below when the trigger fires.
-3. **"Future Operator mode" → Option E pre-decision (no standalone operator).** The da-assembler-controller / standalone compiler operator is cancelled. If a CR-native self-service interface is ever needed (**trigger = a customer RFP explicitly requiring a kubectl-native interface**), implement it as an **optional watch mode embedded in tenant-api** (flag-gated, reusing the existing client-go + `ClaimTenant` single-writer pattern) — **never a standalone operator, never a sixth version line**. Rationale: the watch layer's only value is the thin skin that translates `kubectl apply` into a write request; building a state machine / retries / auth / version-line registration for that skin has negative ROI, so defer-with-trigger plus a pre-sketched shape avoids re-diverging later.
+1. **`da_assembler`'s direct-render mode is retired, kept only for local debugging.** Rules are always produced by CI compilation (recipe → compile → promtool → PR → ConfigMap), the only legal way to ship to production. Direct-render bypasses that pipeline: a CRD-declared alert emits a metric, but CI compiles no matching rule — another alert that silently never fires.
 
-Shipping narrative: **"Zero-Runtime, Pure-GitOps PromQL Compiler"** — multi-tenant / HA-correct / version-aware alert compilation with no new controller installed in the production cluster.
+2. **The `ThresholdConfig` CRD is not installed by default (dormant).** With direct-render retired it has no consumer for now. Not installing it means `kubectl apply` errors on the spot — the most natural "fail loud," better than a warning in a description field nobody reads, or standing up an always-deny component for a CRD nobody uses. The schema is kept for CI validation and reinstated when the need returns.
+
+3. **If a CRD-native self-service interface is ever wanted, build it as an optional mode embedded in tenant-api, not a separate operator.** The original standalone-operator idea is cancelled. The trigger is a customer explicitly needing a kubectl-native interface; at that point, embed a switchable watch mode in tenant-api (reusing the existing single-writer mechanism) — no new component, and no separate release line for it. The reasoning is simple: that skin has limited value, and maintaining a dedicated state machine, retries, auth, and release process for it isn't worth it.
+
+In one sentence: multi-tenant, HA-correct, version-aware alert compilation happens entirely at build time, and the production cluster needs no new controller installed.
 
 ## Evolution Status
 

--- a/docs/adr/008-operator-native-integration-path.md
+++ b/docs/adr/008-operator-native-integration-path.md
@@ -18,7 +18,8 @@ updated_at: 2026-05-13
 ## 狀態
 
 ✅ **Accepted** (v2.3.0) — 平台同時支援 ConfigMap 路徑和 Operator CRD 路徑，由偵測邏輯自動判斷
-📎 **Addendum** (v2.6.0) — 新增架構邊界宣言，見下方 §Addendum
+📎 **Addendum** (v2.6.0) — 新增架構邊界宣言，見下方 §Addendum: 架構邊界宣言
+📎 **Addendum** (v2.10.0) — da-assembler direct-render 退役 + Operator 路徑裁決（Option E），見下方 §Addendum (v2.10.0)
 
 ## 背景
 
@@ -193,13 +194,23 @@ graph LR
 2. **是否需要 exporter 連線 K8s API？** → 如果是，違反邊界，應由外部工具處理
 3. **是否只是「讀取 → 轉換 → 輸出」？** → 如果是，屬於工具鏈範疇，可以進行
 
+## Addendum (v2.10.0)：da-assembler direct-render 退役 + Operator 路徑裁決
+
+[#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692) epic 把「rule-pack drift → 編譯器 operator」展開成實作計畫時，原構想的三個器官各有更好歸宿：**編譯大腦 → CI**（純 build-time、零 runtime）；**寫入心臟 → tenant-api 既有單一寫者平面**（[ADR-023](023-write-plane-single-writer-invariant.md)）；**回放驗證 → PR comment 回測**。故對上方 §演進狀態 的 da-assembler-controller「長期探索」項做三點裁決：
+
+1. **`da_assembler` direct-render → hard-deprecate（debug-only）。** compile-in-CI 定案後，production actuation 的唯一合法路徑 = GitOps CI pipeline（recipe → 編譯 → promtool → PR → ConfigMap）。direct-render 繞過 generator-of-record：CR 宣告的 `_custom_alerts` 會發 `user_threshold` series，但 CI 編不出對應 rule = **結構性 silent alert**。保留僅供本機 debug。
+2. **`ThresholdConfig` CRD → dormant，預設不安裝。** direct-render 退役後 CRD 暫無消費者；不安裝 → `kubectl apply` 立即報錯 = **fail-loud 的天然形式**，優於 description 警語（沒人讀）或 always-deny webhook（為殭屍 CRD 蓋 runtime 元件）。schema 留供 CI 驗證；trigger fire 時隨下列預決策一併恢復安裝。
+3. **「未來 Operator 模式」→ Option E 預決策（取消獨立 operator）。** 原 da-assembler-controller / 獨立編譯器 operator 取消。若將來需要 CR-native 自助介面（**trigger = 客戶 RFP 明確要 kubectl-native 介面**），以 **tenant-api 內嵌的可選 watch mode** 實作（flag 開關、復用既有 client-go + `ClaimTenant` 單寫者樣式），**永不蓋獨立 operator、永不開第六條版號線**。理由：watch 層唯一價值是「把 `kubectl apply` 翻成寫入請求」一層皮，為它做狀態機 / 重試 / 認證 / 版號線註冊的 ROI 為負；故 defer-with-trigger + 預拍實作形狀，避免將來重新發散。
+
+出貨敘事：**"Zero-Runtime, Pure-GitOps PromQL Compiler"**——多租戶 / HA 校正 / 版本感知的告警編譯，production 叢集不裝任何新 controller。
+
 ## 演進狀態
 
 - **v2.3.0**（已完成）：`operator-generate` / `operator-check` 工具鏈、PrometheusRule + AlertmanagerConfig + ServiceMonitor CRD 產出
 - **v2.6.0**（已完成）：架構邊界宣言（見上方 §Addendum）、`operator-generate --kustomize` 多叢集部署、`drift_detect.py --mode operator` 跨叢集 CRD 漂移偵測
 
 **殘留**：
-- **da-assembler-controller**（長期探索）：外部 Operator watch `ThresholdConfig` CRD → 渲染 `conf.d/`。注意：此元件在 threshold-exporter 外部，不違反架構邊界宣言
+- ~~**da-assembler-controller**（長期探索）：外部 Operator watch `ThresholdConfig` CRD → 渲染 `conf.d/`~~ → **v2.10.0 取消**（見下方 §Addendum (v2.10.0)）：direct-render hard-deprecate、CRD dormant、未來 CR-native 介面改 tenant-api 內嵌 watch mode
 - **Helm Chart kube-prometheus-stack values 範例**：提供常見 Operator 部署的 values.yaml 參考
 - **ArgoCD ApplicationSet 整合**：多叢集 Federation 場景的 CRD 部署自動化
 

--- a/docs/adr/008-operator-native-integration-path.md
+++ b/docs/adr/008-operator-native-integration-path.md
@@ -19,7 +19,7 @@ updated_at: 2026-05-13
 
 ✅ **Accepted** (v2.3.0) — 平台同時支援 ConfigMap 路徑和 Operator CRD 路徑，由偵測邏輯自動判斷
 📎 **Addendum** (v2.6.0) — 新增架構邊界宣言，見下方 §Addendum: 架構邊界宣言
-📎 **Addendum** (v2.10.0) — da-assembler direct-render 退役 + Operator 路徑裁決（Option E），見下方 §Addendum (v2.10.0)
+📎 **Addendum** (v2.10.0) — da-assembler direct-render 退役 + Operator 路徑定案，見下方 §Addendum (v2.10.0)
 
 ## 背景
 
@@ -194,15 +194,17 @@ graph LR
 2. **是否需要 exporter 連線 K8s API？** → 如果是，違反邊界，應由外部工具處理
 3. **是否只是「讀取 → 轉換 → 輸出」？** → 如果是，屬於工具鏈範疇，可以進行
 
-## Addendum (v2.10.0)：da-assembler direct-render 退役 + Operator 路徑裁決
+## Addendum (v2.10.0)：da-assembler direct-render 退役 + Operator 路徑定案
 
-[#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692) epic 把「rule-pack drift → 編譯器 operator」展開成實作計畫時，原構想的三個器官各有更好歸宿：**編譯大腦 → CI**（純 build-time、零 runtime）；**寫入心臟 → tenant-api 既有單一寫者平面**（[ADR-023](023-write-plane-single-writer-invariant.md)）；**回放驗證 → PR comment 回測**。故對上方 §演進狀態 的 da-assembler-controller「長期探索」項做三點裁決：
+把本 epic（[#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692)）原本設想的「監聽 CRD、即時編譯規則的 operator」拆開後，它的三個職責各自找到了更好的歸宿：**編譯邏輯留在 CI**（純建置期、不增加任何執行期元件）；**寫入交給 tenant-api 既有的單一寫入平面**（[ADR-023](023-write-plane-single-writer-invariant.md)）；**上線前的回放驗證變成 PR 留言裡的回測**。剩下的只有「把 CRD 翻成一個寫入請求」這層皮，而它的需求還沒出現。據此對上方 §演進狀態 的 da-assembler-controller 探索項做三點定案：
 
-1. **`da_assembler` direct-render → hard-deprecate（debug-only）。** compile-in-CI 定案後，production actuation 的唯一合法路徑 = GitOps CI pipeline（recipe → 編譯 → promtool → PR → ConfigMap）。direct-render 繞過 generator-of-record：CR 宣告的 `_custom_alerts` 會發 `user_threshold` series，但 CI 編不出對應 rule = **結構性 silent alert**。保留僅供本機 debug。
-2. **`ThresholdConfig` CRD → dormant，預設不安裝。** direct-render 退役後 CRD 暫無消費者；不安裝 → `kubectl apply` 立即報錯 = **fail-loud 的天然形式**，優於 description 警語（沒人讀）或 always-deny webhook（為殭屍 CRD 蓋 runtime 元件）。schema 留供 CI 驗證；trigger fire 時隨下列預決策一併恢復安裝。
-3. **「未來 Operator 模式」→ Option E 預決策（取消獨立 operator）。** 原 da-assembler-controller / 獨立編譯器 operator 取消。若將來需要 CR-native 自助介面（**trigger = 客戶 RFP 明確要 kubectl-native 介面**），以 **tenant-api 內嵌的可選 watch mode** 實作（flag 開關、復用既有 client-go + `ClaimTenant` 單寫者樣式），**永不蓋獨立 operator、永不開第六條版號線**。理由：watch 層唯一價值是「把 `kubectl apply` 翻成寫入請求」一層皮，為它做狀態機 / 重試 / 認證 / 版號線註冊的 ROI 為負；故 defer-with-trigger + 預拍實作形狀，避免將來重新發散。
+1. **`da_assembler` 的 direct-render 模式退役，只留本機除錯用。** 規則一律由 CI 編譯產生（recipe → 編譯 → promtool → PR → ConfigMap），這是 production 唯一合法的上線路徑。direct-render 會繞過這條管線：CRD 宣告的告警會送出指標，CI 卻編不出對應規則——又是一條會悄悄不觸發的告警。
 
-出貨敘事：**"Zero-Runtime, Pure-GitOps PromQL Compiler"**——多租戶 / HA 校正 / 版本感知的告警編譯，production 叢集不裝任何新 controller。
+2. **`ThresholdConfig` CRD 預設不安裝（休眠）。** direct-render 退役後它暫時沒有消費者。不安裝的好處是 `kubectl apply` 會當場報錯——這是最自然的「大聲壞掉」，比在描述欄寫一句沒人看的警語、或為一個沒人用的 CRD 立一個 always-deny 元件都好。schema 留著供 CI 驗證，需求出現時再一併恢復。
+
+3. **未來若要 CRD 原生的自助介面，做成 tenant-api 內嵌的選用模式，不另立 operator。** 原本的獨立 operator 構想取消。觸發條件是客戶明確需要 kubectl 原生介面；屆時就在 tenant-api 內嵌一個可開關的監聽模式（沿用既有的單一寫入機制），不蓋新元件、也不為它另開一條發版線。理由很簡單：那層皮的價值有限，為它單獨維護一套狀態機、重試、認證、發版流程並不划算。
+
+對外一句話：多租戶、HA 校正、版本感知的告警編譯全在建置期完成，production 叢集不需要安裝任何新的 controller。
 
 ## 演進狀態
 

--- a/docs/adr/024-version-aware-threshold-via-dimensional-label.en.md
+++ b/docs/adr/024-version-aware-threshold-via-dimensional-label.en.md
@@ -19,7 +19,7 @@ lang: en
 
 Both shipped in v2.9.0. Trackers: [#423](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/423) (version-aware), [#741](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/741) (custom alerts); per-PR history is in the CHANGELOG.
 
-📎 **Addendum** (v2.10.0) — Disk/PVC infrastructure recipe class (per-PVC dimension preservation + CSI precondition + fail-loud dual guard), see §Addendum below; epic [#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692).
+📎 **Addendum** (v2.10.0) — Disk and PVC alerts (capacity evaluated per PVC + CSI driver required + two guards), see §Addendum below; epic [#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692).
 
 > This ADR does **not** replace or modify [config-driven.md §2.6 Scheduled Thresholds](../design/config-driven.md) — they coexist as distinct mechanisms; the boundary is in the last section.
 
@@ -234,37 +234,35 @@ The core judgment is **reuse-over-build**: 90% of the target capability already 
 
 The two are orthogonal: §2.6 handles periodic windows, this ADR handles one-time version alignment.
 
-## Addendum: Disk/PVC Infrastructure Recipe Class (v2.10.0)
+## Addendum: Disk and PVC Alerts (v2.10.0)
 
-The first recipe class to consume **platform infrastructure metrics** (rather than tenant-owned exporter metrics), serving MariaDB-class migration's disk-alerting need ([#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692) P0 ③). It reuses the existing recipes (forecast / ratio / threshold / rate) — no new recipe kind — but adds three infrastructure-specific constraints.
+Lets tenants alert on disk capacity and throughput — the "the disk is filling up" need that comes up most often during database-customer migrations ([#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692)). It reuses the existing recipes (forecast / ratio / threshold / rate) with no new recipe kind, but a few things differ from an ordinary recipe.
 
-**1. Two signals, two granularities (semantic precision)**
+**Two signals, two granularities.**
 
-| Need | Metric | Granularity | Recipe |
-|---|---|---|---|
-| Disk-fill forecast / capacity utilization | `kubelet_volume_stats_{available,capacity,used}_bytes` | **per-PVC** (carries `persistentvolumeclaim`) | forecast(ratio) / ratio / threshold |
-| Disk throughput / IOPS | `container_fs_{writes,reads}_{total,bytes_total}` | **per-container/device** (cAdvisor, **not** per-PVC) | rate / threshold |
+| What you want to alert on | Metric | Granularity |
+|---|---|---|
+| Disk filling up / capacity utilization | `kubelet_volume_stats_*` (available / capacity / used) | **per PVC** (carries `persistentvolumeclaim`) |
+| Disk throughput / IOPS | `container_fs_*` (reads / writes) | **per container** (not per PVC) |
 
-The throughput signal comes from cAdvisor container-filesystem stats; `device` is the node block device and **cannot be attributed to a specific PVC** — a single-PVC pod is roughly equivalent, multi-PVC cannot be split. So a precise per-PVC "IOPS via PVC" is only achievable on the fill side.
+The throughput signal comes from container-filesystem stats, whose `device` is the node's block device and can't be tied to a specific PVC — a single-PVC pod is roughly equivalent, but multiple PVCs can't be told apart. So "precise to one PVC" is only possible on the capacity side.
 
-**2. CSI precondition (spike-verified, 2026-06-14)**
+**Precondition: disk-capacity metrics need a CSI driver.** The kubelet only emits `kubelet_volume_stats_*` for storage backends that implement the volume-stats interface (`NodeGetVolumeStats`). Cloud CSI drivers (EBS, GCE PD, etc.) all do; kind's default local storage (hostPath) emits none — verification measured 751 kubelet metrics but 0 volume-stats. After installing a CSI driver, `kubelet_volume_stats_*{namespace, persistentvolumeclaim}` appears. **So a disk-capacity recipe's hard precondition is PVCs provided by a CSI driver that supports volume stats** (most cloud environments qualify). This is recorded in the recipe usage docs and the BYO integration precondition.
 
-The kubelet emits `kubelet_volume_stats_*` only for volumes whose plugin implements `NodeGetVolumeStats`. kind's default `local-path` (hostPath) emits **none** (measured: 751 kubelet metrics, 0 volume-stats); after installing a CSI driver (NodeGetVolumeStats), `kubelet_volume_stats_*{namespace,persistentvolumeclaim}` appears within ~30s. So **a disk-fill recipe's hard precondition is PVCs backed by a CSI driver implementing NodeGetVolumeStats** (most cloud CSI do). Documented in the recipe catalog and the BYO integration precondition; e2e uses the CSI hostpath driver.
+Tenant attribution reuses the platform's existing 1:1 approach — at scrape time the `namespace` is used as the `tenant`, with the metric name unchanged; the N:1 / 1:N policy is in [ADR-006 §Addendum](006-tenant-mapping-topologies.md).
 
-**3. Tenant attribution = scrape-relabel (recipe-path idiom, 1:1)**
+**Correctness that matters: evaluate each PVC, don't let a sum hide it.** A tenant may mount several PVCs. Summing the metric with `by(tenant)` before comparing to the threshold goes wrong:
 
-The kubelet / cAdvisor scrape jobs add a `metric_relabel` mapping `namespace → tenant` (keeping the real metric name, good migration UX). 1:1 only; the N:1/1:N policy is in [ADR-006 §Addendum: Tenant Attribution for Infrastructure Metrics](006-tenant-mapping-topologies.md). The existing cadvisor cpu/mem rules aggregate `sum by(namespace, pod, container)` and drop any added `tenant` → side-effect safe (verified).
+> A 10GB config disk is already 99% full while a 500GB data disk is only 10% full — summed together "88% space remains," so the alert never fires, but that small disk is about to take the database down.
 
-**4. Per-PVC dimension preservation (aggregation-masking fix, caught by adversarial review)**
+So a disk-capacity recipe **evaluates each PVC and fires if any one crosses**: the aggregation keeps the `persistentvolumeclaim` dimension, the threshold is still one per tenant applied to each of that tenant's PVCs, and the alert names which disk. To keep metric cardinality in check, the only dimension allowed to survive is `persistentvolumeclaim`.
 
-A disk-fill recipe **must evaluate per-PVC**: the metric-side aggregation changes from `by(tenant)` to `by(tenant, persistentvolumeclaim)`, firing if any PVC is weak; the core join stays `on(tenant) group_left(name, mode)` (the per-tenant threshold broadcasts to each PVC; `persistentvolumeclaim` rides the many-side and reaches the alert label). Otherwise `sum by(tenant)` lets a **99%-full 10GB disk be masked by a 10%-full 500GB disk** (aggregate 88% free → never fires, DB still crashes) — same mechanism as [#819 `==` any-match](003-sentinel-alert-pattern.md) (compare before aggregating). The preserved-label whitelist is **`persistentvolumeclaim` only** (bounded; few PVCs per tenant), capping cardinality.
+**Two guards: make a misconfigured alert fail loudly instead of silently.** If a tenant sets an alert on a metric that is never scraped, or scraped without a `tenant` label, the alert compiles fine but never fires — the most dangerous failure. Two guards close it:
 
-**5. Fail-loud dual guard (against the #731-class silent alert)**
+- **At build time (CI)**: parse the Prometheus scrape config directly and confirm every metric a recipe uses (including a ratio's denominator and a forecast's capacity metric) is actually scraped and attributed to a `tenant` by its scrape job; otherwise CI errors. It reads the scrape config as the source of truth rather than maintaining a separate list that would go stale. It can only protect configs aligned with this platform's scrape config; a customer's own Prometheus config is invisible to it, which the next guard covers.
+- **At run time, the watchdog alert `CustomRecipeDiskInert`**: if a tenant set a disk alert and its pods are running but the attributed disk metric never appears, it fires. This turns "topology unsupported," "attribution not set up," and "the tenant mounts no PVC" from silent failures into an alert someone will see.
 
-- **CI lint (build-time)**: reverse-parse `configmap-prometheus.yaml` (the SSOT, mirroring `check_ksm_version_allowlist.py`'s parse-the-manifest, not a prefix heuristic). If a recipe's `metric` / `capacity_metric` / `denominator_metric` is scraped by a job that does not set `tenant` → **ERROR** (the metric would never attribute, the alert would never fire). Honest limit: it cannot see a BYO customer's `prometheus.yml`, so it protects only configs aligned with this platform's scrape SSOT.
-- **Runtime sentinel (`CustomRecipeDiskInert{tenant}`)**: modeled on `VersionAwareThresholdInert`, per-tenant + Running-pod gate — if a tenant declared a disk recipe, its pods are running, but the attributed disk metric is not flowing, it fires. This turns N:1/1:N mis-attribution, a missing relabel, or **a tenant that mounts no PVC** from fail-silent into fail-loud.
-
-**Honesty residue**: the v2.9.0-shipped `disk_will_fill` forecast example (`shop.yaml` / `forecast.yaml`) referenced `kubelet_volume_stats_*` that nothing scraped → a latent silent alert (passed promtool on synthetic fixtures, never fired in a real cluster); this amend's scrape enablement + dual guard fixes it.
+v2.9.0 once shipped a disk-forecast example that referenced `kubelet_volume_stats_*` — which nothing scraped at the time. It looked fine on the test fixtures but never fired in a real cluster. The scrape enablement plus these two guards fix it.
 
 ## Cross-Reference
 

--- a/docs/adr/024-version-aware-threshold-via-dimensional-label.en.md
+++ b/docs/adr/024-version-aware-threshold-via-dimensional-label.en.md
@@ -19,6 +19,8 @@ lang: en
 
 Both shipped in v2.9.0. Trackers: [#423](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/423) (version-aware), [#741](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/741) (custom alerts); per-PR history is in the CHANGELOG.
 
+📎 **Addendum** (v2.10.0) — Disk/PVC infrastructure recipe class (per-PVC dimension preservation + CSI precondition + fail-loud dual guard), see §Addendum below; epic [#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692).
+
 > This ADR does **not** replace or modify [config-driven.md §2.6 Scheduled Thresholds](../design/config-driven.md) — they coexist as distinct mechanisms; the boundary is in the last section.
 
 ## Context
@@ -232,8 +234,41 @@ The core judgment is **reuse-over-build**: 90% of the target capability already 
 
 The two are orthogonal: §2.6 handles periodic windows, this ADR handles one-time version alignment.
 
+## Addendum: Disk/PVC Infrastructure Recipe Class (v2.10.0)
+
+The first recipe class to consume **platform infrastructure metrics** (rather than tenant-owned exporter metrics), serving MariaDB-class migration's disk-alerting need ([#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692) P0 ③). It reuses the existing recipes (forecast / ratio / threshold / rate) — no new recipe kind — but adds three infrastructure-specific constraints.
+
+**1. Two signals, two granularities (semantic precision)**
+
+| Need | Metric | Granularity | Recipe |
+|---|---|---|---|
+| Disk-fill forecast / capacity utilization | `kubelet_volume_stats_{available,capacity,used}_bytes` | **per-PVC** (carries `persistentvolumeclaim`) | forecast(ratio) / ratio / threshold |
+| Disk throughput / IOPS | `container_fs_{writes,reads}_{total,bytes_total}` | **per-container/device** (cAdvisor, **not** per-PVC) | rate / threshold |
+
+The throughput signal comes from cAdvisor container-filesystem stats; `device` is the node block device and **cannot be attributed to a specific PVC** — a single-PVC pod is roughly equivalent, multi-PVC cannot be split. So a precise per-PVC "IOPS via PVC" is only achievable on the fill side.
+
+**2. CSI precondition (spike-verified, 2026-06-14)**
+
+The kubelet emits `kubelet_volume_stats_*` only for volumes whose plugin implements `NodeGetVolumeStats`. kind's default `local-path` (hostPath) emits **none** (measured: 751 kubelet metrics, 0 volume-stats); after installing a CSI driver (NodeGetVolumeStats), `kubelet_volume_stats_*{namespace,persistentvolumeclaim}` appears within ~30s. So **a disk-fill recipe's hard precondition is PVCs backed by a CSI driver implementing NodeGetVolumeStats** (most cloud CSI do). Documented in the recipe catalog and the BYO integration precondition; e2e uses the CSI hostpath driver.
+
+**3. Tenant attribution = scrape-relabel (recipe-path idiom, 1:1)**
+
+The kubelet / cAdvisor scrape jobs add a `metric_relabel` mapping `namespace → tenant` (keeping the real metric name, good migration UX). 1:1 only; the N:1/1:N policy is in [ADR-006 §Addendum: Tenant Attribution for Infrastructure Metrics](006-tenant-mapping-topologies.md). The existing cadvisor cpu/mem rules aggregate `sum by(namespace, pod, container)` and drop any added `tenant` → side-effect safe (verified).
+
+**4. Per-PVC dimension preservation (aggregation-masking fix, caught by adversarial review)**
+
+A disk-fill recipe **must evaluate per-PVC**: the metric-side aggregation changes from `by(tenant)` to `by(tenant, persistentvolumeclaim)`, firing if any PVC is weak; the core join stays `on(tenant) group_left(name, mode)` (the per-tenant threshold broadcasts to each PVC; `persistentvolumeclaim` rides the many-side and reaches the alert label). Otherwise `sum by(tenant)` lets a **99%-full 10GB disk be masked by a 10%-full 500GB disk** (aggregate 88% free → never fires, DB still crashes) — same mechanism as [#819 `==` any-match](003-sentinel-alert-pattern.md) (compare before aggregating). The preserved-label whitelist is **`persistentvolumeclaim` only** (bounded; few PVCs per tenant), capping cardinality.
+
+**5. Fail-loud dual guard (against the #731-class silent alert)**
+
+- **CI lint (build-time)**: reverse-parse `configmap-prometheus.yaml` (the SSOT, mirroring `check_ksm_version_allowlist.py`'s parse-the-manifest, not a prefix heuristic). If a recipe's `metric` / `capacity_metric` / `denominator_metric` is scraped by a job that does not set `tenant` → **ERROR** (the metric would never attribute, the alert would never fire). Honest limit: it cannot see a BYO customer's `prometheus.yml`, so it protects only configs aligned with this platform's scrape SSOT.
+- **Runtime sentinel (`CustomRecipeDiskInert{tenant}`)**: modeled on `VersionAwareThresholdInert`, per-tenant + Running-pod gate — if a tenant declared a disk recipe, its pods are running, but the attributed disk metric is not flowing, it fires. This turns N:1/1:N mis-attribution, a missing relabel, or **a tenant that mounts no PVC** from fail-silent into fail-loud.
+
+**Honesty residue**: the v2.9.0-shipped `disk_will_fill` forecast example (`shop.yaml` / `forecast.yaml`) referenced `kubelet_volume_stats_*` that nothing scraped → a latent silent alert (passed promtool on synthetic fixtures, never fired in a real cluster); this amend's scrape enablement + dual guard fixes it.
+
 ## Cross-Reference
 
+- [ADR-006: Tenant Mapping Topologies](006-tenant-mapping-topologies.md) — the 1:1 infrastructure-attribution policy + N:1/1:N defer.
 - [ADR-003: Sentinel Alert Pattern](003-sentinel-alert-pattern.md) — the sentinel + inhibit basis for silent / tri-state.
 - [ADR-008: Operator-Native Integration Path](008-operator-native-integration-path.md) — the declarative-only rule.
 - [ADR-017: `_defaults.yaml` inheritance](017-defaults-yaml-inheritance-dual-hash.md) — directory-tree inheritance for hierarchical scope.

--- a/docs/adr/024-version-aware-threshold-via-dimensional-label.md
+++ b/docs/adr/024-version-aware-threshold-via-dimensional-label.md
@@ -25,7 +25,7 @@ updated_at: 2026-06-06
 
 兩者均已隨 v2.9.0 落地。Tracker：[#423](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/423)（version-aware）、[#741](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/741)（custom alerts）；逐 PR 紀錄見 CHANGELOG。
 
-📎 **Addendum** (v2.10.0) — Disk/PVC 基礎設施 recipe class（per-PVC 維度保留 + CSI 前提 + fail-loud 雙 guard），見下方 §Addendum；epic [#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692)。
+📎 **Addendum** (v2.10.0) — 磁碟與 PVC 告警（容量逐顆 PVC 評估 + 需 CSI driver + 兩道防線），見下方 §Addendum；epic [#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692)。
 
 > 本 ADR **不取代、不修改** [config-driven.md §2.6 排程式閾值](../design/config-driven.md)——兩者是並存的不同機制，界線見末節。
 
@@ -240,37 +240,35 @@ count by(recipe_id)(count by(recipe_id, tenant)(user_threshold{component="custom
 
 兩者正交：§2.6 處理週期性時段，本 ADR 處理一次性的版本對齊。
 
-## Addendum：Disk/PVC 基礎設施 recipe class (v2.10.0)
+## Addendum：磁碟與 PVC 告警 (v2.10.0)
 
-第一個消費**平台基礎設施指標**（而非租戶自帶 exporter 指標）的 recipe class，回應 MariaDB-class 客戶遷移的磁碟告警需求（[#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692) P0 ③）。沿用既有 recipe（forecast / ratio / threshold / rate），不新增 recipe 種類，但補三個基礎設施專屬約束。
+讓租戶對磁碟的容量與吞吐設告警，回應資料庫客戶遷移時最常見的「磁碟快滿了」需求（[#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692)）。沿用既有的 recipe（forecast / ratio / threshold / rate），不新增種類，但有幾件事和一般 recipe 不同。
 
-**1. 兩種信號、兩種粒度（語意精確）**
+**兩種信號、兩種粒度。**
 
-| 需求 | 指標 | 粒度 | recipe |
-|---|---|---|---|
-| 磁碟寫滿預測 / 容量利用率 | `kubelet_volume_stats_{available,capacity,used}_bytes` | **per-PVC**（帶 `persistentvolumeclaim`） | forecast(ratio) / ratio / threshold |
-| 磁碟吞吐 / IOPS | `container_fs_{writes,reads}_{total,bytes_total}` | **per-container/device**（cAdvisor，**非 per-PVC**） | rate / threshold |
+| 想告警的事 | 用的指標 | 粒度 |
+|---|---|---|
+| 磁碟快寫滿 / 容量利用率 | `kubelet_volume_stats_*`（available / capacity / used） | **每顆 PVC**（帶 `persistentvolumeclaim`） |
+| 磁碟吞吐 / IOPS | `container_fs_*`（reads / writes） | **每個容器**（不是每顆 PVC） |
 
-吞吐信號來自 cAdvisor 的 container filesystem 統計，`device` 是節點區塊裝置、**無法歸到特定 PVC**；單 PVC 的 pod 近似等價、多 PVC 不可切。故「IOPS bound via PVC」的精確 per-PVC 版只有 fill 端做得到。
+吞吐指標來自容器檔案系統統計，它的 `device` 是節點的區塊裝置、對不到特定 PVC——單一 PVC 的 Pod 大致等價，多 PVC 就切不開。所以「精準到某一顆 PVC」目前只有容量這側做得到。
 
-**2. CSI 前提（spike 實證，2026-06-14）**
+**前提：磁碟容量指標需要 CSI driver。** kubelet 只對「實作了 volume stats 介面（`NodeGetVolumeStats`）」的儲存後端吐 `kubelet_volume_stats_*`。一般雲端的 CSI driver（EBS、GCE PD 等）都有；但 kind 預設的本機儲存（hostPath）完全不吐——驗證時實測到 751 個 kubelet 指標、卻 0 個 volume stats。裝上 CSI driver 後，`kubelet_volume_stats_*{namespace, persistentvolumeclaim}` 隨即出現。**所以磁碟容量 recipe 的硬前提是：PVC 由支援 volume stats 的 CSI driver 提供**（多數雲端環境都符合）。這條會寫進 recipe 使用說明與 BYO 整合前提。
 
-kubelet 只對「volume plugin 實作 `NodeGetVolumeStats`」的 volume 吐 `kubelet_volume_stats_*`。kind 預設 `local-path`（hostPath）**完全不吐**（實測：751 kubelet 指標、0 volume-stats）；裝 CSI driver（NodeGetVolumeStats）後 `kubelet_volume_stats_*{namespace,persistentvolumeclaim}` ~30s 出現。故 **disk-fill recipe 的硬前提 = PVC 由實作 NodeGetVolumeStats 的 CSI driver backing**（多數雲端 CSI 皆是）。寫進 recipe catalog 與 BYO 整合前提；e2e 用 CSI hostpath driver。
+租戶歸屬沿用平台既有的 1:1 做法——抓取階段把 `namespace` 當 `tenant`、指標名保持不變；N:1 / 1:N 的政策見 [ADR-006 §Addendum](006-tenant-mapping-topologies.md)。
 
-**3. 租戶歸屬 = scrape-relabel（recipe-path 慣例，1:1）**
+**關鍵正確性：逐顆 PVC 判斷，別被加總掩蓋。** 一個租戶可能掛好幾顆 PVC。如果把指標用 `by(tenant)` 加總再比閾值，就會出事：
 
-kubelet / cAdvisor scrape job 加 `metric_relabel` 將 `namespace → tenant`（保留真實 metric 名，遷移 UX 佳）。僅 1:1；N:1/1:N 政策見 [ADR-006 §Addendum：基礎設施指標的租戶歸屬](006-tenant-mapping-topologies.md)。cadvisor 既有 cpu/mem 規則用 `sum by(namespace, pod, container)`、會丟掉多出的 `tenant` → 副作用安全（已驗）。
+> 一顆 10GB 的設定碟已經 99% 滿、一顆 500GB 的資料碟才 10% 滿——加總後「整體還有 88% 空間」，告警永遠不觸發，但那顆小碟其實快把資料庫弄垮了。
 
-**4. Per-PVC 維度保留（聚合掩蓋修正，對抗式 review 命中）**
+所以磁碟容量 recipe **逐顆 PVC 判斷、任一顆達標就觸發**：聚合時保留 `persistentvolumeclaim` 這個維度，閾值仍是每租戶一個、套用到該租戶的每顆 PVC，告警會標出是哪顆碟。為了不讓指標基數失控，能保留的維度只有 `persistentvolumeclaim` 這一個。
 
-disk-fill recipe **必須逐 PVC 評估**：把 metric 側聚合由 `by(tenant)` 改為 `by(tenant, persistentvolumeclaim)`，任一 PVC 觸發即告警；core join 仍 `on(tenant) group_left(name, mode)`（per-tenant 閾值廣播到每個 PVC，`persistentvolumeclaim` 在 many 側自然留存、進告警標籤）。否則 `sum by(tenant)` 會讓 **99% 滿的 10GB 小碟被 10% 滿的 500GB 大碟掩蓋**（聚合後 88% free → 永不觸發、DB 仍崩）——機制同 [#819 `==` any-match](003-sentinel-alert-pattern.md)（聚合前先比）。保留 label **白名單僅 `persistentvolumeclaim`**（bounded，每租戶 PVC 數小），鎖住基數。
+**兩道防線：讓設錯的告警大聲壞掉、而非悄悄失效。** 如果租戶對一個根本沒被抓取、或抓了卻沒帶 `tenant` 的指標設告警，那條告警會編譯成功、卻永遠不觸發——這是最危險的失效。兩道防線堵住它：
 
-**5. Fail-loud 雙 guard（防 #731-class 啞彈）**
+- **編譯期（CI）**：直接解析 Prometheus 的抓取設定，確認 recipe 用到的每個指標（包含 ratio 的分母、forecast 的容量指標）確實被抓、而且該抓取工作有把它歸屬到 `tenant`，否則 CI 報錯。做法是以抓取設定本身為準，不另外維護一份會過期的清單。它只能保護對齊本平台抓取設定的情況；客戶自帶的 Prometheus 設定看不到，由下一道補上。
+- **執行期看門告警 `CustomRecipeDiskInert`**：租戶設了磁碟告警、Pod 也在跑，但歸屬後的磁碟指標一直沒出現，就觸發。這把「拓撲不支援」「漏設歸屬」「租戶根本沒掛 PVC」這幾種情況，從悄悄失效變成有人會看到的告警。
 
-- **CI lint（build-time）**：反向解析 `configmap-prometheus.yaml`（SSOT，仿 `check_ksm_version_allowlist.py` 的 parse-manifest，非 prefix 啟發式）。recipe 的 `metric` / `capacity_metric` / `denominator_metric` 三者若被某 scrape job 抓、但該 job 未設 `tenant` → **ERROR**（指標永不歸屬、告警永不 fire）。誠實限制：看不到 BYO 客戶的 `prometheus.yml`，只保護對齊本平台 scrape SSOT 的 config。
-- **Runtime sentinel（`CustomRecipeDiskInert{tenant}`）**：仿 `VersionAwareThresholdInert`，per-tenant + Running-pod gate——租戶宣告了 disk recipe、pod 在跑、但歸屬後的 disk 指標沒流 → 告警。把 N:1/1:N 誤歸屬、缺 relabel、或**租戶沒掛 PVC** 從 fail-silent 轉 fail-loud。
-
-**誠實殘留**：v2.9.0 已 ship 的 `disk_will_fill` forecast 範例（`shop.yaml` / `forecast.yaml`）引用的 `kubelet_volume_stats_*` 當時無人 scrape → 是 latent silent-alert（promtool 合成 fixture 過、真叢集永不 fire）；本 amend 的 scrape 啟用 + 雙 guard 一併修復。
+v2.9.0 曾隨範例附過一條磁碟預測告警，引用的正是當時沒人抓取的 `kubelet_volume_stats_*`——它在測試夾具上看起來正常、在真實叢集裡卻從不觸發。本次的抓取啟用加上這兩道防線一併修掉。
 
 ## Cross-Reference
 

--- a/docs/adr/024-version-aware-threshold-via-dimensional-label.md
+++ b/docs/adr/024-version-aware-threshold-via-dimensional-label.md
@@ -25,6 +25,8 @@ updated_at: 2026-06-06
 
 兩者均已隨 v2.9.0 落地。Tracker：[#423](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/423)（version-aware）、[#741](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/741)（custom alerts）；逐 PR 紀錄見 CHANGELOG。
 
+📎 **Addendum** (v2.10.0) — Disk/PVC 基礎設施 recipe class（per-PVC 維度保留 + CSI 前提 + fail-loud 雙 guard），見下方 §Addendum；epic [#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692)。
+
 > 本 ADR **不取代、不修改** [config-driven.md §2.6 排程式閾值](../design/config-driven.md)——兩者是並存的不同機制，界線見末節。
 
 ## 背景
@@ -238,8 +240,41 @@ count by(recipe_id)(count by(recipe_id, tenant)(user_threshold{component="custom
 
 兩者正交：§2.6 處理週期性時段，本 ADR 處理一次性的版本對齊。
 
+## Addendum：Disk/PVC 基礎設施 recipe class (v2.10.0)
+
+第一個消費**平台基礎設施指標**（而非租戶自帶 exporter 指標）的 recipe class，回應 MariaDB-class 客戶遷移的磁碟告警需求（[#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692) P0 ③）。沿用既有 recipe（forecast / ratio / threshold / rate），不新增 recipe 種類，但補三個基礎設施專屬約束。
+
+**1. 兩種信號、兩種粒度（語意精確）**
+
+| 需求 | 指標 | 粒度 | recipe |
+|---|---|---|---|
+| 磁碟寫滿預測 / 容量利用率 | `kubelet_volume_stats_{available,capacity,used}_bytes` | **per-PVC**（帶 `persistentvolumeclaim`） | forecast(ratio) / ratio / threshold |
+| 磁碟吞吐 / IOPS | `container_fs_{writes,reads}_{total,bytes_total}` | **per-container/device**（cAdvisor，**非 per-PVC**） | rate / threshold |
+
+吞吐信號來自 cAdvisor 的 container filesystem 統計，`device` 是節點區塊裝置、**無法歸到特定 PVC**；單 PVC 的 pod 近似等價、多 PVC 不可切。故「IOPS bound via PVC」的精確 per-PVC 版只有 fill 端做得到。
+
+**2. CSI 前提（spike 實證，2026-06-14）**
+
+kubelet 只對「volume plugin 實作 `NodeGetVolumeStats`」的 volume 吐 `kubelet_volume_stats_*`。kind 預設 `local-path`（hostPath）**完全不吐**（實測：751 kubelet 指標、0 volume-stats）；裝 CSI driver（NodeGetVolumeStats）後 `kubelet_volume_stats_*{namespace,persistentvolumeclaim}` ~30s 出現。故 **disk-fill recipe 的硬前提 = PVC 由實作 NodeGetVolumeStats 的 CSI driver backing**（多數雲端 CSI 皆是）。寫進 recipe catalog 與 BYO 整合前提；e2e 用 CSI hostpath driver。
+
+**3. 租戶歸屬 = scrape-relabel（recipe-path 慣例，1:1）**
+
+kubelet / cAdvisor scrape job 加 `metric_relabel` 將 `namespace → tenant`（保留真實 metric 名，遷移 UX 佳）。僅 1:1；N:1/1:N 政策見 [ADR-006 §Addendum：基礎設施指標的租戶歸屬](006-tenant-mapping-topologies.md)。cadvisor 既有 cpu/mem 規則用 `sum by(namespace, pod, container)`、會丟掉多出的 `tenant` → 副作用安全（已驗）。
+
+**4. Per-PVC 維度保留（聚合掩蓋修正，對抗式 review 命中）**
+
+disk-fill recipe **必須逐 PVC 評估**：把 metric 側聚合由 `by(tenant)` 改為 `by(tenant, persistentvolumeclaim)`，任一 PVC 觸發即告警；core join 仍 `on(tenant) group_left(name, mode)`（per-tenant 閾值廣播到每個 PVC，`persistentvolumeclaim` 在 many 側自然留存、進告警標籤）。否則 `sum by(tenant)` 會讓 **99% 滿的 10GB 小碟被 10% 滿的 500GB 大碟掩蓋**（聚合後 88% free → 永不觸發、DB 仍崩）——機制同 [#819 `==` any-match](003-sentinel-alert-pattern.md)（聚合前先比）。保留 label **白名單僅 `persistentvolumeclaim`**（bounded，每租戶 PVC 數小），鎖住基數。
+
+**5. Fail-loud 雙 guard（防 #731-class 啞彈）**
+
+- **CI lint（build-time）**：反向解析 `configmap-prometheus.yaml`（SSOT，仿 `check_ksm_version_allowlist.py` 的 parse-manifest，非 prefix 啟發式）。recipe 的 `metric` / `capacity_metric` / `denominator_metric` 三者若被某 scrape job 抓、但該 job 未設 `tenant` → **ERROR**（指標永不歸屬、告警永不 fire）。誠實限制：看不到 BYO 客戶的 `prometheus.yml`，只保護對齊本平台 scrape SSOT 的 config。
+- **Runtime sentinel（`CustomRecipeDiskInert{tenant}`）**：仿 `VersionAwareThresholdInert`，per-tenant + Running-pod gate——租戶宣告了 disk recipe、pod 在跑、但歸屬後的 disk 指標沒流 → 告警。把 N:1/1:N 誤歸屬、缺 relabel、或**租戶沒掛 PVC** 從 fail-silent 轉 fail-loud。
+
+**誠實殘留**：v2.9.0 已 ship 的 `disk_will_fill` forecast 範例（`shop.yaml` / `forecast.yaml`）引用的 `kubelet_volume_stats_*` 當時無人 scrape → 是 latent silent-alert（promtool 合成 fixture 過、真叢集永不 fire）；本 amend 的 scrape 啟用 + 雙 guard 一併修復。
+
 ## Cross-Reference
 
+- [ADR-006: 租戶映射拓撲](006-tenant-mapping-topologies.md) — 基礎設施指標 1:1 歸屬政策 + N:1/1:N defer。
 - [ADR-003: Sentinel Alert 模式](003-sentinel-alert-pattern.md) — silent / 三態的 sentinel + inhibit 基礎。
 - [ADR-008: Operator-Native 整合路徑](008-operator-native-integration-path.md) — declarative-only 鐵則。
 - [ADR-017: `_defaults.yaml` 繼承](017-defaults-yaml-inheritance-dual-hash.md) — 階層 scope 的目錄樹繼承。

--- a/test/disk-stats-spike/manifest.yaml
+++ b/test/disk-stats-spike/manifest.yaml
@@ -1,0 +1,110 @@
+# #692 P0 ③ spike fixture — VERIFIED on kind 2026-06-14.
+#
+# A tenant pod mounting TWO CSI-backed PVCs of different sizes + a privileged
+# probe pod that scrapes the kubelet the way Prometheus does (in-cluster, with
+# nodes/metrics RBAC).
+#
+# PVCs use `csi-hostpath-sc` — a CSI driver implementing NodeGetVolumeStats.
+# This is REQUIRED: kind's default `local-path` (rancher.io/local-path) is
+# hostPath-backed and emits ZERO kubelet_volume_stats_* (no MetricsProvider).
+# Install the CSI driver first — see run.sh header for the exact command.
+#
+# Two PVCs (data 100Mi + config 50Mi) prove the `persistentvolumeclaim` label
+# DISTINGUISHES them — the basis for per-PVC weakest-link evaluation (a small
+# full disk must not be masked by a large empty one).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: db-a
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+  namespace: db-a
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: csi-hostpath-sc
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: config
+  namespace: db-a
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: csi-hostpath-sc
+  resources:
+    requests:
+      storage: 50Mi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mariadb-sim
+  namespace: db-a
+  labels:
+    app: mariadb
+spec:
+  containers:
+    - name: app
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 3600"]
+      volumeMounts:
+        - name: data
+          mountPath: /var/lib/mysql
+        - name: config
+          mountPath: /etc/mysql/conf.d
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: data
+    - name: config
+      persistentVolumeClaim:
+        claimName: config
+---
+# Privileged probe — scrapes the kubelet :10250/metrics directly (the apiserver
+# node-proxy `/api/v1/nodes/<n>/proxy/metrics` returns NotFound in kind), with a
+# token bound to nodes/metrics — the same authz the platform's Prometheus uses.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kprobe
+  namespace: db-a
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubelet-metrics-reader
+rules:
+  - apiGroups: [""]
+    resources: [nodes/metrics, nodes/proxy, nodes/stats]
+    verbs: [get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kprobe-kubelet
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubelet-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: kprobe
+    namespace: db-a
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kprobe
+  namespace: db-a
+spec:
+  serviceAccountName: kprobe
+  containers:
+    - name: curl
+      image: curlimages/curl:8.10.1
+      command: ["sh", "-c", "sleep 3600"]

--- a/test/disk-stats-spike/run.sh
+++ b/test/disk-stats-spike/run.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# #692 P0 ③ spike — the LOAD-BEARING WALL for kubelet_volume_stats_* scraping.
+# STATUS: GREEN, verified on kind 2026-06-14 (see RESULTS below).
+#
+# Proves what a promtool synthetic fixture structurally CANNOT (it would just
+# hardcode the labels):
+#   (1) the kubelet is reachable + serves /metrics with nodes/metrics RBAC;
+#   (2) the kubelet EMITS kubelet_volume_stats_* for a tenant pod's PVCs;
+#   (3) those series carry BOTH `namespace` AND `persistentvolumeclaim`
+#         - namespace            → namespace→tenant relabel (1:1) is viable;
+#         - persistentvolumeclaim → per-PVC weakest-link eval is viable.
+#
+# ── RESULTS (2026-06-14) ──────────────────────────────────────────────────
+#   * Default kind `local-path` (hostPath) → ZERO kubelet_volume_stats_*
+#     (751 kubelet_ series, 0 volume-stats): hostPath has no kubelet
+#     MetricsProvider. ⇒ disk-fill recipes REQUIRE a CSI driver w/ NodeGetVolumeStats.
+#   * With csi-driver-host-path → 12 volume-stats series appeared in ~30s, e.g.
+#       kubelet_volume_stats_available_bytes{namespace="db-a",persistentvolumeclaim="data"}
+#       kubelet_volume_stats_capacity_bytes{namespace="db-a",persistentvolumeclaim="config"}
+#     ⇒ (1)(2)(3) all confirmed. VALUE CAVEAT: csi-hostpath reports the node's
+#     backing-fs df (~1 TB), not the PVC quota — so promtool fixtures must use
+#     SYNTHETIC per-PVC values with these REAL label shapes to test masking.
+#
+# ── ENVIRONMENT NOTES (hard-won) ──────────────────────────────────────────
+#   * The apiserver node-proxy `/api/v1/nodes/<n>/proxy/metrics` returns
+#     NotFound only via EXTERNAL `kubectl get --raw`. Via an IN-CLUSTER SA token
+#     with nodes/proxy RBAC it returns HTTP 200 (verified: cadvisor path = 1741
+#     container_ series, bare /metrics = 683 kubelet_ series) — which is exactly
+#     what the platform's Prometheus job uses. So PR-1's volume-stats scrape job
+#     should use the SAME apiserver-proxy path as the existing cadvisor job. This
+#     spike scrapes :10250 directly only because the probe-pod path is simpler.
+#   * The csi-driver-host-path deploy scripts are SYMLINK-heavy and Windows-git
+#     renders them as text (BASE_DIR breaks); kustomize-on-Windows also bugs out;
+#     and the dev container collides with kind's 172.18.0.0/16 subnet. So install
+#     the CSI driver from a FRESH LINUX CONTAINER on the kind network:
+#       kind get kubeconfig --internal --name <cluster> > kc-internal
+#       docker run --rm --network kind -v "$PWD:/work" -e KUBECONFIG=/work/kc-internal \
+#         alpine/k8s:1.31.2 sh -c '
+#           git clone --depth 1 https://github.com/kubernetes-csi/csi-driver-host-path /csi
+#           cd /csi/deploy/kubernetes-1.30 && bash ./deploy.sh'
+#       kubectl apply -f - <<<"$(printf 'apiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata: {name: csi-hostpath-sc}\nprovisioner: hostpath.csi.k8s.io\nvolumeBindingMode: Immediate\n')"
+#     (delete kc-internal afterwards — it embeds cluster certs.)
+#
+# Requires: kind + kubectl + docker, and csi-hostpath-sc pre-installed (above).
+# Run:  bash test/disk-stats-spike/run.sh
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLUSTER="${KIND_CLUSTER:-disk-spike}"
+
+# The spike does NOT auto-create/destroy the cluster (CSI install is a manual
+# Linux-container step, above). Run against an existing kind cluster that already
+# has csi-hostpath-sc.
+kubectl cluster-info >/dev/null 2>&1 || { echo "no reachable cluster — create kind + install CSI (see header)"; exit 2; }
+kubectl get sc csi-hostpath-sc >/dev/null 2>&1 \
+  || { echo "csi-hostpath-sc missing — install csi-driver-host-path first (see header ENVIRONMENT NOTES)"; exit 2; }
+
+echo "== deploy tenant pod (two CSI PVCs) + privileged kubelet probe =="
+kubectl apply -f "$HERE/manifest.yaml" >/dev/null
+kubectl -n db-a wait --for=condition=Ready pod/mariadb-sim pod/kprobe --timeout=120s >/dev/null
+
+NODE="$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')"
+HOSTIP="$(kubectl get node "$NODE" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')"
+echo "== scrape kubelet $HOSTIP:10250/metrics in-cluster (volume-stats cadence ~1 min) =="
+metrics=""
+for _ in $(seq 1 18); do
+  metrics="$(kubectl -n db-a exec kprobe -- sh -c \
+    'T=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token); curl -sk -H "Authorization: Bearer $T" https://'"$HOSTIP"':10250/metrics' 2>/dev/null || true)"
+  echo "$metrics" | grep -q '^kubelet_volume_stats_available_bytes' && break
+  sleep 10
+done
+
+kubelet_lines="$(echo "$metrics" | grep -c '^kubelet_' || true)"
+volstats_lines="$(echo "$metrics" | grep -c '^kubelet_volume_stats_' || true)"
+
+echo "== ASSERT (1): kubelet reachable + serving metrics =="
+[ "$kubelet_lines" -gt 0 ] || { echo "FAIL(1): zero kubelet_ metrics — RBAC/reachability (got: $(echo "$metrics" | head -c 120))"; exit 1; }
+echo "  ok ($kubelet_lines kubelet_ series)"
+
+echo "== ASSERT (2): kubelet emits volume-stats =="
+if [ "$volstats_lines" -eq 0 ]; then
+  echo "FAIL(2): kubelet serves metrics but ZERO kubelet_volume_stats_* —"
+  echo "         the PVC storage backend has no kubelet MetricsProvider."
+  kubectl get pv -o jsonpath='{range .items[*]}{"  PV "}{.metadata.name}{" csi="}{.spec.csi.driver}{" hostPath="}{.spec.hostPath.path}{"\n"}{end}'
+  exit 1
+fi
+echo "  ok ($volstats_lines volume-stats series)"
+
+echo "== ASSERT (3): series carry namespace AND persistentvolumeclaim (both PVCs) =="
+sample="$(echo "$metrics" | grep '^kubelet_volume_stats_available_bytes' | grep 'namespace="db-a"' || true)"
+echo "$sample" | sed 's/^/    /'
+echo "$sample" | grep -q 'namespace="db-a"' || { echo "FAIL(3a): no namespace label"; exit 1; }
+echo "$sample" | grep -q 'persistentvolumeclaim="data"' && echo "$sample" | grep -q 'persistentvolumeclaim="config"' \
+  || { echo "FAIL(3b): persistentvolumeclaim missing or does not distinguish data/config"; exit 1; }
+
+echo
+echo "ALL SPIKE ASSERTIONS PASSED:"
+echo "  → namespace→tenant relabel (1:1) viable; per-PVC weakest-link viable."
+echo "  → safe to land the design and proceed to PR-1 scrape enablement."

--- a/test/disk-stats-spike/run.sh
+++ b/test/disk-stats-spike/run.sh
@@ -46,24 +46,27 @@
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLUSTER="${KIND_CLUSTER:-disk-spike}"
+# Bind every kubectl to the spike cluster's context, so the script can never act
+# on whatever context happens to be current (kind names it `kind-<cluster>`).
+KUBECTL=(kubectl --context "kind-${CLUSTER}")
 
 # The spike does NOT auto-create/destroy the cluster (CSI install is a manual
 # Linux-container step, above). Run against an existing kind cluster that already
 # has csi-hostpath-sc.
-kubectl cluster-info >/dev/null 2>&1 || { echo "no reachable cluster — create kind + install CSI (see header)"; exit 2; }
-kubectl get sc csi-hostpath-sc >/dev/null 2>&1 \
+"${KUBECTL[@]}" cluster-info >/dev/null 2>&1 || { echo "no reachable cluster kind-${CLUSTER} — create kind + install CSI (see header)"; exit 2; }
+"${KUBECTL[@]}" get sc csi-hostpath-sc >/dev/null 2>&1 \
   || { echo "csi-hostpath-sc missing — install csi-driver-host-path first (see header ENVIRONMENT NOTES)"; exit 2; }
 
 echo "== deploy tenant pod (two CSI PVCs) + privileged kubelet probe =="
-kubectl apply -f "$HERE/manifest.yaml" >/dev/null
-kubectl -n db-a wait --for=condition=Ready pod/mariadb-sim pod/kprobe --timeout=120s >/dev/null
+"${KUBECTL[@]}" apply -f "$HERE/manifest.yaml" >/dev/null
+"${KUBECTL[@]}" -n db-a wait --for=condition=Ready pod/mariadb-sim pod/kprobe --timeout=120s >/dev/null
 
-NODE="$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')"
-HOSTIP="$(kubectl get node "$NODE" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')"
+NODE="$("${KUBECTL[@]}" get nodes -o jsonpath='{.items[0].metadata.name}')"
+HOSTIP="$("${KUBECTL[@]}" get node "$NODE" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')"
 echo "== scrape kubelet $HOSTIP:10250/metrics in-cluster (volume-stats cadence ~1 min) =="
 metrics=""
 for _ in $(seq 1 18); do
-  metrics="$(kubectl -n db-a exec kprobe -- sh -c \
+  metrics="$("${KUBECTL[@]}" -n db-a exec kprobe -- sh -c \
     'T=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token); curl -sk -H "Authorization: Bearer $T" https://'"$HOSTIP"':10250/metrics' 2>/dev/null || true)"
   echo "$metrics" | grep -q '^kubelet_volume_stats_available_bytes' && break
   sleep 10
@@ -80,7 +83,7 @@ echo "== ASSERT (2): kubelet emits volume-stats =="
 if [ "$volstats_lines" -eq 0 ]; then
   echo "FAIL(2): kubelet serves metrics but ZERO kubelet_volume_stats_* —"
   echo "         the PVC storage backend has no kubelet MetricsProvider."
-  kubectl get pv -o jsonpath='{range .items[*]}{"  PV "}{.metadata.name}{" csi="}{.spec.csi.driver}{" hostPath="}{.spec.hostPath.path}{"\n"}{end}'
+  "${KUBECTL[@]}" get pv -o jsonpath='{range .items[*]}{"  PV "}{.metadata.name}{" csi="}{.spec.csi.driver}{" hostPath="}{.spec.hostPath.path}{"\n"}{end}'
   exit 1
 fi
 echo "  ok ($volstats_lines volume-stats series)"
@@ -89,8 +92,9 @@ echo "== ASSERT (3): series carry namespace AND persistentvolumeclaim (both PVCs
 sample="$(echo "$metrics" | grep '^kubelet_volume_stats_available_bytes' | grep 'namespace="db-a"' || true)"
 echo "$sample" | sed 's/^/    /'
 echo "$sample" | grep -q 'namespace="db-a"' || { echo "FAIL(3a): no namespace label"; exit 1; }
-echo "$sample" | grep -q 'persistentvolumeclaim="data"' && echo "$sample" | grep -q 'persistentvolumeclaim="config"' \
-  || { echo "FAIL(3b): persistentvolumeclaim missing or does not distinguish data/config"; exit 1; }
+if ! { echo "$sample" | grep -q 'persistentvolumeclaim="data"' && echo "$sample" | grep -q 'persistentvolumeclaim="config"'; }; then
+  echo "FAIL(3b): persistentvolumeclaim missing or does not distinguish data/config"; exit 1
+fi
 
 echo
 echo "ALL SPIKE ASSERTIONS PASSED:"


### PR DESCRIPTION
## What

Lands the **design** for [#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692) P0 ③ (tenant-attributed disk/PVC alerting) into three existing ADRs, plus the load-bearing kind spike that verified its premises. Pure docs + one spike test — **zero runtime / schema / compiler change**.

## ADR amends (ZH + EN, synced headings)

- **ADR-006 §Addendum** — infrastructure-metric tenant attribution is **1:1 only**; under N:1 a per-tenant-threshold recipe **fails silently** (metric `tenant="db-a-read"` never joins config key `db-a`) → defer-with-trigger + a runtime sentinel backstop.
- **ADR-024 §Addendum** — Disk/PVC recipe class: two signals / two granularities (fill = **per-PVC** via `kubelet_volume_stats_*`; throughput = per-container via `container_fs_*`), **CSI precondition**, **per-PVC dimension preservation** (the aggregation-masking fix — a 99%-full 10GB disk must not be masked by a 10%-full 500GB one), **fail-loud dual guard** (CI lint reverse-parsing the scrape SSOT + a runtime `CustomRecipeDiskInert{tenant}` sentinel).
- **ADR-008 §Addendum** — `da_assembler` direct-render hard-deprecated (debug-only), `ThresholdConfig` CRD dormant (fail-loud), **Option-E pre-decision** (a future CR-native interface = an embedded optional tenant-api watch mode, never a standalone operator / sixth version line).

## Spike (`test/disk-stats-spike/`) — verified on kind, 2026-06-14

- Default `local-path` (hostPath) emits **0** `kubelet_volume_stats_*` (751 kubelet metrics, 0 volume-stats) → disk-fill requires a **CSI driver implementing `NodeGetVolumeStats`**.
- With `csi-driver-host-path`: `kubelet_volume_stats_*{namespace,persistentvolumeclaim}` appears (~30s) → 1:1 `namespace→tenant` relabel and per-PVC weakest-link evaluation are both viable.
- Also corrected an earlier over-claim: the apiserver node-proxy returns NotFound only via external `kubectl get --raw`; in-cluster (SA token + `nodes/proxy`) it works — so the existing cadvisor job is fine and the new volume-stats job uses the same path.

## Verification

bilingual structure ✓ · doc-links ✓ · adr/planning-index no drift ✓ · **mkdocs strict ✓** (pre-push gate passed).

Design rationale, the two adversarial-review rounds, and the a/b/c option comparison live in the [#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692) comments — evaluation stays out of the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
