### PR TITLE
docs: ADR-023 Deferred 增列 #746 QoS 雙車道 reopen-trigger

### DIFF
--- a/docs/adr/023-write-plane-single-writer-invariant.md
+++ b/docs/adr/023-write-plane-single-writer-invariant.md
@@ -9,7 +9,7 @@ tracking_kind: adr
 status: accepted
 domain: tenant-api
 created_at: 2026-05-30
-updated_at: 2026-06-24
+updated_at: 2026-06-25
 ---
 # ADR-023: tenant-api 寫入平面 — 單一寫者不變式
 
@@ -125,7 +125,10 @@ ADR-023 single-writer invariant violated: tenant-api replicaCount=2 but MUST be 
 - **K8s Lease 分散式寫入鎖（A3，[#787](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/787)）** — 雙重動機：(1) 寫入部署需 zero-downtime 成硬需求；(2) 執行期多寫者向量（`kubectl scale`／KEDA／GitOps patch）需根治。任一觸發即開工。
 - **讀寫拆分部署（A4，[#788](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/788)）** — 觸發：讀取 HA 成需求（Portal 上線、讀 QPS 上升）。前提：binary 新增 read-only 模式 + 路由。
 - **寫入水平擴展** — 觸發：單寫者吞吐量成實測瓶頸。走 Lease，不放寬單鎖。
-- **寫入平面 QoS 雙車道（human-interactive vs machine-batch，[#746](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/746)，2026-06-24 closed-with-trigger）** — 在單寫者內分 human/machine 優先級車道（人類絕對搶佔、機器批次降為 preemptible micro-batch、鎖內偵測高優先即釋放退佇列）。現況的 load-shedding（[#673](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/673)）是 **priority-blind** 單 FIFO 許可佇列，足以應付「全人類寫入」的現狀（所有寫路徑皆 X-Forwarded-Email 歸屬，無機器寫者走 `Writer` 鎖）。**觸發**：第一個走寫平面（`Writer` 鎖／許可佇列）且能非平凡時長持有的 automated writer 上線（auto-GC／過期清理／批次重編譯），與延遲敏感的人類寫入共存時 → 重開 #746，並以 leading SLI（write source 打標 + human-write queue-wait p95 + `ErrWriteOverloaded` by-source 計數）為工程啟動依據。push-timeout 前置（[#630](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/630)）已 DONE。
+- **寫入依優先級分流：真人即時操作優先於機器批次（[#746](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/746)，2026-06-24 暫緩、附重啟條件）** — 構想是讓真人在 Portal 上的即時設定永遠插到機器的大量背景寫入前面（機器寫入切成小段，一發現有人要寫就讓出）。
+    - **為何現在不做**：目前所有寫入都來自真人（以登入身分寫回 git），沒有任何背景程式會自動改租戶設定。現有的過載保護（[#673](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/673)）會在塞車時擋下多餘請求、請對方稍後重試，但它「先到先服務、不分人或機器」—— 對「全是真人寫入」的現狀已足夠。
+    - **何時重啟**：等第一支「會自動寫入、且可能長時間佔住寫入鎖」的背景程式上線時（例如自動清理過期規則、批次重新編譯規則）。判斷不靠「等到出事」：先加一個觀測指標，把每筆寫入標記為人或機器，量「真人寫入平均等多久」「有多少真人寫入因機器佔線被擋下」，指標一惡化就動工。
+    - **前置已備妥**：先前擔心的「git push 卡住會無限佔住寫入鎖」已修好 —— 每個 git 操作都有逾時上限（[#630](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/630)）。
 
 ## 實作對照
 

--- a/docs/adr/023-write-plane-single-writer-invariant.md
+++ b/docs/adr/023-write-plane-single-writer-invariant.md
@@ -9,7 +9,7 @@ tracking_kind: adr
 status: accepted
 domain: tenant-api
 created_at: 2026-05-30
-updated_at: 2026-06-06
+updated_at: 2026-06-24
 ---
 # ADR-023: tenant-api 寫入平面 — 單一寫者不變式
 
@@ -125,6 +125,7 @@ ADR-023 single-writer invariant violated: tenant-api replicaCount=2 but MUST be 
 - **K8s Lease 分散式寫入鎖（A3，[#787](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/787)）** — 雙重動機：(1) 寫入部署需 zero-downtime 成硬需求；(2) 執行期多寫者向量（`kubectl scale`／KEDA／GitOps patch）需根治。任一觸發即開工。
 - **讀寫拆分部署（A4，[#788](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/788)）** — 觸發：讀取 HA 成需求（Portal 上線、讀 QPS 上升）。前提：binary 新增 read-only 模式 + 路由。
 - **寫入水平擴展** — 觸發：單寫者吞吐量成實測瓶頸。走 Lease，不放寬單鎖。
+- **寫入平面 QoS 雙車道（human-interactive vs machine-batch，[#746](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/746)，2026-06-24 closed-with-trigger）** — 在單寫者內分 human/machine 優先級車道（人類絕對搶佔、機器批次降為 preemptible micro-batch、鎖內偵測高優先即釋放退佇列）。現況的 load-shedding（[#673](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/673)）是 **priority-blind** 單 FIFO 許可佇列，足以應付「全人類寫入」的現狀（所有寫路徑皆 X-Forwarded-Email 歸屬，無機器寫者走 `Writer` 鎖）。**觸發**：第一個走寫平面（`Writer` 鎖／許可佇列）且能非平凡時長持有的 automated writer 上線（auto-GC／過期清理／批次重編譯），與延遲敏感的人類寫入共存時 → 重開 #746，並以 leading SLI（write source 打標 + human-write queue-wait p95 + `ErrWriteOverloaded` by-source 計數）為工程啟動依據。push-timeout 前置（[#630](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/630)）已 DONE。
 
 ## 實作對照
 


### PR DESCRIPTION
## 背景

重評已 defer 的 [#746](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/746)（寫入平面 QoS 雙車道）後採 **close-with-trigger**（理由見 [issue 收尾 comment](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/746#issuecomment-4791127705)）。本 PR 把 re-baselined 後的 reopen-trigger **codify 進 ADR-023 Deferred 段**，避免決策資訊只留在已關 issue 裡。

## 變更

`docs/adr/023-write-plane-single-writer-invariant.md`：

- Deferred 段新增一條 bullet（QoS 雙車道，#746）：
  - **現況**：load-shedding（#673）已出貨但 **priority-blind**（單 FIFO 許可佇列）；所有寫路徑皆 X-Forwarded-Email 歸屬，**無機器寫者走 `Writer` 鎖**。
  - **重設後的 trigger**：第一個走寫平面（`Writer` 鎖／許可佇列）且能非平凡時長持有的 automated writer 上線（auto-GC／過期清理／批次重編譯）→ 重開 #746，並以 leading SLI（write source 打標 + human-write queue-wait p95 + `ErrWriteOverloaded` by-source 計數）為工程啟動依據。
  - push-timeout 前置（#630）已 **DONE**。
- `updated_at` → 2026-06-24。

## 為何

原兩條 trigger（機器量>人類 / Portal 503）已過時：(a)「量比」與 issue 自身 root-cause（head-of-line blocking 是 latency-class / duration，非 volume）矛盾，亦違背業界 QoS 慣例；(b) 原本盯的「無限 hang」失效模式已被 ADR-023 / #673 的 graceful-503 + retry **遮蔽**，「一次 Portal 503 事件」可能永不浮現。

## 驗證

- pre-commit 全綠（含 ADR-023 single-writer guard、codename gate、doc-link validation、bilingual purity）。
- `make pr-preflight`：PASS（merge-tree 無衝突、commit scope 合規）。
- `make lint-docs-mkdocs`：STATUS=PASS。
- docs-only：無 `.en.md` pair、planning-index row 不變、無 count drift。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
