### PR TITLE
feat: #902 L1 — third-party image CVE detection (scan + split alerts + ref-resolve lint)

### DIFF
--- a/.github/workflows/image-ref-resolve.yaml
+++ b/.github/workflows/image-ref-resolve.yaml
@@ -1,0 +1,53 @@
+name: Image Ref Resolve
+
+# Verify every concrete PUBLIC third-party image ref in helm values / k8s manifests
+# actually RESOLVES in its registry — catches a typo'd / yanked tag at PR time
+# (the #897 class: a non-existent `mariadb:11.8.1` shipped → ImagePullBackOff).
+# This is #902 L1-B; it complements the nightly scan (which resolves the WORKFLOW
+# MATRIX refs, not the values.yaml ones — so a values typo / matrix↔values drift
+# slips past it).
+#
+# First-party (ghcr.io/vencil/*) and locally-built (federation-audit-sidecar) refs
+# are skipped by the script — see scripts/ops/check_image_refs_resolve.py.
+#
+# Path-filtered: only runs when a deployment source carrying an image ref changes
+# (or the checker itself), so it doesn't tax unrelated PRs.
+
+on:
+  pull_request:
+    paths:
+      - "helm/**/values.yaml"
+      - "k8s/**"
+      - "scripts/ops/check_image_refs_resolve.py"
+      - ".github/workflows/image-ref-resolve.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: image-ref-resolve-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resolve:
+    name: resolve chart/manifest image refs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      # skopeo is the purpose-built registry-query tool (no daemon); the script
+      # prefers it over `docker manifest inspect`. Anonymous manifest inspects are
+      # light (no layer pulls) so Docker Hub rate limits are not a concern here.
+      - name: Install skopeo
+        run: sudo apt-get update && sudo apt-get install -y skopeo
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Resolve image refs
+        run: |
+          python3 -m pip install --quiet pyyaml
+          python3 scripts/ops/check_image_refs_resolve.py

--- a/.github/workflows/nightly-image-scan.yaml
+++ b/.github/workflows/nightly-image-scan.yaml
@@ -9,16 +9,25 @@ name: Nightly Image CVE Scan
 # The gap: a new base-image (Alpine/distroless/nginx) CVE landing between the last
 # PR and a tag push is discovered ONLY at release — blocking it (v2.9.0 hit 3
 # freshly-disclosed HIGHs at tag time; runbook §37). This is the missing third
-# dimension: scan the 5 component images built from CURRENT main every night and
-# file ONE deduped tracking issue when fixable HIGH/CRITICAL CVEs appear, so they
-# surface days early. NON-BLOCKING by construction — it gates nothing (release.yaml
-# stays the last line of defense); it only raises a heads-up.
+# dimension: scan the 5 self-built component images (built from CURRENT main) PLUS
+# the third-party upstream images our charts/manifests pull (#902 L1-A) every night,
+# and file ONE deduped tracking issue when fixable HIGH/CRITICAL CVEs appear, so
+# they surface days early. NON-BLOCKING by construction — it gates nothing
+# (release.yaml stays the last line of defense); it only raises a heads-up.
 #
 # Scope honesty: da-tools is built with STUBBED Go binaries (zero-byte, mirroring
 # component-docker-build.yaml's COPY-path stub) — its OS/base-image CVEs ARE
 # scanned, but its Go binaries' module CVEs are NOT here (covered by release.yaml's
 # real-build scan + Go CI / CodeQL govulncheck). The other 4 images build real, so
 # their full image surface is scanned.
+#
+# Third-party images our helm charts AND k8s/ manifests pull (vector, victoria-logs,
+# envoy, oauth2-proxy, prom-label-proxy, python, mariadb, mysqld-exporter, grafana,
+# prometheus, alertmanager, kube-state-metrics, configmap-reload, alpine/git) are NOT
+# built here — the scan-thirdparty job pulls each ref and Trivy-scans it directly. They
+# had ZERO automated CVE detection before #902 (PR/release/this job's build path
+# all scan only self-built images). Keep each ref in sync with the chart values /
+# k8s manifest it deploys from.
 
 on:
   schedule:
@@ -116,48 +125,81 @@ jobs:
           ignore-unfixed: true
           exit-code: 0
 
+      # Shared fail-loud summarizer → emits frag-<name>.txt for the report job.
+      # Same script as the scan-thirdparty job (one implementation, not two).
       - name: Summarize findings
-        run: |
-          set -euo pipefail
-          NAME='${{ matrix.name }}'
-          JSON="trivy-${NAME}.json"
-          # Fail-LOUD on a broken/changed Trivy JSON. A swallowed jq error that
-          # degrades to COUNT=0 ("clean") is the EXACT fail-open this scan exists to
-          # prevent — it would report "all clear" every night while Trivy is broken
-          # (schema change / OOM-truncated output), until release night undeceives
-          # us. So: assert the file parses + still has the expected shape, and let
-          # ANY jq error abort the job (set -e) instead of hiding it.
-          jq empty "$JSON"                            # malformed / truncated → abort
-          jq -e 'has("Results")' "$JSON" >/dev/null   # schema drift (Results renamed) → abort
-          # One line per UNIQUE CVE (dedup by VulnerabilityID across all packages).
-          # Capture via $() so a jq runtime error propagates (set -e), NOT via a
-          # process substitution whose failure mapfile would silently ignore.
-          RAW="$(jq -r '
-            [.Results[]?.Vulnerabilities[]?]
-            | group_by(.VulnerabilityID)[] | .[0]
-            | "\(.Severity)|\(.VulnerabilityID)|\(.PkgName) \(.InstalledVersion) → \(.FixedVersion // "?")"
-          ' "$JSON")"
-          if [ -n "$RAW" ]; then mapfile -t LINES <<< "$RAW"; else LINES=(); fi
-          COUNT="${#LINES[@]}"
-          FRAG="frag-${NAME}.txt"
-          # Line 1 = machine-readable "name<TAB>count"; the rest = human markdown.
-          printf '%s\t%s\n' "$NAME" "$COUNT" > "$FRAG"
-          if [ "$COUNT" -gt 0 ]; then
-            {
-              printf '<details><summary><b>%s</b> — %s fixable HIGH/CRITICAL</summary>\n\n' "$NAME" "$COUNT"
-              printf '| Severity | CVE | Package (installed → fixed) |\n|---|---|---|\n'
-              for l in "${LINES[@]}"; do
-                IFS='|' read -r sev cve pkg <<< "$l"
-                printf '| %s | %s | %s |\n' "$sev" "$cve" "$pkg"
-              done
-              printf '\n</details>\n'
-            } >> "$FRAG"
-          else
-            printf '✅ **%s** — clean (0 fixable HIGH/CRITICAL)\n' "$NAME" >> "$FRAG"
-          fi
-          # Mirror into this job's Step Summary too.
-          { tail -n +2 "$FRAG"; echo; } >> "$GITHUB_STEP_SUMMARY"
-          echo "scanned ${NAME}: ${COUNT} fixable HIGH/CRITICAL"
+        run: bash scripts/ops/summarize_trivy_cve.sh '${{ matrix.name }}'
+
+      - name: Upload fragment
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cve-frag-${{ matrix.name }}
+          path: frag-${{ matrix.name }}.txt
+          retention-days: 14
+
+  scan-thirdparty:
+    name: scan ${{ matrix.name }} (third-party)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false # scan every image so one pull failure doesn't mask the rest
+      matrix:
+        # Third-party upstream images our charts / k8s manifests PULL (not build).
+        # Trivy pulls each ref and scans it directly — these had ZERO automated CVE
+        # detection before #902. Keep each ref in sync with the source-of-truth file
+        # noted alongside it.
+        #
+        # NOTE: the Docker Hub refs are pulled anonymously; if GH-runner shared-IP
+        # rate limits start failing pulls, they surface as a degraded/"missing"
+        # alert (NOT a silent clean) — add a docker/login-action step then.
+        include:
+          - name: vector # helm/vector/values.yaml
+            ref: "timberio/vector:0.55.0-distroless-libc"
+          - name: victoria-logs # helm/victorialogs/values.yaml
+            ref: "victoriametrics/victoria-logs:v1.50.0"
+          - name: chargeback-python # helm/chargeback-aggregator/values.yaml
+            ref: "python:3.13-slim"
+          - name: envoy # helm/federation-gateway/values.yaml
+            ref: "envoyproxy/envoy:distroless-v1.38.0"
+          - name: oauth2-proxy # helm/da-portal + helm/tenant-api values.yaml
+            ref: "quay.io/oauth2-proxy/oauth2-proxy:v7.15.2"
+          - name: prom-label-proxy # helm/federation-proxy/values.yaml
+            ref: "quay.io/prometheuscommunity/prom-label-proxy:v0.13.0"
+          - name: mariadb # helm/mariadb-instance/values.yaml
+            ref: "mariadb:11.8.8"
+          - name: mysqld-exporter # helm/mariadb-instance/values.yaml
+            ref: "prom/mysqld-exporter:v0.18.0"
+          - name: grafana # k8s/03-monitoring/deployment-grafana.yaml
+            ref: "grafana/grafana:12.4.2"
+          - name: prometheus # k8s/03-monitoring/deployment-prometheus.yaml
+            ref: "prom/prometheus:v3.11.2"
+          - name: alertmanager # k8s/03-monitoring/deployment-alertmanager.yaml
+            ref: "prom/alertmanager:v0.32.0"
+          - name: kube-state-metrics # k8s/03-monitoring/deployment-kube-state-metrics.yaml
+            ref: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0"
+          - name: configmap-reload # k8s/03-monitoring/deployment-alertmanager.yaml (sidecar)
+            ref: "ghcr.io/jimmidyson/configmap-reload:v0.15.0"
+          - name: alpine-git # k8s/04-tenant-api/deployment.yaml (gitops sidecar)
+            ref: "alpine/git:v2.52.0"
+    steps:
+      - uses: actions/checkout@v6 # for scripts/ops/summarize_trivy_cve.sh
+
+      # No build: Trivy pulls the upstream ref and scans it directly. SAME contract
+      # as the scan job (CRITICAL,HIGH + ignore-unfixed, exit-code 0 — capture,
+      # don't gate; the report job decides on alerting).
+      - name: Trivy scan (JSON)
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ matrix.ref }}
+          format: json
+          output: trivy-${{ matrix.name }}.json
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: 0
+
+      - name: Summarize findings
+        run: bash scripts/ops/summarize_trivy_cve.sh '${{ matrix.name }}'
 
       - name: Upload fragment
         if: always()
@@ -169,7 +211,7 @@ jobs:
 
   report:
     name: aggregate + alert
-    needs: scan
+    needs: [scan, scan-thirdparty]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -188,7 +230,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          EXPECTED: "5"
+          # 5 self-built (scan) + 14 third-party (scan-thirdparty) = 19 expected frags.
+          EXPECTED: "19"
           # schedule always files; manual dispatch only when file_issue is checked.
           DO_FILE: ${{ github.event_name == 'schedule' || inputs.file_issue }}
         run: |
@@ -272,7 +315,7 @@ jobs:
             if [ -n "$num" ]; then
               echo "all ${EXPECTED} images build clean — closing tracking issue #${num}"
               gh issue comment "$num" --repo "$REPO" \
-                --body "✅ All ${EXPECTED} component images build clean (0 fixable HIGH/CRITICAL) as of $(date -u +%F). Auto-closing. (${RUN_URL})"
+                --body "✅ All ${EXPECTED} images build clean (0 fixable HIGH/CRITICAL) as of $(date -u +%F). Auto-closing. (${RUN_URL})"
               gh issue close "$num" --repo "$REPO"
             else
               echo "all clean, no open issue — nothing to do."

--- a/.github/workflows/nightly-image-scan.yaml
+++ b/.github/workflows/nightly-image-scan.yaml
@@ -130,11 +130,13 @@ jobs:
       - name: Summarize findings
         run: bash scripts/ops/summarize_trivy_cve.sh '${{ matrix.name }}'
 
+      # Artifact prefixed `sb-` so the report buckets self-built apart from
+      # third-party (`tp-`) — #902 L1-A.1.
       - name: Upload fragment
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: cve-frag-${{ matrix.name }}
+          name: cve-frag-sb-${{ matrix.name }}
           path: frag-${{ matrix.name }}.txt
           retention-days: 14
 
@@ -205,7 +207,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: cve-frag-${{ matrix.name }}
+          name: cve-frag-tp-${{ matrix.name }}
           path: frag-${{ matrix.name }}.txt
           retention-days: 14
 
@@ -218,106 +220,45 @@ jobs:
       contents: read
       issues: write
     steps:
-      - name: Download fragments
+      - uses: actions/checkout@v6 # for scripts/ops/file_cve_report.sh
+
+      # Self-built and third-party fragments download into SEPARATE dirs → SEPARATE
+      # tracking issues (#902 L1-A.1): a self-built regression (release.yaml
+      # Trivy-gated) must not get buried under the larger third-party CVE debt.
+      - name: Download self-built fragments
         uses: actions/download-artifact@v4
         with:
-          pattern: cve-frag-*
-          path: frags
+          pattern: cve-frag-sb-*
+          path: frags-sb
           merge-multiple: true
 
-      - name: Aggregate + maybe file the tracking issue
+      - name: Download third-party fragments
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cve-frag-tp-*
+          path: frags-tp
+          merge-multiple: true
+
+      - name: Aggregate + maybe file the tracking issues
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          # 5 self-built (scan) + 14 third-party (scan-thirdparty) = 19 expected frags.
-          EXPECTED: "19"
           # schedule always files; manual dispatch only when file_issue is checked.
           DO_FILE: ${{ github.event_name == 'schedule' || inputs.file_issue }}
         run: |
           set -euo pipefail
-          shopt -s nullglob
-          frags=(frags/frag-*.txt)
-          present="${#frags[@]}"
-          total=0
-          table=$'| Image | Fixable HIGH/CRITICAL |\n|---|---|\n'
-          details=""
-          for f in "${frags[@]}"; do
-            head1="$(head -n1 "$f")"
-            name="${head1%%$'\t'*}"
-            count="${head1#*$'\t'}"
-            count="${count//[^0-9]/}"; count="${count:-0}"
-            total=$(( total + count ))
-            table="${table}| ${name} | ${count} |"$'\n'
-            details="${details}$(tail -n +2 "$f")"$'\n\n'
-          done
-          missing=$(( EXPECTED - present ))
-
-          {
-            echo "# Nightly Image CVE Scan — $(date -u +%F)"
-            echo ""
-            echo "Fixable HIGH/CRITICAL across ${present}/${EXPECTED} images: **${total}**"
-            if [ "$missing" -gt 0 ]; then
-              echo ""
-              echo "⚠️ ${missing} image(s) failed to build/scan — see the matrix jobs above."
-            fi
-            echo ""
-            printf '%s' "$table"
-            echo ""
-            printf '%s' "$details"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          if [ "$DO_FILE" != "true" ]; then
-            echo "manual dispatch without file_issue — leaving issues untouched."
-            exit 0
-          fi
-
-          LABEL=nightly-cve
-          TITLE="🛡️ Nightly image scan — open findings (CVEs / build failures) on main"
-          gh label create "$LABEL" --repo "$REPO" --color B60205 \
-            --description "Nightly image scan: fixable HIGH/CRITICAL CVEs and/or images failing to build/scan on main" \
-            --force || true
-          num="$(gh issue list --repo "$REPO" --label "$LABEL" --state open --json number --jq '.[0].number // empty')"
-
-          # A "problem" is EITHER fixable CVEs (total>0) OR an image that failed to
-          # build/scan (missing>0). Folding build-failures in means a broken
-          # Dockerfile on main can't sit silently until release night — the scan
-          # must NOT claim "clean" when it didn't actually scan everything.
-          problem=0
-          [ "$total" -gt 0 ] && problem=1
-          [ "$missing" -gt 0 ] && problem=1
-          degraded_note=""
-          if [ "$missing" -gt 0 ]; then
-            # Build via direct expansion + $'\n\n', NOT $(printf '...\n\n') whose
-            # command substitution strips trailing newlines → the note would run
-            # straight into the next sentence.
-            degraded_note="🚨 **Scan degraded** — ${missing} of ${EXPECTED} images failed to build/scan (see the matrix jobs in ${RUN_URL}). Results below are PARTIAL, and a non-building image is itself a release blocker."$'\n\n'
-          fi
-
-          if [ "$problem" -eq 1 ]; then
-            body="$(printf '%sNightly image scan on `main` (%s): **%s** fixable HIGH/CRITICAL CVE(s) across %s/%s images scanned.\n\n%s\n%s\n**Remediate**: most CVEs are upstream base-image (Alpine / distroless / nginx) — a fresh rebuild or base-image bump usually clears them; otherwise bump the pinned package. A failed build is a Dockerfile/COPY break to fix directly. The release-time Trivy gate (release.yaml) blocks a tag until CVEs are 0, so fixing now avoids a release-night scramble (security-audit-runbook §37). This issue is REFRESHED nightly (body edited in place — no comment spam) and auto-closes once all images build clean.' \
-              "$degraded_note" "$RUN_URL" "$total" "$present" "$EXPECTED" "$table" "$details")"
-            if [ -n "$num" ]; then
-              # EDIT the body in place rather than adding a daily comment: a comment
-              # emails the assignee EVERY morning while an upstream patch is pending
-              # (alert nagging → fatigue → muted scan). An edit keeps the issue
-              # current WITHOUT a notification; only the initial create (state 0→1)
-              # and the final close notify.
-              echo "refreshing existing tracking issue #${num} (silent body edit)"
-              gh issue edit "$num" --repo "$REPO" --body "$body"
-            else
-              echo "filing new tracking issue (state change → notify)"
-              gh issue create --repo "$REPO" --title "$TITLE" --label "$LABEL" \
-                --assignee vencil --body "$body"
-            fi
-          else
-            # problem==0 ⇒ total==0 AND missing==0 ⇒ genuinely all-clean, all scanned.
-            if [ -n "$num" ]; then
-              echo "all ${EXPECTED} images build clean — closing tracking issue #${num}"
-              gh issue comment "$num" --repo "$REPO" \
-                --body "✅ All ${EXPECTED} images build clean (0 fixable HIGH/CRITICAL) as of $(date -u +%F). Auto-closing. (${RUN_URL})"
-              gh issue close "$num" --repo "$REPO"
-            else
-              echo "all clean, no open issue — nothing to do."
-            fi
-          fi
+          rc=0
+          # Self-built (5) — feeds the release.yaml Trivy gate; keep this signal clean.
+          bash scripts/ops/file_cve_report.sh frags-sb \
+            nightly-cve \
+            "🛡️ Nightly image scan — self-built component CVEs / build failures on main" \
+            5 "self-built component" \
+            "The release-time Trivy gate (release.yaml) blocks a tag until these are 0 (security-audit-runbook §37)." || rc=1
+          # Third-party (14) — informational; remediation is an upstream image bump.
+          bash scripts/ops/file_cve_report.sh frags-tp \
+            nightly-cve-thirdparty \
+            "🛡️ Nightly image scan — third-party upstream image CVEs on main" \
+            14 "third-party upstream image" \
+            "Remediation = bump the pinned upstream image tag (tracked toward #902 L2 digest-pin + L3 auto-bump)." || rc=1
+          exit $rc

--- a/.github/workflows/nightly-image-scan.yaml
+++ b/.github/workflows/nightly-image-scan.yaml
@@ -53,6 +53,8 @@ jobs:
     name: scan ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }} # mirror for the `if` guard below
     strategy:
       fail-fast: false # scan every image so one build break doesn't mask the rest
       matrix:
@@ -75,6 +77,16 @@ jobs:
             context: .
             dockerfile: components/recipe-preview/Dockerfile
     steps:
+      # Authenticated Docker Hub pulls (200/6h, per-account not shared-IP) when creds
+      # are set; guarded — a no-op for forks / when the secret is unset. `secrets`
+      # isn't allowed in `if`, so gate on the mirrored env var (#902 / #907 review).
+      - name: Docker Hub login (no-op without creds)
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
@@ -144,6 +156,8 @@ jobs:
     name: scan ${{ matrix.name }} (third-party)
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }} # mirror for the `if` guard below
     strategy:
       fail-fast: false # scan every image so one pull failure doesn't mask the rest
       matrix:
@@ -185,6 +199,14 @@ jobs:
           - name: alpine-git # k8s/04-tenant-api/deployment.yaml (gitops sidecar)
             ref: "alpine/git:v2.52.0"
     steps:
+      # Authenticated Docker Hub pulls (rate-limit headroom); guarded no-op without creds.
+      - name: Docker Hub login (no-op without creds)
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - uses: actions/checkout@v6 # for scripts/ops/summarize_trivy_cve.sh
 
       # No build: Trivy pulls the upstream ref and scans it directly. SAME contract

--- a/scripts/ops/check_image_refs_resolve.py
+++ b/scripts/ops/check_image_refs_resolve.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Verify every concrete container image ref in helm values + k8s manifests
+actually RESOLVES in its registry (#902 L1-B).
+
+Motivation: #897 shipped a typo'd, non-existent tag (`mariadb:11.8.1`) in a chart
+values file → fresh-deploy `ImagePullBackOff`. Nothing caught it at PR time: the
+nightly scan (scan-thirdparty) resolves the refs in the WORKFLOW MATRIX, not the
+ones in `values.yaml`, so a values typo (or matrix↔values drift) slips through.
+This lint closes that gap — it parses the actual deployment sources and checks
+each concrete ref against the registry.
+
+Parsing (NOT grep — comments/prose would yield phantom refs): yaml.safe_load each
+file and walk the tree, collecting
+  * any mapping with string `repository` + non-empty `tag` -> "<registry>/<repo>:<tag>"
+  * any `image:` key whose value is a "repo:tag" string
+Empty / templated ({{ ... }}) tags are SKIPPED: first-party `tag: ""` resolves to
+the chart appVersion (built at release, exists by construction), and Helm template
+expressions aren't real refs.
+
+Resolution: `skopeo inspect docker://<ref>` (preferred) or `docker manifest
+inspect <ref>`. If NEITHER tool is available the check SKIPS (exit 0) with a loud
+note — so a dev box without skopeo/docker doesn't false-fail; CI installs skopeo.
+
+Exit: 0 = all concrete refs resolve (or resolver unavailable / nothing to check);
+1 = at least one ref does not resolve (the #897 class).
+
+Usage:
+  check_image_refs_resolve.py [--root DIR] [--list] [--timeout SECS]
+    --root    repo root to scan (default: cwd)
+    --list    print the discovered concrete refs and exit 0 (no network) — for tests
+    --timeout per-ref resolver timeout in seconds (default 30)
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - pyyaml is a hard dep in CI / pre-commit
+    print("check_image_refs_resolve: PyYAML not installed", file=sys.stderr)
+    sys.exit(2)
+
+# Globs of the deployment sources humans hand-edit image refs into.
+SOURCE_GLOBS = ("helm/*/values.yaml", "k8s/**/*.yaml", "k8s/**/*.yml")
+
+# Images BUILT LOCALLY by a chart's own Dockerfile and NOT published to a public
+# registry (the deployer builds/loads them, or pushes to their own registry). They
+# cannot be resolved against a public registry, so the resolve check would
+# false-fail on them — skip by repository name. (federation-gateway audit-sidecar:
+# helm/federation-gateway/audit-sidecar/Dockerfile, values repository has no host.)
+LOCAL_BUILT_IMAGES = {"federation-audit-sidecar"}
+
+# First-party images live in our own registry namespace: their currency is the
+# release pipeline's job, and resolving them needs ghcr auth (would false-fail an
+# anonymous CI check). L1-B targets the PUBLIC third-party refs (the #897 typo
+# class), so skip our own namespace here.
+SKIP_REPO_PREFIXES = ("ghcr.io/vencil/",)
+
+
+def _repo_of(ref: str) -> str:
+    """The repository portion of a ref (strip @digest then :tag)."""
+    return ref.split("@", 1)[0].rsplit(":", 1)[0]
+
+
+def _is_concrete(ref: str) -> bool:
+    """A ref we can actually resolve: has a tag, isn't a Helm template."""
+    if "{{" in ref or "}}" in ref:
+        return False
+    # Need a tag (or digest) after the final path segment's colon.
+    last = ref.rsplit("/", 1)[-1]
+    return ":" in last or "@" in last
+
+
+def _refs_from_node(node) -> set[str]:
+    """Recursively collect concrete image refs from a parsed YAML node."""
+    found: set[str] = set()
+
+    def walk(n):
+        if isinstance(n, dict):
+            # Shape A: {repository, tag[, registry]} image block.
+            repo = n.get("repository")
+            tag = n.get("tag")
+            if isinstance(repo, str) and isinstance(tag, str) and tag.strip():
+                registry = n.get("registry")
+                ref = f"{registry}/{repo}" if isinstance(registry, str) and registry else repo
+                digest = n.get("digest")
+                ref = f"{ref}:{tag}@{digest}" if isinstance(digest, str) and digest else f"{ref}:{tag}"
+                if _is_concrete(ref):
+                    found.add(ref)
+            # Shape B: `image:` as a single "repo:tag" string (e.g. mariadb.image,
+            # raw k8s container image).
+            img = n.get("image")
+            if isinstance(img, str) and _is_concrete(img):
+                found.add(img.strip())
+            for v in n.values():
+                walk(v)
+        elif isinstance(n, list):
+            for v in n:
+                walk(v)
+
+    walk(node)
+    return found
+
+
+def discover_refs(root: Path) -> set[str]:
+    refs: set[str] = set()
+    for pattern in SOURCE_GLOBS:
+        for path in sorted(root.glob(pattern)):
+            try:
+                docs = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+            except yaml.YAMLError as exc:
+                print(f"::warning:: skipping unparseable {path}: {exc}", file=sys.stderr)
+                continue
+            for doc in docs:
+                if doc is not None:
+                    refs |= _refs_from_node(doc)
+    # Skip locally-built (never published) + first-party (needs ghcr auth; release's
+    # job) refs — an anonymous resolve would false-fail them. L1-B = public third-party.
+    def _keep(r: str) -> bool:
+        repo = _repo_of(r)
+        return repo not in LOCAL_BUILT_IMAGES and not repo.startswith(SKIP_REPO_PREFIXES)
+
+    return {r for r in refs if _keep(r)}
+
+
+def _resolver():
+    """Return (cmd_builder, name) for the available resolver, or (None, None)."""
+    if shutil.which("skopeo"):
+        return (lambda ref: ["skopeo", "inspect", "--no-tags", f"docker://{ref}"], "skopeo")
+    if shutil.which("docker"):
+        return (lambda ref: ["docker", "manifest", "inspect", ref], "docker")
+    return (None, None)
+
+
+def _resolve_once(cmd: list[str], timeout: int) -> tuple[bool, str]:
+    """Run one resolver command; return (resolved, last-line-of-reason)."""
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return (False, f"timeout after {timeout}s")
+    if proc.returncode == 0:
+        return (True, "")
+    lines = (proc.stderr or proc.stdout or "non-zero exit").strip().splitlines()
+    return (False, lines[-1] if lines else "non-zero exit")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Verify chart/manifest image refs resolve in their registry.")
+    ap.add_argument("--root", default=".", help="repo root to scan (default: cwd)")
+    ap.add_argument("--list", action="store_true", help="print discovered concrete refs and exit (no network)")
+    ap.add_argument("--timeout", type=int, default=30, help="per-ref resolver timeout (s)")
+    args = ap.parse_args()
+
+    refs = sorted(discover_refs(Path(args.root)))
+
+    if args.list:
+        for ref in refs:
+            print(ref)
+        return 0
+
+    if not refs:
+        print("check_image_refs_resolve: no concrete image refs found — nothing to check.")
+        return 0
+
+    build_cmd, name = _resolver()
+    if build_cmd is None:
+        print("::warning:: neither skopeo nor docker available — SKIPPING image-ref "
+              "resolution (install skopeo in CI to enforce). Refs that WOULD be checked:")
+        for ref in refs:
+            print(f"  - {ref}")
+        return 0
+
+    print(f"Resolving {len(refs)} concrete image ref(s) via {name}...")
+    failed: list[tuple[str, str]] = []
+    for ref in refs:
+        ok, reason = _resolve_once(build_cmd(ref), args.timeout)
+        if not ok:
+            # One retry absorbs a transient registry blip before failing the gate.
+            ok, reason = _resolve_once(build_cmd(ref), args.timeout)
+        if ok:
+            print(f"  ok       {ref}")
+        else:
+            failed.append((ref, reason))
+            print(f"  FAIL     {ref}  ({reason})")
+
+    if failed:
+        print(f"\n::error:: {len(failed)} image ref(s) do NOT resolve in their registry "
+              f"(the #897 class — typo'd / yanked tag):", file=sys.stderr)
+        for ref, reason in failed:
+            print(f"  - {ref}: {reason}", file=sys.stderr)
+        return 1
+
+    print(f"\nAll {len(refs)} image refs resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ops/file_cve_report.sh
+++ b/scripts/ops/file_cve_report.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# file_cve_report.sh — aggregate per-image Trivy fragments for ONE class and
+# file/refresh ONE tracking issue (#902 L1-A.1).
+#
+# Why split: self-built component CVEs feed the release.yaml Trivy hard-gate, so
+# a self-built regression must stay VISIBLE — it must not get buried under the
+# (much larger, informational) third-party upstream CVE debt. So self-built and
+# third-party findings get SEPARATE tracking issues, each filed by one call here.
+#
+# Usage:
+#   file_cve_report.sh <frags_dir> <label> <title> <expected> <kind> [extra_note]
+# Env:
+#   REPO, RUN_URL            — repo slug + run URL (filing + body)
+#   DO_FILE   (default false) — "true" to create/edit/close the issue; else summary-only
+#   DRY_RUN   (default 0)     — "1" to echo gh actions instead of running them (offline test)
+#   GITHUB_STEP_SUMMARY       — appended to when set (no-op locally / in tests)
+#
+# Emits the human markdown to the step summary always; files the issue only when
+# DO_FILE=true. Fail-LOUD inherited from the per-image fragments (summarize step).
+set -euo pipefail
+
+FRAGS_DIR="${1:?usage: file_cve_report.sh <frags_dir> <label> <title> <expected> <kind> [extra_note]}"
+LABEL="${2:?label}"
+TITLE="${3:?title}"
+EXPECTED="${4:?expected}"
+KIND="${5:?kind}"            # human noun, e.g. "self-built component" / "third-party upstream image"
+EXTRA_NOTE="${6:-}"          # optional bucket-specific remediation sentence
+
+DO_FILE="${DO_FILE:-false}"
+DRY_RUN="${DRY_RUN:-0}"
+RUN_URL="${RUN_URL:-(local)}"
+REPO="${REPO:-}"
+
+shopt -s nullglob
+frags=("$FRAGS_DIR"/frag-*.txt)
+present="${#frags[@]}"
+total=0
+table=$'| Image | Fixable HIGH/CRITICAL |\n|---|---|\n'
+details=""
+for f in "${frags[@]}"; do
+  head1="$(head -n1 "$f")"
+  name="${head1%%$'\t'*}"
+  count="${head1#*$'\t'}"
+  count="${count//[^0-9]/}"; count="${count:-0}"
+  total=$(( total + count ))
+  table="${table}| ${name} | ${count} |"$'\n'
+  details="${details}$(tail -n +2 "$f")"$'\n\n'
+done
+missing=$(( EXPECTED - present ))
+
+{
+  echo "# Nightly Image CVE Scan — ${KIND} — $(date -u +%F)"
+  echo ""
+  echo "Fixable HIGH/CRITICAL across ${present}/${EXPECTED} ${KIND} images: **${total}**"
+  if [ "$missing" -gt 0 ]; then
+    echo ""
+    echo "⚠️ ${missing} image(s) failed to build/scan — see the matrix jobs above."
+  fi
+  echo ""
+  printf '%s' "$table"
+  echo ""
+  printf '%s' "$details"
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+if [ "$DO_FILE" != "true" ]; then
+  echo "[${LABEL}] summary-only (DO_FILE!=true) — leaving issues untouched."
+  exit 0
+fi
+
+# gh wrapper honoring DRY_RUN (offline test prints the action instead of running).
+gh_do() { if [ "$DRY_RUN" = "1" ]; then echo "DRY_RUN gh $*"; else gh "$@"; fi; }
+
+gh_do label create "$LABEL" --repo "$REPO" --color B60205 \
+  --description "Nightly image scan: fixable HIGH/CRITICAL CVEs and/or ${KIND} images failing to build/scan on main" \
+  --force || true
+
+num=""
+if [ "$DRY_RUN" != "1" ]; then
+  num="$(gh issue list --repo "$REPO" --label "$LABEL" --state open --json number --jq '.[0].number // empty')"
+fi
+
+# A "problem" is EITHER fixable CVEs (total>0) OR an image that failed to
+# build/scan (missing>0). Folding build-failures in means a broken image can't
+# sit silently — the scan must NOT claim "clean" when it didn't scan everything.
+problem=0
+[ "$total" -gt 0 ] && problem=1
+[ "$missing" -gt 0 ] && problem=1
+
+degraded_note=""
+if [ "$missing" -gt 0 ]; then
+  # Direct expansion + $'\n\n', NOT $(printf '...\n\n') whose command substitution
+  # strips trailing newlines → the note would run into the next sentence.
+  degraded_note="🚨 **Scan degraded** — ${missing} of ${EXPECTED} ${KIND} images failed to build/scan (see the matrix jobs in ${RUN_URL}). Results below are PARTIAL."$'\n\n'
+fi
+
+if [ "$problem" -eq 1 ]; then
+  body="$(printf '%sNightly image scan on `main` (%s): **%s** fixable HIGH/CRITICAL CVE(s) across %s/%s %s images scanned.\n\n%s\n%s\n**Remediate**: most are upstream base-image CVEs — a fresh rebuild or image/tag bump usually clears them; otherwise bump the pinned package. A failed build/scan is a Dockerfile/COPY break or a bad/missing image ref to fix directly. %sThis issue is REFRESHED in place (body edited — no comment spam) and auto-closes once clean.' \
+    "$degraded_note" "$RUN_URL" "$total" "$present" "$EXPECTED" "$KIND" "$table" "$details" "${EXTRA_NOTE:+$EXTRA_NOTE }")"
+  if [ -n "$num" ]; then
+    # EDIT in place rather than a daily comment: a comment emails the assignee
+    # every morning while an upstream patch is pending (fatigue → muted scan).
+    # Only the initial create (state 0→1) and the final close notify.
+    echo "refreshing existing ${LABEL} issue #${num} (silent body edit)"
+    gh_do issue edit "$num" --repo "$REPO" --body "$body"
+  else
+    echo "filing new ${LABEL} tracking issue (state change → notify)"
+    gh_do issue create --repo "$REPO" --title "$TITLE" --label "$LABEL" --assignee vencil --body "$body"
+  fi
+else
+  # problem==0 ⇒ total==0 AND missing==0 ⇒ genuinely all-clean, all scanned.
+  if [ -n "$num" ]; then
+    echo "all ${EXPECTED} ${KIND} images clean — closing ${LABEL} issue #${num}"
+    gh_do issue comment "$num" --repo "$REPO" \
+      --body "✅ All ${EXPECTED} ${KIND} images clean (0 fixable HIGH/CRITICAL) as of $(date -u +%F). Auto-closing. (${RUN_URL})"
+    gh_do issue close "$num" --repo "$REPO"
+  else
+    echo "[${LABEL}] all clean, no open issue — nothing to do."
+  fi
+fi

--- a/scripts/ops/summarize_trivy_cve.sh
+++ b/scripts/ops/summarize_trivy_cve.sh
@@ -29,7 +29,14 @@ jq -e 'has("Results")' "$JSON" >/dev/null   # schema drift (Results renamed) →
 # Capture via $() so a jq runtime error propagates (set -e), NOT via a process
 # substitution whose failure mapfile would silently ignore.
 RAW="$(jq -r '
-  [.Results[]?.Vulnerabilities[]?]
+  [
+    .Results[]?.Vulnerabilities[]?
+    # Defensive: only fixable HIGH/CRITICAL, regardless of the workflow Trivy
+    # flags — keeps this script self-consistent with its "fixable HIGH/CRITICAL"
+    # label if the severity/ignore-unfixed flags ever drift (CodeRabbit #907).
+    | select((.Severity == "HIGH" or .Severity == "CRITICAL")
+             and ((.FixedVersion // "") != ""))
+  ]
   | group_by(.VulnerabilityID)[] | .[0]
   | "\(.Severity)|\(.VulnerabilityID)|\(.PkgName) \(.InstalledVersion) → \(.FixedVersion // "?")"
 ' "$JSON")"

--- a/scripts/ops/summarize_trivy_cve.sh
+++ b/scripts/ops/summarize_trivy_cve.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Summarize a Trivy JSON scan into a fragment file (frag-<name>.txt) for the
+# nightly-image-scan `report` job to aggregate. Extracted from the inline
+# "Summarize findings" step so the self-built (`scan`) and third-party
+# (`scan-thirdparty`) jobs share ONE fail-loud implementation (#902 L1-A).
+#
+# Usage: summarize_trivy_cve.sh <name> [trivy-json]
+#   <name>       label for this image (becomes the fragment key + report table row)
+#   [trivy-json] path to the Trivy JSON (default: trivy-<name>.json)
+#
+# Emits: frag-<name>.txt  — line 1 = "<name>\t<count>" (machine-readable),
+#                           rest = human markdown (details block or clean line).
+# Also appends the human markdown to $GITHUB_STEP_SUMMARY when that var is set
+# (a no-op locally / in tests, where it is unset).
+#
+# Fail-LOUD: a malformed / schema-drifted Trivy JSON aborts (set -e) instead of
+# silently degrading to COUNT=0 ("clean"). That fail-open — reporting "all clear"
+# while Trivy is actually broken (schema change / OOM-truncated output) — is the
+# exact thing this nightly scan exists to prevent.
+set -euo pipefail
+
+NAME="${1:?usage: summarize_trivy_cve.sh <name> [trivy-json]}"
+JSON="${2:-trivy-${NAME}.json}"
+
+jq empty "$JSON"                            # malformed / truncated → abort
+jq -e 'has("Results")' "$JSON" >/dev/null   # schema drift (Results renamed) → abort
+
+# One line per UNIQUE CVE (dedup by VulnerabilityID across all packages).
+# Capture via $() so a jq runtime error propagates (set -e), NOT via a process
+# substitution whose failure mapfile would silently ignore.
+RAW="$(jq -r '
+  [.Results[]?.Vulnerabilities[]?]
+  | group_by(.VulnerabilityID)[] | .[0]
+  | "\(.Severity)|\(.VulnerabilityID)|\(.PkgName) \(.InstalledVersion) → \(.FixedVersion // "?")"
+' "$JSON")"
+if [ -n "$RAW" ]; then mapfile -t LINES <<< "$RAW"; else LINES=(); fi
+COUNT="${#LINES[@]}"
+
+FRAG="frag-${NAME}.txt"
+# Line 1 = machine-readable "name<TAB>count"; the rest = human markdown.
+printf '%s\t%s\n' "$NAME" "$COUNT" > "$FRAG"
+if [ "$COUNT" -gt 0 ]; then
+  {
+    printf '<details><summary><b>%s</b> — %s fixable HIGH/CRITICAL</summary>\n\n' "$NAME" "$COUNT"
+    printf '| Severity | CVE | Package (installed → fixed) |\n|---|---|---|\n'
+    for l in "${LINES[@]}"; do
+      IFS='|' read -r sev cve pkg <<< "$l"
+      printf '| %s | %s | %s |\n' "$sev" "$cve" "$pkg"
+    done
+    printf '\n</details>\n'
+  } >> "$FRAG"
+else
+  printf '✅ **%s** — clean (0 fixable HIGH/CRITICAL)\n' "$NAME" >> "$FRAG"
+fi
+
+# Mirror into the job's Step Summary too (no-op when GITHUB_STEP_SUMMARY unset).
+{ tail -n +2 "$FRAG"; echo; } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+echo "scanned ${NAME}: ${COUNT} fixable HIGH/CRITICAL"

--- a/tests/ops/test_check_image_refs_resolve.py
+++ b/tests/ops/test_check_image_refs_resolve.py
@@ -1,0 +1,100 @@
+"""Tests for scripts/ops/check_image_refs_resolve.py (#902 L1-B).
+
+Exercises the EXTRACTION (parse) logic via `--list` — no network / skopeo, so it
+runs in the plain Python Tests CI job. The resolution (skopeo) path is enforced
+by the image-ref-resolve workflow, not here.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "ops" / "check_image_refs_resolve.py"
+
+
+def _write(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _list_refs(root: Path) -> set[str]:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root), "--list"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+
+
+def test_extracts_all_shapes_and_skips_empty_and_templated(tmp_path: Path) -> None:
+    # Shape A: repository + tag.
+    _write(tmp_path / "helm/a/values.yaml", 'image:\n  repository: foo/bar\n  tag: "1.0"\n')
+    # Shape A nested in a sub-block (oauth2-proxy pattern) + empty tag (first-party) skipped.
+    _write(
+        tmp_path / "helm/b/values.yaml",
+        'image:\n  repository: ghcr.io/x/y\n  tag: ""\n'           # empty → skip (appVersion)
+        'oauth2Proxy:\n  image:\n    repository: quay.io/o/p\n    tag: v1\n',
+    )
+    # Shape B: single-string `image:` (mariadb-instance pattern).
+    _write(
+        tmp_path / "helm/c/values.yaml",
+        'mariadb:\n  image: "mariadb:11.8.8"\nexporter:\n  image: "prom/e:v2"\n',
+    )
+    # Templated tag → skip (not a real ref).
+    _write(tmp_path / "helm/d/values.yaml", 'image:\n  repository: t\n  tag: "{{ .Chart.AppVersion }}"\n')
+    # Raw k8s manifest container image (nested under spec.template...containers[]).
+    _write(
+        tmp_path / "k8s/mon/deploy.yaml",
+        "apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n    spec:\n"
+        '      containers:\n        - name: c\n          image: "registry.k8s.io/foo:v3"\n',
+    )
+    # registry + repository + tag (explicit registry key).
+    _write(tmp_path / "helm/e/values.yaml", 'image:\n  registry: example.com\n  repository: r\n  tag: t9\n')
+
+    refs = _list_refs(tmp_path)
+    assert refs == {
+        "foo/bar:1.0",
+        "quay.io/o/p:v1",
+        "mariadb:11.8.8",
+        "prom/e:v2",
+        "registry.k8s.io/foo:v3",
+        "example.com/r:t9",
+    }, f"unexpected ref set: {sorted(refs)}"
+
+
+def test_digest_is_preserved(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "helm/a/values.yaml",
+        'image:\n  repository: foo/bar\n  tag: "1.0"\n  digest: "sha256:abc"\n',
+    )
+    assert _list_refs(tmp_path) == {"foo/bar:1.0@sha256:abc"}
+
+
+def test_empty_tree_yields_nothing(tmp_path: Path) -> None:
+    _write(tmp_path / "helm/a/values.yaml", "replicaCount: 2\nservice:\n  port: 80\n")
+    assert _list_refs(tmp_path) == set()
+
+
+def test_local_built_image_is_skipped(tmp_path: Path) -> None:
+    # federation-audit-sidecar is built locally (no registry, never published) → it
+    # must NOT be resolve-checked, or the lint false-fails. A real third-party ref
+    # alongside it is still collected.
+    _write(
+        tmp_path / "helm/fg/values.yaml",
+        "auditLog:\n  image:\n    repository: federation-audit-sidecar\n    tag: \"3.0.8\"\n"
+        "image:\n  repository: envoyproxy/envoy\n  tag: distroless-v1.0\n",
+    )
+    assert _list_refs(tmp_path) == {"envoyproxy/envoy:distroless-v1.0"}
+
+
+def test_first_party_namespace_is_skipped(tmp_path: Path) -> None:
+    # ghcr.io/vencil/* (first-party) is the release pipeline's job + needs ghcr auth
+    # to resolve → skipped by L1-B; a public third-party ref alongside is still kept.
+    _write(
+        tmp_path / "k8s/x/deploy.yaml",
+        "spec:\n  template:\n    spec:\n      containers:\n"
+        '        - image: "ghcr.io/vencil/tenant-api:v2.7.0"\n'
+        '        - image: "quay.io/o/p:v1"\n',
+    )
+    assert _list_refs(tmp_path) == {"quay.io/o/p:v1"}

--- a/tests/ops/test_file_cve_report.sh
+++ b/tests/ops/test_file_cve_report.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Offline unit test for scripts/ops/file_cve_report.sh (#902 L1-A.1).
+# Uses DRY_RUN=1 so the gh create/edit/close actions are echoed, not run —
+# a schedule-only workflow can't exercise this in PR CI. Requires bash 4.
+#
+#   bash tests/ops/test_file_cve_report.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../../scripts/ops/file_cve_report.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# Helper: write a fragment as the summarizer would (line1 = name<TAB>count).
+mkfrag() { # <dir> <name> <count>
+  printf '%s\t%s\n' "$2" "$3" > "$1/frag-$2.txt"
+  if [ "$3" -gt 0 ]; then echo "<details>... $3 ...</details>" >> "$1/frag-$2.txt"
+  else echo "clean" >> "$1/frag-$2.txt"; fi
+}
+
+# --- Case 1: CVEs present, all scanned → file (create path under DRY_RUN) ---
+d1="$WORK/d1"; mkdir -p "$d1"; mkfrag "$d1" alpha 3; mkfrag "$d1" beta 0
+sum1="$WORK/sum1"; : > "$sum1"
+out1="$(GITHUB_STEP_SUMMARY="$sum1" DO_FILE=true DRY_RUN=1 REPO=o/r RUN_URL=http://run \
+  bash "$SCRIPT" "$d1" nightly-cve "Self-built CVEs" 2 "self-built component" "Release gate note." 2>&1)"
+echo "$out1" | grep -q "filing new nightly-cve" || fail "case1 expected create path; got: $out1"
+echo "$out1" | grep -q "DRY_RUN gh issue create" || fail "case1 expected DRY_RUN create"
+grep -q "across 2/2 self-built component images: \*\*3\*\*" "$sum1" || fail "case1 summary total wrong: $(cat "$sum1")"
+echo "ok: case1 (CVEs present → create, total=3)"
+
+# --- Case 2: all clean, all scanned → no issue (no create) ---
+d2="$WORK/d2"; mkdir -p "$d2"; mkfrag "$d2" alpha 0; mkfrag "$d2" beta 0
+out2="$(GITHUB_STEP_SUMMARY=/dev/null DO_FILE=true DRY_RUN=1 REPO=o/r RUN_URL=http://run \
+  bash "$SCRIPT" "$d2" nightly-cve "T" 2 "self-built component" 2>&1)"
+echo "$out2" | grep -q "all clean, no open issue" || fail "case2 expected clean path; got: $out2"
+echo "$out2" | grep -q "DRY_RUN gh issue create" && fail "case2 must NOT create"
+echo "ok: case2 (all clean → no issue)"
+
+# --- Case 3: missing frag (present < expected) → degraded + file ---
+d3="$WORK/d3"; mkdir -p "$d3"; mkfrag "$d3" alpha 0   # 1 present, expected 3
+out3="$(GITHUB_STEP_SUMMARY=/dev/null DO_FILE=true DRY_RUN=1 REPO=o/r RUN_URL=http://run \
+  bash "$SCRIPT" "$d3" nightly-cve-thirdparty "TP" 3 "third-party upstream image" 2>&1)"
+echo "$out3" | grep -q "filing new nightly-cve-thirdparty" || fail "case3 expected file (missing→problem); got: $out3"
+echo "$out3" | grep -q "Scan degraded" || fail "case3 expected degraded note in body"
+echo "ok: case3 (missing → degraded + file)"
+
+# --- Case 4: DO_FILE unset → summary-only, no gh at all ---
+d4="$WORK/d4"; mkdir -p "$d4"; mkfrag "$d4" alpha 5
+out4="$(GITHUB_STEP_SUMMARY=/dev/null DRY_RUN=1 REPO=o/r \
+  bash "$SCRIPT" "$d4" nightly-cve "T" 1 "self-built component" 2>&1)"
+echo "$out4" | grep -q "summary-only" || fail "case4 expected summary-only; got: $out4"
+echo "$out4" | grep -q "DRY_RUN gh" && fail "case4 must not touch gh"
+echo "ok: case4 (DO_FILE unset → summary-only)"
+
+echo "PASS: all file_cve_report.sh cases"

--- a/tests/ops/test_nightly_scan_matrix_drift.py
+++ b/tests/ops/test_nightly_scan_matrix_drift.py
@@ -1,0 +1,82 @@
+"""Drift guard for the nightly third-party scan matrix (#902 L1-A drift guard).
+
+Closes the dual-SSOT gap raised in #907 review: the `scan-thirdparty` matrix in
+nightly-image-scan.yaml hardcodes the 14 third-party refs, while the actual
+deployment refs live in helm values / k8s manifests. If a maintainer bumps a
+manifest (e.g. grafana 12.4.2 -> 12.5.0) but forgets the scan matrix, the scan
+would keep reporting the OLD version as "safe" while prod runs the new one —
+false security ("scanning a parallel universe").
+
+This guard makes the L1-B extractor (which reads the real values/manifests) the
+single source of truth and fails CI on drift:
+  * scan-thirdparty matrix refs MUST equal `check_image_refs_resolve.py --list`
+  * the report's EXPECTED counts MUST equal the matrix sizes (so the "X/Y images"
+    + degraded-scan logic stays correct).
+
+Network-free (uses --list), so it runs in the plain Python Tests CI job.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "nightly-image-scan.yaml"
+EXTRACTOR = ROOT / "scripts" / "ops" / "check_image_refs_resolve.py"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _matrix_include(job: str) -> list[dict]:
+    return _workflow()["jobs"][job]["strategy"]["matrix"]["include"]
+
+
+def _aggregate_run() -> str:
+    steps = _workflow()["jobs"]["report"]["steps"]
+    agg = next(s for s in steps if "Aggregate" in (s.get("name") or ""))
+    return agg["run"]
+
+
+def test_thirdparty_matrix_equals_deployed_refs() -> None:
+    """scan-thirdparty matrix == the refs the extractor finds in values/manifests."""
+    matrix_refs = {e["ref"] for e in _matrix_include("scan-thirdparty")}
+
+    proc = subprocess.run(
+        [sys.executable, str(EXTRACTOR), "--root", str(ROOT), "--list"],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    deployed = {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+
+    assert matrix_refs == deployed, (
+        "scan-thirdparty matrix drifted from the deployed third-party image set.\n"
+        f"  only in scan matrix : {sorted(matrix_refs - deployed)}\n"
+        f"  only in deployed    : {sorted(deployed - matrix_refs)}\n"
+        "Sync the scan-thirdparty matrix in .github/workflows/nightly-image-scan.yaml "
+        "with the chart values / k8s manifests (or adjust the extractor skip-lists)."
+    )
+
+
+def test_report_expected_counts_match_matrix_sizes() -> None:
+    """The report's hardcoded EXPECTED (5 / 14) must track the matrix sizes."""
+    n_selfbuilt = len(_matrix_include("scan"))
+    n_thirdparty = len(_matrix_include("scan-thirdparty"))
+    run = _aggregate_run()
+
+    m_sb = re.search(r'frags-sb.*?\s(\d+)\s+"self-built component"', run, re.S)
+    m_tp = re.search(r'frags-tp.*?\s(\d+)\s+"third-party upstream image"', run, re.S)
+
+    assert m_sb is not None, "could not find the self-built file_cve_report.sh EXPECTED arg"
+    assert m_tp is not None, "could not find the third-party file_cve_report.sh EXPECTED arg"
+    assert int(m_sb.group(1)) == n_selfbuilt, (
+        f"report self-built EXPECTED={m_sb.group(1)} != {n_selfbuilt} scan matrix entries"
+    )
+    assert int(m_tp.group(1)) == n_thirdparty, (
+        f"report third-party EXPECTED={m_tp.group(1)} != {n_thirdparty} scan-thirdparty entries"
+    )

--- a/tests/ops/test_summarize_trivy_cve.sh
+++ b/tests/ops/test_summarize_trivy_cve.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Offline unit test for scripts/ops/summarize_trivy_cve.sh (#902 L1-A).
+# A schedule/dispatch-only workflow (nightly-image-scan.yaml) can't exercise its
+# own bash in PR CI, so the extracted summarizer is validated offline here with
+# real-shaped Trivy JSON. Requires jq + bash 4 (run in the dev container).
+#
+#   bash tests/ops/test_summarize_trivy_cve.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../../scripts/ops/summarize_trivy_cve.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# --- Case 1: CVEs present, dedup by VulnerabilityID (3 vulns, 1 dup → 2 unique) ---
+cat > trivy-imgA.json <<'JSON'
+{
+  "Results": [
+    {
+      "Target": "imgA (debian 13)",
+      "Vulnerabilities": [
+        {"Severity": "HIGH", "VulnerabilityID": "CVE-2026-1111", "PkgName": "libfoo", "InstalledVersion": "1.0", "FixedVersion": "1.1"},
+        {"Severity": "CRITICAL", "VulnerabilityID": "CVE-2026-2222", "PkgName": "libbar", "InstalledVersion": "2.0", "FixedVersion": "2.1"},
+        {"Severity": "HIGH", "VulnerabilityID": "CVE-2026-1111", "PkgName": "libfoo-extra", "InstalledVersion": "1.0", "FixedVersion": "1.1"}
+      ]
+    }
+  ]
+}
+JSON
+bash "$SCRIPT" imgA
+head1="$(head -n1 frag-imgA.txt)"
+[ "$head1" = "$(printf 'imgA\t2')" ] || fail "case1 header expected 'imgA<TAB>2', got '$head1'"
+grep -q "CVE-2026-1111" frag-imgA.txt || fail "case1 missing CVE-2026-1111"
+grep -q "CVE-2026-2222" frag-imgA.txt || fail "case1 missing CVE-2026-2222"
+grep -q "fixable HIGH/CRITICAL</summary>" frag-imgA.txt || fail "case1 missing details summary"
+echo "ok: case1 (dedup → count=2)"
+
+# --- Case 2: no vulnerabilities → clean line, count 0 ---
+cat > trivy-imgB.json <<'JSON'
+{ "Results": [ { "Target": "imgB", "Vulnerabilities": [] } ] }
+JSON
+bash "$SCRIPT" imgB
+head1="$(head -n1 frag-imgB.txt)"
+[ "$head1" = "$(printf 'imgB\t0')" ] || fail "case2 header expected 'imgB<TAB>0', got '$head1'"
+grep -q "clean (0 fixable HIGH/CRITICAL)" frag-imgB.txt || fail "case2 missing clean line"
+echo "ok: case2 (clean → count=0)"
+
+# --- Case 3: Results key absent (schema drift) → MUST abort (fail-loud) ---
+echo '{"Foo": 1}' > trivy-imgC.json
+if bash "$SCRIPT" imgC >/dev/null 2>&1; then
+  fail "case3 schema-drift JSON should abort, but exited 0"
+fi
+echo "ok: case3 (schema drift → abort)"
+
+# --- Case 4: malformed/truncated JSON → MUST abort (fail-loud) ---
+printf '{"Results": [ {"Vuln' > trivy-imgD.json   # truncated
+if bash "$SCRIPT" imgD >/dev/null 2>&1; then
+  fail "case4 malformed JSON should abort, but exited 0"
+fi
+echo "ok: case4 (malformed → abort)"
+
+echo "PASS: all summarize_trivy_cve.sh cases"

--- a/tests/ops/test_summarize_trivy_cve.sh
+++ b/tests/ops/test_summarize_trivy_cve.sh
@@ -62,4 +62,20 @@ if bash "$SCRIPT" imgD >/dev/null 2>&1; then
 fi
 echo "ok: case4 (malformed → abort)"
 
+# --- Case 5: defensive filter — LOW + unfixed are excluded even if Trivy emits them ---
+cat > trivy-imgE.json <<'JSON'
+{ "Results": [ { "Vulnerabilities": [
+  {"Severity":"LOW","VulnerabilityID":"CVE-2026-9001","PkgName":"a","InstalledVersion":"1","FixedVersion":"2"},
+  {"Severity":"HIGH","VulnerabilityID":"CVE-2026-9002","PkgName":"b","InstalledVersion":"1","FixedVersion":""},
+  {"Severity":"CRITICAL","VulnerabilityID":"CVE-2026-9003","PkgName":"c","InstalledVersion":"1","FixedVersion":"2"}
+] } ] }
+JSON
+bash "$SCRIPT" imgE
+head1="$(head -n1 frag-imgE.txt)"
+[ "$head1" = "$(printf 'imgE\t1')" ] || fail "case5 expected 'imgE<TAB>1' (only fixable HIGH/CRITICAL), got '$head1'"
+grep -q "CVE-2026-9003" frag-imgE.txt || fail "case5 missing the fixable CRITICAL"
+grep -q "CVE-2026-9001" frag-imgE.txt && fail "case5 LOW must be excluded"
+grep -q "CVE-2026-9002" frag-imgE.txt && fail "case5 unfixed HIGH must be excluded"
+echo "ok: case5 (defensive filter excludes LOW + unfixed)"
+
 echo "PASS: all summarize_trivy_cve.sh cases"


### PR DESCRIPTION
## What — #902 L1 (third-party image CVE detection)

Three commits closing the verified gap that **third-party upstream images had zero automated CVE detection** (PR / release / the existing nightly job all scanned only the 5 self-built component images):

- **L1-A** — `scan-thirdparty` job Trivy-scans the **14 public upstream images** (envoy, oauth2-proxy, prom-label-proxy, vector, victoria-logs, python, mariadb, mysqld-exporter, grafana, prometheus, alertmanager, kube-state-metrics, configmap-reload, alpine/git). Shared fail-loud `scripts/ops/summarize_trivy_cve.sh`.
- **L1-A.1** — **split alerts**: self-built (`nightly-cve`, the release-gate signal) vs third-party (`nightly-cve-thirdparty`, informational) tracking issues, so a self-built regression isn't buried under third-party debt. Shared `scripts/ops/file_cve_report.sh`.
- **L1-B** — **`image-ref-resolve` PR gate**: parses helm values + k8s manifests and verifies every concrete public third-party ref resolves in its registry — catches a typo'd / yanked tag at PR time (the #897 `mariadb:11.8.1` class, which the nightly scan can't catch since it resolves the matrix, not values). `scripts/ops/check_image_refs_resolve.py`.

## Why this shape (not the original #902)

The original "pin ALL chart images + Renovate" framing was over-scoped. #902 is now a 3-layer plan; this PR is **L1 (detection)**. **L2** (selective digest pin, trust-boundary order) and **L3** (Renovate auto-bump, deferred to ride the planned lang-dep Renovate) follow separately. L1 (Trivy) and L3 (Renovate) are complementary — Renovate does not do base-image OS CVE detection.

## Validation

- **L1-A end-to-end** (`workflow_dispatch` on this branch): 20/20 jobs green, all 14 third-party scanned, report aggregated. Surfaced **~160 fixable HIGH/CRITICAL CVEs** across the 14 (previously invisible) — grafana 32, KSM 18, mariadb/vlogs/configmap-reload 16 each, … (remediation = upstream tag bumps → the L2/L3 business case).
- **L1-B end-to-end** (docker): `mariadb:11.8.1` → FAIL (`no such manifest`), `python:3.13-slim` → ok, exit 1 — exactly the #897 scenario. The L1-B gate runs on this PR (it touches the checker) over the 14 public refs (all known-good → expected green).
- Offline unit tests: `summarize` 4/4, `file_cve_report` 4/4 (DRY_RUN), `check_image_refs_resolve` 5/5. YAML + structural sanity.
- **Adversarial review caught + fixed**: 5 missed `k8s/` images (L1-A); a missing report-job `checkout` (L1-A.1); local-built + first-party false-positives (L1-B).

## Scope notes

- First-party (`ghcr.io/vencil/*`) + locally-built (`federation-audit-sidecar`) + grafana plugin + `try-local/` compose: intentionally out of scope (release-flow / not-an-image / dev-only).
- Docker Hub refs pulled anonymously; manifest inspects are light so rate limits are unlikely (the scan's full pulls noted separately).
- Node.js 20 deprecation warnings on existing actions are pre-existing, not introduced here.

## Review follow-ups (in this PR)

- **CodeRabbit nitpick** — `summarize_trivy_cve.sh` now defensively `select`s fixable HIGH/CRITICAL inside jq, so the count stays self-consistent even if the workflow Trivy flags ever drift (no-op under current flags; pure defense-in-depth).
- **Drift guard** (`tests/ops/test_nightly_scan_matrix_drift.py`) — the `scan-thirdparty` matrix is asserted **equal to the L1-B extractor's deployed-ref SSOT**, and the report's `EXPECTED` counts to the matrix sizes. A manifest bump that forgets the scan matrix now **fails CI** instead of silently scanning a stale version (addresses the Gemini #907 dual-SSOT review). Renovate `regexManagers` (when L3 lands) is the complementary auto-sync.

Part of #902. Supersedes the #566 T5 detection gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
