### PR TITLE
docs: sync ADR-025 deferred table to implementation reality

### DIFF
--- a/docs/adr/025-alerting-plane-self-liveness.en.md
+++ b/docs/adr/025-alerting-plane-self-liveness.en.md
@@ -12,7 +12,13 @@ lang: en
 
 ## Status
 
-🟡 **In Progress**. This ADR records a decision: give the platform's alerting plane (Prometheus + Alertmanager) a liveness heartbeat so that its own death is noticed from the outside, and draw the responsibility boundary that high availability and large-scale storage stay the operator's job. The MVP (D1 Watchdog + external dead-man's-switch) implementation has started ([#838](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/838)); the canary tenant / rule linter / end-to-end synthetic probe remain deferred-with-trigger (see "Deferred" below). Operator setup and the silence/inhibit no-go zones live in the [Alerting-Plane Self-Liveness Operator Guide](../integration/alerting-plane-self-liveness.en.md).
+🟡 **In Progress**. This ADR records a decision: give the platform's alerting plane (Prometheus + Alertmanager) a liveness heartbeat so that its own death is noticed from the outside, and draw the responsibility boundary that high availability and large-scale storage stay the operator's job. The MVP (D1 Watchdog + external dead-man's-switch) is implemented and shipped ([#838](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/838)), and CI static rule linting (pint) has been adopted ([#843](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/843)); the runtime canary tenant / end-to-end synthetic probe / backend compatibility test remain deferred-with-trigger (see "Implementation progress" and "Deferred" below). Operator setup and the silence/inhibit no-go zones live in the [Alerting-Plane Self-Liveness Operator Guide](../integration/alerting-plane-self-liveness.en.md).
+
+**Implementation progress** (status stays in-progress: the engine-death blind spot is closed, but the end-to-end guarantee that "rule evaluation is correct" is not yet in place):
+
+- **D1 Watchdog + external dead-man's-switch** — implemented ([#838](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/838)).
+- **CI static rule linting (pint)** — adopted OSS `pint` with a hard-gated `alerts/template` check that catches "an aggregation drops the label the template uses → the alert is silent forever," a class this repo has been burned by repeatedly; baseline 0 blocking ([#843](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/843)).
+- **runtime canary tenant / end-to-end synthetic probe / backend compatibility test** — still deferred-with-trigger (triggers in the "Deferred" table below).
 
 ## Summary
 
@@ -106,10 +112,13 @@ If the platform ever does provide an HA reference, the chargeback telemetry (not
 
 | Item | One line | Trigger |
 |---|---|---|
-| **Canary tenant** | A permanent fake tenant + an always-firing alert, end-to-end validating that the whole "rule compilation + routing" chain isn't broken (not just that the engine is alive) | **Deploy it as a safety net before the next major rule-compiler refactor or multi-tenant routing change** — no need to wait for an incident |
-| **Static rule linting** | Adopt a mature open-source rule linter in CI to catch inefficient / dangerous queries | When tenant-authored query complexity starts loading the backend |
+| **Canary tenant (runtime)** | A permanent fake tenant + an always-firing alert (`CustomAlertPipelineCanaryDown` meta-alert), end-to-end validating that the whole "rule compilation + routing" chain isn't broken and catching the exporter / compile-pipeline death the Watchdog can't see (not just that the engine is alive) | **Deploy it as a safety net before the next major rule-compiler refactor or multi-tenant routing change** — no need to wait for an incident |
 | **End-to-end synthetic probe** | Send a test alert from outside and verify it travels the full Prometheus→Alertmanager→external path | After heartbeat + canary ship, when a "rule evaluation silently failed" incident occurs |
 | **Backend compatibility test** | Verify rules evaluate correctly on the customer's large-scale backend (including staleness timing differences) | First customer integration on their own backend |
+
+> **Shipped, no longer deferred**: the **static rule linting (CI rule linter)** that was listed here is implemented via OSS `pint` in [#843](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/843) (hard-gated `alerts/template`); see "Implementation progress" above.
+>
+> **The CI-gate variant of the canary was evaluated and rejected (recorded here so nobody re-walks it)**: a **CI-gate** canary that feeds a synthetic `absence` fixture through "the real compiler + promtool + amtool" was evaluated, but it overlaps ~90% with the existing `absence` golden test (`tests/dx/fixtures/custom_alerts_promtool/absence.yaml`), the Go `rulepack_contract_test.go` `component` / `tenant` label contract, and the routing orchestration in `test_generate_routes_orchestration.py`; and since CI has no exporter it must synthesize the series itself — which shrinks the end-to-end the ADR wants to verify down to a property of the CI fixture → rejected. The table keeps the **runtime** canary (a resident fake tenant that catches the [#731](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/731)-class silent exporter / compile-pipeline death), complementary to the engine heartbeat and still deferred-with-trigger.
 
 ## Scope
 
@@ -121,7 +130,7 @@ If the platform ever does provide an HA reference, the chargeback telemetry (not
 ## Consequences
 
 - **Positive**: with "one rule + one route + one routing test" and zero new components, it closes the "the alerting system died and nobody knew" blind spot; consistent with the storage-backend-neutral stance, and it doesn't fight the customer's backend.
-- **Negative**: the external heartbeat is an operator-supplied dependency (the air-gap fallback is pull-based polling); the heartbeat only proves "the engine is alive," not "rule evaluation is correct" (→ left to the canary tenant); under the single-replica demo deployment, a real outage still needs manual recovery (HA is the operator's responsibility).
+- **Negative**: the external heartbeat is an operator-supplied dependency (the air-gap fallback is pull-based polling); the heartbeat only proves "the engine is alive," not "rule evaluation is correct" (→ left to the runtime canary tenant); under the single-replica demo deployment, a real outage still needs manual recovery (HA is the operator's responsibility).
 
 ## Related
 

--- a/docs/adr/025-alerting-plane-self-liveness.md
+++ b/docs/adr/025-alerting-plane-self-liveness.md
@@ -9,7 +9,7 @@ tracking_kind: adr
 status: in-progress
 domain: observability
 created_at: 2026-06-14
-updated_at: 2026-06-14
+updated_at: 2026-06-16
 ---
 
 # ADR-025: 告警平面自我存活性 — 讓告警系統能偵測自己的死亡
@@ -18,7 +18,13 @@ updated_at: 2026-06-14
 
 ## 狀態
 
-🟡 **In Progress**（實作中）。本 ADR 記錄一個決策：為平台的告警平面（Prometheus + Alertmanager）加上「自己死掉會被外部察覺」的存活心跳，並劃清「高可用與大規模儲存由 operator 負責」的責任邊界。MVP（D1 Watchdog + 外部 dead-man's-switch）實作已啟動（[#838](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/838)）；canary 租戶 / 規則 linter / 端到端合成探測等仍為 defer-with-trigger（見下方「之後再說」）。operator 設定與靜音/抑制禁區見 [告警平面自我存活性 Operator 指南](../integration/alerting-plane-self-liveness.md)。
+🟡 **In Progress**（實作中）。本 ADR 記錄一個決策：為平台的告警平面（Prometheus + Alertmanager）加上「自己死掉會被外部察覺」的存活心跳，並劃清「高可用與大規模儲存由 operator 負責」的責任邊界。MVP（D1 Watchdog + 外部 dead-man's-switch）已實作上線（[#838](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/838)），CI 規則靜態檢查（pint）亦已採用（[#843](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/843)）；runtime canary 租戶 / 端到端合成探測 / 後端相容性測試仍為 defer-with-trigger（見下方「實作進度」與「之後再說」）。operator 設定與靜音/抑制禁區見 [告警平面自我存活性 Operator 指南](../integration/alerting-plane-self-liveness.md)。
+
+**實作進度**（狀態維持 in-progress：引擎死亡的盲點已補，但「規則評估正確性」的端到端保證尚未到位）：
+
+- **D1 Watchdog + 外部 dead-man's-switch** — 已實作（[#838](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/838)）。
+- **CI 規則靜態檢查（pint）** — 已採用 OSS `pint`、hard-gate `alerts/template`，攔截「聚合砍掉 template 用到的 label → 告警永遠靜默」這個本 repo 燒過多次的類別；baseline 0 blocking（[#843](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/843)）。
+- **runtime canary 租戶 / 端到端合成探測 / 後端相容性測試** — 仍 defer-with-trigger（觸發條件見下方「之後再說」表）。
 
 ## 摘要
 
@@ -110,10 +116,13 @@ receivers:
 
 | 項目 | 一句話 | 觸發條件 |
 |---|---|---|
-| **Canary 租戶** | 一個常駐假租戶 + 必觸發告警，端到端驗證「規則編譯 + 路由」整條沒被改壞（不只是引擎還活著） | **下次重大的規則編譯邏輯重構、或多租戶路由規則大改時，先行佈署當安全網**；不必等事故發生 |
-| **規則靜態檢查** | CI 引入成熟的開源規則 linter，攔截低效 / 危險查詢 | 租戶自寫查詢的複雜度開始造成後端負載 |
+| **Canary 租戶（runtime）** | 一個常駐假租戶 + 必觸發告警（`CustomAlertPipelineCanaryDown` meta-alert），端到端驗證「規則編譯 + 路由」整條沒被改壞，並抓得到 Watchdog 看不到的 exporter / 編譯管線死亡（不只是引擎還活著） | **下次重大的規則編譯邏輯重構、或多租戶路由規則大改時，先行佈署當安全網**；不必等事故發生 |
 | **端到端合成探測** | 從外部送一條測試告警，驗證它真的走完 Prometheus→Alertmanager→外部 | 心跳 + canary 上線後，出現「規則評估悄悄失敗」事件 |
 | **後端相容性測試** | 驗證規則在客戶的大規模後端上正確評估（含資料過期時序差異） | 首個客戶整合到自有後端 |
+
+> **已落地、不再 defer**：原列於此的 **規則靜態檢查（CI 規則 linter）** 已於 [#843](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/843) 採用 OSS `pint` 實作（hard-gate `alerts/template`），詳見上方「實作進度」。
+>
+> **canary 的 CI-gate 變體已評估並否決（記此免重走）**：曾評估一個把合成 `absence` fixture 餵進「真編譯器 + promtool + amtool」的 **CI-gate** canary，但它與既有 `absence` golden 測試（`tests/dx/fixtures/custom_alerts_promtool/absence.yaml`）、Go `rulepack_contract_test.go` 的 `component` / `tenant` 標籤契約、`test_generate_routes_orchestration.py` 的路由 orchestration 測試重疊約九成；且 CI 無 exporter、須自行合成 series，反而把 ADR 要驗的端到端**砍小**為 CI fixture 自身的性質 → **否決**。上表保留的是 **runtime** canary（常駐假租戶，能抓 [#731](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/731)-class 的 exporter / 編譯管線靜默死亡），與引擎心跳互補、仍 defer-with-trigger。
 
 ## 範圍邊界
 
@@ -125,7 +134,7 @@ receivers:
 ## 後果
 
 - **正面**：用「一條規則 + 一條路由 + 一個路由測試」、零新增元件，補上「告警系統自己死掉沒人知道」的盲點；與「儲存後端中立」定位一致，不和客戶後端打架。
-- **負面**：外部心跳是 operator 要自備的依賴（斷網退路＝被動探測）；心跳只能證明「引擎還活著」、不能證明「規則評估正確」（→ 留給 Canary 租戶）；單副本示範部署下，真出事仍需人工復原（高可用是 operator 的責任）。
+- **負面**：外部心跳是 operator 要自備的依賴（斷網退路＝被動探測）；心跳只能證明「引擎還活著」、不能證明「規則評估正確」（→ 留給 runtime Canary 租戶）；單副本示範部署下，真出事仍需人工復原（高可用是 operator 的責任）。
 
 ## 相關
 


### PR DESCRIPTION
## 摘要

把 ADR-025（告警平面自我存活性）的 doc 更新到與實作一致——**只更 status / deferred 表，不動 D1/D2/D3 核心設計**。先前曾把「deferred 項都落地了」講過頭：實際只有 pint 真的進 main，ADR doc 沒跟著同步。本 PR 收這個 doc-staleness。

## 變更

- **pint 規則 linter（[#843](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/843) 已 merge）** → 從「之後再說」deferred 表移除，記入新增的「實作進度」清單。
- **canary 列** → 標明為 **runtime canary**（保留 defer-with-trigger），並把它的 **CI-gate 變體已評估並否決** 記成 operative residue（與既有 `absence` golden（`tests/dx/fixtures/custom_alerts_promtool/absence.yaml`）/ Go `rulepack_contract_test.go` / `test_generate_routes_orchestration.py` 路由 orchestration 測試重疊約九成；CI 無 exporter 須自合成 series → 把端到端砍小成 CI fixture 自身性質），避免未來重走死路。完整評估留在 PR / 對話、不灌進 ADR。
- **新增「實作進度」清單**：D1 Watchdog（[#838](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/838)）、pint（[#843](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/843)）已落地；runtime canary / 端到端合成探測 / 後端相容性測試仍 defer-with-trigger。**狀態維持 in-progress**（核心盲點已補，但「規則評估正確性」端到端保證未竟）。
- zh + en 雙語同步（heading parity 不變）。

## 剩餘 deferred 項評估（為何不在本 PR 開發）

| 項目 | 觸發條件 | 現況 |
|---|---|---|
| runtime canary 租戶 | 下次重大規則編譯重構 / 多租戶路由大改 | **未觸發**（Unreleased 全為 additive rule pack + fix，無 compiler 重構） |
| 端到端合成探測 | 心跳 + canary 上線後出現「規則評估悄悄失敗」事件 | **不可達**（canary 未上線） |
| 後端相容性測試 | 首個客戶整合自有後端 | **未發生** |
| HA / chargeback HA-immunity | 平台真要出 HA reference | D3 明訂 operator-owned，**不自建** |

## 驗證

- `generate_adr_index.py --check` / `generate_planning_index.py --check`：no drift
- `check_bilingual_structure.py --ci`：0 errors / 0 warnings（ADR-025 無 nav issue）
- `bump_docs.py --check`：all version references consistent
- `mkdocs_strict_check.sh`：PASS
- `pr_preflight.py`：READY

承 ADR-025（#838 MVP、#843 pint）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
