### PR TITLE
docs: BYO disk-fill onboarding guide (#692 P0③ W4)

### DIFF
--- a/docs/integration/byo-prometheus-integration.en.md
+++ b/docs/integration/byo-prometheus-integration.en.md
@@ -349,6 +349,101 @@ da-tools validate-config --config-dir /data/conf.d
 
 ---
 
+## Advanced: Disk-Fill Alerts (Disk-Fill Recipes, requires CSI)
+
+Let tenants self-serve "disk is filling up" alerts — a `forecast` (predict exhaustion N hours out) or `ratio` (usage over a threshold) recipe over a PVC's `kubelet_volume_stats_*` metrics. This is an **optional** capability with one **hard prerequisite** — read the prerequisite before deciding to enable it.
+
+### Prerequisite: a CSI driver implementing NodeGetVolumeStats
+
+`kubelet_volume_stats_*` is produced by the kubelet via CSI's `NodeGetVolumeStats`. **Without it, the metrics simply do not exist** — a disk recipe compiles fine but **never fires** in the cluster (fail-silent).
+
+- ❌ kind's default `local-path` (hostPath) does **not** implement it → zero volume-stats.
+- ✅ Cloud CSI drivers (EBS / PD / Azure Disk…) and `csi-driver-host-path` do → metrics flow normally.
+- **How to check**: query your Prometheus — if `kubelet_volume_stats_available_bytes` returns **no** series at all, your storage backend has no kubelet MetricsProvider. To confirm cluster capability *before* configuring scraping, see the internal spike [`test/disk-stats-spike/`](https://github.com/vencil/Dynamic-Alerting-Integrations/tree/main/test/disk-stats-spike) (it deploys a PVC + pod and checks directly whether the kubelet emits volume-stats).
+
+> **Why only 1:1 tenant attribution** (disk / PVC / node infrastructure metrics do not support N:1): see [ADR-006 Tenant-Mapping Topologies](../adr/006-tenant-mapping-topologies.md).
+
+### Step A: Scrape kubelet volume-stats and inject `tenant`
+
+volume-stats carry `namespace` and `persistentvolumeclaim` natively, but **not `tenant`**. Add a scrape job for the kubelet's main `/metrics` endpoint, and use `metric_relabel_configs` to rewrite `namespace` into `tenant` (1:1, same effect as Step 1; but because `namespace` is a **native metric label** on kubelet metrics, this uses `metric_relabel_configs` rather than Step 1's `relabel_configs`):
+
+```yaml
+scrape_configs:
+  # ★ kubelet volume-stats (per-PVC disk capacity) — requires CSI NodeGetVolumeStats
+  - job_name: "kubelet-volume-stats"
+    scheme: https
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecure_skip_verify: true
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    kubernetes_sd_configs:
+      - role: node
+    relabel_configs:
+      # Scrape kubelet /metrics via the apiserver node-proxy (avoids direct-kubelet TLS issues)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics
+    metric_relabel_configs:
+      # Keep only volume-stats from tenant namespaces (same idiom as Step 1)
+      - source_labels: [namespace]
+        action: keep
+        regex: "db-.+"                     # ← change to YOUR cluster's tenant-namespace pattern!
+      - source_labels: [__name__]
+        action: keep
+        regex: "kubelet_volume_stats_.*"
+      # ★ Core: 1:1 inject namespace as tenant (same effect as Step 1's relabel)
+      - source_labels: [namespace]
+        target_label: tenant
+```
+
+> The platform's own reference deployment already ships this job; for the full runnable version see `kubelet-volume-stats` in [`k8s/03-monitoring/configmap-prometheus.yaml`](https://github.com/vencil/Dynamic-Alerting-Integrations/blob/main/k8s/03-monitoring/configmap-prometheus.yaml). The job needs `nodes/proxy` RBAC (same as the existing kubelet-cadvisor job). On a non-CSI cluster it is **harmless** — the `metric_relabel_configs` keeps drop everything to 0 series.
+
+### Step B: A tenant declares a disk recipe
+
+Declare it in the tenant's conf.d `_custom_alerts` (forecast ratio mode — predict the PVC filling within the horizon):
+
+```yaml
+tenants:
+  db-a:
+    _custom_alerts:
+      - recipe: forecast
+        name: disk_will_fill
+        metric: kubelet_volume_stats_available_bytes
+        capacity_metric: kubelet_volume_stats_capacity_bytes
+        op: "<"
+        horizon: 4h                        # predict 4 hours out
+        threshold: "0.15:warning"          # available fraction will drop below 15%
+        for: 30m                           # require the prediction to persist 30m (smooth transient slope flips)
+        group_by: [persistentvolumeclaim]  # evaluate per-PVC (a small near-full volume isn't hidden by a large empty one)
+```
+
+For the full example (threshold / rate / ratio / p99 / absence / `==` recipes) see [`recipes/examples/conf.d/shop.yaml`](https://github.com/vencil/Dynamic-Alerting-Integrations/blob/main/rule-packs/recipes/examples/conf.d/shop.yaml); for recipe syntax, per-mode semantics, and safe-adoption guidance (incl. the dead-exporter blind spot) see [Custom Rule Governance](../custom-rule-governance.md). Run `make custom-alerts-compile` to recompile the rule pack after editing.
+
+### Step C: Verify
+
+```bash
+da-tools byo-check prometheus --prometheus http://<your-prometheus>:9090
+```
+
+`byo-check`'s disk-recipe step checks whether **tenants that declared a disk recipe AND have Running pods actually receive tenant-attributed volume-stats**. When they don't, it names the three things to check: CSI / scrape job / relabel.
+
+**✅ Pass criteria**: the disk-recipe step is `pass` (or `skip` when no tenant has declared a disk recipe yet).
+
+### When it breaks: the `CustomRecipeDiskInert` alert
+
+Even if you skip the byo-check above, the platform has a runtime safety net: when a tenant has **declared a disk recipe, has a Running pod, but the attributed volume-stats are absent**, `CustomRecipeDiskInert` fires and lists the three most common causes in order:
+
+1. the workload mounts no persistent volume (most common; e.g. a stateless Pod, a PVC stuck `Pending`, or a StatefulSet missing `volumeClaimTemplates`) → check the tenant's deployment;
+2. the kubelet volume-stats scrape job or `namespace→tenant` relabel is missing (Step A skipped);
+3. the CSI driver does not implement NodeGetVolumeStats (prerequisite unmet).
+
+> **Capability boundary (honest)**: volume-stats reflect the tenant's view of **logical** quota. A thin-provisioned backing pool that is physically full (while `volume_stats` still reports free space and I/O has frozen) is out of scope for this alert and should be defended by the platform SRE via `node_filesystem_*` / CSI controller metrics (the infrastructure view).
+
+---
+
 ## Advanced: Integration with Thanos / VictoriaMetrics
 
 The platform's rule packs are based purely on standard PromQL, making them fully compatible with Thanos and VictoriaMetrics:

--- a/docs/integration/byo-prometheus-integration.md
+++ b/docs/integration/byo-prometheus-integration.md
@@ -349,6 +349,101 @@ da-tools validate-config --config-dir /data/conf.d
 
 ---
 
+## 進階：磁碟填滿告警（Disk-Fill Recipes，需 CSI）
+
+讓租戶自助宣告「磁碟快滿」告警——對 PVC 的 `kubelet_volume_stats_*` 指標跑 forecast（預測幾小時後填滿）或 ratio（使用率超標）recipe。這是**可選**能力，且有一個**硬前提**——請先讀完前提再決定是否啟用。
+
+### 前提：叢集需有實作 NodeGetVolumeStats 的 CSI driver
+
+`kubelet_volume_stats_*` 由 kubelet 透過 CSI 的 `NodeGetVolumeStats` 取得——**沒有，就完全沒有這組指標**，磁碟 recipe 會編譯成功但在叢集裡**永遠不會觸發**（fail-silent）。
+
+- ❌ kind 預設的 `local-path`（hostPath）**不**實作 → 零 volume-stats。
+- ✅ 雲商 CSI（EBS / PD / Azure Disk…）或 `csi-driver-host-path` 等有實作 → 正常吐指標。
+- **如何確認**：查你的 Prometheus，若 `kubelet_volume_stats_available_bytes` 查不到**任何** series，代表你的儲存後端沒有 kubelet MetricsProvider。若想在配置 scrape 前就確認叢集能力，可參考內部 spike [`test/disk-stats-spike/`](https://github.com/vencil/Dynamic-Alerting-Integrations/tree/main/test/disk-stats-spike)（部署一個 PVC + pod、直接驗 kubelet 是否吐 volume-stats）。
+
+> **為何只支援 1:1 tenant 歸屬**（disk / PVC / node 等基礎設施指標不支援 N:1）：見 [ADR-006 租戶映射拓撲](../adr/006-tenant-mapping-topologies.md)。
+
+### 步驟 A：抓取 kubelet volume-stats 並注入 `tenant`
+
+volume-stats 原生帶 `namespace` 與 `persistentvolumeclaim`，但**不帶 `tenant`**。新增一個抓 kubelet 主 `/metrics` 端點的 scrape job，並用 `metric_relabel_configs` 把 `namespace` 改寫為 `tenant`（1:1，效果同步驟 1；但 kubelet 指標的 `namespace` 是**原生 metric label**，故這裡用 `metric_relabel_configs` 而非步驟 1 的 `relabel_configs`）：
+
+```yaml
+scrape_configs:
+  # ★ kubelet volume-stats（per-PVC 磁碟容量）— 需 CSI NodeGetVolumeStats
+  - job_name: "kubelet-volume-stats"
+    scheme: https
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecure_skip_verify: true
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    kubernetes_sd_configs:
+      - role: node
+    relabel_configs:
+      # 經 apiserver node-proxy 抓 kubelet /metrics（避開直連 kubelet 的 TLS 問題）
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics
+    metric_relabel_configs:
+      # 只留 tenant namespace 的 volume-stats（與步驟 1 同慣例）
+      - source_labels: [namespace]
+        action: keep
+        regex: "db-.+"                     # ← 改成你叢集的 tenant namespace 命名模式！
+      - source_labels: [__name__]
+        action: keep
+        regex: "kubelet_volume_stats_.*"
+      # ★ 核心：1:1 把 namespace 注入為 tenant（與步驟 1 的 relabel 同效）
+      - source_labels: [namespace]
+        target_label: tenant
+```
+
+> 平台自帶的 reference 部署已含這個 job；完整可運行版本見 [`k8s/03-monitoring/configmap-prometheus.yaml`](https://github.com/vencil/Dynamic-Alerting-Integrations/blob/main/k8s/03-monitoring/configmap-prometheus.yaml) 的 `kubelet-volume-stats`。此 job 需 `nodes/proxy` RBAC（與既有的 kubelet-cadvisor job 相同）。非 CSI 叢集套了也**無害**——`metric_relabel_configs` 的 keep 會 drop 到 0 series。
+
+### 步驟 B：租戶宣告磁碟 recipe
+
+在租戶 conf.d 的 `_custom_alerts` 宣告（forecast ratio 模式，預測 PVC 在 horizon 內填滿）：
+
+```yaml
+tenants:
+  db-a:
+    _custom_alerts:
+      - recipe: forecast
+        name: disk_will_fill
+        metric: kubelet_volume_stats_available_bytes
+        capacity_metric: kubelet_volume_stats_capacity_bytes
+        op: "<"
+        horizon: 4h                        # 預測未來 4 小時
+        threshold: "0.15:warning"          # 可用比例將跌破 15%
+        for: 30m                           # 預測需持續 30m（濾掉瞬時斜率翻轉）
+        group_by: [persistentvolumeclaim]  # 逐 PVC 評估（小卷快滿不被大空卷掩蓋）
+```
+
+完整範例（threshold / rate / ratio / p99 / absence / `==` 等所有 recipe）見 [`recipes/examples/conf.d/shop.yaml`](https://github.com/vencil/Dynamic-Alerting-Integrations/blob/main/rule-packs/recipes/examples/conf.d/shop.yaml)；recipe 語法、各模式語義與安全採用指引（含 dead-exporter 盲點）見 [Custom Rule Governance](../custom-rule-governance.md)。改完跑 `make custom-alerts-compile` 重編規則包。
+
+### 步驟 C：驗證
+
+```bash
+da-tools byo-check prometheus --prometheus http://<your-prometheus>:9090
+```
+
+`byo-check` 的磁碟 recipe 步驟會檢查：**宣告了磁碟 recipe 且有 Running pod 的租戶，是否真的收到 tenant-attributed volume-stats**。未到貨時會明確報出「CSI / scrape job / relabel」三項待查方向。
+
+**✅ 通過條件**：磁碟 recipe 步驟為 `pass`（尚未有租戶宣告磁碟 recipe 時為 `skip`）。
+
+### 出問題時：`CustomRecipeDiskInert` 告警
+
+即使略過上面的 byo-check，平台仍有 runtime 安全網：當租戶**宣告了磁碟 recipe、有 Running pod、但歸屬後的 volume-stats 缺席**時，`CustomRecipeDiskInert` 會觸發，並依序提示三個最常見原因：
+
+1. 工作負載未掛載持久化磁碟（最常見；例如 Pod 為純無狀態服務、PVC 卡在 `Pending`、或 StatefulSet 漏寫 `volumeClaimTemplates`）→ 查該租戶的部署架構；
+2. 缺 kubelet volume-stats scrape job 或 `namespace→tenant` relabel（步驟 A 漏做）；
+3. CSI 未實作 NodeGetVolumeStats（前提不滿足）。
+
+> **能力界線（誠實）**：volume-stats 反映租戶視角的**邏輯**配額。底層 thin-provisioning 的實體爆盤（`volume_stats` 仍顯示有空間、實際 I/O 已凍結）不在此告警範圍內，應由平台 SRE 以 `node_filesystem_*` / CSI controller 指標（基礎設施視角）防禦。
+
+---
+
 ## 進階：與 Thanos / VictoriaMetrics 整合
 
 本平台的規則包純粹基於標準 PromQL，因此與 Thanos 和 VictoriaMetrics 完全相容：


### PR DESCRIPTION
## 摘要

#692 P0③ **W4 — disk-fill 的 layer-5 adoption**:在 BYO Prometheus 整合指南加一段 **「進階：磁碟填滿告警（Disk-Fill Recipes，需 CSI）」**(ZH + EN 鏡像),把 W1–W3 已 codified 的磁碟告警機制兜成租戶/operator 可照著走的 onboarding flow。這也是 **P0③ disk-fill epic(W1–W4)的收尾片**。

## 內容(`engineering:documentation` 原則:lede-first / show-don't-tell / link-not-duplicate)

- **前提先行**:CSI `NodeGetVolumeStats` 是硬前提(kind local-path 吐 0、fail-silent)——放最前面 + 給冷啟動檢查法,讓 operator 投資 scrape 設定前就知道能不能做。
- **步驟 A**:kubelet volume-stats scrape job + `namespace→tenant` metric_relabel(連結平台 shipped 的 `configmap-prometheus.yaml`、註明 metric_relabel vs relabel 機制差異)。
- **步驟 B**:租戶 forecast 磁碟 recipe(對齊 `shop.yaml` 的真實範例)。
- **步驟 C**:`da-tools byo-check prometheus` 驗證(W3 Step 4)。
- **出問題時**:`CustomRecipeDiskInert` runtime backstop + thin-provisioning 能力界線(誠實標界外 → `node_filesystem`/SRE)。

## 為何**不**做 verify-csi-prereq.sh(原計畫項)

對抗式分析後判定為冗餘:byo_check Step 4(W3)已涵蓋 post-scrape 驗證;pre-scrape 的「叢集 CSI 能不能吐 volume-stats」**無乾淨輕量檢查**(只有重、特權的 disk-stats-spike,已在文件引用)。業界 idiom = **document-prereq + runtime-verify**,非 bespoke capability probe。**docs-only → 無 CHANGELOG 條**(能力本身已由 W1–W3 入 CHANGELOG)。

## 驗證

`check_bilingual_structure`(28=28 headings 鏡像、0 錯誤)、`check_doc_links`(全 valid;docs/ 外目標用絕對 GitHub URL)、`bump_docs`。**對抗式 doc-review**(模擬 BYO operator 冷讀):scrape YAML + forecast recipe **逐欄位**比對 shipped configmap + shop.yaml = 正確且完整;2 個 nit(ZH/EN emphasis、relabel 機制說明)已修。

Refs: #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)
