### PR TITLE
feat: lint — configmap-rules-* must be mounted in Prometheus (#869 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,9 @@ jobs:
       - name: "Rule-pack 3-copy sync incl. operator (HARD gate — ADR-024 PR3-pre)"
         run: python scripts/tools/lint/check_rulepack_sync.py --ci
 
+      - name: "ConfigMap mount completeness (#869 dead-rule guard)"
+        run: python scripts/tools/lint/check_configmap_mount_completeness.py --ci
+
       # #741 S3b: the deployed custom-alert pack is COMPILED from the live conf.d
       # _custom_alerts (not hand-edited). This is the source→pack drift gate that
       # sits upstream of the configmap/operator copies above — edit a tenant's

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -784,6 +784,14 @@ repos:
         # branch. Source-only: configmaps are sync-checked against source
         # separately. Semantic proof: tests/rulepacks/*-void_test.yaml.
 
+      - id: configmap-mount-completeness
+        name: "Every configmap-rules-* must be mounted in Prometheus projected volume (#869 dead-rule guard)"
+        entry: python3 -X utf8 scripts/tools/lint/check_configmap_mount_completeness.py --ci
+        language: python
+        pass_filenames: false
+        additional_dependencies: ['pyyaml']
+        files: ^k8s/03-monitoring/(configmap-rules-.*\.yaml|deployment-prometheus\.yaml)$
+
       - id: rulepack-configmap-drift
         name: "ADR-024: configmap-rules-*.yaml must match rule-packs/ source (Commit 4 hard gate)"
         entry: python3 -X utf8 scripts/tools/dx/generate_rulepack_configmaps.py --check

--- a/docs/internal/tool-map.en.md
+++ b/docs/internal/tool-map.en.md
@@ -83,6 +83,7 @@ lang: en
 | Tool | Description |
 |------|------|
 | `_atomic_write.py` | Atomic write helper for regen tools (v2.8.0 Trap #60 mitigation). |
+| `_recipe_preview.py` | recipe would-fire preview core (#657 P2). |
 | `add_frontmatter.py` | Add YAML front matter to documentation files for MkDocs/Docusaurus integration. |
 | `analyze_bench_history.py` | Aggregate bench-record nightly history into per-benchmark stats. |
 | `analyze_tier1_fp_rate.py` | Tier 1 bench-gate friction-rate observer (issue #433 W3). |
@@ -142,6 +143,7 @@ lang: en
 | `check_codename_gate.py` | Layer 2 glossary-driven codename gate (#469). |
 | `check_codename_leak.py` | Block internal codenames from leaking to user-facing files. |
 | `check_commit_scope_doc.py` | Commit-scope doc drift gate (L1 pre-commit hook + validate_all integration). |
+| `check_configmap_mount_completeness.py` | Guard: every `configmap-rules-*.yaml` must be mounted into Prometheus. |
 | `check_design_token_usage.py` | JSX 設計 token 使用完整性 lint |
 | `check_dev_bypass_manifest.py` | ADR-022 Layer 4 (deploy-time guard). |
 | `check_dev_rules_enforcement.py` | detect doc-drift in dev-rules.md. |

--- a/docs/internal/tool-map.md
+++ b/docs/internal/tool-map.md
@@ -143,6 +143,7 @@ lang: zh
 | `check_codename_gate.py` | Layer 2 glossary-driven codename gate (#469). |
 | `check_codename_leak.py` | Block internal codenames from leaking to user-facing files. |
 | `check_commit_scope_doc.py` | Commit-scope doc drift gate (L1 pre-commit hook + validate_all integration). |
+| `check_configmap_mount_completeness.py` | Guard: every `configmap-rules-*.yaml` must be mounted into Prometheus. |
 | `check_design_token_usage.py` | JSX 設計 token 使用完整性 lint |
 | `check_dev_bypass_manifest.py` | ADR-022 Layer 4 (deploy-time guard). |
 | `check_dev_rules_enforcement.py` | detect doc-drift in dev-rules.md. |

--- a/scripts/tools/lint/check_configmap_mount_completeness.py
+++ b/scripts/tools/lint/check_configmap_mount_completeness.py
@@ -95,11 +95,13 @@ def deployment_mounts(deployment_path: Path) -> Dict[str, Set[str]]:
     return out
 
 
-def check(monitor_dir: Path, deployment_path: Path) -> List[str]:
-    """Return a list of human-readable violation strings (empty = ok)."""
+def check(packs: Dict[str, Set[str]], mounts: Dict[str, Set[str]]) -> List[str]:
+    """Return a list of human-readable violation strings (empty = ok).
+
+    `packs` / `mounts` are precomputed by the caller (configmap_rule_packs /
+    deployment_mounts) so each manifest is parsed exactly once.
+    """
     violations: List[str] = []
-    packs = configmap_rule_packs(monitor_dir)
-    mounts = deployment_mounts(deployment_path)
 
     for name, data_keys in sorted(packs.items()):
         if name not in mounts:
@@ -145,12 +147,14 @@ def main(argv: List[str] | None = None) -> int:
         return EXIT_CALLER_ERROR
 
     try:
-        violations = check(monitor_dir, deployment)
+        packs = configmap_rule_packs(monitor_dir)
+        mounts = deployment_mounts(deployment)
+        violations = check(packs, mounts)
     except yaml.YAMLError as exc:
         print(f"Error: failed to parse YAML: {exc}", file=sys.stderr)
         return EXIT_CALLER_ERROR
 
-    n_packs = len(configmap_rule_packs(monitor_dir))
+    n_packs = len(packs)
     if violations:
         print(f"ConfigMap mount completeness: {len(violations)} violation(s) "
               f"across {n_packs} configmap-rules-* pack(s):", file=sys.stderr)

--- a/scripts/tools/lint/check_configmap_mount_completeness.py
+++ b/scripts/tools/lint/check_configmap_mount_completeness.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Guard: every `configmap-rules-*.yaml` must be mounted into Prometheus.
+
+The `rules` projected volume in `k8s/03-monitoring/deployment-prometheus.yaml`
+is a hand-maintained **by-name** list of `configMap` sources. A new rule-pack
+ConfigMap (e.g. `configmap-rules-liveness.yaml`) that is NOT added to that list
+is silently never projected into `/etc/prometheus/rules/*.yml` → its alert/
+recording rules are dead code in the actual deployment, even though promtool
+unit tests (which point straight at the rule YAML) stay green.
+
+This burned #869: `prometheus-rules-liveness` shipped but unmounted →
+`TenantExporterAbsent` never loaded in prod. No existing check caught it
+(promtool tests expr semantics; check_doc_k8s_refs validates doc→manifest
+paths; the 3-copy gate compares rule-pack↔configmap↔operator — none verify
+configmap→projected-volume mount completeness).
+
+Checks (per configmap-rules-*.yaml):
+  1. its `metadata.name` MUST appear as a `configMap.name` in the deployment's
+     `rules` projected volume — else the whole pack is unmounted (VIOLATION).
+  2. every `items[].key` the deployment projects for that ConfigMap MUST be a
+     real `data:` key (else the path projects nothing → rule file missing).
+  3. every `data:` key in the ConfigMap MUST be projected by some `items[].key`
+     (else that rule file is silently dropped even though the pack is mounted).
+
+Exit codes: 0 ok / 1 violation / 2 caller error (see _lib_exitcodes).
+
+Usage:
+    python3 scripts/tools/lint/check_configmap_mount_completeness.py            # human
+    python3 scripts/tools/lint/check_configmap_mount_completeness.py --ci       # CI
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List, Set
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # scripts/tools
+from _lib_exitcodes import EXIT_CALLER_ERROR, EXIT_OK, EXIT_VIOLATION  # noqa: E402
+
+MONITOR_DIR = Path("k8s/03-monitoring")
+DEPLOYMENT = MONITOR_DIR / "deployment-prometheus.yaml"
+RULES_VOLUME_NAME = "rules"
+
+# `configmap-rules-custom-*.yaml` are tenant/customer-managed packs (migrate_rule.py
+# exports), NOT platform gold-standard packs — the deployment projected volume is a
+# hand-maintained list of platform packs only; custom packs are mounted/applied by
+# the customer or compiled dynamically (see deployment-prometheus.yaml header note:
+# "大型客戶可…改用 migrate_rule.py 轉出的 自訂規則包"). They are out of scope for the
+# "platform forgot to mount a new gold-standard pack" guard this lint enforces.
+CUSTOMER_MANAGED_PREFIX = "configmap-rules-custom-"
+
+
+def configmap_rule_packs(monitor_dir: Path) -> Dict[str, Set[str]]:
+    """{metadata.name: {data keys}} for every configmap-rules-*.yaml."""
+    out: Dict[str, Set[str]] = {}
+    for path in sorted(monitor_dir.glob("configmap-rules-*.yaml")):
+        if path.name.startswith(CUSTOMER_MANAGED_PREFIX):
+            continue  # customer-managed, not in the platform gold-standard mount list
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(doc, dict) or doc.get("kind") != "ConfigMap":
+            continue
+        name = ((doc.get("metadata") or {}).get("name")) or ""
+        data = doc.get("data")
+        keys = set(data.keys()) if isinstance(data, dict) else set()
+        if name:
+            out[str(name)] = keys
+    return out
+
+
+def deployment_mounts(deployment_path: Path) -> Dict[str, Set[str]]:
+    """{configMap.name: {projected items[].key}} from the `rules` projected volume."""
+    out: Dict[str, Set[str]] = {}
+    for doc in yaml.safe_load_all(deployment_path.read_text(encoding="utf-8")):
+        if not isinstance(doc, dict) or doc.get("kind") != "Deployment":
+            continue
+        volumes = (((doc.get("spec") or {}).get("template") or {}).get("spec") or {}).get("volumes") or []
+        for vol in volumes:
+            if not isinstance(vol, dict) or vol.get("name") != RULES_VOLUME_NAME:
+                continue
+            sources = ((vol.get("projected") or {}).get("sources")) or []
+            for src in sources:
+                cm = (src or {}).get("configMap") if isinstance(src, dict) else None
+                if not isinstance(cm, dict):
+                    continue
+                name = cm.get("name")
+                if not name:
+                    continue
+                items = cm.get("items") or []
+                keys = {it.get("key") for it in items if isinstance(it, dict) and it.get("key")}
+                # No `items:` means the whole ConfigMap is projected (all keys).
+                out[str(name)] = keys
+    return out
+
+
+def check(monitor_dir: Path, deployment_path: Path) -> List[str]:
+    """Return a list of human-readable violation strings (empty = ok)."""
+    violations: List[str] = []
+    packs = configmap_rule_packs(monitor_dir)
+    mounts = deployment_mounts(deployment_path)
+
+    for name, data_keys in sorted(packs.items()):
+        if name not in mounts:
+            violations.append(
+                f"ConfigMap '{name}' (configmap-rules-*.yaml) is NOT mounted in "
+                f"{deployment_path}'s '{RULES_VOLUME_NAME}' projected volume → its rules "
+                f"are never loaded by Prometheus (dead code). Add a configMap source for it."
+            )
+            continue
+        item_keys = mounts[name]
+        if not item_keys:
+            # whole-ConfigMap projection: every data key reaches /etc/prometheus/rules
+            continue
+        for k in sorted(item_keys - data_keys):
+            violations.append(
+                f"ConfigMap '{name}': projected items[].key '{k}' has no matching data: "
+                f"key → that path projects nothing (rule file missing). Fix the key/path."
+            )
+        for k in sorted(data_keys - item_keys):
+            violations.append(
+                f"ConfigMap '{name}': data: key '{k}' is not projected by any items[].key → "
+                f"that rule file is silently dropped. Add an items entry (key+path)."
+            )
+    return violations
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--ci", action="store_true", help="CI mode (machine-terse output)")
+    parser.add_argument("--monitor-dir", type=Path, default=MONITOR_DIR)
+    parser.add_argument("--deployment", type=Path, default=None,
+                        help="override deployment manifest (default: <monitor-dir>/deployment-prometheus.yaml)")
+    args = parser.parse_args(argv)
+
+    monitor_dir: Path = args.monitor_dir
+    deployment: Path = args.deployment or (monitor_dir / "deployment-prometheus.yaml")
+
+    if not monitor_dir.is_dir():
+        print(f"Error: monitor dir not found: {monitor_dir}", file=sys.stderr)
+        return EXIT_CALLER_ERROR
+    if not deployment.is_file():
+        print(f"Error: deployment manifest not found: {deployment}", file=sys.stderr)
+        return EXIT_CALLER_ERROR
+
+    try:
+        violations = check(monitor_dir, deployment)
+    except yaml.YAMLError as exc:
+        print(f"Error: failed to parse YAML: {exc}", file=sys.stderr)
+        return EXIT_CALLER_ERROR
+
+    n_packs = len(configmap_rule_packs(monitor_dir))
+    if violations:
+        print(f"ConfigMap mount completeness: {len(violations)} violation(s) "
+              f"across {n_packs} configmap-rules-* pack(s):", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return EXIT_VIOLATION
+
+    if not args.ci:
+        print(f"ConfigMap mount completeness: {n_packs} configmap-rules-* pack(s) "
+              f"all mounted in {deployment.name} with matching keys.")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/lint/check_configmap_mount_completeness.py
+++ b/scripts/tools/lint/check_configmap_mount_completeness.py
@@ -52,6 +52,12 @@ RULES_VOLUME_NAME = "rules"
 # "platform forgot to mount a new gold-standard pack" guard this lint enforces.
 CUSTOMER_MANAGED_PREFIX = "configmap-rules-custom-"
 
+# Prometheus loads rules via `rule_files: /etc/prometheus/rules/*.yml`
+# (configmap-prometheus.yaml:33). A projected `path:` (or, for whole-ConfigMap
+# projection, a data key) that does NOT end with this suffix is mounted but never
+# globbed → silently dead code — one layer deeper than "is it mounted at all".
+RULE_FILE_GLOB_SUFFIX = ".yml"
+
 
 def configmap_rule_packs(monitor_dir: Path) -> Dict[str, Set[str]]:
     """{metadata.name: {data keys}} for every configmap-rules-*.yaml."""
@@ -70,9 +76,12 @@ def configmap_rule_packs(monitor_dir: Path) -> Dict[str, Set[str]]:
     return out
 
 
-def deployment_mounts(deployment_path: Path) -> Dict[str, Set[str]]:
-    """{configMap.name: {projected items[].key}} from the `rules` projected volume."""
-    out: Dict[str, Set[str]] = {}
+def deployment_mounts(deployment_path: Path) -> Dict[str, Dict[str, str]]:
+    """{configMap.name: {projected items[].key: path}} from the `rules` projected volume.
+
+    An empty inner dict means no `items:` → the whole ConfigMap is projected.
+    """
+    out: Dict[str, Dict[str, str]] = {}
     for doc in yaml.safe_load_all(deployment_path.read_text(encoding="utf-8")):
         if not isinstance(doc, dict) or doc.get("kind") != "Deployment":
             continue
@@ -89,9 +98,13 @@ def deployment_mounts(deployment_path: Path) -> Dict[str, Set[str]]:
                 if not name:
                     continue
                 items = cm.get("items") or []
-                keys = {it.get("key") for it in items if isinstance(it, dict) and it.get("key")}
-                # No `items:` means the whole ConfigMap is projected (all keys).
-                out[str(name)] = keys
+                # {key: projected path}; path defaults to key when omitted.
+                key_paths = {
+                    str(it["key"]): str(it.get("path", it["key"]))
+                    for it in items
+                    if isinstance(it, dict) and it.get("key")
+                }
+                out[str(name)] = key_paths
     return out
 
 
@@ -107,14 +120,23 @@ def check(packs: Dict[str, Set[str]], mounts: Dict[str, Set[str]]) -> List[str]:
         if name not in mounts:
             violations.append(
                 f"ConfigMap '{name}' (configmap-rules-*.yaml) is NOT mounted in "
-                f"{deployment_path}'s '{RULES_VOLUME_NAME}' projected volume → its rules "
+                f"{DEPLOYMENT.name}'s '{RULES_VOLUME_NAME}' projected volume → its rules "
                 f"are never loaded by Prometheus (dead code). Add a configMap source for it."
             )
             continue
-        item_keys = mounts[name]
-        if not item_keys:
-            # whole-ConfigMap projection: every data key reaches /etc/prometheus/rules
+        key_paths = mounts[name]
+        if not key_paths:
+            # whole-ConfigMap projection: each data key becomes a file named after the
+            # key, so each key must itself end with the rule_files glob suffix.
+            for k in sorted(data_keys):
+                if not k.endswith(RULE_FILE_GLOB_SUFFIX):
+                    violations.append(
+                        f"ConfigMap '{name}': data: key '{k}' (whole-ConfigMap projection → "
+                        f"filename) does not end with '{RULE_FILE_GLOB_SUFFIX}' → Prometheus "
+                        f"rule_files glob ignores it (dead code)."
+                    )
             continue
+        item_keys = set(key_paths)
         for k in sorted(item_keys - data_keys):
             violations.append(
                 f"ConfigMap '{name}': projected items[].key '{k}' has no matching data: "
@@ -125,6 +147,14 @@ def check(packs: Dict[str, Set[str]], mounts: Dict[str, Set[str]]) -> List[str]:
                 f"ConfigMap '{name}': data: key '{k}' is not projected by any items[].key → "
                 f"that rule file is silently dropped. Add an items entry (key+path)."
             )
+        for k in sorted(item_keys):
+            path = key_paths[k]
+            if path and not path.endswith(RULE_FILE_GLOB_SUFFIX):
+                violations.append(
+                    f"ConfigMap '{name}': projected items[].path '{path}' (key '{k}') does not "
+                    f"end with '{RULE_FILE_GLOB_SUFFIX}' → mounted but Prometheus rule_files "
+                    f"glob ignores it (dead code). Fix the path extension."
+                )
     return violations
 
 


### PR DESCRIPTION
## 這是什麼

防「新增 rule-pack ConfigMap 但忘了掛進 Prometheus」的 silent gap 的新 lint（pre-commit + CI）。

**背景**：#869（[PR #878](https://github.com/vencil/Dynamic-Alerting-Integrations/pull/878)）踩過——新增 `configmap-rules-liveness.yaml`（ConfigMap `prometheus-rules-liveness`）但忘了加進 `deployment-prometheus.yaml` 的 `rules` projected volume（by-name 手維護清單）→ 主規則 `TenantExporterAbsent` 在實際部署完全不載入 = **dead code**。**現有 CI 完全攔不到**（promtool 只測 expr 語意、`check_doc_k8s_refs` 只驗 doc→manifest 路徑、3-copy 只比 rule-pack↔configmap↔operator）。

## `check_configmap_mount_completeness.py`

對每個 `k8s/03-monitoring/configmap-rules-*.yaml`：
1. 其 `metadata.name` 必須出現在 deployment 的 `rules` projected volume 的某個 `configMap.name` — 缺 → exit 1「未掛載 = dead code」。
2. deployment 為它投影的每個 `items[].key` 必須是真的 `data:` key（防 key→path 寫錯，rule 檔投影不出來）。
3. 它的每個 `data:` key 必須被某 `items[].key` 投影（防整個 rule 檔被靜默漏掉）。

**排除** `configmap-rules-custom-*.yaml`：客戶自管（`migrate_rule.py` 轉出），非平台 gold-standard 清單（見 deployment header 註解）— 否則對 `custom-alerts` 是 false positive。

## 驗收（已測）
- 當前 15 個 gold-standard 包全掛載 + key 對齊 → **exit 0**。
- 故意放一個未掛載的 ConfigMap → **exit 1** 並指名。

wire：pre-commit（`files:` 涵蓋 configmap-rules-* + deployment-prometheus）+ ci.yml drift job + tool-map 登錄。exit code 用 `_lib_exitcodes`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
