### PR TITLE
ci: exempt Renovate (renovate/*) PRs from Self-Review-Pass-2 trailer gate

### DIFF
--- a/.github/workflows/self-review-pass2.yaml
+++ b/.github/workflows/self-review-pass2.yaml
@@ -27,6 +27,12 @@ jobs:
   self-review-pass2:
     name: Validate Self-Review-Pass-2 trailer
     runs-on: ubuntu-latest
+    # Bot-authored PRs (Renovate #902 L3 image-digest auto-bumps) legitimately
+    # carry no Self-Review-Pass-2 trailer — they're machine-generated dependency
+    # bumps, not human changes that dogfood the intentional-break self-review. Skip
+    # the gate for `renovate/*` branches so it doesn't show a perpetual red status
+    # row on every Renovate PR. The gate still runs for ALL human-authored PRs.
+    if: ${{ !startsWith(github.head_ref, 'renovate/') }}
     # Soft-fail rollout: status appears but doesn't block merge until adoption
     # plateaus. Track #454 follow-up to flip off.
     continue-on-error: true


### PR DESCRIPTION
## 問題

Renovate 的 #902 L3 image-digest auto-bump PR(例如剛開的 #928)在 **「Validate Self-Review-Pass-2 trailer」恆常紅一格** —— 那是機器生成的 bot commit,天生沒有 `Self-Review-Pass-2` trailer(該 trailer 供人工變更 dogfood intentional-break self-review)。此 gate 本來就是 soft-fail(`continue-on-error`,#454)、**不擋 merge**,但每個 Renovate PR 都紅一格是長期噪音。

## 修法

`self-review-pass2.yaml` 的 job 加:

```yaml
if: ${{ !startsWith(github.head_ref, 'renovate/') }}
```

`renovate/*` 分支直接 **skip**(顯示為 skipped,不再紅);**所有人工 PR 照常驗**(含本 PR 自己 —— 非 `renovate/*`,仍須帶 trailer,已帶)。

`branchPrefix` 用 Renovate 預設 `renovate/`(`renovate.json` 未覆寫);#928 的 head 即 `renovate/third-party-container-images`,已確認。

## 範圍

只動這一個 workflow 的 job-level `if`。不改 trailer 檢查邏輯本身、不改 `continue-on-error`(人工 PR 仍維持原 soft-fail rollout 行為)。

Refs: #902, #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
