### PR TITLE
fix(ci): pages-health live probe — add curl --compressed (#861 follow-up)

### DIFF
--- a/.github/workflows/pages-health.yaml
+++ b/.github/workflows/pages-health.yaml
@@ -88,39 +88,54 @@ jobs:
           probe() {
             # $1 = url. Echoes the HTTP status; sets BODY to the response body.
             local url="$1" code
+            # --compressed: REQUIRED. GitHub Pages sends `Vary: Accept-Encoding`
+            # and the CI runner's curl requests gzip, so WITHOUT this the body
+            # arrives as gzip bytes and the content grep below never matches
+            # (200-but-"sentinel missing" — the #864 false-red). --compressed
+            # makes curl decompress, so BODY is always plaintext HTML. (The bug
+            # was masked when reproduced with a bare local `curl` that sends no
+            # Accept-Encoding and thus gets identity.)
             # No -f: keep the real status code (and body) on 4xx/5xx for
-            # diagnostics. A non-zero exit then means a transport error
-            # (DNS/timeout), which falls through to BODY="" / code="".
-            BODY=$(curl -sS --max-time 20 -w '\n%{http_code}' "$url" 2>/dev/null) || BODY=""
+            # diagnostics. A non-zero exit = transport error (DNS/timeout),
+            # which falls through to BODY="" / code="".
+            BODY=$(curl -sS --compressed --max-time 20 -w '\n%{http_code}' "$url" 2>/dev/null) || BODY=""
             code="${BODY##*$'\n'}"
             BODY="${BODY%$'\n'*}"
             echo "$code"
           }
 
-          check_url() {
-            local url="$1" want_content="$2"
-            for attempt in 1 2 3 4 5 6; do
-              code=$(probe "$url")
-              if [ "$code" = "200" ]; then
-                if [ "$want_content" = "1" ] && ! grep -qiF "$sentinel" <<<"$BODY"; then
-                  echo "  attempt ${attempt}: 200 but content sentinel '${sentinel}' missing — retrying"
-                else
-                  echo "  ${url} -> 200 OK"
-                  return 0
-                fi
-              else
-                echo "  attempt ${attempt}: ${url} -> ${code:-no-response} (retrying)"
-              fi
-              sleep 20
-            done
-            echo "::error::${url} did not return HTTP 200 with expected content after retries (last status: ${code:-no-response}). The live docs site is unhealthy."
-            return 1
-          }
-
-          rc=0
-          # Root must serve the real rendered home (status + content).
-          check_url "${base}/" 1 || rc=1
-          # English locale root: status-only (its <title> differs from the
-          # zh site_name sentinel; a 200 is enough to prove the i18n tree built).
-          check_url "${base}/en/" 0 || rc=1
-          exit $rc
+          # Shared retry window across BOTH URLs (one budget, not one per URL),
+          # a modest cushion for genuine transient post-deploy unavailability —
+          # the workflow_run fires the moment deploy-pages reports success.
+          # NOTE: the #864 false-red was NOT a propagation/timing issue — it was
+          # the missing `--compressed` above (gzip body → unsearchable sentinel).
+          # Retries never fixed it; don't inflate this budget chasing a ghost.
+          ATTEMPTS=8
+          SLEEP=20
+          ok=0
+          root_status=""; en_status=""; root_ok=0
+          for attempt in $(seq 1 "$ATTEMPTS"); do
+            root_status=$(probe "${base}/"); root_body="$BODY"
+            en_status=$(probe "${base}/en/")
+            root_ok=0; en_ok=0
+            # Root: status 200 AND rendered-home content — guards the "200 but
+            # wrong content" inverse (a stray static file 200 while the real
+            # root is broken, the shape the original outage could have taken).
+            if [ "$root_status" = "200" ] && grep -qiF "$sentinel" <<<"$root_body"; then root_ok=1; fi
+            # /en/: status-only. Its <title> also carries the sentinel, but a
+            # 200 is enough to prove the i18n locale tree built and serves.
+            if [ "$en_status" = "200" ]; then en_ok=1; fi
+            if [ "$root_ok" = 1 ] && [ "$en_ok" = 1 ]; then
+              echo "✅ attempt ${attempt}/${ATTEMPTS}: / -> 200 (content OK), /en/ -> 200"
+              ok=1; break
+            fi
+            if [ "$root_ok" = 1 ]; then root_note=ok; else root_note="bad(${root_status:-no-response})"; fi
+            if [ "$en_ok" = 1 ]; then en_note=ok; else en_note="bad(${en_status:-no-response})"; fi
+            echo "attempt ${attempt}/${ATTEMPTS}: root=${root_note} /en/=${en_note} — waiting for propagation"
+            if [ "$attempt" -lt "$ATTEMPTS" ]; then sleep "$SLEEP"; fi
+          done
+          if [ "$ok" != 1 ]; then
+            root_content=$([ "$root_ok" = 1 ] && echo ok || echo missing)
+            echo "::error::Live docs site unhealthy after ${ATTEMPTS} attempts (~$((ATTEMPTS * SLEEP / 60)) min). Last: root status=${root_status:-no-response} content=${root_content}, /en/ status=${en_status:-no-response}. Either the deploy didn't actually serve, or propagation is abnormally slow."
+            exit 1
+          fi


### PR DESCRIPTION
## 問題

[#861](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/861) 合併後，`pages-health` 的 `live-health` job **每次跑都 false-red**：root 回 200，但內容 sentinel「Dynamic Alerting Platform」抓不到。

## 根因（更正先前誤判）

**缺 `curl --compressed`。** GitHub Pages 回 `Vary: Accept-Encoding`，CI runner 的 curl 會要求 gzip → body 是 gzip bytes → `grep` 搜不到明文。

我一開始誤判為「部署後 CDN 傳播時序」——因為本機用 plain `curl`（不送 Accept-Encoding → 拿 identity 明文）重現時「找得到」。但**手動重跑 `pages-health`（站台早已就緒）仍紅**，才推翻 timing 假設、揪出真凶是編碼。診斷坐實：

- `curl -H 'Accept-Encoding: gzip' <url>` → body 開頭 `1f 8b`（gzip magic）、`grep` MISSING
- `curl --compressed <url>` → FOUND ✅

（站台本身一直健康：`/`、`/en/`、`/interactive/`、`/adr/`、`/CHANGELOG/` 均 200。）

## 修法

- **probe 的 curl 加 `--compressed`**（送 Accept-Encoding 並自動解壓 → BODY 恆為明文 HTML）。這是真正的 root-cause fix。
- 順帶把兩 URL 的重試改成**共用單一窗**（`set -e` 安全、最後一次不空睡），budget 收斂為 `8×20s`，作為「部署剛完成的短暫不可用」的合理緩衝（移除先前誤稱的 6min 傳播窗）。

新 probe 在模擬 runner 的 gzip 條件下實測 sentinel FOUND；`bash -n` + YAML parse 驗過。

> 教訓：此 workflow 在 PR 上不會執行（`pages-health` 只在 schedule / `workflow_run` 觸發），CI 測不到——這個 bug 只在 production 首跑才現形，且「本機重現」會被 plain-curl 的 identity 編碼**遮蔽**，導致第一輪誤判 timing。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
