### PR TITLE
fix(dx): repair rule-pack-readme generator + revive dead drift gate

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -313,10 +313,10 @@ jobs:
         run: |
           pip install pyyaml
 
-      - name: Run drift checks (versions, tool-map, doc-map, rule-pack-stats)
+      - name: Run drift checks (versions, tool-map, doc-map, rule-pack-stats, rule-pack-readme)
         run: |
           python scripts/tools/validate_all.py \
-            --only versions,tool_map,doc_map,rule_pack_stats,changelog,glossary,includes,repo_name,alerts \
+            --only versions,tool_map,doc_map,rule_pack_stats,rule_packs,changelog,glossary,includes,repo_name,alerts \
             --ci
 
   i4-runbook-smoke-test:

--- a/Makefile
+++ b/Makefile
@@ -614,8 +614,8 @@ generate-nav: ## 從文件 front matter 產生 MkDocs nav 結構 (使用: make g
 	@python3 ./scripts/tools/dx/generate_nav.py
 
 .PHONY: generate-rule-pack-readme
-generate-rule-pack-readme: ## 從 Rule Pack YAML 產生 rule-packs/README.md
-	@python3 ./scripts/tools/dx/generate_rule_pack_readme.py
+generate-rule-pack-readme: ## 從 Rule Pack YAML 產生（寫入）rule-packs/README.md（dry-run 用 --check）
+	@python3 ./scripts/tools/dx/generate_rule_pack_readme.py --update
 
 .PHONY: platform-data
 platform-data: ## 產生 docs/assets/platform-data.json 與 Tenant Metadata
@@ -700,7 +700,7 @@ lint-extract: ## 拆新 lint script（PR #154/#162/#166/#169/#170 共通 boilerp
 
 lint-docs: ## 一站式文件 lint（versions + drift + tool consistency，支援 ARGS="--parallel"）
 	@python3 ./scripts/tools/validate_all.py \
-		--only versions,tool_map,doc_map,rule_pack_stats,changelog,glossary,includes,platform_data,tool_consistency,alerts \
+		--only versions,tool_map,doc_map,rule_pack_stats,rule_packs,changelog,glossary,includes,platform_data,tool_consistency,alerts \
 		$(ARGS)
 
 .PHONY: lint-egress

--- a/rule-packs/README.md
+++ b/rule-packs/README.md
@@ -22,8 +22,8 @@ lang: zh
 | Elasticsearch | rule-pack-elasticsearch.yaml | 11 | 7 | 18 |
 | JVM | rule-pack-jvm.yaml | 9 | 7 | 16 |
 | Kafka | rule-pack-kafka.yaml | 13 | 9 | 22 |
-| Kubernetes | rule-pack-kubernetes.yaml | 7 | 4 | 11 |
-| Mariadb | rule-pack-mariadb.yaml | 11 | 8 | 19 |
+| Kubernetes | rule-pack-kubernetes.yaml | 15 | 9 | 24 |
+| Mariadb | rule-pack-mariadb.yaml | 11 | 10 | 21 |
 | Mongodb | rule-pack-mongodb.yaml | 10 | 6 | 16 |
 | Nginx | rule-pack-nginx.yaml | 9 | 6 | 15 |
 | Operational | rule-pack-operational.yaml | 0 | 4 | 4 |
@@ -31,7 +31,7 @@ lang: zh
 | Postgresql | rule-pack-postgresql.yaml | 11 | 9 | 20 |
 | Rabbitmq | rule-pack-rabbitmq.yaml | 12 | 8 | 20 |
 | Redis | rule-pack-redis.yaml | 11 | 6 | 17 |
-| **TOTAL** | | **139** | **95** | **234** |
+| **TOTAL** | | **147** | **102** | **249** |
 
 ## 架構說明
 
@@ -117,4 +117,4 @@ Alert Rules 透過 `* on(tenant) group_left(runbook_url, owner, tier) tenant_met
 - **clickhouse_exporter**: https://github.com/ClickHouse/clickhouse_exporter (或 ClickHouse 內建 /metrics)
 - **kafka_exporter**: https://github.com/danielqsj/kafka-exporter
 - **rabbitmq_exporter**: https://github.com/kbudde/rabbitmq_exporter
-- **kube-state-metrics**: https://github.com/kubernetes/kube-state-metr
+- **kube-state-metrics**: https://github.com/kubernetes/kube-state-metrics

--- a/scripts/tools/dx/generate_rule_pack_readme.py
+++ b/scripts/tools/dx/generate_rule_pack_readme.py
@@ -268,6 +268,13 @@ def count_preloaded_packs(rule_packs_dir: Path) -> int:
             1 for f in configmap_dir.glob("configmap-rules-*.yaml")
             if f.stem.replace("configmap-rules-", "") not in exclude
         )
+    # Degraded fallback (k8s tree unreachable): count ALL rule-pack files,
+    # INCLUDING custom-alerts. This deliberately does NOT reuse `exclude` —
+    # rule-packs/ has no `platform` configmap-only pack, so counting
+    # custom-alerts numerically substitutes for it to approximate the
+    # authoritative 15. Excluding it here would undercount to 14, diverging
+    # from the configmap-based primary branch above. (Hit only on a
+    # --rule-packs-dir override to a detached copy; never in CI / normal use.)
     return len(list(rule_packs_dir.glob("rule-pack-*.yaml")))
 
 

--- a/scripts/tools/dx/generate_rule_pack_readme.py
+++ b/scripts/tools/dx/generate_rule_pack_readme.py
@@ -24,6 +24,12 @@ sys.path.insert(0, _THIS_DIR)  # Docker flat layout
 sys.path.insert(0, os.path.join(_THIS_DIR, ".."))  # Repo subdir layout
 from _lib_exitcodes import EXIT_OK, EXIT_VIOLATION, EXIT_CALLER_ERROR  # noqa: E402
 
+# Repo root = FOUR parents up (scripts/tools/dx/<file> → dx → tools → scripts →
+# repo). The original default used three (→ the non-existent scripts/rule-packs/),
+# which made both `make generate-rule-pack-readme` and the validate_all `--check`
+# drift gate error out (FileNotFoundError → exit 2): a silently dead gate.
+DEFAULT_RULE_PACKS_DIR = Path(__file__).resolve().parents[3] / "rule-packs"
+
 
 def extract_rule_counts(yaml_file: Path) -> Tuple[int, int]:
     """
@@ -101,9 +107,15 @@ def generate_table_rows(rule_packs_dir: Path) -> Tuple[List[Dict], int, int]:
     return rows, total_records, total_alerts
 
 
-def generate_readme_content(rows: List[Dict], total_records: int, total_alerts: int) -> str:
+def generate_readme_content(rows: List[Dict], total_records: int, total_alerts: int,
+                            pack_count: int) -> str:
     """
     Generate the full README.md content with header, table, and footer.
+
+    `pack_count` is the prose pack-count (number of preloaded platform rule
+    packs; see the derivation in main()). It is derived by the caller rather
+    than hardcoded so the header / "Dynamic Runbook Injection" prose can't go
+    stale as packs are added.
     """
     # Build table header
     lines = []
@@ -117,10 +129,16 @@ def generate_readme_content(rows: List[Dict], total_records: int, total_alerts: 
     lines.append("# Rule Packs — 模組化 Prometheus 規則")
     lines.append("")
     lines.append("> 每個 Rule Pack 包含完整的三件套：Normalization Recording Rules + Threshold Normalization + Alert Rules。")
-    lines.append("> **所有 15 個 Rule Pack 已透過 Projected Volume 架構預載入 Prometheus 中** (分散於 `configmap-rules-*.yaml`)。")
+    lines.append(f"> **所有 {pack_count} 個 Rule Pack 已透過 Projected Volume 架構預載入 Prometheus 中** (分散於 `configmap-rules-*.yaml`)。")
     lines.append("> 未部署 exporter 的 pack 不會產生 metrics，因此 alert 不會誤觸發 (near-zero cost)。")
     lines.append(">")
-    lines.append("> **其他文件：** [README](../README.md) (概覽) · [Migration Guide](../docs/migration-guide.md) (遷移指南) · [Architecture & Design](../docs/architecture-and-design.md) (技術深度)")
+    # MkDocs-relative paths: rule_packs_bridge.py copies this file to
+    # docs/rule-packs/README.md at build time, so `../X.md` resolves to
+    # docs/X.md. These are intentionally allowlisted in .doclinkignore
+    # (check_doc_links.py traverses from the repo-root rule-packs/ dir where
+    # they look broken). Do NOT "fix" to ../README.md / ../docs/X.md — that
+    # breaks `mkdocs build --strict` (→ docs/docs/X.md, which does not exist).
+    lines.append("> **其他文件：** [Home](../index.md) (概覽) · [Migration Guide](../migration-guide.md) (遷移指南) · [Architecture & Design](../architecture-and-design.md) (技術深度)")
     lines.append("")
     lines.append("## 支援的整合 (Supported Integrations)")
     lines.append("")
@@ -189,7 +207,7 @@ def generate_readme_content(rows: List[Dict], total_records: int, total_alerts: 
     lines.append("  - name: <db>-threshold-normalization")
     lines.append("    rules:")
     lines.append("      - record: tenant:alert_threshold:<metric>")
-    lines.append("        expr: max by(tenant) (user_threshold{metric=\"<metric>\", severity=\"warning\"})")
+    lines.append("        expr: max by(tenant) (user_threshold{component=\"<component>\", metric=\"<metric>\", severity=\"warning\"})")
     lines.append("")
     lines.append("  # 3. Alert Rules (使用 group_left + unless maintenance + runbook injection)")
     lines.append("  - name: <db>-alerts")
@@ -211,7 +229,7 @@ def generate_readme_content(rows: List[Dict], total_records: int, total_alerts: 
     lines.append("")
     lines.append("Alert Rules 透過 `* on(tenant) group_left(runbook_url, owner, tier) tenant_metadata_info` 將租戶 metadata 注入 alert labels，再由 annotations 引用。`tenant_metadata_info` 由 threshold-exporter 根據租戶 `_metadata` 配置自動輸出（值永遠為 1），保證 `group_left` join 不會漏掉任何 tenant。")
     lines.append("")
-    lines.append("若租戶未設定 `_metadata`，`tenant_metadata_info` 不存在，`group_left` 回傳空向量。因此已內建的 11 個 Rule Pack 均已加入此 join，但 **自訂 Rule Pack 建議同步採用此 pattern** 以確保 runbook URL 與 owner 資訊可自動傳遞至通知。")
+    lines.append(f"若租戶未設定 `_metadata`，`tenant_metadata_info` 不存在，`group_left` 回傳空向量。因此已內建的 {pack_count} 個 Rule Pack 均已加入此 join，但 **自訂 Rule Pack 建議同步採用此 pattern** 以確保 runbook URL 與 owner 資訊可自動傳遞至通知。")
     lines.append("")
     lines.append("## Exporter 文件連結")
     lines.append("")
@@ -227,6 +245,30 @@ def generate_readme_content(rows: List[Dict], total_records: int, total_alerts: 
     lines.append("- **kube-state-metrics**: https://github.com/kubernetes/kube-state-metrics")
 
     return "\n".join(lines) + "\n"
+
+
+def count_preloaded_packs(rule_packs_dir: Path) -> int:
+    """Prose pack-count: the platform's preloaded rule packs.
+
+    = the configmap-rules-*.yaml set minus the tenant-authored custom-alerts
+    pack (which the coverage TABLE also excludes, per #741 S3b). Counting the
+    configmaps — not rule-pack-*.yaml — matches the AUTHORITATIVE set in
+    validate_docs_versions.count_rule_packs (rule-packs ∪ k8s configmaps −
+    custom-alerts): the configmaps add the configmap-only `platform`
+    self-monitoring pack that has no rule-pack-*.yaml. This is the "15" used
+    canonically across the docs (and enforced for the root READMEs by
+    validate_docs_versions). Falls back to the rule-pack file count if the k8s
+    tree isn't reachable (e.g. a --rule-packs-dir override pointed at a
+    detached copy).
+    """
+    exclude = {"custom-alerts"}
+    configmap_dir = rule_packs_dir.parent / "k8s" / "03-monitoring"
+    if configmap_dir.is_dir():
+        return sum(
+            1 for f in configmap_dir.glob("configmap-rules-*.yaml")
+            if f.stem.replace("configmap-rules-", "") not in exclude
+        )
+    return len(list(rule_packs_dir.glob("rule-pack-*.yaml")))
 
 
 def main():
@@ -247,7 +289,7 @@ def main():
     parser.add_argument(
         "--rule-packs-dir",
         type=Path,
-        default=Path(__file__).parent.parent.parent / "rule-packs",
+        default=DEFAULT_RULE_PACKS_DIR,
         help="Path to rule-packs directory",
     )
 
@@ -259,7 +301,8 @@ def main():
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(EXIT_CALLER_ERROR)
 
-    generated_content = generate_readme_content(rows, total_records, total_alerts)
+    pack_count = count_preloaded_packs(args.rule_packs_dir)
+    generated_content = generate_readme_content(rows, total_records, total_alerts, pack_count)
     readme_path = args.rule_packs_dir / "README.md"
 
     if args.check:
@@ -277,7 +320,7 @@ def main():
                 file=sys.stderr,
             )
             print(
-                "Run: python3 scripts/tools/generate_rule_pack_readme.py --update",
+                "Run: python3 scripts/tools/dx/generate_rule_pack_readme.py --update",
                 file=sys.stderr,
             )
             sys.exit(EXIT_VIOLATION)
@@ -286,9 +329,11 @@ def main():
             sys.exit(EXIT_OK)
 
     elif args.update:
-        # Write to file
+        # Write to file. newline="\n" forces LF on all platforms so a regen on
+        # the Windows host matches the `*.md eol=lf` .gitattributes + Linux-CI
+        # generator output (otherwise a CRLF working tree shows phantom drift).
         try:
-            with open(readme_path, "w", encoding="utf-8") as f:
+            with open(readme_path, "w", encoding="utf-8", newline="\n") as f:
                 f.write(generated_content)
             os.chmod(readme_path, 0o644)
             print(f"Updated {readme_path}", file=sys.stderr)

--- a/tests/dx/test_generate_rule_pack_readme.py
+++ b/tests/dx/test_generate_rule_pack_readme.py
@@ -1,0 +1,72 @@
+"""Regression tests for scripts/tools/dx/generate_rule_pack_readme.py.
+
+Pins the two failure modes that left rule-packs/README.md badly stale on main
+behind a dead drift gate (the generator never ran successfully, so nobody
+noticed):
+
+1. **Path default** — the argparse ``--rule-packs-dir`` default must resolve to
+   the real repo-root ``rule-packs/`` dir. The original bug used one too few
+   ``.parent`` hops (``parents[2]`` → ``scripts/rule-packs/``, which does not
+   exist), so every invocation exited 2 (FileNotFoundError) and the
+   ``validate_all`` ``--check`` gate silently no-op'd.
+
+2. **Prose pack-count** — the header / "Dynamic Runbook Injection" "N 個 Rule
+   Pack" figure must be DERIVED and equal the AUTHORITATIVE count
+   (``validate_docs_versions.count_rule_packs``), not a hardcoded literal that
+   silently goes stale (it was frozen at "11" while the platform shipped 15).
+
+conftest.py already puts scripts/tools{,/dx,/lint} on sys.path, so the tool
+modules import directly.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import generate_rule_pack_readme as grpr  # noqa: E402  (path via conftest)
+import validate_docs_versions as vdv  # noqa: E402  (path via conftest)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR = REPO_ROOT / "scripts" / "tools" / "dx" / "generate_rule_pack_readme.py"
+
+
+def test_default_rule_packs_dir_resolves_to_repo_root():
+    """Regression: parents[3] (repo root), not parents[2] (scripts/)."""
+    default = grpr.DEFAULT_RULE_PACKS_DIR
+    assert default == REPO_ROOT / "rule-packs"
+    assert default.is_dir(), f"{default} is not a directory (path-default bug?)"
+    # ...and it actually holds rule-pack YAMLs, so generate_table_rows won't bail.
+    assert list(default.glob("rule-pack-*.yaml")), "no rule-pack-*.yaml under default dir"
+
+
+def test_prose_pack_count_is_derived_and_matches_authoritative():
+    """Prose count derives from the authoritative pack SET, not a literal.
+
+    count_preloaded_packs (configmap set − custom-alerts) must equal
+    validate_docs_versions.count_rule_packs()['pack_count'] (rule-packs ∪
+    configmaps − custom-alerts) — the same set, so they must agree now and as
+    packs are added. (Guards against the old hardcoded "11" / "15" and against
+    a derivation that only coincidentally lands on the right number.)
+    """
+    generated = grpr.count_preloaded_packs(grpr.DEFAULT_RULE_PACKS_DIR)
+    authoritative = vdv.count_rule_packs()["pack_count"]
+    assert generated == authoritative, (
+        f"prose pack-count {generated} != authoritative {authoritative}"
+    )
+
+
+def test_check_mode_passes_with_default_dir():
+    """End-to-end: ``--check`` with the default dir exits 0 (gate live + in sync).
+
+    Before the path-default fix this exited 2 (FileNotFoundError) regardless of
+    drift — the exact symptom that made the validate_all gate dead.
+    """
+    result = subprocess.run(
+        [sys.executable, str(GENERATOR), "--check"],
+        capture_output=True, text=True, cwd=str(REPO_ROOT), timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"--check exited {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )


### PR DESCRIPTION
## 背景

`generate_rule_pack_readme.py` 從沒成功跑過（path bug + make target 沒 `--update` + drift gate 沒接線），導致 `rule-packs/README.md` 在 main 上嚴重 stale，而本該擋住它的 `validate_all` `rule_packs --check` 靜默 no-op。源於 #692 P0③ W2 的對抗式 review（W2 當時刻意排除此 README 以免把這包 staleness + buggy "11" 帶進 D2）。

## 修了什麼

- **path**：`--rule-packs-dir` default 由 `parents[2]`（`scripts/rule-packs/`，不存在 → exit 2）改 `parents[3]`（repo root），抽成 `DEFAULT_RULE_PACKS_DIR`。
- **dead gate**：`rule_packs --check` 原本不在 CI drift job 也不在 `lint-docs --only`（只接了 `rule_pack_stats`）→ 從未被呼叫。兩處都補上 `rule_packs`，未來 staleness 會讓 CI 紅。
- **make target**：`generate-rule-pack-readme` 原本無 `--update`（dry-run）→ 永不寫檔，現加 `--update`。
- **prose count**：寫死 "11"（平台實際 15）。改由 `count_preloaded_packs`（configmap set − custom-alerts）派生，與權威 `validate_docs_versions.count_rule_packs` 同集（非巧合 15）。
- **stale template**：補回 #731 的 `component="<component>"` threshold selector；**保留** MkDocs-relative 連結（`../index.md` 等經 `rule_packs_bridge` 在 build 時解析；改成 `../docs/X` 會破 `mkdocs --strict`）。
- **LF**：寫檔 `newline="\n"`，Windows-host / Linux-CI 位元一致。

## Regenerated README

`Kubernetes 7/4/11 → 15/9/24`、`Mariadb 11/8/19 → 11/10/21`、`TOTAL 139/95/234 → 147/102/249`（含 #845 CustomRecipeDiskInert）、`kube-state-metr → kube-state-metrics`。連結與 prose（15）不變。

## 對抗式 review 攔截

兩階段 subagent review（spec+quality / adversarial）。adversarial 抓到原始「連結是 broken、應改 `../docs/X`」前提**是反的**——`rule_packs_bridge.py` 在 build 時把檔案複製到 `docs/rule-packs/`，舊連結反而正確、新連結會破 `mkdocs --strict`（實證重現）。已 reframe + 修正：連結維持原狀，改的是 generator template。

## 驗證

- `rule_packs --check` / `versions` / `rule_pack_stats` / `bump_docs --check` 皆 green
- 新增 `tests/dx/test_generate_rule_pack_readme.py`（3 回歸測試：path default / count==authoritative / `--check` exit 0）→ pass；`tests/dx/` 全綠（1251 passed）
- pre-commit + pre-push mkdocs-strict gate 皆 passed

Refs #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)
