### PR TITLE
refactor(tenant-api): parse write-path validate body once, drop 3rd redundant unmarshal (#708)

### DIFF
--- a/components/tenant-api/internal/gitops/writer.go
+++ b/components/tenant-api/internal/gitops/writer.go
@@ -519,7 +519,12 @@ func validate(configDir, tenantID, yamlContent string) []string {
 	if configDir == "" {
 		keyErrs = tcfg.ValidateTenantKeys()
 	} else {
-		merged := cfg.MergeTenantWithRootDefaults(configDir, tenantID, []byte(yamlContent))
+		// Reuse the body we already decoded into tcfg above instead of handing
+		// raw bytes to MergeTenantWithRootDefaults, which would Unmarshal the
+		// same yamlContent a third time (#708). tcfg.Tenants[tenantID] is proven
+		// present by the check above, so the byte variant's flat-KV fallback —
+		// the only behavior the parsed sibling omits — is unreachable here.
+		merged := cfg.MergeParsedTenantWithRootDefaults(configDir, tcfg)
 		keyErrs = merged.ValidateTenantKeys()
 	}
 	// S5 shift-left preflight (ADR-024 §S5): validate the tenant's OWN `_custom_alerts`

--- a/components/threshold-exporter/app/pkg/config/merge_tenant.go
+++ b/components/threshold-exporter/app/pkg/config/merge_tenant.go
@@ -157,7 +157,10 @@ func mergeTenantConfig(configDir string, tenantCfg ThresholdConfig) ThresholdCon
 	// Merge the tenant config's `tenants:` block on top.
 	for tenant, overrides := range tenantCfg.Tenants {
 		if merged.Tenants[tenant] == nil {
-			merged.Tenants[tenant] = make(map[string]ScheduledValue)
+			// Pre-size to the known override count: a tenant can carry many
+			// metric thresholds, so sizing the destination lets the copy below
+			// fill without incremental map growth/rehashing (#708 review nit).
+			merged.Tenants[tenant] = make(map[string]ScheduledValue, len(overrides))
 		}
 		for k, v := range overrides {
 			merged.Tenants[tenant][k] = v

--- a/components/threshold-exporter/app/pkg/config/merge_tenant.go
+++ b/components/threshold-exporter/app/pkg/config/merge_tenant.go
@@ -56,14 +56,16 @@ func CheckTenantRootKeys(yamlContent []byte) []string {
 //
 // This is the single source of truth for the lightweight, root-only merge used
 // across the tenant-api boundary:
-//   - GET  /api/v1/tenants/{id}            (handler.loadMergedConfig)
-//   - POST /api/v1/tenants/{id}/validate   (dry-run validation)
-//   - PUT  /api/v1/tenants/{id}            (gitops write-boundary validation)
+//   - GET  /api/v1/tenants/{id}            (handler.loadMergedConfig, raw bytes)
+//   - POST /api/v1/tenants/{id}/validate   (dry-run validation, raw bytes)
+//   - PUT  /api/v1/tenants/{id}            (gitops write-boundary validation,
+//     via the MergeParsedTenantWithRootDefaults sibling — same merge core, a
+//     pre-decoded body to avoid a redundant Unmarshal, #708)
 //
-// Consolidating these three call sites here is deliberate: a previous copy in
-// the write path did NOT merge defaults, so a tenant-only body validated clean
-// on GET//validate but was rejected at write time — the asymmetry tracked by
-// ADR-024 PR4 / #704.
+// Consolidating these call sites on one merge core is deliberate: a previous
+// copy in the write path did NOT merge defaults, so a tenant-only body validated
+// clean on GET//validate but was rejected at write time — the asymmetry tracked
+// by ADR-024 PR4 / #704.
 //
 // It is intentionally NOT the full L0..Ln cascade that ResolveEffective walks
 // (that one is parity-pinned to describe_tenant.py for the /effective
@@ -71,6 +73,64 @@ func CheckTenantRootKeys(yamlContent []byte) []string {
 // _defaults.yaml cascades are out of scope here, matching the historical
 // loadMergedConfig behavior this consolidates.
 func MergeTenantWithRootDefaults(configDir, tenantID string, tenantData []byte) ThresholdConfig {
+	// Decode the tenant body into the typed config. A decode error contributes
+	// no overrides (the historical behavior: the merge loop was guarded by
+	// `err == nil`); YAML validity is the caller's gate.
+	var tenantCfg ThresholdConfig
+	if err := yaml.Unmarshal(tenantData, &tenantCfg); err != nil {
+		tenantCfg = ThresholdConfig{}
+	}
+
+	merged := mergeTenantConfig(configDir, tenantCfg)
+
+	// Fallback: a flat key-value document (no `tenants:` wrapper) is wrapped
+	// under tenantID. Preserves the historical loadMergedConfig behavior. This
+	// raw-bytes re-decode lives only on the byte entry point — the parsed
+	// variant's callers (the write boundary) have already asserted a
+	// `tenants.<id>` block, so the fallback is unreachable for them.
+	if _, exists := merged.Tenants[tenantID]; !exists {
+		var flatKV map[string]ScheduledValue
+		if err := yaml.Unmarshal(tenantData, &flatKV); err == nil && len(flatKV) > 0 {
+			merged.Tenants[tenantID] = flatKV
+		}
+	}
+
+	merged.ApplyProfiles()
+	return merged
+}
+
+// MergeParsedTenantWithRootDefaults is the parse-once variant of
+// MergeTenantWithRootDefaults for callers that have ALREADY decoded the tenant
+// body into a ThresholdConfig. It overlays that parsed config on the root
+// _defaults.yaml in configDir without re-Unmarshalling the same bytes.
+//
+// Motivation (#708): the tenant-api write-path validation (gitops.validate)
+// decoded the incoming YAML three times — once for the structural tenant check,
+// once for the root-key contract, and a third time inside this merge. validate
+// now decodes the typed body once and threads it here, dropping that redundant
+// third decode. The root-key contract (CheckTenantRootKeys) still decodes a
+// separate map[string]any because a typed ThresholdConfig cannot surface stray
+// top-level keys — that decode targets a genuinely different shape, not the same
+// one twice.
+//
+// It deliberately omits the byte variant's flat-KV fallback (that path serves
+// the GET read path's legacy flat on-disk files; a parsed caller has already
+// asserted a `tenants.<id>` block is present). The defaults overlay, tenant
+// merge, and ApplyProfiles are otherwise identical, so for a tenants-block body
+// this returns the same result as the byte entry point.
+func MergeParsedTenantWithRootDefaults(configDir string, tenantCfg ThresholdConfig) ThresholdConfig {
+	merged := mergeTenantConfig(configDir, tenantCfg)
+	merged.ApplyProfiles()
+	return merged
+}
+
+// mergeTenantConfig is the shared core behind both Merge*TenantWithRootDefaults
+// entry points: it builds a fresh ThresholdConfig, overlays the root
+// _defaults.yaml (Defaults + StateFilters) from configDir, then merges the
+// already-decoded tenantCfg's `tenants:` block on top. It does NOT run the
+// flat-KV fallback or ApplyProfiles — the entry points layer those on so each
+// preserves its exact step ordering.
+func mergeTenantConfig(configDir string, tenantCfg ThresholdConfig) ThresholdConfig {
 	merged := ThresholdConfig{
 		Defaults:     make(map[string]float64),
 		StateFilters: make(map[string]StateFilter),
@@ -94,28 +154,15 @@ func MergeTenantWithRootDefaults(configDir, tenantID string, tenantData []byte) 
 		}
 	}
 
-	// Merge the tenant file's `tenants:` block on top.
-	var tenantCfg ThresholdConfig
-	if err := yaml.Unmarshal(tenantData, &tenantCfg); err == nil {
-		for tenant, overrides := range tenantCfg.Tenants {
-			if merged.Tenants[tenant] == nil {
-				merged.Tenants[tenant] = make(map[string]ScheduledValue)
-			}
-			for k, v := range overrides {
-				merged.Tenants[tenant][k] = v
-			}
+	// Merge the tenant config's `tenants:` block on top.
+	for tenant, overrides := range tenantCfg.Tenants {
+		if merged.Tenants[tenant] == nil {
+			merged.Tenants[tenant] = make(map[string]ScheduledValue)
+		}
+		for k, v := range overrides {
+			merged.Tenants[tenant][k] = v
 		}
 	}
 
-	// Fallback: a flat key-value document (no `tenants:` wrapper) is wrapped
-	// under tenantID. Preserves the historical loadMergedConfig behavior.
-	if _, exists := merged.Tenants[tenantID]; !exists {
-		var flatKV map[string]ScheduledValue
-		if err := yaml.Unmarshal(tenantData, &flatKV); err == nil && len(flatKV) > 0 {
-			merged.Tenants[tenantID] = flatKV
-		}
-	}
-
-	merged.ApplyProfiles()
 	return merged
 }

--- a/components/threshold-exporter/app/pkg/config/merge_tenant_test.go
+++ b/components/threshold-exporter/app/pkg/config/merge_tenant_test.go
@@ -252,9 +252,16 @@ func TestMergeTenantWithRootDefaults_MalformedDefaultsTolerated(t *testing.T) {
 // shape), the parsed-input MergeParsedTenantWithRootDefaults returns a config
 // deep-equal to the byte-input MergeTenantWithRootDefaults on the same body — so
 // the write boundary's switch from re-Unmarshalling raw bytes a third time to
-// threading the already-decoded ThresholdConfig is behavior-preserving. A
-// divergence in the shared merge core (defaults overlay, state_filters
-// propagation, multi-tenant merge, ApplyProfiles) fails here.
+// threading the already-decoded ThresholdConfig is behavior-preserving.
+//
+// The DeepEqual is a PARITY/DRIFT guard between the two entry points, NOT an
+// absolute check of the shared mergeTenantConfig core: both arms route through
+// that core, so a regression INSIDE it breaks both identically and DeepEqual
+// still holds. It catches one entry point drifting from its sibling (e.g. the
+// parsed arm stops loading defaults, drops ApplyProfiles, or reorders steps).
+// The explicit assertions on `parsed` below add absolute coverage so a shared-
+// core regression (lost defaults overlay / state_filters / tenant merge) also
+// fails here, not only via the byte-path tests above (#708 adversarial review).
 func TestMergeParsedTenantWithRootDefaults_MatchesByteVariant(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
@@ -286,6 +293,21 @@ func TestMergeParsedTenantWithRootDefaults_MatchesByteVariant(t *testing.T) {
 			bytewise := MergeTenantWithRootDefaults(dir, tt.tenantID, []byte(tt.body))
 			if !reflect.DeepEqual(parsed, bytewise) {
 				t.Errorf("parsed variant diverged from byte variant:\n parsed = %+v\n bytes  = %+v", parsed, bytewise)
+			}
+			// Absolute pins on the parsed result itself (independent of the byte
+			// arm) so a shared-core regression — which the parity check above
+			// cannot catch, since it would break both arms identically — still
+			// fails here. Both table bodies carry db-a.container_cpu and share the
+			// _defaults.yaml above (container_cpu default + container_crashloop
+			// state_filter), so these hold for every case.
+			if parsed.Defaults["container_cpu"] != 80 {
+				t.Errorf("parsed: defaults overlay lost — container_cpu = %v, want 80", parsed.Defaults["container_cpu"])
+			}
+			if sf, ok := parsed.StateFilters["container_crashloop"]; !ok || sf.Severity != "critical" {
+				t.Errorf("parsed: state_filters not propagated from _defaults.yaml, got: %v", parsed.StateFilters)
+			}
+			if _, ok := parsed.Tenants[tt.tenantID]["container_cpu"]; !ok {
+				t.Errorf("parsed: tenant override missing — Tenants[%q] = %v", tt.tenantID, parsed.Tenants[tt.tenantID])
 			}
 		})
 	}

--- a/components/threshold-exporter/app/pkg/config/merge_tenant_test.go
+++ b/components/threshold-exporter/app/pkg/config/merge_tenant_test.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // TestMergeTenantWithRootDefaults_PopulatesDefaults verifies the consolidation
@@ -242,5 +244,77 @@ func TestMergeTenantWithRootDefaults_MalformedDefaultsTolerated(t *testing.T) {
 	}
 	if _, ok := merged.Tenants["db-a"]["container_cpu"]; !ok {
 		t.Error("tenant body should still merge despite a malformed _defaults.yaml")
+	}
+}
+
+// TestMergeParsedTenantWithRootDefaults_MatchesByteVariant pins the #708
+// parse-once consolidation: for a tenants-block body (the tenant-api write-path
+// shape), the parsed-input MergeParsedTenantWithRootDefaults returns a config
+// deep-equal to the byte-input MergeTenantWithRootDefaults on the same body — so
+// the write boundary's switch from re-Unmarshalling raw bytes a third time to
+// threading the already-decoded ThresholdConfig is behavior-preserving. A
+// divergence in the shared merge core (defaults overlay, state_filters
+// propagation, multi-tenant merge, ApplyProfiles) fails here.
+func TestMergeParsedTenantWithRootDefaults_MatchesByteVariant(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	defaults := "defaults:\n  container_cpu: 80\n  mysql_cpu: 80\n" +
+		"state_filters:\n" +
+		"  container_crashloop:\n" +
+		"    reasons: [\"CrashLoopBackOff\"]\n" +
+		"    severity: critical\n"
+	if err := os.WriteFile(filepath.Join(dir, "_defaults.yaml"), []byte(defaults), 0o644); err != nil {
+		t.Fatalf("write defaults: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		tenantID string
+		body     string
+	}{
+		{"single tenant", "db-a", "tenants:\n  db-a:\n    container_cpu: \"70\"\n"},
+		{"multi tenant block", "db-a", "tenants:\n  db-a:\n    container_cpu: \"70\"\n  db-b:\n    mysql_cpu: \"60\"\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var tcfg ThresholdConfig
+			if err := yaml.Unmarshal([]byte(tt.body), &tcfg); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			parsed := MergeParsedTenantWithRootDefaults(dir, tcfg)
+			bytewise := MergeTenantWithRootDefaults(dir, tt.tenantID, []byte(tt.body))
+			if !reflect.DeepEqual(parsed, bytewise) {
+				t.Errorf("parsed variant diverged from byte variant:\n parsed = %+v\n bytes  = %+v", parsed, bytewise)
+			}
+		})
+	}
+}
+
+// TestMergeParsedTenantWithRootDefaults_OmitsFlatKVFallback documents the one
+// intentional difference from the byte entry point: the parsed variant does NOT
+// wrap a flat key-value document under tenantID. That fallback serves the GET
+// read path's legacy on-disk files; the write boundary that uses this variant
+// has already asserted a `tenants.<id>` block is present (gitops.validate's
+// structural check), so the fallback is unreachable for it. A flat body decodes
+// into a ThresholdConfig with no `tenants:`, so the merged result has no entry
+// for the tenant — unlike MergeTenantWithRootDefaults, which synthesises one.
+func TestMergeParsedTenantWithRootDefaults_OmitsFlatKVFallback(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir() // no _defaults.yaml needed
+
+	flat := "container_cpu: \"70\"\nmysql_cpu: \"60\"\n" // no tenants: wrapper
+	var tcfg ThresholdConfig
+	if err := yaml.Unmarshal([]byte(flat), &tcfg); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got := MergeParsedTenantWithRootDefaults(dir, tcfg); len(got.Tenants) != 0 {
+		t.Errorf("parsed variant must not synthesise a tenant from a flat-KV body, got tenants: %v", got.Tenants)
+	}
+
+	// The byte entry point, by contrast, still applies the flat-KV fallback —
+	// pinning that this refactor left the GET read-path behavior untouched.
+	if _, ok := MergeTenantWithRootDefaults(dir, "db-a", []byte(flat)).Tenants["db-a"]; !ok {
+		t.Error("byte variant should still wrap a flat-KV body under tenantID (GET read-path behavior)")
 	}
 }


### PR DESCRIPTION
## 背景

承 [#708](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/708)（#706 ADR-024 PR4 對抗式 review 揪出的 tech-debt）：tenant-api 寫入路徑驗證 `gitops.validate()` 對同一份 PUT body 反覆 `yaml.Unmarshal` **三次** —— (1) 結構性 tenant 檢查的 `ThresholdConfig`、(2) root-key 契約的 `map[string]any`、(3) `MergeTenantWithRootDefaults` 內部又解一次成 `ThresholdConfig`。第 (1)、(3) 是把**相同 bytes 解成相同型別**的純冗餘。

## 改動

把第一次已解碼的 `ThresholdConfig`（tcfg）穿進新的 parse-once sibling `cfg.MergeParsedTenantWithRootDefaults`，消掉第三次冗餘 decode。

- 兩個 `Merge*` entry point 共用同一個 `mergeTenantConfig` core → byte-input GET 讀路徑（`handler.loadMergedConfig`）行為**完全不變**，含 flat-KV fallback（parsed sibling 刻意省略，因寫入邊界已先斷言 `tenants.<id>` 存在，fallback 對它本就 unreachable）。
- 保留 `CheckTenantRootKeys` 的 `map[string]any` root-key decode：typed `ThresholdConfig` 無法揭露 stray 頂層 key，是**不同 shape**、非同一份解兩次。
- 淨效果：寫入路徑 validate 由 3 次 decode → 2 次（兩種不同 shape、零冗餘）。

issue 提到的相容性約束（`MergeTenantWithRootDefaults` 與 GET 讀路徑共用、簽章須維持 raw `[]byte`）有遵守：byte 版簽章不動，新增 parsed 變體供寫入路徑使用。

## 為何安全（零行為變更）

- 新增 `TestMergeParsedTenantWithRootDefaults_MatchesByteVariant`：對 tenants-block body 釘住 parsed 與 byte 兩 entry point `reflect.DeepEqual` 一致（涵蓋 defaults overlay / state_filters / 多租戶 merge / ApplyProfiles）。
- `TestMergeParsedTenantWithRootDefaults_OmitsFlatKVFallback`：記錄唯一刻意差異（flat-KV 僅 byte 版有，服務 GET 讀路徑 legacy 扁平檔）。
- `ApplyProfiles` 在此合併情境 `Profiles` 恆空 → no-op；byte 版維持「defaults → merge tenants → flat-KV fallback → ApplyProfiles」原順序。

## 驗證

- `go test ./pkg/config/`（threshold-exporter/app）✅
- `go test ./internal/gitops/` + `./internal/handler/`（tenant-api）✅
  - full `gitops` 套件閒置機器重跑全綠；一個 `TestWritePR_AnchorsOnFreshOriginBase` 在並行負載下命中 5s `git fetch` timeout flake，**隔離重跑通過**、屬 TRK-318 base-fetch 路徑、與本次（只動 validate key-validation 分支）無關。
- `gofmt -l` / `go vet` clean；兩 module `go build ./...` clean。
- host `pre-commit run --files`（3 個改動檔）全綠。

無 API / schema / CLI / 計數變更 → 不觸發 doc-as-code 三檔同步；純內部 parse-count 重構，未入使用者重點區 CHANGELOG。

Closes #708
