### PR TITLE
feat(dx): custom-alerts group_by for per-PVC disk-fill alerts

### DIFF
--- a/components/threshold-exporter/app/pkg/config/custom_alert.go
+++ b/components/threshold-exporter/app/pkg/config/custom_alert.go
@@ -66,6 +66,7 @@ type CustomAlertSpec struct {
 	SelectorsRe       map[string]string `yaml:"selectors_re"`
 	Mode              string            `yaml:"mode"`
 	For               string            `yaml:"for"`
+	GroupBy           []string          `yaml:"group_by"` // bounded per-dimension eval (e.g. per PVC)
 }
 
 var (
@@ -99,10 +100,40 @@ var (
 	customAlertForValid = map[string]bool{
 		"0s": true, "1m": true, "5m": true, "15m": true, "30m": true, "1h": true,
 	}
+	// permitted group_by dimensions (ADR-024 §Addendum disk recipes) — bounded so a
+	// per-PVC disk-fill alert can fire per volume (a small full disk is not masked
+	// by a large empty one in a by(tenant) sum) without unbounding cardinality.
+	// Each entry enters the recipe_id slug. MUST match shape.py ALLOWED_GROUP_BY +
+	// the schema enum.
+	customAlertGroupByValid = map[string]bool{"persistentvolumeclaim": true}
 )
 
 func customAlertSanitise(s string) string {
 	return customAlertSanitiseRe.ReplaceAllString(s, "_")
+}
+
+// customAlertGroupBy validates + canonicalises group_by into a sorted, deduped
+// slice. Empty → nil, so a recipe without group_by keeps a byte-identical slug
+// (existing golden vectors unaffected). Bounded to customAlertGroupByValid; sorted
+// for cross-language slug determinism. MUST match shape.py::_normalize_group_by.
+func customAlertGroupBy(spec CustomAlertSpec) ([]string, error) {
+	if len(spec.GroupBy) == 0 {
+		return nil, nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, label := range spec.GroupBy {
+		if !customAlertGroupByValid[label] {
+			return nil, fmt.Errorf("group_by label %q must be one of [persistentvolumeclaim] "+
+				"(bounded whitelist, ADR-024 Addendum)", label)
+		}
+		if !seen[label] {
+			seen[label] = true
+			out = append(out, label)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
 }
 
 func validateCustomAlertMetric(metric, field string) error {
@@ -238,6 +269,27 @@ func RecipeID(spec CustomAlertSpec) (string, error) {
 		forVal = "1m"
 	}
 	parts = append(parts, "for"+forVal)
+
+	// group_by dimensions (ADR-024 §Addendum): per-dimension eval (e.g. per PVC).
+	// Only for value-crossing recipes — reject for absence (a per-tenant presence
+	// check) and op "==" (exact code match isn't per-PVC), keeping the eq/absence
+	// cores per-tenant. Appended LAST and only when present → no group_by keeps a
+	// byte-identical slug. MUST stay byte-identical to shape.py::recipe_id.
+	gb, err := customAlertGroupBy(spec)
+	if err != nil {
+		return "", err
+	}
+	if len(gb) > 0 && (spec.Recipe == "absence" || op == "==") {
+		what := "op \"==\""
+		if spec.Recipe == "absence" {
+			what = "the absence recipe"
+		}
+		return "", fmt.Errorf("group_by (per-dimension eval) is not supported for %s — "+
+			"it applies only to value-crossing recipes (ADR-024 Addendum)", what)
+	}
+	for _, g := range gb {
+		parts = append(parts, "gb_"+g)
+	}
 	return customAlertSanitise(strings.Join(parts, "__")), nil
 }
 

--- a/components/threshold-exporter/app/pkg/config/custom_alert.go
+++ b/components/threshold-exporter/app/pkg/config/custom_alert.go
@@ -275,6 +275,14 @@ func RecipeID(spec CustomAlertSpec) (string, error) {
 	// check) and op "==" (exact code match isn't per-PVC), keeping the eq/absence
 	// cores per-tenant. Appended LAST and only when present → no group_by keeps a
 	// byte-identical slug. MUST stay byte-identical to shape.py::recipe_id.
+	//   SLUG-ORDER CONTRACT: a NEW slug field added later MUST go in the SAME
+	//   position in shape.py::recipe_id (the golden vector enforces parity). Keep
+	//   new fields only-when-present like gb_ (an ALWAYS-appended field — like
+	//   `for` — re-slugs every existing rule, a deliberate breaking migration).
+	//   FORESIGHT: the "==" rejection is safe ONLY because the whitelist is PVC-only
+	//   (error codes aren't per-PVC). If a topology dim (e.g. pod) is whitelisted, a
+	//   tenant may legitimately want group_by:[pod] + op:"==" — then relax this AND
+	//   thread group_by into the eq-core aggregation (recipes.py::_eq_core_record).
 	gb, err := customAlertGroupBy(spec)
 	if err != nil {
 		return "", err

--- a/docs/schemas/tenant-config.schema.json
+++ b/docs/schemas/tenant-config.schema.json
@@ -1031,6 +1031,14 @@
           "description": "Pending duration before firing. Enum-bounded (TRK-326): `for` is part of the recipe_id slug, so it is restricted to a small constant set to keep vectorized-rule cardinality bounded (no O(M)→O(N) blow-up). Default 1m.",
           "enum": ["0s", "1m", "5m", "15m", "30m", "1h"],
           "default": "1m"
+        },
+        "group_by": {
+          "type": "array",
+          "title": "Per-Dimension Evaluation (bounded whitelist)",
+          "description": "Extra label(s) to keep in the rule's aggregation so the alert is evaluated SEPARATELY per that dimension and fires if ANY one crosses. Bounded to a whitelist to keep cardinality safe; today only `persistentvolumeclaim` — a disk-fill alert must fire per PVC, so a small full volume is not masked by a large empty one. Like `for`, it enters the recipe_id slug (instances differing in group_by compile to distinct rules). The per-tenant threshold still broadcasts to each dimension. WARNING: every metric the recipe aggregates — including a ratio's `denominator_metric` and a forecast's `capacity_metric` — MUST carry this label, or the per-dimension join yields an empty vector and the alert SILENTLY NEVER FIRES (the kubelet disk-fill metrics both carry `persistentvolumeclaim`, so the shipped example is safe). The CI scrape-config lint (#692 P0 ③ guard) enforces this, since the compiler cannot see live label sets.",
+          "items": { "enum": ["persistentvolumeclaim"] },
+          "uniqueItems": true,
+          "examples": [["persistentvolumeclaim"]]
         }
       },
       "additionalProperties": false

--- a/rule-packs/recipes/examples/conf.d/shop.yaml
+++ b/rule-packs/recipes/examples/conf.d/shop.yaml
@@ -107,6 +107,11 @@ tenants:
       # supplies `horizon` (NOT a window/lookback) — the platform derives
       # lookback = max(2·horizon, 1h). `for: 30m` requires the prediction to
       # persist, smoothing transient slope flips.
+      # group_by: [persistentvolumeclaim] evaluates EACH PVC separately (ADR-024
+      # §Addendum), so a small nearly-full volume fires even when a large empty one
+      # would hide it in a by(tenant) sum. Disk-fill REQUIRES PVCs backed by a CSI
+      # driver that implements NodeGetVolumeStats (most cloud CSI do; kind's default
+      # local-path does not) — see the recipe catalog / BYO integration precondition.
       - recipe: forecast
         name: disk_will_fill
         metric: kubelet_volume_stats_available_bytes
@@ -115,3 +120,4 @@ tenants:
         horizon: 4h
         threshold: "0.15:warning"
         for: 30m
+        group_by: [persistentvolumeclaim]

--- a/rule-packs/recipes/forecast.yaml
+++ b/rule-packs/recipes/forecast.yaml
@@ -45,3 +45,7 @@ example:
   horizon: 4h
   threshold: "0.15:warning"
   for: 30m
+  # evaluate EACH PVC separately so a small nearly-full volume fires even when a
+  # large empty one would hide it in a by(tenant) sum (ADR-024 §Addendum). Requires
+  # PVCs backed by a CSI driver implementing NodeGetVolumeStats.
+  group_by: [persistentvolumeclaim]

--- a/scripts/tools/dx/custom_alerts/loader.py
+++ b/scripts/tools/dx/custom_alerts/loader.py
@@ -270,6 +270,11 @@ def build_shapes(config_dir: Path,
                 "selectors": inst.get("selectors") or {},
                 "selectors_re": inst.get("selectors_re") or {},
                 "for": inst.get("for", "1m"),
+                # bounded per-dimension eval (e.g. per PVC; ADR-024 §Addendum) —
+                # MUST be carried so emit_shape threads it into the metric-side by();
+                # without it the slug gets `gb_*` but the rule stays by(tenant) and
+                # the per-PVC masking fix silently no-ops.
+                "group_by": inst.get("group_by") or [],
             }
         shape_sev[rid].add(sev)
 

--- a/scripts/tools/dx/custom_alerts/recipes.py
+++ b/scripts/tools/dx/custom_alerts/recipes.py
@@ -41,6 +41,15 @@ def _norm_version(expr: str) -> str:
     return f'label_replace({expr}, "version", "default", "version", "^$")'
 
 
+def _gb_suffix(group_by) -> str:
+    """', l1, l2' for the bounded group_by dims (or '') — appended inside a `by()`
+    label list so the metric-side aggregation PRESERVES each dimension (per-PVC
+    disk-fill: fire if ANY PVC crosses; ADR-024 §Addendum). The per-tenant threshold
+    record and the on()/group_left join keys stay unchanged: the extra dimension
+    rides the many-side of the join and reaches the alert label automatically."""
+    return "".join(", " + g for g in (group_by or ()))
+
+
 def _duration_to_seconds(d: str) -> int:
     m = _DUR_RE.match(str(d))
     if not m:
@@ -49,7 +58,7 @@ def _duration_to_seconds(d: str) -> int:
 
 
 def _forecast_records(rid: str, metric: str, sel: str, horizon: str,
-                      capacity: str) -> List[dict]:
+                      capacity: str, gb=()) -> List[dict]:
     """forecast emission (ADR-024 §Forecast Recipe): predict (linear) a gauge/ratio
     crossing a threshold within `horizon`. Two records:
 
@@ -65,16 +74,17 @@ def _forecast_records(rid: str, metric: str, sel: str, horizon: str,
     """
     h_s = _duration_to_seconds(horizon)
     lb_s = max(2 * h_s, 3600)            # max(2·horizon, 1h), integer seconds
+    g = _gb_suffix(gb)                   # extra by() dims (e.g. per PVC), or ""
     base = f"custom:fcbase:{rid}"
     if capacity:  # ratio mode: headroom ratio (avail/capacity) falling to a floor
         _shape.validate_metric_name(capacity, "capacity_metric")
         base_inner = (
-            f"sum by(tenant) ({metric}{sel})\n"
+            f"sum by(tenant{g}) ({metric}{sel})\n"
             f"  /\n"
-            f"(sum by(tenant) ({capacity}{sel}) > 0)"   # >0 guard → no +Inf / div-by-zero
+            f"(sum by(tenant{g}) ({capacity}{sel}) > 0)"   # >0 guard → no +Inf / div-by-zero
         )
     else:         # raw mode: a gauge crossing an absolute threshold
-        base_inner = f"max by(tenant, version) ({metric}{sel})"
+        base_inner = f"max by(tenant, version{g}) ({metric}{sel})"
     # predict_linear over the RECORDED base (predict_linear cannot range-select a
     # division/aggregation inline — hence the base recording rule). Bare `and`:
     # both operands derive from the same `base` series → identical label set, so
@@ -109,23 +119,25 @@ def _threshold_record(rid: str, metric: str) -> dict:
 
 
 def _metric_record(rid: str, recipe: str, metric: str, sel: str,
-                   window: str, quantile: str, denom: str) -> dict:
+                   window: str, quantile: str, denom: str, gb=()) -> dict:
+    g = _gb_suffix(gb)  # extra by() dims (e.g. ", persistentvolumeclaim"), or ""
     if recipe == "threshold":
-        inner = f"max by(tenant, version) ({metric}{sel})"
+        inner = f"max by(tenant, version{g}) ({metric}{sel})"
     elif recipe == "rate":
-        inner = f"sum by(tenant, version) (rate({metric}{sel}[{window}]))"
+        inner = f"sum by(tenant, version{g}) (rate({metric}{sel}[{window}]))"
     elif recipe == "ratio":
         # by(tenant) only (ratio is per-tenant aggregate, version-agnostic in MVP);
         # `(den > 0)` drops zero/negative denominators → empty vector, never +Inf.
+        # group_by extends BOTH sides so the ratio is computed per-dimension.
         inner = (
-            f"sum by(tenant) (rate({metric}{sel}[{window}]))\n"
+            f"sum by(tenant{g}) (rate({metric}{sel}[{window}]))\n"
             f"  /\n"
-            f"(sum by(tenant) (rate({denom}{sel}[{window}])) > 0)"
+            f"(sum by(tenant{g}) (rate({denom}{sel}[{window}])) > 0)"
         )
     elif recipe == "p99_latency":
         inner = (
             f"histogram_quantile({quantile},\n"
-            f"  sum by(le, tenant, version) (rate({metric}_bucket{sel}[{window}])))"
+            f"  sum by(le, tenant, version{g}) (rate({metric}_bucket{sel}[{window}])))"
         )
     else:  # absence has no separate metric record
         raise _shape.RecipeError(f"_metric_record called for {recipe!r}")
@@ -298,6 +310,10 @@ def emit_shape(shape: dict) -> Tuple[List[dict], List[dict]]:
     sel = _shape.assemble_selector(shape)
     for_ = str(shape.get("for", "1m"))
     severities = shape["severities"]
+    # bounded extra aggregation dims (e.g. per PVC; ADR-024 §Addendum). Validated +
+    # sorted; rejected for absence/== by recipe_id, so only the metric/forecast
+    # records below need it (the standard core inherits it via custom:metric).
+    gb = _shape._normalize_group_by(shape)
 
     recording: List[dict] = [_threshold_record(rid, metric)]
     if recipe == "forecast":
@@ -305,11 +321,11 @@ def emit_shape(shape: dict) -> Tuple[List[dict], List[dict]]:
         # the standard _core_record then compares custom:metric {op} threshold.
         recording.extend(_forecast_records(
             rid, metric, sel, str(shape.get("horizon", "")),
-            shape.get("capacity_metric", "")))
+            shape.get("capacity_metric", ""), gb))
     elif recipe != "absence" and op != "==":
         # `==` inlines the raw metric in its any-match core (no maxed metric
         # record) — see _eq_core_record. absence has no metric record either.
-        recording.append(_metric_record(rid, recipe, metric, sel, window, quantile, denom))
+        recording.append(_metric_record(rid, recipe, metric, sel, window, quantile, denom, gb))
     for sev in severities:
         recording.append(_core_record(rid, recipe, op, sev, metric, sel, window))
 

--- a/scripts/tools/dx/custom_alerts/shape.py
+++ b/scripts/tools/dx/custom_alerts/shape.py
@@ -305,10 +305,19 @@ def recipe_id(inst: dict) -> str:
     # group_by dimensions (ADR-024 §Addendum): each preserved label is a distinct
     # rule from the per-tenant default, so it enters the slug. Appended LAST and
     # only when present → a recipe without group_by keeps a byte-identical slug
-    # (existing recipe_id vectors unaffected). Per-dimension eval only applies to
-    # value-crossing recipes, so reject it for absence (a per-tenant presence
-    # check) and op '==' (exact code match is not per-PVC) — keeps the eq/absence
-    # cores per-tenant. MUST match custom_alert.go.
+    # (existing recipe_id vectors unaffected).
+    #   SLUG-ORDER CONTRACT: a NEW slug field added later MUST go in the SAME
+    #   position in custom_alert.go::RecipeID (the golden vector enforces parity).
+    #   Keep new fields only-when-present like gb_ (an ALWAYS-appended field — like
+    #   `for` — re-slugs every existing rule, a deliberate breaking migration).
+    # Per-dimension eval only applies to value-crossing recipes, so reject it for
+    # absence (a per-tenant presence check) and op '==' (exact code match is not
+    # per-PVC) — keeps the eq/absence cores per-tenant.
+    #   FORESIGHT: the '==' rejection is safe ONLY because the whitelist is PVC-only
+    #   (error codes aren't per-PVC). If a topology dim (e.g. pod) is whitelisted, a
+    #   tenant may legitimately want group_by:[pod] + op:'==' ("any pod's errno == X")
+    #   — then relax this rejection AND thread group_by into _eq_core_record's
+    #   `max by(...)`. MUST match custom_alert.go.
     group_by = _normalize_group_by(inst)
     if group_by and (recipe == "absence" or op == "=="):
         what = "the absence recipe" if recipe == "absence" else "op '=='"

--- a/scripts/tools/dx/custom_alerts/shape.py
+++ b/scripts/tools/dx/custom_alerts/shape.py
@@ -19,6 +19,10 @@ recipe_id grammar (parts joined by `__`, each part sanitised to [a-z0-9_]):
   op_slug: >→gt  >=→ge  <→lt  <=→le  ==→eq  (absence → "absent")
   for: pending-duration; part of rule identity (control-plane static attr,
        TRK-326) — always emitted, enum-bounded in schema. Default "1m".
+  group_by part:  gb_{label}  (sorted; ADR-024 §Addendum disk recipes) — a
+       preserved aggregation dimension so the alert fires per that dimension
+       (e.g. per PVC). Emitted ONLY when present, so a recipe without group_by
+       keeps a byte-identical slug. Bounded to ALLOWED_GROUP_BY.
 Sanitisation maps every char outside [a-zA-Z0-9_] to '_' (deterministic, and keeps
 the slug valid as a Prometheus recording-rule name component).
 """
@@ -63,6 +67,14 @@ ALLOWED_FOR = frozenset({"0s", "1m", "5m", "15m", "30m", "1h"})
 # the recipe_id slug. The platform derives lookback = max(2·horizon, 1h) from this
 # (compile-time only — see recipes.py). MUST match the schema + Go customAlertHorizonValid.
 ALLOWED_HORIZON = frozenset({"1h", "2h", "4h", "12h", "24h", "48h"})
+
+# Permitted `group_by` dimensions (ADR-024 §Addendum disk recipes). A disk-fill
+# alert must fire PER PVC — a 99%-full 10GB volume must not be hidden by a 10%-full
+# 500GB one in a `by(tenant)` sum. group_by preserves the named label in the
+# metric-side aggregation so each dimension is evaluated separately. Bounded to a
+# whitelist to keep cardinality safe (a tenant has few PVCs). Each entry enters the
+# recipe_id slug + shape_signature. MUST match the schema enum + custom_alert.go.
+ALLOWED_GROUP_BY = frozenset({"persistentvolumeclaim"})
 
 RECIPES = ("threshold", "rate", "ratio", "absence", "p99_latency", "forecast")
 
@@ -137,6 +149,35 @@ def _normalize_horizon(inst: dict) -> str:
             f"horizon {value!r} must be one of {sorted(ALLOWED_HORIZON)}"
         )
     return value
+
+
+def _normalize_group_by(inst: dict) -> Tuple[str, ...]:
+    """Validate + canonicalise `group_by` into a sorted, deduped tuple.
+
+    Each entry is a label preserved in the metric-side aggregation so the alert is
+    evaluated per that dimension (e.g. per PVC), firing if ANY one crosses. Falsy
+    (missing / null / empty) → empty tuple, so a recipe without group_by keeps a
+    byte-identical recipe_id (the existing golden vectors stay valid). Bounded to
+    ALLOWED_GROUP_BY; sorted for cross-language slug determinism. MUST match
+    custom_alert.go::customAlertGroupBy.
+    """
+    raw = inst.get("group_by")
+    if raw in (None, ""):
+        return ()
+    if not isinstance(raw, (list, tuple)):
+        raise RecipeError(
+            f"group_by must be a list of labels, got {type(raw).__name__}"
+        )
+    out = []
+    for label in raw:
+        label = str(label)
+        if label not in ALLOWED_GROUP_BY:
+            raise RecipeError(
+                f"group_by label {label!r} must be one of {sorted(ALLOWED_GROUP_BY)} "
+                f"(bounded whitelist, ADR-024 §Addendum)"
+            )
+        out.append(label)
+    return tuple(sorted(set(out)))
 
 
 def validate_metric_name(metric: str, field: str = "metric") -> None:
@@ -261,6 +302,23 @@ def recipe_id(inst: dict) -> str:
     # MUST stay byte-identical to custom_alert.go::RecipeID.
     parts.append("for" + _normalize_for(inst))
 
+    # group_by dimensions (ADR-024 §Addendum): each preserved label is a distinct
+    # rule from the per-tenant default, so it enters the slug. Appended LAST and
+    # only when present → a recipe without group_by keeps a byte-identical slug
+    # (existing recipe_id vectors unaffected). Per-dimension eval only applies to
+    # value-crossing recipes, so reject it for absence (a per-tenant presence
+    # check) and op '==' (exact code match is not per-PVC) — keeps the eq/absence
+    # cores per-tenant. MUST match custom_alert.go.
+    group_by = _normalize_group_by(inst)
+    if group_by and (recipe == "absence" or op == "=="):
+        what = "the absence recipe" if recipe == "absence" else "op '=='"
+        raise RecipeError(
+            f"group_by (per-dimension eval) is not supported for {what} — it "
+            f"applies only to value-crossing recipes (ADR-024 §Addendum)"
+        )
+    for gb in group_by:
+        parts.append("gb_" + gb)
+
     return _sanitise("__".join(parts))
 
 
@@ -287,6 +345,8 @@ def shape_signature(inst: dict) -> Tuple:
         tuple(_selector_items(inst)),
         # `for` distinguishes shapes (control-plane static attr; see recipe_id).
         _normalize_for(inst),
+        # group_by dimensions distinguish per-dimension shapes (ADR-024 §Addendum).
+        _normalize_group_by(inst),
     )
 
 

--- a/tests/dx/fixtures/custom_alerts_promtool/forecast.yaml
+++ b/tests/dx/fixtures/custom_alerts_promtool/forecast.yaml
@@ -6,7 +6,9 @@
 # stays silent — the forecast is the signal, not the current value.
 #
 # Input series carry realistic K8s scrape labels (namespace / persistentvolumeclaim
-# / instance / job) which the base record's `sum by(tenant)` collapses (#651:
+# / instance / job). With group_by:[persistentvolumeclaim] the base record is
+# `sum by(tenant, persistentvolumeclaim)` — it KEEPS the PVC dimension (so each
+# volume is forecast separately) while collapsing namespace/instance/job (#651:
 # lab-clean fixtures hide label-topology bugs). 1m evaluation interval keeps the
 # 8h-lookback series tractable.
 rule_files:
@@ -15,22 +17,31 @@ rule_files:
 evaluation_interval: 1m
 
 tests:
-  # ── shop-a: avail falling 800→ -1.2/min, capacity flat 1000 → ratio 0.8 → ~0.18.
-  #    At eval 520m current ratio ≈ 0.176 (STILL above the 0.15 floor), but the
-  #    8h slope predicts < 0.15 within 4h → fires (lead time). for:30m satisfied. ──
+  # ── shop-a (per-PVC, ADR-024 §Addendum): TWO PVCs prove group_by isolates each.
+  #    data-shop-0:   avail falling -1.2/min, cap flat 1000 → ratio 0.8 → ~0.18; the
+  #      8h slope predicts < 0.15 within 4h → FIRES (lead time, for:30m satisfied).
+  #    config-shop-0: large + flat (avail 9000 / cap 10000 = 0.9) → never fires.
+  #    MASKING PROOF: WITHOUT group_by, sum(avail)/sum(cap) ≈ 0.89 (the 9000-byte
+  #      config volume dwarfs the 800-byte data volume) → never crosses 0.15, so the
+  #      about-to-fill data PVC is SILENTLY MASKED. Per-PVC fires it, named below. ──
   - interval: 1m
     input_series:
       - series: 'kubelet_volume_stats_available_bytes{tenant="shop-a", namespace="shop", persistentvolumeclaim="data-shop-0", instance="10.0.0.1:10250", job="kubelet"}'
         values: '800-1.2x540'
       - series: 'kubelet_volume_stats_capacity_bytes{tenant="shop-a", namespace="shop", persistentvolumeclaim="data-shop-0", instance="10.0.0.1:10250", job="kubelet"}'
         values: '1000+0x540'
-      - series: 'user_threshold{component="custom", metric="kubelet_volume_stats_available_bytes", recipe_id="forecast__kubelet_volume_stats_available_bytes__lt__h4h__den_kubelet_volume_stats_capacity_bytes__for30m", tenant="shop-a", severity="warning", name="disk_will_fill", mode="page"}'
+      # healthy large volume that WOULD mask the data PVC under a by(tenant) sum.
+      - series: 'kubelet_volume_stats_available_bytes{tenant="shop-a", namespace="shop", persistentvolumeclaim="config-shop-0", instance="10.0.0.1:10250", job="kubelet"}'
+        values: '9000+0x540'
+      - series: 'kubelet_volume_stats_capacity_bytes{tenant="shop-a", namespace="shop", persistentvolumeclaim="config-shop-0", instance="10.0.0.1:10250", job="kubelet"}'
+        values: '10000+0x540'
+      - series: 'user_threshold{component="custom", metric="kubelet_volume_stats_available_bytes", recipe_id="forecast__kubelet_volume_stats_available_bytes__lt__h4h__den_kubelet_volume_stats_capacity_bytes__for30m__gb_persistentvolumeclaim", tenant="shop-a", severity="warning", name="disk_will_fill", mode="page"}'
         values: '0.15+0x540'
       - series: 'tenant_metadata_info{tenant="shop-a", runbook_url="http://rb/shop", owner="team-shop", tier="gold"}'
         values: '1x540'
     alert_rule_test:
       - eval_time: 520m
-        alertname: Custom_forecast__kubelet_volume_stats_available_bytes__lt__h4h__den_kubelet_volume_stats_capacity_bytes__for30m
+        alertname: Custom_forecast__kubelet_volume_stats_available_bytes__lt__h4h__den_kubelet_volume_stats_capacity_bytes__for30m__gb_persistentvolumeclaim
         exp_alerts:
           - exp_labels:
               component: custom
@@ -40,6 +51,7 @@ tests:
               name: disk_will_fill
               mode: page
               version: default
+              persistentvolumeclaim: data-shop-0
               runbook_url: "http://rb/shop"
               owner: team-shop
               tier: gold
@@ -60,9 +72,9 @@ tests:
         values: '500+0x540'
       - series: 'kubelet_volume_stats_capacity_bytes{tenant="stable-c", namespace="stab", persistentvolumeclaim="data-stab-0", instance="10.0.0.2:10250", job="kubelet"}'
         values: '1000+0x540'
-      - series: 'user_threshold{component="custom", metric="kubelet_volume_stats_available_bytes", recipe_id="forecast__kubelet_volume_stats_available_bytes__lt__h4h__den_kubelet_volume_stats_capacity_bytes__for30m", tenant="stable-c", severity="warning", name="disk_will_fill", mode="page"}'
+      - series: 'user_threshold{component="custom", metric="kubelet_volume_stats_available_bytes", recipe_id="forecast__kubelet_volume_stats_available_bytes__lt__h4h__den_kubelet_volume_stats_capacity_bytes__for30m__gb_persistentvolumeclaim", tenant="stable-c", severity="warning", name="disk_will_fill", mode="page"}'
         values: '0.15+0x540'
     alert_rule_test:
       - eval_time: 520m
-        alertname: Custom_forecast__kubelet_volume_stats_available_bytes__lt__h4h__den_kubelet_volume_stats_capacity_bytes__for30m
+        alertname: Custom_forecast__kubelet_volume_stats_available_bytes__lt__h4h__den_kubelet_volume_stats_capacity_bytes__for30m__gb_persistentvolumeclaim
         exp_alerts: []

--- a/tests/dx/fixtures/recipe_id_vectors.json
+++ b/tests/dx/fixtures/recipe_id_vectors.json
@@ -65,6 +65,11 @@
       "_note": "grammar coverage (#810): op \"==\" → eq (threshold-recipe-only; status/error-code-as-value match, e.g. MariaDB semi-sync errno 1236)",
       "input": {"recipe": "threshold", "metric": "mysql_semisync_master_last_errno", "op": "==", "window": "5m"},
       "recipe_id": "threshold__mysql_semisync_master_last_errno__eq__w5m__for1m"
+    },
+    {
+      "_note": "group_by (ADR-024 §Addendum): per-PVC disk-fill — `gb_persistentvolumeclaim` is appended LAST so a no-group_by slug stays byte-identical; the metric-side aggregation keeps the PVC dimension so a small full volume is not masked by a large empty one in a by(tenant) sum",
+      "input": {"recipe": "forecast", "metric": "kubelet_volume_stats_available_bytes", "capacity_metric": "kubelet_volume_stats_capacity_bytes", "op": "<", "horizon": "4h", "for": "30m", "group_by": ["persistentvolumeclaim"]},
+      "recipe_id": "forecast__kubelet_volume_stats_available_bytes__lt__h4h__den_kubelet_volume_stats_capacity_bytes__for30m__gb_persistentvolumeclaim"
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a bounded `group_by` recipe field (whitelist: `persistentvolumeclaim`) so disk-fill alerts are evaluated **per PVC** — a 99%-full 10GB volume fires even when a 10%-full 500GB one would mask it in a `by(tenant)` sum (ADR-024 §Addendum, [#692](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/692) P0 ③). Reuses the existing recipes; no new recipe kind.

## Cross-language lockstep

The recipe_id slug must stay **byte-identical** between Python and Go, else every `on(tenant) group_left` join silently matches the empty set (#731 class).

- **schema** — `group_by` field + enum whitelist + an anti-masking WARNING.
- **shape.py** — `_normalize_group_by` + slug (`gb_` appended LAST, only when present → a no-group_by slug stays byte-identical, protecting the existing golden vectors) + shape_signature + absence/`==` rejection.
- **recipes.py** — `_gb_suffix` threaded into the metric-side `by()`; the threshold stays per-tenant; the PVC rides the join's many-side into the alert label.
- **loader.py** — the shape dict now carries `group_by`, fixing a real bug where the slug got `gb_` but the rule stayed `by(tenant)` (per-PVC silently no-op'd). The **end-to-end promtool test caught what the unit emit-check missed**.
- **custom_alert.go** — `GroupBy` field + `customAlertGroupBy` + the same `RecipeID` slug logic.

## Verification

golden vector (Python == Go) · **promtool masking golden** (two PVCs: the weak one fires, the large healthy one doesn't; a double-sided control confirms `by(tenant)` masks) · 81 pytest · Go pkg/config · gofmt.

A two-agent adversarial review (promtool-grounded) confirmed the version-aware fallback / metadata fan-out / maintenance suppression / cold-start gate are all correct, and surfaced one footgun: `ratio`/forecast-ratio + `group_by` where the **denominator/capacity metric lacks the grouped label** compiles to a silently-empty rule. The shipped disk-fill is **safe** (kubelet emits `available_bytes` and `capacity_bytes` both with `persistentvolumeclaim`); it's now documented in the schema, and the codified guard (a scrape-config lint that *has* label knowledge) lands in PR-2.

## Scope

Disk recipes remain **examples-only** (not live). Real-cluster scrape enablement, the D1 (scrape-config) + D2 (runtime sentinel) guards, and reviving the shipped examples are **PR-2**. The committed-pack drift gate compiles from live conf.d, so this change correctly doesn't regenerate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
