### PR TITLE
docs: pin ADR-026 frontmatter version to v2.9.0 (fix Version Consistency)

### DIFF
--- a/docs/adr/026-node-maintenance-liveness-suppression.md
+++ b/docs/adr/026-node-maintenance-liveness-suppression.md
@@ -2,7 +2,7 @@
 title: "ADR-026: Node/Cluster 維護告警抑制 — Liveness-Class Gap，不是子系統"
 tags: [adr, alerting, maintenance, k8s]
 audience: [platform-engineers, sre]
-version: v2.10.0
+version: v2.9.0
 lang: zh
 id: ADR-026
 tracking_kind: adr


### PR DESCRIPTION
## What

`docs/adr/026-node-maintenance-liveness-suppression.md` carried `version: v2.10.0` in its front matter; the bump_docs source of truth is the current released version **v2.9.0** (the frontmatter `version:` is a last-touched stamp, not the feature's target version — sibling design docs such as `runtime-canary.md` use v2.9.0 too). One-line stamp fix, no content change.

## Why it matters

The **Version Consistency** check runs on the PR's virtual merge with main, so this drift on main fails that check for **every open PR**, not just this ADR (e.g. [#868](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/868)). `bump_docs.py --check` is green after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
