### PR TITLE
ci: gate Renovate python minor bumps behind the Dependency Dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,12 @@
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "#902 L3 — `python:3.x-slim` numbers its tag by Python FEATURE release, so a 3.13→3.14 bump is semver-MINOR to Docker but a real language-version jump (new interpreter, possible C-ABI / stdlib breakage for dependent components). Gate python's MINOR bumps behind the Dependency Dashboard like a major, rather than letting them auto-flow in the grouped PR. Digest-only refreshes (same tag, security re-pin) still auto-flow — only the version bump waits for a tick.",
+      "matchDepNames": ["python"],
+      "matchUpdateTypes": ["minor"],
+      "dependencyDashboardApproval": true
     }
   ]
 }

--- a/tests/ops/test_renovate_config.py
+++ b/tests/ops/test_renovate_config.py
@@ -180,3 +180,24 @@ def test_no_re2_incompatible_lookarounds():
                     f"RE2 (Renovate) does not support lookaround {tok!r}; it would crash "
                     f"at runtime though Python's re accepts it. Offending matchString: {s[:90]}"
                 )
+
+
+def test_python_minor_bump_requires_dashboard_approval():
+    """`python:3.x-slim` numbers its tag by Python FEATURE release, so a 3.13→3.14
+    bump is semver-MINOR to Docker but a real language-version jump. Assert a
+    packageRule gates python's MINOR updates behind dependencyDashboardApproval (so
+    it can't silently auto-flow in the grouped PR), while NOT gating its digest-only
+    refresh — the security re-pin must stay automatic."""
+    cfg = _load_config()
+    gated = [
+        r for r in cfg.get("packageRules", [])
+        if "python" in r.get("matchDepNames", [])
+        and "minor" in r.get("matchUpdateTypes", [])
+        and r.get("dependencyDashboardApproval") is True
+    ]
+    assert gated, "expected a packageRule gating python MINOR bumps behind the Dependency Dashboard"
+    for r in gated:
+        assert "digest" not in r.get("matchUpdateTypes", []), (
+            "python digest-only refresh must stay automatic — only the version (minor) "
+            "bump should wait for a Dependency Dashboard tick"
+        )


### PR DESCRIPTION
## 背景

#928 把 `python:3.13-slim → 3.14-slim` 靜默 auto-merge 進來 —— Docker 把它當 **semver-MINOR**(major=`3` 沒變),所以它**繞過了**「major → Dependency Dashboard 審」閘門。但 3.13→3.14 是 Python **語言功能大版**(換直譯器、可能 C-ABI / stdlib breakage for dependent components)。

## 修法

`renovate.json` 加一條 packageRule:python 的 **minor** 也 `dependencyDashboardApproval: true`(像 major 一樣等人工勾選);**digest-only 安全重 pin 仍自動流** —— 只擋版本跳,不擋 CVE 重 pin。

新增離線測 `test_python_minor_bump_requires_dashboard_approval` 鎖住此意圖(結構驗證:python minor 有 gating、且 digest **不**在 gating 內)。

## 驗證

- 離線測本機跑:**6 passed**(含新測)/ 1 skipped(`renovate-config-validator`,Python lane 無 node);`test_coverage_is_complete_and_exact` 仍綠 → **coverage 14/14 不變**,digest 自動流保留。

Refs: #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)
