### PR TITLE
feat: recipe-preview helm chart + L4 SAST parity (#657)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,7 @@ jobs:
 
   iac-helm-sast:
     # Container/k8s SAST Layers 2 + 4 (#448 / TRK-312 + TRK-314).
-    #   L2 (Helm template): renders 9 charts via helm + kube-linter (~1-2 min).
+    #   L2 (Helm template): renders 10 charts via helm + kube-linter (~1-2 min).
     #   L4 (raw k8s): kube-linter on k8s/ raw manifests (no render, ~3-5s).
     # Both run in this one job because they share the kube-linter engine setup
     # below; dedicated (not folded into Lint) so the slow render doesn't gate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -148,7 +148,7 @@ repos:
       # + source scan for ALLOW_EMPTY/INSECURE (Mode A) + capabilities.add
       # rule. Severity->action with a CENTRALIZED exemption registry (in
       # check_iac_helm.py; mirrored to docs/internal/iac-lint-baseline.md).
-      # MANUAL stage on purpose: rendering 9 charts via helm+kube-linter is
+      # MANUAL stage on purpose: rendering 10 charts via helm+kube-linter is
       # ~1-2 min — too slow for every commit. The hard gate is the dedicated
       # CI job "Container SAST L2 (Helm)" in ci.yml; run locally on demand:
       #   pre-commit run iac-helm-sast-check --hook-stage manual --all-files

--- a/helm/recipe-preview/Chart.yaml
+++ b/helm/recipe-preview/Chart.yaml
@@ -2,6 +2,10 @@ apiVersion: v2
 name: recipe-preview            # → Service name "recipe-preview" (matches da-portal recipePreviewUrl)
 description: Would-fire preview service for the Dynamic Alerting Platform (#657)
 type: application
+# version / appVersion are PROVISIONAL. recipe-preview bundles the platform
+# compiler, so at release it is "sync-bumped" to the platform version (like
+# exporter/portal) — the release wiring (PR-D2) sets these so the derived image
+# tag (v<appVersion>) matches the published recipe-preview/v<platform> image.
 version: 0.1.0
 appVersion: "0.1.0"
 home: https://github.com/vencil/Dynamic-Alerting-Integrations

--- a/helm/recipe-preview/Chart.yaml
+++ b/helm/recipe-preview/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: recipe-preview            # → Service name "recipe-preview" (matches da-portal recipePreviewUrl)
+description: Would-fire preview service for the Dynamic Alerting Platform (#657)
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/vencil/Dynamic-Alerting-Integrations
+maintainers:
+  - name: vencil

--- a/helm/recipe-preview/templates/_helpers.tpl
+++ b/helm/recipe-preview/templates/_helpers.tpl
@@ -1,0 +1,26 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "recipe-preview.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "recipe-preview.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/name: {{ include "recipe-preview.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: dynamic-alerting
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "recipe-preview.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "recipe-preview.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/recipe-preview/templates/deployment.yaml
+++ b/helm/recipe-preview/templates/deployment.yaml
@@ -33,6 +33,13 @@ spec:
               drop:
                 - ALL
           env:
+            # promtool is Go: pre-Go-1.25 it sets GOMAXPROCS to the NODE's CPU
+            # count (NOT this cgroup's cpu limit), so on a many-core node a light
+            # `promtool test` would spin up dozens of OS threads thrashing in this
+            # ~200m-CPU cgroup. Pin to the cpu limit — one short rule-eval needs no
+            # parallelism. (Python ignores GOMAXPROCS; only the promtool child reads it.)
+            - name: GOMAXPROCS
+              value: "1"
             - name: PREVIEW_TENANT_API_URL
               value: {{ .Values.tenantApiUrl | quote }}
             - name: PREVIEW_LISTEN_PORT

--- a/helm/recipe-preview/templates/deployment.yaml
+++ b/helm/recipe-preview/templates/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "recipe-preview.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "recipe-preview.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "recipe-preview.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "recipe-preview.labels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "recipe-preview.name" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: recipe-preview
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: PREVIEW_TENANT_API_URL
+              value: {{ .Values.tenantApiUrl | quote }}
+            - name: PREVIEW_LISTEN_PORT
+              value: {{ .Values.service.port | quote }}
+            - name: PREVIEW_MAX_CONCURRENCY
+              value: {{ .Values.preview.maxConcurrency | quote }}
+            - name: PREVIEW_RATE_LIMIT_PER_MIN
+              value: {{ .Values.preview.rateLimitPerMin | quote }}
+            - name: PREVIEW_MAX_BODY_BYTES
+              value: {{ .Values.preview.maxBodyBytes | quote }}
+            - name: PREVIEW_REQUEST_TIMEOUT
+              value: {{ .Values.preview.requestTimeout | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          volumeMounts:
+            # readOnlyRootFilesystem: true → promtool needs a writable /tmp for its
+            # synthetic rule + data files (the eval core uses tempfile.mkdtemp).
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            failureThreshold: 3
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 32Mi

--- a/helm/recipe-preview/templates/networkpolicy.yaml
+++ b/helm/recipe-preview/templates/networkpolicy.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "recipe-preview.name" . }}-netpol
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "recipe-preview.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "recipe-preview.selectorLabels" . | nindent 6 }}
+  # Ingress-only (mirrors tenant-api's default posture). recipe-preview blindly
+  # trusts the X-Forwarded-* identity headers, so the load-bearing security control
+  # is that ONLY the da-portal pod (the same-origin /preview proxy) may reach :8082.
+  # Any other pod reaching it directly could spoof identity. (Egress restriction —
+  # to tenant-api + DNS only — is a hardening follow-up; left open here so the
+  # /access call can't break on a mis-specified egress rule.)
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ .Values.networkPolicy.daPortalName }}
+      ports:
+        - port: {{ .Values.service.port }}
+          protocol: TCP
+{{- end }}

--- a/helm/recipe-preview/templates/service.yaml
+++ b/helm/recipe-preview/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "recipe-preview.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "recipe-preview.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "recipe-preview.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP

--- a/helm/recipe-preview/templates/serviceaccount.yaml
+++ b/helm/recipe-preview/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "recipe-preview.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "recipe-preview.labels" . | nindent 4 }}
+# recipe-preview makes NO in-cluster Kubernetes API calls (it talks to tenant-api
+# over HTTP, not the API server), so it never needs a mounted SA token.
+automountServiceAccountToken: false

--- a/helm/recipe-preview/values.yaml
+++ b/helm/recipe-preview/values.yaml
@@ -1,0 +1,65 @@
+# recipe-preview — would-fire preview service (#657)
+# A small stateless PEP: it answers POST /preview by running the platform's
+# compiler + promtool, delegating tenant authz to tenant-api's /access probe.
+# It sits behind the da-portal same-origin /preview proxy (no own oauth2-proxy)
+# and trusts the portal-forwarded X-Forwarded-* identity headers.
+#
+# DEPLOY CONTRACT: install into the `monitoring` namespace
+# (`helm install recipe-preview ./helm/recipe-preview/ -n monitoring`) — da-portal's
+# `recipePreviewUrl` hardcodes recipe-preview.monitoring.svc.cluster.local:8082, so
+# the Service name (= Chart.Name, stable regardless of release name) + namespace
+# must resolve to that FQDN or the portal's /preview proxy gets a 502.
+
+# In-memory per-tenant rate limiter is per-replica (app.py RateLimiter); >1 replica
+# multiplies the effective per-tenant ceiling. Keep at 1 unless a shared store lands.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/vencil/recipe-preview
+  # tag "" → derived "v{{ .Chart.AppVersion }}" (the tested image-tag invariant, #682).
+  # Do NOT hardcode a tag here.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 8082                    # single port; matches da-portal recipePreviewUrl :8082
+
+# tenant-api base URL the PEP calls for the /access authz probe.
+tenantApiUrl: "http://tenant-api.monitoring.svc.cluster.local:8080"
+
+# §6 guardrails (app.py env). These match the binary defaults; override if needed.
+preview:
+  maxConcurrency: 4
+  rateLimitPerMin: 30
+  maxBodyBytes: 65536
+  requestTimeout: 60
+  # NB: PREVIEW_DEV_BYPASS_AUTH is deliberately NOT templated. The app refuses to
+  # start if it is truthy inside Kubernetes (ADR-022 containment); leaving it unset
+  # is correct-by-construction in prod.
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    # Headroom for up to PREVIEW_MAX_CONCURRENCY (4) concurrent promtool
+    # subprocesses (~30-40Mi each) + the Python parent. 128Mi could OOMKill
+    # under full concurrent preview load — keep this >= maxConcurrency * ~40Mi.
+    memory: 256Mi
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
+
+networkPolicy:
+  enabled: true
+  # recipe-preview blindly trusts X-Forwarded-Email, so ingress MUST be locked to
+  # the da-portal pod (the same-origin /preview proxy) — the anti-spoof boundary.
+  daPortalName: da-portal
+
+podAnnotations: {}              # no /metrics endpoint yet (deferred), so no scrape annotations

--- a/helm/recipe-preview/values.yaml
+++ b/helm/recipe-preview/values.yaml
@@ -25,8 +25,11 @@ service:
   type: ClusterIP
   port: 8082                    # single port; matches da-portal recipePreviewUrl :8082
 
-# tenant-api base URL the PEP calls for the /access authz probe.
-tenantApiUrl: "http://tenant-api.monitoring.svc.cluster.local:8080"
+# tenant-api base URL the PEP calls for the /access authz probe. Short same-
+# namespace name (NOT the .cluster.local FQDN) for DNS portability — clusters with
+# a custom DNS domain still resolve it via the pod's search domain; also matches
+# app.py's own default. Override with an FQDN for a cross-namespace tenant-api.
+tenantApiUrl: "http://tenant-api:8080"
 
 # §6 guardrails (app.py env). These match the binary defaults; override if needed.
 preview:

--- a/scripts/tools/lint/check_dev_bypass_manifest.py
+++ b/scripts/tools/lint/check_dev_bypass_manifest.py
@@ -39,7 +39,10 @@ from _lib_exitcodes import EXIT_OK, EXIT_VIOLATION  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 SCAN_DIRS = ("helm", "k8s", "operator-manifests")
-FORBIDDEN = re.compile(r"(?i)(TA_DEV_BYPASS_AUTH|dev-bypass-auth)")
+# tenant-api uses TA_DEV_BYPASS_AUTH / --dev-bypass-auth; recipe-preview (#657) uses
+# PREVIEW_DEV_BYPASS_AUTH. Both are local-dev-only escape hatches that must never
+# appear in a deployable manifest (ADR-022 L4); list every component's token here.
+FORBIDDEN = re.compile(r"(?i)(TA_DEV_BYPASS_AUTH|PREVIEW_DEV_BYPASS_AUTH|dev-bypass-auth)")
 
 
 def find_violations(root: Path | None = None) -> list[tuple[str, int, str]]:

--- a/tests/helm/test_image_tag_derivation.py
+++ b/tests/helm/test_image_tag_derivation.py
@@ -35,6 +35,7 @@ _CHARTS = [
     ("helm/threshold-exporter", "ghcr.io/vencil/threshold-exporter"),
     ("helm/tenant-api", "ghcr.io/vencil/tenant-api"),
     ("helm/da-portal", "ghcr.io/vencil/da-portal"),
+    ("helm/recipe-preview", "ghcr.io/vencil/recipe-preview"),
 ]
 
 _DERIVE_RE = re.compile(

--- a/tests/lint/test_check_dev_bypass_manifest.py
+++ b/tests/lint/test_check_dev_bypass_manifest.py
@@ -35,6 +35,19 @@ def test_flags_env_var_in_helm_template(tmp_path: Path):
     assert "deployment.yaml" in v[0][0]
 
 
+def test_flags_preview_env_var_in_recipe_preview_chart(tmp_path: Path):
+    # #657 parity: recipe-preview's PREVIEW_DEV_BYPASS_AUTH must be caught too
+    # (the app's runtime k8s guard is L3; this is the L4 deploy-time backstop).
+    _write(
+        tmp_path,
+        "helm/recipe-preview/templates/deployment.yaml",
+        'env:\n  - name: PREVIEW_DEV_BYPASS_AUTH\n    value: "true"\n',
+    )
+    v = guard.find_violations(tmp_path)
+    assert len(v) == 1
+    assert "deployment.yaml" in v[0][0]
+
+
 def test_flags_flag_form_in_k8s_manifest(tmp_path: Path):
     _write(tmp_path, "k8s/04-tenant-api/deploy.yaml", "args: [--dev-bypass-auth]\n")
     assert len(guard.find_violations(tmp_path)) == 1


### PR DESCRIPTION
## 目的

部署 recipe-preview (#657) 到叢集的 **IaC 半部**——一支精簡 stateless chart（mirror tenant-api），kube-lint **0-BLOCK**（10 個 chart 跨檢、零豁免）。image 發布 + release 線是 follow-up（PR-D2）。

承你拍板「現在做 deploy」；經 3-agent scout + 外部對抗設計 review + IaC blast-radius review 收斂而成。

## 變更

- **`helm/recipe-preview/` 7 檔**：Deployment + Service + ServiceAccount + NetworkPolicy + _helpers；image tag derived（`image.tag ""`→`v<appVersion>`，註冊進 `test_image_tag_derivation`）。securityContext kube-lint 乾淨（readOnlyRootFilesystem + `/tmp` emptyDir 給 promtool + runAsNonRoot 65534 + caps drop ALL）；probe 打 `/healthz`。
- **NetworkPolicy ingress-only = 承重安全控制**：只准 da-portal pod 打 :8082。recipe-preview 盲信 `X-Forwarded-Email`（擺 da-portal 同源 `/preview` proxy 後、無自己的 oauth2-proxy），其他 pod 直連即可偽造身分。egress 留開（避免打壞 tenant-api `/access`；egress 限制列為 hardening follow-up）。
- **mem limit 256Mi**（非 128Mi）：blast-radius review 發現 4 個並發 promtool 子程序 + Python 父程序在 128Mi 下會 **OOMKill**。
- **L4 SAST parity**：`check_dev_bypass_manifest.py` 原本只配 `TA_DEV_BYPASS_AUTH`，補 `PREVIEW_DEV_BYPASS_AUTH`（recipe-preview 拿到同樣的 ADR-022 四層防線；app 的 runtime k8s guard 是 L3，這是 L4 deploy-time 後盾）+ 回歸測試。

## 部署契約

裝進 `monitoring` namespace（da-portal 的 `recipePreviewUrl` 硬寫 `recipe-preview.monitoring.svc.cluster.local:8082`）。

## 驗證

- ✅ `check_iac_helm` kube-lint：recipe-preview **0 findings / 0 BLOCK**（10 chart 跨檢）
- ✅ **19 個 Python 測試**（L4 lint + image-tag derivation）
- ✅ 細節 review + 對抗式 review：抓到並修了 mem-limit OOMKill + appVersion sync-bump 一致性

## 範圍 / 接下來

chart 是 IaC（kube-lint 驗過），但 image 還沒發布 → 裝了會 ImagePullBackOff，直到 **PR-D2**（release 線 `recipe-preview/v*`「同步升」+ 多架構 inline + promtool 版本 gate + `/healthz` build-SHA）。

Refs #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)
