### PR TITLE
feat: pin remaining third-party images by digest (#902 L2, slice 2)

### DIFF
--- a/.github/workflows/nightly-image-scan.yaml
+++ b/.github/workflows/nightly-image-scan.yaml
@@ -171,11 +171,11 @@ jobs:
         # alert (NOT a silent clean) — add a docker/login-action step then.
         include:
           - name: vector # helm/vector/values.yaml
-            ref: "timberio/vector:0.55.0-distroless-libc"
+            ref: "timberio/vector:0.55.0-distroless-libc@sha256:2fe99882ec787d8641bc620a7e3a1ce3b5e41375c8d681cacfac219620ba7a7e"
           - name: victoria-logs # helm/victorialogs/values.yaml
-            ref: "victoriametrics/victoria-logs:v1.50.0"
+            ref: "victoriametrics/victoria-logs:v1.50.0@sha256:ae9bea8d8a3b0fc47c7f0058bcca410e79c84b4a0acd12d4dac71b9302526590"
           - name: chargeback-python # helm/chargeback-aggregator/values.yaml
-            ref: "python:3.13-slim"
+            ref: "python:3.13-slim@sha256:c33f0bc4364a6881bed1ec0cc2665e6c53c87a43e774aaeab88e6f17af105e4f"
           - name: envoy # helm/federation-gateway/values.yaml
             ref: "envoyproxy/envoy:distroless-v1.38.0@sha256:a7a56545102f7a682e0cafea2c9b8448af1b09ebb710eab688dfb931e3ec7ff6"
           - name: oauth2-proxy # helm/da-portal + helm/tenant-api values.yaml
@@ -183,21 +183,21 @@ jobs:
           - name: prom-label-proxy # helm/federation-proxy/values.yaml
             ref: "quay.io/prometheuscommunity/prom-label-proxy:v0.13.0@sha256:11ccecc8f08d0ff8f978ada9de7f3a31518c9bb0ce8e15e6cf97dd5251b84f59"
           - name: mariadb # helm/mariadb-instance/values.yaml
-            ref: "mariadb:11.8.8"
+            ref: "mariadb:11.8.8@sha256:be1ef4fe5f14589325c08a41c76334097ce66c86264b75e1d28342c742782a61"
           - name: mysqld-exporter # helm/mariadb-instance/values.yaml
-            ref: "prom/mysqld-exporter:v0.18.0"
+            ref: "prom/mysqld-exporter:v0.18.0@sha256:2598c0571f383708e19016d119bb45c06128a9ebc962c9f49483278ac5a94c41"
           - name: grafana # k8s/03-monitoring/deployment-grafana.yaml
-            ref: "grafana/grafana:12.4.2"
+            ref: "grafana/grafana:12.4.2@sha256:83749231c3835e390a3144e5e940203e42b9589761f20ef3169c716e734ad505"
           - name: prometheus # k8s/03-monitoring/deployment-prometheus.yaml
-            ref: "prom/prometheus:v3.11.2"
+            ref: "prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78"
           - name: alertmanager # k8s/03-monitoring/deployment-alertmanager.yaml
-            ref: "prom/alertmanager:v0.32.0"
+            ref: "prom/alertmanager:v0.32.0@sha256:58e117eabccebbff04e6643a3432d6315a2cc3a8c24ab5849bc628886bf08857"
           - name: kube-state-metrics # k8s/03-monitoring/deployment-kube-state-metrics.yaml
-            ref: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0"
+            ref: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0@sha256:1545919b72e3ae035454fc054131e8d0f14b42ef6fc5b2ad5c751cafa6b2130e"
           - name: configmap-reload # k8s/03-monitoring/deployment-alertmanager.yaml (sidecar)
-            ref: "ghcr.io/jimmidyson/configmap-reload:v0.15.0"
+            ref: "ghcr.io/jimmidyson/configmap-reload:v0.15.0@sha256:b578b7599d65c0279f6e1aad201bba737b9b15e6a4f308281d9e26f765e6657f"
           - name: alpine-git # k8s/04-tenant-api/deployment.yaml (gitops sidecar)
-            ref: "alpine/git:v2.52.0"
+            ref: "alpine/git:v2.52.0@sha256:4a0e72d49596a1f5d3701aeedafdadc5c0da4062be4657c7bdc4017387f591cc"
     steps:
       # Authenticated Docker Hub pulls (rate-limit headroom); guarded no-op without creds.
       - name: Docker Hub login (no-op without creds)

--- a/helm/chargeback-aggregator/Chart.yaml
+++ b/helm/chargeback-aggregator/Chart.yaml
@@ -7,7 +7,8 @@ type: application
 # 0.1.1 — #539: self-review — exec_time_ms→_s (correctness), PVC resource-policy: keep, query both _s + _ms legacy across upgrade window
 # 0.1.2 — #566 T5: image.digest knob (supply-chain pinning); default empty so existing deploys are no-op
 # 0.2.0 — #566 batch C: CSV sha256 sidecar + append-only manifest.jsonl (T2-4 tamper-evident); extraEnv/extraEnvFrom (Q5 platform convention)
-version: 0.2.0
+# 0.2.1 — #902 L2 slice-2: pin the python base image by digest (image.digest)
+version: 0.2.1
 # appVersion: pinned python image
 appVersion: "3.13"
 keywords:

--- a/helm/chargeback-aggregator/values.yaml
+++ b/helm/chargeback-aggregator/values.yaml
@@ -16,7 +16,9 @@ image:
   tag: "3.13-slim"
   # Optional digest pin (#566 T5). See helm/victorialogs/values.yaml
   # for rationale + how to fetch.
-  digest: ""
+  # ⛔ Digest AUTHORITATIVE: `--set image.tag=…` alone won't upgrade (k8s keeps THIS
+  #    digest); also set/clear image.digest. #902 L2 (L3/Renovate will automate).
+  digest: "sha256:c33f0bc4364a6881bed1ec0cc2665e6c53c87a43e774aaeab88e6f17af105e4f"
   pullPolicy: IfNotPresent
 
 # Where the report lands. PVC because: CronJob output that nobody reads

--- a/helm/mariadb-instance/Chart.yaml
+++ b/helm/mariadb-instance/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: mariadb-instance
 description: MariaDB instance with mysqld-exporter sidecar for Prometheus monitoring
-version: 0.1.0
+# 0.1.1 — #902 L2 slice-2: pin mariadb + mysqld-exporter images by digest
+version: 0.1.1
 appVersion: "11"
 type: application

--- a/helm/mariadb-instance/values.yaml
+++ b/helm/mariadb-instance/values.yaml
@@ -4,7 +4,7 @@
 instance: db-a
 
 mariadb:
-  image: mariadb:11.8.8
+  image: mariadb:11.8.8@sha256:be1ef4fe5f14589325c08a41c76334097ce66c86264b75e1d28342c742782a61
   # SECURITY: Override these via --set or external secret manager in production.
   # Example: helm install ... --set mariadb.rootPassword=$(openssl rand -base64 24)
   rootPassword: ""    # REQUIRED — must be provided at install time
@@ -32,7 +32,7 @@ mariadb:
     long_query_time = 1
 
 exporter:
-  image: prom/mysqld-exporter:v0.18.0
+  image: prom/mysqld-exporter:v0.18.0@sha256:2598c0571f383708e19016d119bb45c06128a9ebc962c9f49483278ac5a94c41
   collectors:
     - global_status
     - global_variables

--- a/helm/tenant-api/Chart.yaml
+++ b/helm/tenant-api/Chart.yaml
@@ -4,7 +4,8 @@ description: Tenant Management API for the Dynamic Alerting Platform (ADR-009)
 type: application
 # version: Helm Chart 版本（隨 Chart 結構/模板變更升級）
 # 2.9.8 — #902 L2: pin oauth2-proxy sidecar by digest (oauth2Proxy.image.digest)
-version: 2.9.8
+# 2.9.9 — #902 L2 slice-2: pin the alpine/git init-container image by digest
+version: 2.9.9
 # appVersion: Go binary 版本
 appVersion: "2.7.0"
 keywords:

--- a/helm/tenant-api/templates/deployment.yaml
+++ b/helm/tenant-api/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       {{- if .Values.gitRepoUrl }}
       initContainers:
         - name: git-clone
-          image: alpine/git:v2.52.0
+          image: alpine/git:v2.52.0@sha256:4a0e72d49596a1f5d3701aeedafdadc5c0da4062be4657c7bdc4017387f591cc
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/helm/vector/Chart.yaml
+++ b/helm/vector/Chart.yaml
@@ -14,7 +14,8 @@ type: application
 # 0.4.0 — #566 T2-1: VRL gateway-origin filter (suspicious_audit reclassification); image.digest knob (T5); nil-safe `audit:` block lookup to survive `helm upgrade --reuse-values` from 0.3.x
 # 0.5.0 — #566 batch B: additionalSinks `_buffer_type: disk` mode (X-3); fail-loud guard on unknown buffer type; VRL audit-signing schema seam reserved (X-2)
 # 0.6.0 — ADR-021 Phase 1 / #609: (b) tenant-sanitized projection fan-out — log_event_id (uuid_v7) in demux; tenant_project (eligibility+enrichment+drop_fields, drop_on_error fail-closed) + tenant_route → static per-AccountID sinks (tenantProjections); demux/0:0 platform copy unchanged
-version: 0.6.0
+# 0.6.1 — #902 L2 slice-2: pin the Vector image by digest (image.digest)
+version: 0.6.1
 # appVersion: pinned Vector release
 appVersion: "0.55.0"
 keywords:

--- a/helm/vector/values.yaml
+++ b/helm/vector/values.yaml
@@ -16,7 +16,9 @@ image:
   tag: "0.55.0-distroless-libc"
   # Optional digest pin (#566 T5). See helm/victorialogs/values.yaml
   # for rationale + how to fetch.
-  digest: ""
+  # ⛔ Digest AUTHORITATIVE: `--set image.tag=…` alone won't upgrade (k8s keeps THIS
+  #    digest); also set/clear image.digest. #902 L2 (L3/Renovate will automate).
+  digest: "sha256:2fe99882ec787d8641bc620a7e3a1ce3b5e41375c8d681cacfac219620ba7a7e"
   pullPolicy: IfNotPresent
 
 # Where to ship logs. Default points at the in-cluster VictoriaLogs

--- a/helm/victorialogs/Chart.yaml
+++ b/helm/victorialogs/Chart.yaml
@@ -9,7 +9,8 @@ type: application
 # 0.1.3 — #566 T5: image.digest knob (supply-chain pinning); default empty so existing deploys are no-op
 # 0.1.4 — #566 Q5: extraEnv/extraEnvFrom (platform convention with helm/vector + helm/chargeback-aggregator)
 # 0.2.0 — ADR-021 Phase 1 / #609: Layer-1 query guardrails (.Values.search → -search.maxQueryTimeRange / maxQueryDuration / maxConcurrentRequests / maxQueueDuration); maxQueryDuration 25s < gateway 30s (cascading-timeout)
-version: 0.2.0
+# 0.2.1 — #902 L2 slice-2: pin the VictoriaLogs image by digest (image.digest)
+version: 0.2.1
 # appVersion: pinned VictoriaLogs release
 appVersion: "v1.50.0"
 keywords:

--- a/helm/victorialogs/values.yaml
+++ b/helm/victorialogs/values.yaml
@@ -26,7 +26,9 @@ image:
   # Empty (default) keeps `repo:tag` form — vulnerable to upstream
   # registry compromise but matches existing chart convention. Flip
   # the moment you have a supply-chain threat model that names this.
-  digest: ""
+  # ⛔ Digest AUTHORITATIVE: `--set image.tag=…` alone won't upgrade (k8s keeps THIS
+  #    digest); also set/clear image.digest. #902 L2 (L3/Renovate will automate).
+  digest: "sha256:ae9bea8d8a3b0fc47c7f0058bcca410e79c84b4a0acd12d4dac71b9302526590"
   pullPolicy: IfNotPresent
 
 # HTTP listen port for ingestion + query. VictoriaLogs default is 9428.

--- a/k8s/03-monitoring/deployment-alertmanager.yaml
+++ b/k8s/03-monitoring/deployment-alertmanager.yaml
@@ -29,7 +29,7 @@ spec:
           # generic webhook since v0.26.0 (PR prometheus/alertmanager#3223). The
           # pin below (a current stable release) is well past that floor — keep any
           # future bump ≥ v0.26.0 so the heartbeat secret keeps loading.
-          image: prom/alertmanager:v0.32.0
+          image: prom/alertmanager:v0.32.0@sha256:58e117eabccebbff04e6643a3432d6315a2cc3a8c24ab5849bc628886bf08857
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -77,7 +77,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
         - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.15.0
+          image: ghcr.io/jimmidyson/configmap-reload:v0.15.0@sha256:b578b7599d65c0279f6e1aad201bba737b9b15e6a4f308281d9e26f765e6657f
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/03-monitoring/deployment-grafana.yaml
+++ b/k8s/03-monitoring/deployment-grafana.yaml
@@ -24,7 +24,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: grafana
-          image: grafana/grafana:12.4.2
+          image: grafana/grafana:12.4.2@sha256:83749231c3835e390a3144e5e940203e42b9589761f20ef3169c716e734ad505
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/03-monitoring/deployment-kube-state-metrics.yaml
+++ b/k8s/03-monitoring/deployment-kube-state-metrics.yaml
@@ -95,7 +95,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: kube-state-metrics
-          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.18.0@sha256:1545919b72e3ae035454fc054131e8d0f14b42ef6fc5b2ad5c751cafa6b2130e
           # ADR-024 version-aware threshold HARD PREREQUISITE: by default KSM emits
           # ZERO pod-label series for `kube_pod_labels` (only HELP, no samples), so
           # the rule pack's (0a) version-injection join matches nothing and EVERY

--- a/k8s/03-monitoring/deployment-prometheus.yaml
+++ b/k8s/03-monitoring/deployment-prometheus.yaml
@@ -25,7 +25,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: prometheus
-          image: prom/prometheus:v3.11.2
+          image: prom/prometheus:v3.11.2@sha256:5550dc63da361dc30f6fe02ac0e4dfc736ededfef3c8d12a634db04a67824d78
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/04-tenant-api/deployment.yaml
+++ b/k8s/04-tenant-api/deployment.yaml
@@ -53,7 +53,7 @@ spec:
       # container and use a hostPath volume instead (see volumes section).
       initContainers:
         - name: git-clone
-          image: alpine/git:v2.52.0
+          image: alpine/git:v2.52.0@sha256:4a0e72d49596a1f5d3701aeedafdadc5c0da4062be4657c7bdc4017387f591cc
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false  # git needs to write .git/

--- a/tests/shared/test_helm_chart_log_aggregation.py
+++ b/tests/shared/test_helm_chart_log_aggregation.py
@@ -285,22 +285,22 @@ class TestVector:
 
     @_needs_helm
     def test_image_digest_knob(self, repo_root: Path) -> None:
-        """#566 T5: image.digest empty → `repo:tag`; digest set →
-        `repo:tag@sha256:...`. Templating the @-form wrong silently
-        ships a colon-without-digest and kubelet falls back to tag pulls
-        — defeating the pinning."""
-        # Empty default → no @
-        docs = _render(repo_root / "helm/vector")
-        ds = [d for d in docs if d.get("kind") == "DaemonSet"][0]
-        img = ds["spec"]["template"]["spec"]["containers"][0]["image"]
-        assert "@" not in img, "default empty digest must NOT add @"
-        # Set digest → @sha256: appended
-        docs = _render(repo_root / "helm/vector", sets={
-            "image.digest": "sha256:0123456789abcdef",
-        })
-        ds = [d for d in docs if d.get("kind") == "DaemonSet"][0]
-        img = ds["spec"]["template"]["spec"]["containers"][0]["image"]
-        assert img.endswith("@sha256:0123456789abcdef")
+        """#566 T5 knob + #902 L2 pin: the chart now SHIPS a pinned digest by
+        default (`repo:tag@sha256:...`); the knob can be cleared
+        (`--set image.digest=""` → `repo:tag`) or overridden. Templating the
+        @-form wrong silently ships a colon-without-digest and kubelet falls
+        back to tag pulls — defeating the pinning."""
+        def _image(sets=None):
+            docs = _render(repo_root / "helm/vector", sets=sets) if sets else _render(repo_root / "helm/vector")
+            ds = [d for d in docs if d.get("kind") == "DaemonSet"][0]
+            return ds["spec"]["template"]["spec"]["containers"][0]["image"]
+
+        # Default now ships a pinned digest (#902 L2).
+        assert "@sha256:" in _image(), "default should now ship a pinned digest (#902 L2)"
+        # Cleared digest → plain repo:tag (knob still works).
+        assert "@" not in _image({"image.digest": ""}), "cleared digest must NOT add @"
+        # Overridden digest → that @sha256: appended.
+        assert _image({"image.digest": "sha256:0123456789abcdef"}).endswith("@sha256:0123456789abcdef")
 
     @_needs_helm
     def test_extra_env_renders_into_daemonset(self, repo_root: Path) -> None:


### PR DESCRIPTION
## What

**L2 of #902, slice 2** — pin the **remaining 11** third-party images by `@sha256` digest, **completing third-party digest coverage (14/14** with slice 1's 3 boundary images).

| Form | Images |
|---|---|
| Chart `image.digest` knob | vector, victoria-logs, python (chargeback base) |
| Single-string helm value | mariadb, mysqld-exporter (mariadb-instance) |
| Raw `k8s/03-monitoring` manifests | prometheus, alertmanager, kube-state-metrics, configmap-reload, grafana |
| init image (chart template + raw) | alpine/git (tenant-api + k8s/04-tenant-api) |

Per-change Chart bumps: vector 0.6.1 / victoria-logs 0.2.1 / chargeback 0.2.1 / mariadb-instance 0.1.1 / tenant-api 2.9.9 (all `version != appVersion`, no release-coupling).

## Consistency (the drift-guard is the safety net for this 14-image batch)

- The `scan-thirdparty` matrix is synced in lockstep; the **drift-guard** asserts all 14 third-party refs are pinned + identical across values / manifests / matrix.
- Digests resolved via `docker buildx imagetools inspect <ref> --format '{{ .Manifest.Digest }}'` (multi-arch manifest-list digest — pins all arches, not just amd64).
- Resolve gate handles `repo:tag@digest` (normalizes to `repo@digest` for skopeo — slice-1 fix); Trivy / go-containerregistry accepts the form directly (verified).

## Notes

- **Single-string refs** (mariadb / k8s raw / alpine-git) get **no** tag-override ⛔ warning — `--set image=…` replaces the whole ref including the digest, so there's no version-upgrade illusion (that was specific to the split `repo:tag@digest` knob, which the 3 chart-knob charts carry + warn on).
- This **completes L2** (all 14 third-party pinned). **L3 (Renovate auto-bump) is now the must-have closing mechanism** — until it lands, the `nightly-cve-thirdparty` issue stays red on a pinned image until a manual digest bump (see #902).

Part of #902 (L2 — completes the pinning). Builds on L1 (#907) + L2 slice 1 (#910).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
