### PR TITLE
feat: recipe would-fire preview P2 — backend eval core (#657)

### DIFF
--- a/docs/internal/tool-map.md
+++ b/docs/internal/tool-map.md
@@ -113,6 +113,7 @@ lang: zh
 | `migrate_conf_d.py` | Migrate flat conf.d/ to hierarchical domain/region/env/ layout. |
 | `migrate_ssot_language.py` | SSOT 語言切換遷移工具 (DORMANT, S#101 policy lock) |
 | `pr_preflight.py` | PR Preflight Check — branch 收尾前的自動化檢查。 |
+| `recipe_preview.py` | recipe would-fire preview core (#657 P2). |
 | `render_soak_diff.py` | v2.8.0 readiness harness: chaos soak result renderer. |
 | `reword_chain.py` | 批次改寫 commit chain 的 subject line（preserve tree + author/committer date） |
 | `run_chaos_soak.py` | v2.8.0 readiness harness: compressed-time chaos soak runner. |

--- a/docs/internal/tool-map.md
+++ b/docs/internal/tool-map.md
@@ -83,6 +83,7 @@ lang: zh
 | 工具 | 用途 |
 |------|------|
 | `_atomic_write.py` | Atomic write helper for regen tools (v2.8.0 Trap #60 mitigation). |
+| `_recipe_preview.py` | recipe would-fire preview core (#657 P2). |
 | `add_frontmatter.py` | Add YAML front matter to documentation files for MkDocs/Docusaurus integration. |
 | `analyze_bench_history.py` | Aggregate bench-record nightly history into per-benchmark stats. |
 | `analyze_tier1_fp_rate.py` | Tier 1 bench-gate friction-rate observer (issue #433 W3). |
@@ -113,7 +114,6 @@ lang: zh
 | `migrate_conf_d.py` | Migrate flat conf.d/ to hierarchical domain/region/env/ layout. |
 | `migrate_ssot_language.py` | SSOT 語言切換遷移工具 (DORMANT, S#101 policy lock) |
 | `pr_preflight.py` | PR Preflight Check — branch 收尾前的自動化檢查。 |
-| `recipe_preview.py` | recipe would-fire preview core (#657 P2). |
 | `render_soak_diff.py` | v2.8.0 readiness harness: chaos soak result renderer. |
 | `reword_chain.py` | 批次改寫 commit chain 的 subject line（preserve tree + author/committer date） |
 | `run_chaos_soak.py` | v2.8.0 readiness harness: compressed-time chaos soak runner. |

--- a/scripts/tools/dx/_recipe_preview.py
+++ b/scripts/tools/dx/_recipe_preview.py
@@ -81,6 +81,11 @@ def build_preview_test(recipe, tenant, value, slug):
     mode = recipe.get("mode")
     selectors = {str(k): v for k, v in (recipe.get("selectors") or {}).items()}
 
+    # NOTE (P3): this +10/+5 buffer is correct ONLY for a flat constant series.
+    # Time-dependent recipes (rate / ratio / absence) — currently gated to
+    # supported:false — will need `n`/`eval_min` to become polymorphic by
+    # recipe_type: `absence` needs the series to STOP at a point then eval after
+    # the gap + `for:`; `rate` needs eval_time to fully populate the lookback.
     for_min = _FOR_MINUTES[str(recipe.get("for", "1m"))]   # caller pre-validates membership
     n = for_min + 10            # series length (interval 1m): clears `for:` + buffer
     eval_min = for_min + 5      # eval PAST the pending window

--- a/scripts/tools/dx/_recipe_preview.py
+++ b/scripts/tools/dx/_recipe_preview.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
-"""recipe_preview.py — recipe would-fire preview core (#657 P2).
+"""_recipe_preview.py — recipe would-fire preview core (#657 P2).
 
 Given ONE ADR-024 custom-alert recipe + a scenario value, answer "would it
 fire?" by going through the SAME authoritative engine the platform uses —
 `compile_custom_alerts.build_pack` + `promtool` — never re-implementing eval
 (the two-eval-homes rule; see docs/design/recipe-would-fire-preview.md).
 
-MVP scope: the `threshold` recipe (ops >, >=, <, <=, ==). These are NOT
-time-dependent, so a flat constant synthetic series is correct + sufficient.
-Time-dependent recipes (rate / ratio / forecast / absence / p99_latency) need
-recipe-type-aware synthetic series → `supported: false` until P3.
+MVP scope: the `threshold` recipe (ops >, >=, <, <=, ==) with at most exact
+`selectors`. These are NOT time-dependent, so a flat constant synthetic series
+is correct + sufficient. Two shapes fall back to `supported: false` because a
+flat exact-match series can't faithfully stand in for them:
+  - time-dependent recipes (rate / ratio / forecast / absence / p99_latency) —
+    need recipe-type-aware series (deferred to P3);
+  - `selectors_re` (regex label filters) — we can't synthesize a value
+    guaranteed to match an arbitrary regex, so a preview could silently report
+    a false "inactive". Refusing is honest; lying is not.
 
 Eval mechanism (§5.2): `promtool test rules` is an ASSERT tool, so we run an
 INVERTED assert (synthetic input + `exp_alerts: []`): returncode 0 → nothing
@@ -48,8 +53,16 @@ _TIMEOUT = 60
 
 
 def _labels(d):
-    """Render a Prometheus label set `{k="v", ...}` (insertion order)."""
-    return "{" + ", ".join(f'{k}="{v}"' for k, v in d.items()) + "}"
+    """Render a Prometheus label set `{k="v", ...}` (insertion order).
+
+    Values are escaped with the compiler's own `shape._escape_value`, so a
+    selector value containing a quote, backslash, or newline yields the SAME
+    label literal the compiled rule matches against — otherwise the synthetic
+    series wouldn't match (false "inactive") or would be an unparseable series.
+    """
+    return "{" + ", ".join(
+        f'{k}="{shape._escape_value(str(v))}"' for k, v in d.items()
+    ) + "}"
 
 
 def build_preview_test(recipe, tenant, value, slug):
@@ -153,6 +166,22 @@ def preview_recipe(recipe, tenant, scenario):
             ],
         }
 
+    # selectors_re (regex label filters) gate: we hand-build a flat synthetic
+    # series and can't synthesize a value guaranteed to match an arbitrary
+    # regex, so the compiled `{k=~"re"}` filter could exclude our series and
+    # the preview would silently report a false "inactive". Refuse honestly
+    # (exact `selectors` ARE reproducible — see _labels / build_preview_test).
+    if recipe.get("selectors_re"):
+        return {
+            "alertname": None,
+            "supported": False,
+            "states": [],
+            "warnings": [
+                "would-fire preview does not yet support regex selectors "
+                "(`selectors_re`); only exact `selectors` can be previewed"
+            ],
+        }
+
     # Compute the slug via the compiler's OWN function (zero cross-language
     # drift, §5.3). A structurally invalid recipe fails loud here → state:error.
     try:
@@ -167,6 +196,13 @@ def preview_recipe(recipe, tenant, scenario):
     value = (scenario or {}).get("value")
     if value is None:
         return _err("scenario.value is required for a threshold preview",
+                    alertname=f"Custom_{slug}")
+    # Numeric-only: reject e.g. "1+2" / "5.." which promtool's series grammar
+    # would misread as a slope/range rather than a flat constant → wrong verdict.
+    try:
+        float(value)
+    except (TypeError, ValueError):
+        return _err(f"scenario.value must be numeric, got {value!r}",
                     alertname=f"Custom_{slug}")
 
     work = Path(tempfile.mkdtemp(prefix="recipe-preview-"))
@@ -186,11 +222,14 @@ def preview_recipe(recipe, tenant, scenario):
             return _err(f"recipe failed to compile: {exc}", alertname=f"Custom_{slug}")
 
         pack_path = work / "rule-pack-custom-alerts.yaml"
-        pack_path.write_text(cc._render(pack["groups"]), encoding="utf-8")
 
-        # ── syntax gate, then inverted-assert; both fail-closed to state:error
-        # rather than ever mislabel an infra/timeout failure as firing (§5.2) ──
+        # ── render → syntax gate → inverted-assert. Every failure here is
+        # fail-closed to state:error rather than ever mislabel an infra / IO /
+        # timeout failure as firing (§5.2 layering). `except OSError` catches
+        # promtool vanishing after the `which` probe or an unwritable temp dir,
+        # so the {state:error} contract holds even then. ──
         try:
+            pack_path.write_text(cc._render(pack["groups"]), encoding="utf-8")
             chk = subprocess.run(
                 [_PROMTOOL, "check", "rules", pack_path.name],
                 cwd=work, capture_output=True, text=True, timeout=_TIMEOUT,
@@ -207,6 +246,8 @@ def preview_recipe(recipe, tenant, scenario):
             )
         except subprocess.TimeoutExpired:
             return _err(f"promtool timed out (>{_TIMEOUT}s)", alertname=f"Custom_{slug}")
+        except OSError as exc:
+            return _err(f"promtool eval failed: {exc}", alertname=f"Custom_{slug}")
 
         out = (res.stdout or "") + (res.stderr or "")
         state = classify_promtool_result(res.returncode, out)

--- a/scripts/tools/dx/_recipe_preview.py
+++ b/scripts/tools/dx/_recipe_preview.py
@@ -189,10 +189,9 @@ def preview_recipe(recipe, tenant, scenario):
     except shape.RecipeError as exc:
         return _err(str(exc))
 
-    if _PROMTOOL is None:
-        return {"alertname": f"Custom_{slug}", "supported": True, "states": [],
-                "warnings": ["promtool not available — cannot evaluate locally"]}
-
+    # Validate the request BEFORE the promtool-availability check, so bad input
+    # is reported as an error regardless of whether we can evaluate locally
+    # (the "Python Tests" CI job has no promtool on PATH).
     value = (scenario or {}).get("value")
     if value is None:
         return _err("scenario.value is required for a threshold preview",
@@ -204,6 +203,10 @@ def preview_recipe(recipe, tenant, scenario):
     except (TypeError, ValueError):
         return _err(f"scenario.value must be numeric, got {value!r}",
                     alertname=f"Custom_{slug}")
+
+    if _PROMTOOL is None:
+        return {"alertname": f"Custom_{slug}", "supported": True, "states": [],
+                "warnings": ["promtool not available — cannot evaluate locally"]}
 
     work = Path(tempfile.mkdtemp(prefix="recipe-preview-"))
     try:

--- a/scripts/tools/dx/_recipe_preview.py
+++ b/scripts/tools/dx/_recipe_preview.py
@@ -81,7 +81,7 @@ def build_preview_test(recipe, tenant, value, slug):
     mode = recipe.get("mode")
     selectors = {str(k): v for k, v in (recipe.get("selectors") or {}).items()}
 
-    for_min = _FOR_MINUTES.get(str(recipe.get("for", "1m")), 1)
+    for_min = _FOR_MINUTES[str(recipe.get("for", "1m"))]   # caller pre-validates membership
     n = for_min + 10            # series length (interval 1m): clears `for:` + buffer
     eval_min = for_min + 5      # eval PAST the pending window
 
@@ -202,6 +202,16 @@ def preview_recipe(recipe, tenant, scenario):
         float(value)
     except (TypeError, ValueError):
         return _err(f"scenario.value must be numeric, got {value!r}",
+                    alertname=f"Custom_{slug}")
+    # `for:` is enum-bounded by shape.ALLOWED_FOR, but the preview must also be
+    # able to SIZE the synthetic series from it. If the two ever drift (a new
+    # ALLOWED_FOR value unmapped in _FOR_MINUTES), fail closed to error rather
+    # than silently shrink the window to 1m → wrong eval_time/length → a real
+    # firing misread as inactive (CodeRabbit #873).
+    _for = str(recipe.get("for", "1m"))
+    if _for not in _FOR_MINUTES:
+        return _err(f"preview cannot size the series for for-window {_for!r} "
+                    f"(sync _FOR_MINUTES with shape.ALLOWED_FOR)",
                     alertname=f"Custom_{slug}")
 
     if _PROMTOOL is None:

--- a/scripts/tools/dx/recipe_preview.py
+++ b/scripts/tools/dx/recipe_preview.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""recipe_preview.py — recipe would-fire preview core (#657 P2).
+
+Given ONE ADR-024 custom-alert recipe + a scenario value, answer "would it
+fire?" by going through the SAME authoritative engine the platform uses —
+`compile_custom_alerts.build_pack` + `promtool` — never re-implementing eval
+(the two-eval-homes rule; see docs/design/recipe-would-fire-preview.md).
+
+MVP scope: the `threshold` recipe (ops >, >=, <, <=, ==). These are NOT
+time-dependent, so a flat constant synthetic series is correct + sufficient.
+Time-dependent recipes (rate / ratio / forecast / absence / p99_latency) need
+recipe-type-aware synthetic series → `supported: false` until P3.
+
+Eval mechanism (§5.2): `promtool test rules` is an ASSERT tool, so we run an
+INVERTED assert (synthetic input + `exp_alerts: []`): returncode 0 → nothing
+fired (inactive); returncode != 0 → it fired. A compile error must NOT be
+mislabeled as firing, so we gate with `build_pack` exception handling +
+`promtool check rules` (syntax) BEFORE the inverted-assert (§5.2 layering).
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _THIS_DIR)
+import compile_custom_alerts as cc  # noqa: E402
+from custom_alerts import shape  # noqa: E402
+
+# The `threshold` recipe covers >, >=, <, <=, == (equals): all value-crossing,
+# none time-dependent → a flat series previews them correctly. The others are
+# deferred to P3 (recipe-type-aware series). Per-type gating (§7): an
+# unsupported type returns supported:false WITHOUT attempting a compile, so it
+# is never mislabeled firing/error.
+SUPPORTED_RECIPES_MVP = frozenset({"threshold"})
+
+# `for:` is enum-bounded (shape.ALLOWED_FOR). Map to minutes to size the
+# synthetic series + pick an eval_time PAST the pending window.
+_FOR_MINUTES = {"0s": 0, "1m": 1, "5m": 5, "15m": 15, "30m": 30, "1h": 60}
+
+_PROMTOOL = shutil.which("promtool")
+
+_TIMEOUT = 60
+
+
+def _labels(d):
+    """Render a Prometheus label set `{k="v", ...}` (insertion order)."""
+    return "{" + ", ".join(f'{k}="{v}"' for k, v in d.items()) + "}"
+
+
+def build_preview_test(recipe, tenant, value, slug):
+    """Build a promtool test (YAML str) for a threshold recipe — inverted assert.
+
+    Emits the minimal label-correct graph the compiled rule joins against:
+      - the observed metric @ the scenario test value (+ any selector labels);
+      - `user_threshold` @ the configured threshold, carrying the compiler's
+        recipe_id slug + severity + name (+ mode when the recipe sets it);
+      - a constant `tenant_metadata_info` for the group_left enrichment.
+    Flat constant series held long enough to clear the recipe's `for:` window.
+    Returns (yaml_text, severity, mode, threshold_value).
+    """
+    thr_value, severity = shape.parse_threshold(recipe["threshold"])
+    name = recipe["name"]
+    mode = recipe.get("mode")
+    selectors = {str(k): v for k, v in (recipe.get("selectors") or {}).items()}
+
+    for_min = _FOR_MINUTES.get(str(recipe.get("for", "1m")), 1)
+    n = for_min + 10            # series length (interval 1m): clears `for:` + buffer
+    eval_min = for_min + 5      # eval PAST the pending window
+
+    metric_labels = {"tenant": tenant, **selectors}
+    ut_labels = {
+        "component": "custom",
+        "metric": recipe["metric"],
+        "recipe_id": slug,
+        "tenant": tenant,
+        "severity": severity,
+        "name": name,
+    }
+    if mode:
+        ut_labels["mode"] = str(mode)
+
+    doc = (
+        "rule_files:\n"
+        "  - rule-pack-custom-alerts.yaml\n"
+        "evaluation_interval: 1m\n"
+        "tests:\n"
+        "  - interval: 1m\n"
+        "    input_series:\n"
+        f"      - series: '{recipe['metric']}{_labels(metric_labels)}'\n"
+        f"        values: '{value}x{n}'\n"
+        f"      - series: 'user_threshold{_labels(ut_labels)}'\n"
+        f"        values: '{thr_value}x{n}'\n"
+        f"      - series: 'tenant_metadata_info{{tenant=\"{tenant}\", "
+        f"runbook_url=\"http://rb/{tenant}\", owner=\"team-{tenant}\", tier=\"gold\"}}'\n"
+        f"        values: '1x{n}'\n"
+        "    alert_rule_test:\n"
+        f"      - eval_time: {eval_min}m\n"
+        f"        alertname: Custom_{slug}\n"
+        "        exp_alerts: []\n"
+    )
+    return doc, severity, mode, thr_value
+
+
+def _err(reason, alertname=None):
+    return {"alertname": alertname, "supported": True,
+            "states": [{"state": "error", "reason": reason}], "warnings": []}
+
+
+def classify_promtool_result(returncode, output):
+    """Map a promtool `test rules` (run with `exp_alerts: []`) result to a state.
+
+    rc != 0 alone is NOT "firing": promtool exits non-zero for OOM/kill, a
+    missing binary, or a test-file parse error too. Treating any of those as
+    "firing" would be a false positive (the exact false-confidence the design
+    forbids). So FIRING requires the alert-mismatch signature promtool prints
+    when an alert fires against our empty expectation — `FAILED:` plus a
+    non-empty `got:` block (verified verbatim on promtool 2.53.2). Anything
+    else with rc != 0 is an infrastructure/parse error → `error`.
+
+      rc == 0                      → inactive (nothing fired)
+      rc != 0 + FAILED: + got:[    → firing
+      rc != 0 otherwise            → error
+    """
+    if returncode == 0:
+        return "inactive"
+    if "FAILED:" in output and "got:[" in output:
+        return "firing"
+    return "error"
+
+
+def preview_recipe(recipe, tenant, scenario):
+    """Would-fire preview for ONE recipe. Returns the §4 contract dict:
+    {alertname, supported, states:[{severity, mode, state, reason}], warnings}.
+
+    state ∈ firing | inactive | error. Per-type gating: unsupported recipe
+    types return supported:false (no compile). promtool absent → supported:true
+    with a warning and no states (cannot evaluate locally).
+    """
+    rtype = recipe.get("recipe")
+    if rtype not in SUPPORTED_RECIPES_MVP:
+        return {
+            "alertname": None,
+            "supported": False,
+            "states": [],
+            "warnings": [
+                f"would-fire preview for recipe type {rtype!r} is coming soon "
+                f"(P3); supported now: {sorted(SUPPORTED_RECIPES_MVP)}"
+            ],
+        }
+
+    # Compute the slug via the compiler's OWN function (zero cross-language
+    # drift, §5.3). A structurally invalid recipe fails loud here → state:error.
+    try:
+        slug = shape.recipe_id(recipe)
+    except shape.RecipeError as exc:
+        return _err(str(exc))
+
+    if _PROMTOOL is None:
+        return {"alertname": f"Custom_{slug}", "supported": True, "states": [],
+                "warnings": ["promtool not available — cannot evaluate locally"]}
+
+    value = (scenario or {}).get("value")
+    if value is None:
+        return _err("scenario.value is required for a threshold preview",
+                    alertname=f"Custom_{slug}")
+
+    work = Path(tempfile.mkdtemp(prefix="recipe-preview-"))
+    try:
+        confd = work / "conf.d"
+        confd.mkdir()
+        (confd / f"{tenant}.yaml").write_text(
+            yaml.safe_dump({"tenants": {tenant: {"_custom_alerts": [recipe]}}},
+                           sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+
+        # ── compile (errors → state:error, never mislabeled firing) ──
+        try:
+            pack = cc.build_pack(confd)
+        except Exception as exc:  # RecipeError / CustomAlertConfigError / loader errors
+            return _err(f"recipe failed to compile: {exc}", alertname=f"Custom_{slug}")
+
+        pack_path = work / "rule-pack-custom-alerts.yaml"
+        pack_path.write_text(cc._render(pack["groups"]), encoding="utf-8")
+
+        # ── syntax gate, then inverted-assert; both fail-closed to state:error
+        # rather than ever mislabel an infra/timeout failure as firing (§5.2) ──
+        try:
+            chk = subprocess.run(
+                [_PROMTOOL, "check", "rules", pack_path.name],
+                cwd=work, capture_output=True, text=True, timeout=_TIMEOUT,
+            )
+            if chk.returncode != 0:
+                return _err(f"compiled rule failed promtool check: "
+                            f"{(chk.stderr or chk.stdout).strip()[:300]}",
+                            alertname=f"Custom_{slug}")
+            test_doc, severity, mode, thr_value = build_preview_test(recipe, tenant, value, slug)
+            (work / "preview_test.yaml").write_text(test_doc, encoding="utf-8")
+            res = subprocess.run(
+                [_PROMTOOL, "test", "rules", "preview_test.yaml"],
+                cwd=work, capture_output=True, text=True, timeout=_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            return _err(f"promtool timed out (>{_TIMEOUT}s)", alertname=f"Custom_{slug}")
+
+        out = (res.stdout or "") + (res.stderr or "")
+        state = classify_promtool_result(res.returncode, out)
+        if state == "error":
+            return _err(f"promtool eval error (rc={res.returncode}): "
+                        f"{out.strip()[:300] or 'no output'}", alertname=f"Custom_{slug}")
+        op = recipe.get("op", ">")
+        verb = "==" if op == "==" else op
+        reason = (f"value {value} {verb} threshold {thr_value}" if state == "firing"
+                  else f"value {value} does not cross threshold {thr_value} ({op})")
+        return {
+            "alertname": f"Custom_{slug}",
+            "supported": True,
+            "states": [{
+                "severity": severity,
+                "mode": str(mode) if mode else "page",
+                "state": state,
+                "reason": reason,
+            }],
+            "warnings": [],
+        }
+    finally:
+        shutil.rmtree(work, ignore_errors=True)

--- a/tests/dx/test_recipe_preview.py
+++ b/tests/dx/test_recipe_preview.py
@@ -13,7 +13,7 @@ import pytest
 
 _DX = os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "tools", "dx")
 sys.path.insert(0, _DX)
-import recipe_preview as rp  # noqa: E402
+import _recipe_preview as rp  # noqa: E402
 
 _needs_promtool = pytest.mark.skipif(
     shutil.which("promtool") is None, reason="promtool not on PATH"
@@ -50,6 +50,35 @@ class TestGatingAndErrors:
         assert out["states"][0]["state"] == "error"
         assert "metric" in out["states"][0]["reason"]
 
+    def test_selectors_re_not_previewable(self):
+        """A threshold recipe with regex selectors → supported:false: we can't
+        synthesize a series value guaranteed to match an arbitrary regex, so
+        previewing it would risk a silent false 'inactive'."""
+        r = dict(_THRESHOLD, selectors_re={"pod": "web-.*"})
+        out = rp.preview_recipe(r, "shop-a", {"value": 5000})
+        assert out["supported"] is False
+        assert out["states"] == []
+        assert any("selectors_re" in w or "regex" in w for w in out["warnings"])
+
+    def test_non_numeric_value_is_error(self):
+        """A non-numeric scenario value ("1+2" reads as promtool slope syntax)
+        → state:error, never a wrong verdict."""
+        out = rp.preview_recipe(_THRESHOLD, "shop-a", {"value": "1+2"})
+        assert out["states"][0]["state"] == "error"
+        assert "numeric" in out["states"][0]["reason"]
+
+    def test_oserror_during_eval_is_fail_closed(self, monkeypatch):
+        """promtool vanishing mid-run (OSError) → state:error, never a crash
+        or a wrong verdict (the fail-closed contract)."""
+        def boom(*a, **k):
+            raise FileNotFoundError("promtool disappeared")
+        monkeypatch.setattr(rp, "_PROMTOOL", "/nonexistent/promtool")
+        monkeypatch.setattr(rp.subprocess, "run", boom)
+        out = rp.preview_recipe(_THRESHOLD, "shop-a", {"value": 1500})
+        assert out["supported"] is True
+        assert out["states"][0]["state"] == "error"
+        assert "promtool eval failed" in out["states"][0]["reason"]
+
 
 # ── synthetic-input builder (pure; no promtool) ──
 
@@ -71,6 +100,15 @@ class TestBuildPreviewTest:
         doc, *_ = rp.build_preview_test(r, "shop-a", 1500, rp.shape.recipe_id(r))
         assert "eval_time: 35m" in doc          # 30 + 5
         assert "x40'" in doc                    # series length 30 + 10
+
+    def test_exact_selector_value_is_escaped(self):
+        """An exact-selector value is escaped via the compiler's own SSOT, so
+        the synthetic series matches the compiled `{k="..."}` matcher (a quote
+        left unescaped would make the series unparseable / a false 'inactive')."""
+        r = dict(_THRESHOLD, selectors={"path": 'a"b'})
+        doc, *_ = rp.build_preview_test(r, "shop-a", 1500, rp.shape.recipe_id(r))
+        esc = rp.shape._escape_value('a"b')     # compiler's canonical escaping
+        assert f'path="{esc}"' in doc
 
 
 # ── promtool result classification (pure; finding 2 — rc!=0 ≠ firing) ──
@@ -119,4 +157,12 @@ class TestWouldFire:
     def test_below_op_fires_under_threshold(self):
         r = dict(_THRESHOLD, **{"op": "<", "threshold": "100:warning"})
         out = rp.preview_recipe(r, "shop-a", {"value": 50})
+        assert out["states"][0]["state"] == "firing"
+
+    def test_exact_selector_fires_e2e(self):
+        """An exact selector still fires through the real compiler+promtool —
+        the synthetic series carries the selector label the rule joins on (the
+        coverage gap the adversarial review flagged)."""
+        r = dict(_THRESHOLD, selectors={"queue": "checkout"})
+        out = rp.preview_recipe(r, "shop-a", {"value": 1500})
         assert out["states"][0]["state"] == "firing"

--- a/tests/dx/test_recipe_preview.py
+++ b/tests/dx/test_recipe_preview.py
@@ -79,6 +79,15 @@ class TestGatingAndErrors:
         assert out["states"][0]["state"] == "error"
         assert "promtool eval failed" in out["states"][0]["reason"]
 
+    def test_unsupported_for_window_is_error(self, monkeypatch):
+        """If `for:` is valid for the compiler but unmapped in _FOR_MINUTES
+        (enum drift), fail closed to error — never silently shrink to 1m and
+        risk a false 'inactive' (CodeRabbit #873)."""
+        monkeypatch.setattr(rp, "_FOR_MINUTES", {"5m": 5})  # drop "1m"
+        out = rp.preview_recipe(_THRESHOLD, "shop-a", {"value": 1500})  # for: 1m
+        assert out["states"][0]["state"] == "error"
+        assert "for-window" in out["states"][0]["reason"]
+
 
 # ── synthetic-input builder (pure; no promtool) ──
 

--- a/tests/dx/test_recipe_preview.py
+++ b/tests/dx/test_recipe_preview.py
@@ -1,0 +1,122 @@
+"""Tests for recipe_preview.preview_recipe — recipe would-fire preview (#657 P2).
+
+The firing/inactive assertions need `promtool` (they go through the real
+compiler + promtool, the two-eval-homes rule) → scoped skip, NOT a module-level
+skip, so the gating / error / synthetic-input tests still run everywhere
+(the #655 lesson: a module-level promtool skip silently hides host coverage).
+"""
+import os
+import shutil
+import sys
+
+import pytest
+
+_DX = os.path.join(os.path.dirname(__file__), "..", "..", "scripts", "tools", "dx")
+sys.path.insert(0, _DX)
+import recipe_preview as rp  # noqa: E402
+
+_needs_promtool = pytest.mark.skipif(
+    shutil.which("promtool") is None, reason="promtool not on PATH"
+)
+
+_THRESHOLD = {
+    "recipe": "threshold", "metric": "order_queue_depth", "op": ">",
+    "window": "5m", "for": "1m", "threshold": "1000:warning", "name": "queue_depth_high",
+}
+_EQUALS = {
+    "recipe": "threshold", "metric": "mysql_semisync_master_last_errno", "op": "==",
+    "window": "5m", "for": "1m", "threshold": "1236:critical", "name": "errno_1236",
+}
+
+
+# ── per-type gating + error handling (no promtool needed — run everywhere) ──
+
+class TestGatingAndErrors:
+    def test_unsupported_recipe_type_not_compiled(self):
+        """rate/ratio/forecast/absence/p99 → supported:false, no compile, no states."""
+        rate = {"recipe": "rate", "metric": "http_requests_total", "op": ">",
+                "window": "5m", "threshold": "1:warning", "name": "r"}
+        out = rp.preview_recipe(rate, "shop-a", {"value": 5})
+        assert out["supported"] is False
+        assert out["states"] == []
+        assert any("rate" in w for w in out["warnings"])
+
+    def test_malformed_recipe_is_error_not_firing(self):
+        """A structurally invalid recipe → state:error (never mislabeled firing)."""
+        bad = {"recipe": "threshold", "metric": "not a metric", "op": ">",
+               "window": "5m", "threshold": "1:warning", "name": "bad"}
+        out = rp.preview_recipe(bad, "shop-a", {"value": 5})
+        assert out["supported"] is True
+        assert out["states"][0]["state"] == "error"
+        assert "metric" in out["states"][0]["reason"]
+
+
+# ── synthetic-input builder (pure; no promtool) ──
+
+class TestBuildPreviewTest:
+    def test_label_correct_graph(self):
+        """The synthetic test carries the 3-series label-correct graph + slug."""
+        slug = rp.shape.recipe_id(_THRESHOLD)
+        doc, severity, mode, thr = rp.build_preview_test(_THRESHOLD, "shop-a", 1500, slug)
+        assert severity == "warning" and thr == "1000"
+        assert f"recipe_id=\"{slug}\"" in doc
+        assert "order_queue_depth{tenant=\"shop-a\"}" in doc
+        assert "user_threshold{" in doc and "tenant_metadata_info{" in doc
+        assert "exp_alerts: []" in doc          # inverted-assert
+        assert f"alertname: Custom_{slug}" in doc
+
+    def test_for_window_sizes_eval_time(self):
+        """A longer `for:` pushes eval_time past the pending window."""
+        r = dict(_THRESHOLD, **{"for": "30m"})
+        doc, *_ = rp.build_preview_test(r, "shop-a", 1500, rp.shape.recipe_id(r))
+        assert "eval_time: 35m" in doc          # 30 + 5
+        assert "x40'" in doc                    # series length 30 + 10
+
+
+# ── promtool result classification (pure; finding 2 — rc!=0 ≠ firing) ──
+
+class TestClassifyPromtoolResult:
+    def test_rc0_is_inactive(self):
+        assert rp.classify_promtool_result(0, "Unit Testing: t\nSUCCESS") == "inactive"
+
+    def test_mismatch_signature_is_firing(self):
+        out = ("  FAILED:\n    alertname: Custom_x, time: 6m, \n        exp:[], \n"
+               "        got:[\n  0:\n    Labels:{alertname=\"Custom_x\"}\n  ]")
+        assert rp.classify_promtool_result(1, out) == "firing"
+
+    def test_nonzero_without_marker_is_error_not_firing(self):
+        # OOM-kill / missing binary / test-file parse error all exit non-zero
+        # but must NOT be mislabeled as firing (finding 2).
+        assert rp.classify_promtool_result(137, "Killed") == "error"
+        assert rp.classify_promtool_result(1, "error loading test file: yaml: line 3") == "error"
+
+
+# ── end-to-end firing/inactive (needs promtool) ──
+
+@_needs_promtool
+class TestWouldFire:
+    def test_threshold_fires_above(self):
+        out = rp.preview_recipe(_THRESHOLD, "shop-a", {"value": 1500})
+        assert out["supported"] is True
+        assert out["states"][0]["state"] == "firing"
+        assert out["states"][0]["severity"] == "warning"
+        assert out["alertname"] == "Custom_" + rp.shape.recipe_id(_THRESHOLD)
+
+    def test_threshold_inactive_below(self):
+        out = rp.preview_recipe(_THRESHOLD, "shop-a", {"value": 500})
+        assert out["states"][0]["state"] == "inactive"
+
+    def test_equals_fires_on_exact_match(self):
+        out = rp.preview_recipe(_EQUALS, "shop-a", {"value": 1236})
+        assert out["states"][0]["state"] == "firing"
+        assert out["states"][0]["severity"] == "critical"
+
+    def test_equals_inactive_on_mismatch(self):
+        """1593 != 1236 → inactive (== is exact, not >=)."""
+        out = rp.preview_recipe(_EQUALS, "shop-a", {"value": 1593})
+        assert out["states"][0]["state"] == "inactive"
+
+    def test_below_op_fires_under_threshold(self):
+        r = dict(_THRESHOLD, **{"op": "<", "threshold": "100:warning"})
+        out = rp.preview_recipe(r, "shop-a", {"value": 50})
+        assert out["states"][0]["state"] == "firing"


### PR DESCRIPTION
## 目的

#657 would-fire 預覽的 **P2 後端核心**（P1 設計 + 契約已於 #868 落地）。給定**一條** recipe + 一個情境值，回答「這條會不會觸發？」——走平台**同一套權威引擎**（`compile_custom_alerts.build_pack` + `promtool`），不另外重寫 eval（設計文件的 two-eval-homes 原則）。

## 變更

- **`scripts/tools/dx/recipe_preview.py`**（library module，無 CLI）
  - `preview_recipe(recipe, tenant, scenario)` → 契約 dict `{alertname, supported, states, warnings}`，`state ∈ firing | inactive | error`
  - **MVP 範圍**：`threshold` recipe（`>`, `>=`, `<`, `<=`, `==`）——非時間相依，flat 常數序列即正確充分；時間相依型別（rate / ratio / forecast / absence / p99）回 `supported:false`，留待 P3
  - **fail-closed 分層**：`build_pack` 例外 → `error`；`promtool check rules`（語法）→ `error`；最後才跑倒置斷言——編譯／基礎設施失敗**絕不**被誤標成「觸發」
  - `classify_promtool_result`：rc 0 → inactive；rc≠0 **須同時**有 `FAILED:` + `got:[` 簽章才算 firing（OOM／找不到 binary／解析錯也會 rc≠0 → `error`），promtool 2.53.2 實測
  - eval 時間設在 recipe `for:` 視窗之後，pending 不會被誤判成「不會觸發」
- **`tests/dx/test_recipe_preview.py`**：12 pytest（gating／error／builder／classify 到處跑；firing/inactive 由 promtool gate，沿用 #655「不要 module-level skip 藏 host 覆蓋」教訓）
- **`docs/internal/tool-map.md`**：新增 `recipe_preview.py` 條目（自動重生）

## 驗證

- ✅ 12 pytest pass（dev container，promtool 在場）
- ✅ `bump_docs --check` 一致、mkdocs strict PASS、tool-map drift gate 綠
- ✅ pre-commit 全綠（subprocess timeout audit FATAL、hardcoded-tenant、commitlint…）

## 不在本 PR / 接下來

- facade preview service 接線（HTTP `POST /preview` → 本核心）
- P3：時間相依型別的 recipe-type-aware 合成序列
- 本核心非 user-facing（無 CLI、未接線），依 #868 先例不單獨寫 CHANGELOG；待功能整體 ship 時 distill 成一條

Refs #657 · 延續 #868（P1 設計 + 契約凍結）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
