### PR TITLE
chore: repoint observed-map defer anchors #721 → #916

### DIFF
--- a/scripts/tools/lint/check_threshold_observed_map.py
+++ b/scripts/tools/lint/check_threshold_observed_map.py
@@ -22,7 +22,7 @@ What it checks (via _observed_map_lib.check_consistency)
   observed-series prefix (split-brain). These fail CI.
 - **infos (OK)**: known-deferred keys (KNOWN_DEFERRED allowlist, e.g. the
   version-aware ``container_cpu`` / ``container_memory`` whose comparison lives
-  in a ``:core`` recording rule, deferred to #721 item 7). Printed as INFO,
+  in a ``:core`` recording rule, deferred to #916). Printed as INFO,
   NEVER an error — otherwise this bugfix could never merge.
 - **orphan_thresholds (WARN)**: a ``record: tenant:alert_threshold:<key>`` with
   NO alert referencing it — a rule-pack gap, surfaced for the pack authors, not

--- a/scripts/tools/ops/_observed_map_lib.py
+++ b/scripts/tools/ops/_observed_map_lib.py
@@ -20,7 +20,7 @@ Guardrails baked in (#719 / Gemini adversarial review):
     ``needs_review`` (don't auto-pick), unless a clean ``<key>_critical`` sibling
     disambiguates it.
   - R2 direction: capture ``>`` / ``<``. Lower-bound (``<``) metrics get
-    ``needs_review`` (P95-upper recommendation is wrong for them; #721 item 6).
+    ``needs_review`` (P95-upper recommendation is wrong for them; #916).
   - R3 denylist: only ``tenant:`` / ``tenant_version:`` colon-delimited recording
     rules count as observed; ``tenant_metadata_info`` / ``user_state_filter`` /
     ``tenant:alert_threshold:*`` are excluded.
@@ -193,7 +193,7 @@ def build_map(pack_paths: list[str]) -> dict[str, Any]:
         # Only auto-resolve a single observed_series for SUPPORTED (tenant) scope.
         # Unsupported-scope (e.g. tenant_version) alerts are often compound
         # (sentinels cross-reference multiple thresholds) so containment can't
-        # reliably pick the operand — emit candidates honestly for #721 item 7.
+        # reliably pick the operand — emit candidates honestly for #916.
         resolved: Optional[str] = None
         if scope not in SUPPORTED_SCOPES:
             resolved = None
@@ -214,7 +214,7 @@ def build_map(pack_paths: list[str]) -> dict[str, Any]:
         if scope not in SUPPORTED_SCOPES:
             reasons.append(
                 f"unsupported recommendation scope '{scope}' — engine supports "
-                "'tenant' granularity only (deferred #721 item 7)"
+                "'tenant' granularity only (deferred #916)"
             )
         if e["scaled"]:
             reasons.append("alert applies numeric scaling to observed operand — verify exact query expression")
@@ -223,7 +223,7 @@ def build_map(pack_paths: list[str]) -> dict[str, Any]:
         elif len(dirs) > 1:
             reasons.append(f"ambiguous direction {dirs}")
         elif dirs == ["<"]:
-            reasons.append("lower-bound (<) metric — P95-upper recommendation not applicable (#721 item 6)")
+            reasons.append("lower-bound (<) metric — P95-upper recommendation not applicable (#916)")
         if not resolved and len(cands) != 1:
             reasons.append(f"{len(cands)} observed candidates in composite alert — pick one")
 
@@ -262,11 +262,11 @@ DEFAULT_RULE_PACKS_DIR = os.path.join(_REPO_ROOT, "rule-packs")
 # Keys deliberately NOT in the observed-map: their threshold comparison lives in
 # a recording rule (`:core`), not a `- alert:`, so the alert-based extractor
 # cannot reach them. Version-aware (ADR-024) recommendation — extraction AND
-# per-version logic — is tracked as #721 item 7. The drift-guard treats these as
+# per-version logic — is tracked as #916. The drift-guard treats these as
 # INFO (known-deferred), NOT an error, so this bugfix can merge.
 KNOWN_DEFERRED: dict[str, str] = {
-    "container_cpu": "version-aware (ADR-024) — recording-rule sourced, #721 item 7",
-    "container_memory": "version-aware (ADR-024) — recording-rule sourced, #721 item 7",
+    "container_cpu": "version-aware (ADR-024) — recording-rule sourced, #916",
+    "container_memory": "version-aware (ADR-024) — recording-rule sourced, #916",
 }
 
 
@@ -343,7 +343,7 @@ def resolve_observed(entry: dict[str, Any]) -> tuple[Optional[str], Optional[str
     if scope not in SUPPORTED_SCOPES:
         return None, (
             f"unsupported scope '{scope}' — engine supports 'tenant' only "
-            "(deferred #721 item 7)"
+            "(deferred #916)"
         )
     direction = entry.get("direction")
     if direction != ">":
@@ -352,7 +352,7 @@ def resolve_observed(entry: dict[str, Any]) -> tuple[Optional[str], Optional[str
         # through to a recommendation — the percentile strategy is only valid
         # for ``observed > threshold`` alerts.
         if direction == "<":
-            return None, "lower-bound (<) metric — not supported (#721 item 6)"
+            return None, "lower-bound (<) metric — not supported (#916)"
         return None, "missing or ambiguous comparison direction — manual review required"
     series = entry.get("observed_series")
     if not series:

--- a/scripts/tools/ops/metric_observed_map.yaml
+++ b/scripts/tools/ops/metric_observed_map.yaml
@@ -39,8 +39,7 @@ keys:
     candidates:
     - tenant:db2_bufferpool_hit_ratio:min
     needs_review: true
-    reason: lower-bound (<) metric — P95-upper recommendation not applicable (#721
-      item 6)
+    reason: lower-bound (<) metric — P95-upper recommendation not applicable (#916)
   db2_connections_active:
     pack: rule-pack-db2.yaml
     scope: tenant
@@ -120,8 +119,7 @@ keys:
     candidates:
     - tenant:kafka_active_controllers:max
     needs_review: true
-    reason: lower-bound (<) metric — P95-upper recommendation not applicable (#721
-      item 6)
+    reason: lower-bound (<) metric — P95-upper recommendation not applicable (#916)
   kafka_broker_count:
     pack: rule-pack-kafka.yaml
     scope: tenant
@@ -129,8 +127,7 @@ keys:
     candidates:
     - tenant:kafka_broker_count:max
     needs_review: true
-    reason: lower-bound (<) metric — P95-upper recommendation not applicable (#721
-      item 6)
+    reason: lower-bound (<) metric — P95-upper recommendation not applicable (#916)
   kafka_consumer_lag:
     pack: rule-pack-kafka.yaml
     scope: tenant
@@ -285,8 +282,7 @@ keys:
     candidates:
     - tenant:rabbitmq_consumers:max
     needs_review: true
-    reason: lower-bound (<) metric — P95-upper recommendation not applicable (#721
-      item 6)
+    reason: lower-bound (<) metric — P95-upper recommendation not applicable (#916)
   rabbitmq_node_mem_percent:
     pack: rule-pack-rabbitmq.yaml
     scope: tenant

--- a/tests/ops/test_observed_map_lib.py
+++ b/tests/ops/test_observed_map_lib.py
@@ -90,7 +90,7 @@ class TestExtraction:
         m = L.build_map([p])
         assert m["bar"].get("needs_review") is True
         assert m["bar"]["direction"] == "<"
-        assert "#721 item 6" in m["bar"]["reason"]
+        assert "#916" in m["bar"]["reason"]
         assert "observed_series" not in m["bar"]
 
     def test_composite_needs_review_with_candidates(self, tmp_path):

--- a/tests/ops/test_observed_map_lib.py
+++ b/tests/ops/test_observed_map_lib.py
@@ -90,7 +90,7 @@ class TestExtraction:
         m = L.build_map([p])
         assert m["bar"].get("needs_review") is True
         assert m["bar"]["direction"] == "<"
-        assert "#916" in m["bar"]["reason"]
+        assert "lower-bound" in m["bar"]["reason"]  # semantic, not a brittle issue-ref pin
         assert "observed_series" not in m["bar"]
 
     def test_composite_needs_review_with_candidates(self, tmp_path):

--- a/tests/ops/test_threshold_govern.py
+++ b/tests/ops/test_threshold_govern.py
@@ -416,14 +416,14 @@ def test_collect_ungoverned_isolates_lower_bound():
         _report("db-a", [
             _kr("mysql_connections", "2000", 100.0, -95.0, recommend.CONFIDENCE_HIGH),
             _kr("db2_hit_ratio", "0.9",
-                reason="skipped: lower-bound (<) metric — not supported (#721 item 6)"),
+                reason="skipped: lower-bound (<) metric — not supported (#916)"),
             _kr("redis_mem", "x",
                 reason="no observed-load mapping for this key — not in observed-map (skipped)"),
         ]),
         _report("db-b", [
             _kr("kafka_active_controllers", "1",
                 reason="skipped: lower-bound (<) metric — P95-upper recommendation "
-                       "not applicable (#721 item 6)"),
+                       "not applicable (#916)"),
         ]),
     ]
     ung = tg.collect_ungoverned_lower_bound(reports)
@@ -436,7 +436,7 @@ def test_run_surfaces_ungoverned_but_keeps_it_out_of_plans(monkeypatch):
     reports = [_report("db-a", [
         _kr("mysql_connections", "2000", 100.0, -95.0, recommend.CONFIDENCE_HIGH, p95=100.0),
         _kr("db2_hit_ratio", "0.9",
-            reason="skipped: lower-bound (<) metric — not supported (#721 item 6)"),
+            reason="skipped: lower-bound (<) metric — not supported (#916)"),
     ])]
     monkeypatch.setattr(recommend, "run_analysis", lambda *a, **k: reports)
     plans, outcomes, ungoverned = tg.run(_args(apply=False))

--- a/tests/ops/test_threshold_recommend.py
+++ b/tests/ops/test_threshold_recommend.py
@@ -289,13 +289,13 @@ class TestAnalyzeTenant:
             "direction": "<",
             "candidates": ["tenant:broker_count:max"],
             "needs_review": True,
-            "reason": "lower-bound (<) metric — #721 item 6",
+            "reason": "lower-bound (<) metric — #916",
         },
         "container_cpu": {
             "scope": "tenant_version",
             "candidates": ["tenant_version:pod_weakest_cpu_percent:vlabeled"],
             "needs_review": True,
-            "reason": "unsupported scope — #721 item 7",
+            "reason": "unsupported scope — #916",
         },
     }
 
@@ -318,16 +318,16 @@ class TestAnalyzeTenant:
         assert "not in observed-map" in rec.reason
 
     def test_lower_bound_key_skipped(self):
-        """下界 (<) key skip（#721 item 6）。"""
+        """下界 (<) key skip（#916）。"""
         config = {"broker_count": 3}
         report = tr.analyze_tenant("db-a", config, dry_run=True, observed_map=self.HERMETIC_MAP)
         rec = report.keys[0]
         assert rec.promql == ""
         assert "skipped" in rec.reason
-        assert "#721 item 6" in rec.reason
+        assert "#916" in rec.reason
 
     def test_unsupported_scope_key_skipped(self):
-        """version-aware (tenant_version scope) key skip（#721 item 7）。"""
+        """version-aware (tenant_version scope) key skip（#916）。"""
         config = {"container_cpu": 80}
         report = tr.analyze_tenant("db-a", config, dry_run=True, observed_map=self.HERMETIC_MAP)
         rec = report.keys[0]
@@ -476,7 +476,7 @@ class TestExportPatch:
                                      delta_pct=-2.2, confidence="HIGH",
                                      reason="within 5% margin, no change needed"),
                 tr.KeyRecommendation("kafka_broker_count", "3", recommended=None,
-                                     reason="skipped: lower-bound (<) metric — #721 item 6"),
+                                     reason="skipped: lower-bound (<) metric — #916"),
             ],
             total_keys=3,
             recommended_changes=1,

--- a/tests/ops/test_threshold_recommend.py
+++ b/tests/ops/test_threshold_recommend.py
@@ -324,7 +324,7 @@ class TestAnalyzeTenant:
         rec = report.keys[0]
         assert rec.promql == ""
         assert "skipped" in rec.reason
-        assert "#916" in rec.reason
+        assert "lower-bound" in rec.reason  # semantic, not a brittle issue-ref pin
 
     def test_unsupported_scope_key_skipped(self):
         """version-aware (tenant_version scope) key skip（#916）。"""


### PR DESCRIPTION
## 摘要

#721（DEC-F deferred-with-trigger omnibus）拆解的機械收尾：把原始碼中指向 `#721 item 6/7` 的 14 處 defer 錨點 repoint 至聚焦 issue #916（下界 metric 推薦策略 + observed-map 長尾覆蓋）。

## 變更

- `scripts/tools/ops/_observed_map_lib.py`：9 處註解 / reason 字串 `#721 item 6/7` → `#916`
- `scripts/tools/ops/metric_observed_map.yaml`：4 筆 lower-bound `needs_review` reason `#721 item 6` → `#916`（順帶從 2-line wrap 收斂為單行）
- `scripts/tools/lint/check_threshold_observed_map.py`：1 處 INFO known-deferred 文件字串

## 為什麼安全

- **純註解 / reason 字串變更，零行為變更。**
- **未重生 map**（`write_observed_map()` 會覆蓋 #719 手動 resolve 的條目）→ 改以 hand-edit 同步 reason 字串。
- drift-guard `check_threshold_observed_map.py` 改動前後皆綠（structural 一致、2 known-deferred / 0 orphan / 0 gap）。
- 其餘 `#721` 引用（`threshold_recommend.py` in-place-edit defer、`cli-reference.md/.en.md`）語意屬 item 1（in-place YAML 編輯）範疇，刻意保留指向已收尾的 #721。

## Refs
#916 / #721 / #719
