### PR TITLE
fix(ci): pin renovatebot/github-action to full version (no @v46 major alias)

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -74,7 +74,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Renovate
-        uses: renovatebot/github-action@v46
+        # renovatebot/github-action ships ONLY full vMAJOR.MINOR.PATCH tags — there is no
+        # floating @v46 major alias (unlike actions/checkout@v6), so a bare @v46 fails to
+        # resolve ("unable to find version v46"). Pin the full version. Renovate won't
+        # self-bump this (enabledManagers is images-only), so it's manually maintained.
+        uses: renovatebot/github-action@v46.1.16
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## 問題

啟用 #902 L3 時,首次 `workflow_dispatch` dry-run 在 **"Set up job" 階段即失敗**:

```
Unable to resolve action `renovatebot/github-action@v46`, unable to find version `v46`
```

`renovatebot/github-action` **只發完整 `vMAJOR.MINOR.PATCH` tag,沒有浮動 `@v46` major alias**(不像 `actions/checkout@v6`),所以 `@v46` 無法解析。此缺陷只在實跑 `workflow_dispatch` 才會浮現 —— 離線守門測(`tests/ops/test_renovate_config.py`)只驗 `renovate.json` 的 regex 覆蓋,驗不到 workflow 的 action pin;而 dispatch-only workflow 又無法在自己的 PR CI 內跑。

## 修法

`renovatebot/github-action@v46` → `@v46.1.16`(現行最新),並加註解防止再被改回 `@v46`。Renovate 不會自升此 action(`enabledManagers` 僅 images),故手動維護。

## 驗證(在本 fix 分支實跑 dry-run,run 28181699073 ✅ success)

- `INFO: Dependency extraction complete`;**14 個第三方 image 全數解析**(envoy / oauth2-proxy / prom-label-proxy / vector / victoria-logs / grafana / prometheus / alertmanager / kube-state-metrics / configmap-reload / alpine/git / mysqld-exporter / mariadb / python)。
- `DRY-RUN: Would commit files to branch renovate/third-party-container-images` → 單一 grouped PR 成形。
- `DRY-RUN: Would ensure Dependency Dashboard`。
- 無 401(token 正常)、無 config 錯誤、**無 Docker Hub rate-limit**。

token / `renovate.json` config 均未受影響;本 PR 只動 workflow 的 action 版本字串。

Refs: #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)
