### PR TITLE
docs(dx): register TRK-327 raw-mode forecast anti-flap defer (#936)

### DIFF
--- a/docs/internal/planning-id-mapping.md
+++ b/docs/internal/planning-id-mapping.md
@@ -159,6 +159,7 @@ SOT 在 [`dx-tooling-backlog.md`](dx-tooling-backlog.md)。
 | TRK-324 | [#677](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/677) | 幽靈副本：滾動更新交疊多寫者（Recreate now-fix / Lease deferred） | TRK-317 |
 | TRK-325 | [#678](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/678) | 讀寫拆分部署（CQRS）+ read-only enforcement 模式（deferred、**已關閉**；RFC dup [#788](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/788)；re-trigger codify 成 alert `TenantApiReadHANeeded`，見 ADR-023 A4） | TRK-317 |
 | TRK-326 | [#751](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/751) | Custom-alert `for` divergence：`for` 納 recipe_id slug + schema enum（向量化靜默覆蓋 P0） | [#741](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/741) |
+| TRK-327 | [#936](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/936) | Raw-mode forecast 缺現值防抖動地板（anti-flap floor）— defer-with-trigger（Gemini Day-2 review；ratio 模式已有 `_FORECAST_CURRENT_BAND`，raw 模式 out-of-scope at GA） | [#741](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/741) |
 
 ## 不在 mapping 範圍
 

--- a/scripts/tools/dx/custom_alerts/recipes.py
+++ b/scripts/tools/dx/custom_alerts/recipes.py
@@ -111,7 +111,9 @@ def _forecast_records(rid: str, metric: str, sel: str, horizon: str,
     else:
         # raw mode: an arbitrary gauge (may exceed 1 or be legitimately negative) — no
         # [0,1] clamp, no ratio band. A raw-mode anti-flap gate would have to be
-        # threshold-relative; out of scope here (raw-mode forecast is rare).
+        # threshold-relative; out of scope here (raw-mode forecast is rare). Deferred
+        # with trigger — see TRK-327 (#936): wakes on raw-mode adoption crossing an
+        # early band, or the first transient-spike false-positive ticket.
         predict_inner = (
             f"predict_linear({base}[{lb_s}s], {h_s})\n"
             f"  and\n"


### PR DESCRIPTION
把 Gemini Day-2 adversarial review 命中的 forecast raw-mode 邊角落為可追蹤的 defer-with-trigger 票（TRK-327 / #936）。

- planning-id-mapping.md 加 TRK-327 對映列（lineage #741 / ADR-024 Forecast Recipe）
- recipes.py raw-mode 就地 defer 註解補 `TRK-327 (#936)` 交叉引用，讓程式碼裡的 延後決策指向活票（codified beats documented）

背景：ratio 模式已有現值地板（`_FORECAST_CURRENT_BAND` + clamp_min + cold-start gate）；raw 模式因地板須 threshold-relative 而於 GA 刻意 out-of-scope。喚醒條件： raw-mode 採用跨越早期門檻（需主動盯，非自浮現），或第一張短暫尖峰偽陽性客訴。

planning-index 不受影響：generator 只讀 frontmatter / `// TECH-DEBT(...)` 機械註解， 不讀 mapping 表，且 frozen defer 票本就不在 status enum 內。

Refs: TRK-327, #936, #741
Self-Review-Pass-2: bump_docs green; doc row + code xref only; planning-index untouched

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] Feature (new functionality)
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactoring (no behavior change)
- [ ] CI/CD / Tooling
- [ ] Release

## Documentation Checklist

<!-- For documentation-related PRs, check applicable items -->

- [ ] Frontmatter `version` updated (`check_frontmatter_versions.py --fix`)
- [ ] Cross-language counterpart updated (ZH ↔ EN)
- [ ] No orphan documents introduced (new .md files linked from at least one other doc)
- [ ] CHANGELOG.md updated (if user-facing change)
- [ ] Numbers accurate (tool count, scenario count, Rule Pack count match source of truth)
- [ ] **No internal codenames in customer-facing text** — any new proper noun in `docs/**` (excluding `docs/internal/**`), `README*.md`, or `components/*/README.md` must be registered in [`docs/glossary.md`](../docs/glossary.md): customer-facing terms in the A–Z dictionary, planning/tracking codenames in the "內部代號 — 禁止用於對外文件" section (which the gate then rejects in customer docs). Use feature names + version labels instead of codenames. Verify with `python scripts/tools/lint/check_codename_leak.py --full-scan` (Layer 1, fast-path) and `python scripts/tools/lint/check_codename_gate.py` (Layer 2, glossary-driven) ([#462](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/462) / [#469](https://github.com/vencil/Dynamic-Alerting-Integrations/issues/469))

## Quality Gates

```bash
make version-check                                    # Version consistency
make lint-docs                                        # Documentation lint
pre-commit run --all-files                            # Auto hooks
pre-commit run --hook-stage manual --all-files        # Manual hooks (heavier)
```

## Test Plan

<!-- How was this tested? -->

## Pre-merge Self-Review

> **Discipline**: pre-merge deep self-review is **default for every PR**, not opt-in. If user has to prompt "做 self-review 了嗎?" before merge, you skipped this section. See [`docs/internal/testing-playbook.md`](../docs/internal/testing-playbook.md) §v2.8.0 LL §5 (Self-review pass 2) + §6 (Intentional-break dogfood) for rationale — search for "Self-review pass 2" inside the file.

### Pass 1 — 5+1 standard checks (S#73)

<!-- Strikethrough N/A items rather than ticking them. -->

- [ ] (1) Function/API signatures match every caller; no orphan signature changes
- [ ] (2) Module-level constants for stable identity where `useMemo`/`useCallback` deps care
- [ ] (3) Rules-of-Hooks discipline (hooks invoked unconditionally above early returns)
- [ ] (4) Wiring triple complete (front-matter `dependencies` + `import` block + `window.__X` self-register)
- [ ] (5) Conditional **usage** (not conditional invocation) for hooks
- [ ] (6) **Verify-reference**: APIs / library behaviors / hook scripts read & empirically confirmed (not assumed). Includes hooks I didn't write — PR #164 found `_batch_cat_blobs` Popen pipe deadlock latent for months because nobody verified the hook script.

### Pass 2 — deeper scrutiny (S#77 / PR #166 amend)

- [ ] **Counts / numbers in PR body / CHANGELOG / docstrings cross-checked** against `pytest --collect-only`, file `wc -l`, raw audit. (LL §5 case (i): "Path derivation × 5" vs actual 10 — exact instance happened in PR #171 v1.)
- [ ] **Internal helper functions have direct tests**, not only via integration / parametrized fixtures. If you wrote an `if`-branch but no test walks it, it's hidden dead code.
- [ ] **Edge cases tested**: paths-outside-`PROJECT_ROOT` / single-element / empty / boundary values. PR #166 amend caught `BlobViolation.render()` crash on `tmp_path` exactly because new `TestMain` fixtures landed.
- [ ] `tmp_path` (or equivalent) fixtures stress assumptions about where input comes from.

### Pass 2 — regression tests specifically (LL §6)

- [ ] **Intentional-break dogfood loop** done: backup fix → revert to broken pattern → run test → confirm fail → restore → re-run pass. **Without this loop, the regression test is article-of-faith** (see PR #166's 300×1KB headline test that didn't actually trigger Windows pipe-buffer deadlock; only 1000×2KB did).
- [ ] Defense-in-depth ladder: pytest-timeout marker (Layer 1 fast-fail) + soft `assert elapsed < X.0` budget (Layer 2 slow-regression catch) + inner production timeout (Layer 3 actual fix).
- [ ] Empirical threshold table in docstring if test parameters are tuned (path count vs total bytes vs OS pipe buffer).

### Anti-patterns to flag yourself for

- [ ] I'm NOT skipping pass 2 because "this PR is small / doc-only / refactor"
- [ ] I'm NOT confusing `pass` with `pytest.skip("TODO")` in stub methods (silent green vs xfail-style visible — see PR #171 amend Fix 2)
- [ ] I'm NOT reactively expanding the PR scope to fix things I noticed during self-review without bumping the PR description / commits accordingly

### `Self-Review-Pass-2:` trailer (expected default)

Add to **any** commit message in this PR (CI strict-mode gate via `self-review-pass2.yaml` — soft-fail today, will flip to hard-fail once adoption plateaus, #454):

```
Self-Review-Pass-2: dogfood mutated <function>; <test_name> caught (✓)
```

The trailer must be on its own line in the bottom paragraph, separated from the body by a blank line — that's the git native trailer convention the check enforces (case-insensitive, multi-line values OK).

Skip only if the PR is **doc-only / chore-only with zero logic change**; in that case state so in the Summary section above so the soft-fail status row is interpretable.

---

<!-- Don't tick boxes you didn't actually do. The honesty contract is the point. -->

